### PR TITLE
Update tsconfig.json & fix part of type errors

### DIFF
--- a/spx-gui/src/App.vue
+++ b/spx-gui/src/App.vue
@@ -32,7 +32,7 @@ import {
   NLayoutContent,
 } from "naive-ui";
 import TopMenu from "@/components/top-menu/TopMenu.vue";
-import "@/assets/theme.ts";
+import "@/assets/theme";
 /**
  * @description: Override spx-gui theme
  * @return {*}

--- a/spx-gui/src/api/asset.ts
+++ b/spx-gui/src/api/asset.ts
@@ -7,7 +7,7 @@
  * @Description: 
  */
 import { service } from "@/axios";
-import { Asset, PageData } from "@/interface/library.ts"; // Adjust the import paths as needed
+import type { Asset, PageData } from "@/interface/library.ts"; // Adjust the import paths as needed
 
 
 /**

--- a/spx-gui/src/api/project.ts
+++ b/spx-gui/src/api/project.ts
@@ -1,5 +1,5 @@
 import { service } from "@/axios";
-import {Project} from "@/interface/library.ts";
+import {Project} from "@/interface/library";
 
 /**
  * Saves a project.

--- a/spx-gui/src/api/project.ts
+++ b/spx-gui/src/api/project.ts
@@ -1,5 +1,5 @@
 import { service } from "@/axios";
-import {Project} from "@/interface/library";
+import type { Project } from "@/interface/library";
 
 /**
  * Saves a project.

--- a/spx-gui/src/axios/index.ts
+++ b/spx-gui/src/axios/index.ts
@@ -7,7 +7,7 @@
  * @Description:
  */
 import { createDiscreteApi } from "naive-ui";
-import axios, { AxiosResponse } from "axios";
+import axios, { type AxiosResponse } from "axios";
 
 const baseURL = "http://116.62.66.126:8081";
 

--- a/spx-gui/src/class/AssetBase.ts
+++ b/spx-gui/src/class/AssetBase.ts
@@ -6,10 +6,11 @@
  * @FilePath: \builder\spx-gui\src\class\AssetBase.ts
  * @Description: The abstract class of an asset.
  */
-import file, { Config } from "@/interface/file";
+import type file from "@/interface/file";
 import { getStorage } from "@/util/class";
 import FileWithUrl from "@/class/FileWithUrl";
 import { isObjectEmpty } from "@/util/global";
+import type { Config } from '@/interface/file';
 
 /**
  * @abstract

--- a/spx-gui/src/class/backdrop.ts
+++ b/spx-gui/src/class/backdrop.ts
@@ -6,11 +6,12 @@
  * @FilePath: \builder\spx-gui\src\class\backdrop.ts
  * @Description: The class of a backdrop.
  */
-import file, { BackdropConfig, Scene } from "@/interface/file";
+import type { BackdropConfig, Scene } from "@/interface/file";
 import AssetBase from "./AssetBase";
 import { isInstance, getAllFromLocal } from "@/util/class";
 import { useSpriteStore } from "@/store/modules/sprite";
-import { rawFile } from "@/types/file";
+import type { rawFile } from "@/types/file";
+import type file from '@/interface/file';
 
 /**
  * @class Backdrop

--- a/spx-gui/src/class/sound.ts
+++ b/spx-gui/src/class/sound.ts
@@ -6,10 +6,11 @@
  * @FilePath: \builder\spx-gui\src\class\sound.ts
  * @Description: The class of a sound.
  */
-import file, { SoundConfig } from "@/interface/file";
+import type file from "@/interface/file";
 import AssetBase from "./AssetBase";
 import { isInstance, getAllFromLocal } from "@/util/class";
-import { rawFile } from "@/types/file";
+import type { rawFile } from "@/types/file";
+import type { SoundConfig } from '@/interface/file';
 
 /**
  * @class Sound

--- a/spx-gui/src/class/sprite.ts
+++ b/spx-gui/src/class/sprite.ts
@@ -7,10 +7,11 @@
  * @Description: The class of a sprite.
  */
 
-import file, { Costume, SpriteConfig } from "@/interface/file";
+import type file from "@/interface/file";
+import type { Costume, SpriteConfig } from "@/interface/file";
 import AssetBase from "./AssetBase";
 import { isInstance, getAllFromLocal } from "@/util/class";
-import { rawFile } from "@/types/file";
+import type { rawFile } from "@/types/file";
 
 /**
  * @class Sprite

--- a/spx-gui/src/components/sounds/SoundsEdit.vue
+++ b/spx-gui/src/components/sounds/SoundsEdit.vue
@@ -143,7 +143,7 @@ import RegionsPlugin from 'wavesurfer.js/dist/plugin/wavesurfer.regions.js';
 import CursorPlugin from 'wavesurfer.js/dist/plugin/wavesurfer.cursor.js';
 import { ref, onMounted, Ref } from 'vue';
 import { nextTick } from "@vue/runtime-dom";
-import { WavesurferEdit } from "@/util/wavesurferEdit.ts";
+import { WavesurferEdit } from "@/util/wavesurferEdit";
 import { NGradientText, NInput, useMessage, MessageApi } from "naive-ui";
 
 const message: MessageApi = useMessage();

--- a/spx-gui/src/components/sounds/SoundsEdit.vue
+++ b/spx-gui/src/components/sounds/SoundsEdit.vue
@@ -141,10 +141,10 @@ import WaveSurfer from 'wavesurfer.js';
 import TimelinePlugin from 'wavesurfer.js/dist/plugin/wavesurfer.timeline.js';
 import RegionsPlugin from 'wavesurfer.js/dist/plugin/wavesurfer.regions.js';
 import CursorPlugin from 'wavesurfer.js/dist/plugin/wavesurfer.cursor.js';
-import { ref, onMounted, Ref } from 'vue';
+import { ref, onMounted, type Ref } from 'vue';
 import { nextTick } from "@vue/runtime-dom";
 import { WavesurferEdit } from "@/util/wavesurferEdit";
-import { NGradientText, NInput, useMessage, MessageApi } from "naive-ui";
+import { NGradientText, NInput, useMessage, type MessageApi } from "naive-ui";
 
 const message: MessageApi = useMessage();
 let wavesurfer: WaveSurfer = ref(null);

--- a/spx-gui/src/components/sounds/SoundsEditCard.vue
+++ b/spx-gui/src/components/sounds/SoundsEditCard.vue
@@ -24,7 +24,7 @@
 
 <script setup lang="ts">
 
-import { Asset } from "@/interface/library.ts";
+import { Asset } from "@/interface/library";
 import { defineProps } from "vue";
 
 const props = defineProps({

--- a/spx-gui/src/components/sounds/SoundsEditCard.vue
+++ b/spx-gui/src/components/sounds/SoundsEditCard.vue
@@ -24,7 +24,7 @@
 
 <script setup lang="ts">
 
-import { Asset } from "@/interface/library";
+import { type Asset } from "@/interface/library";
 import { defineProps } from "vue";
 
 const props = defineProps({

--- a/spx-gui/src/components/sounds/SoundsHome.vue
+++ b/spx-gui/src/components/sounds/SoundsHome.vue
@@ -30,10 +30,10 @@
 import SoundsEditCard from "@/components/sounds/SoundsEditCard.vue";
 import { NLayout, NLayoutContent, NLayoutSider } from "naive-ui";
 import SoundsEdit from "@/components/sounds/SoundsEdit.vue";
-import { Asset } from "@/interface/library.ts";
+import { Asset } from "@/interface/library";
 import { onMounted, ref } from "vue";
-import { getAssetList } from "@/api/asset.ts";
-import { AssetType } from "@/constant/constant.ts";
+import { getAssetList } from "@/api/asset";
+import { AssetType } from "@/constant/constant";
 
 const assets = ref<Asset[]>([]);
 

--- a/spx-gui/src/components/sounds/SoundsHome.vue
+++ b/spx-gui/src/components/sounds/SoundsHome.vue
@@ -30,7 +30,7 @@
 import SoundsEditCard from "@/components/sounds/SoundsEditCard.vue";
 import { NLayout, NLayoutContent, NLayoutSider } from "naive-ui";
 import SoundsEdit from "@/components/sounds/SoundsEdit.vue";
-import { Asset } from "@/interface/library";
+import type { Asset } from "@/interface/library";
 import { onMounted, ref } from "vue";
 import { getAssetList } from "@/api/asset";
 import { AssetType } from "@/constant/constant";

--- a/spx-gui/src/components/sprite-list/BackdropList.vue
+++ b/spx-gui/src/components/sprite-list/BackdropList.vue
@@ -21,7 +21,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ComputedRef } from "vue";
+import { computed, type ComputedRef } from "vue";
 import { useBackdropStore } from "@/store/modules/backdrop";
 import ImageCardCom from "@/components/sprite-list/ImageCardCom.vue";
 import SpriteAddBtn from "@/components/sprite-list/SpriteAddBtn.vue";

--- a/spx-gui/src/components/sprite-list/SpriteAddBtn.vue
+++ b/spx-gui/src/components/sprite-list/SpriteAddBtn.vue
@@ -67,7 +67,7 @@ import { ref, defineProps, computed } from "vue";
 import type { UploadFileInfo } from "naive-ui";
 import { NIcon, NUpload, NButton, useMessage } from "naive-ui";
 import { Add as AddIcon } from "@vicons/ionicons5";
-import { commonColor } from "@/assets/theme.ts";
+import { commonColor } from "@/assets/theme";
 import { useSpriteStore } from "@/store/modules/sprite";
 import { useBackdropStore } from "@/store/modules/backdrop";
 import LibraryModal from "@/components/spx-library/LibraryModal.vue";

--- a/spx-gui/src/components/sprite-list/SpriteList.vue
+++ b/spx-gui/src/components/sprite-list/SpriteList.vue
@@ -45,7 +45,7 @@
 
 <script setup lang="ts">
 // ----------Import required packages / components-----------
-import { ComputedRef, computed,ref } from "vue";
+import { type ComputedRef, computed,ref } from "vue";
 import { NGrid, NGridItem, NFlex } from "naive-ui";
 import BackdropList from "@/components/sprite-list/BackdropList.vue";
 import SpriteEditBtn from "@/components/sprite-list/SpriteEditBtn.vue";

--- a/spx-gui/src/components/spx-library/LibraryModal.vue
+++ b/spx-gui/src/components/spx-library/LibraryModal.vue
@@ -96,7 +96,7 @@ import {
 import { FireFilled as hotIcon } from "@vicons/antd";
 import { NewReleasesFilled as newIcon } from "@vicons/material";
 import type { Asset } from "@/interface/library";
-import { AssetType } from "@/constant/constant.ts";
+import { AssetType } from "@/constant/constant";
 import SpriteCard from "./SpriteCard.vue";
 import { getAssetList } from "@/api/asset";
 

--- a/spx-gui/src/components/spx-stage/Sprite.vue
+++ b/spx-gui/src/components/spx-stage/Sprite.vue
@@ -24,7 +24,7 @@ import type { SpriteConfig, Costume as CostumeConfig } from "@/interface/file";
 import SpriteType from "@/class/sprite"
 
 import Costume from "./Costume.vue"
-import { defineProps, onMounted, computed, defineEmits, ComputedRef, Ref } from "vue"
+import { defineProps, onMounted, computed, defineEmits, type ComputedRef } from "vue"
 
 // ----------props & emit------------------------------------
 const props = defineProps<{

--- a/spx-gui/src/components/top-menu/TopMenu.vue
+++ b/spx-gui/src/components/top-menu/TopMenu.vue
@@ -30,7 +30,7 @@ import {
 import { Book as TutorialIcon } from "@vicons/ionicons5";
 import {
   tutorialColor, publishColor, saveColor, fileColor, codeColor
-} from "@/assets/theme.ts";
+} from "@/assets/theme";
 import { useProjectStore } from "@/store/modules/project";
 const projectStore = useProjectStore();
 
@@ -87,7 +87,7 @@ const { locale } = useI18n({
 const languageStore = useLanguageStore();
 
 // theme style config
-import { ThemeStyleType } from "@/constant/constant.ts";
+import { ThemeStyleType } from "@/constant/constant";
 
 const themeStyle = ref<number>(ThemeStyleType.Pink);
 const themeMap = ["Pink", "Yellow", "Blue"];

--- a/spx-gui/src/interface/file.ts
+++ b/spx-gui/src/interface/file.ts
@@ -8,7 +8,7 @@
  */
 
 import FileWithUrl from "@/class/FileWithUrl";
-import { rawFile } from "@/types/file";
+import type { rawFile } from "@/types/file";
 
 /**
  * file interface

--- a/spx-gui/src/language/index.ts
+++ b/spx-gui/src/language/index.ts
@@ -6,7 +6,7 @@
  * @FilePath: /builder/spx-gui/src/language/index.ts
  * @Description:
 */
-import { App } from "vue";
+import type { App } from "vue";
 import { useLanguageStore } from "@/store/modules/language";
 import { createI18n } from "vue-i18n";
 

--- a/spx-gui/src/main.ts
+++ b/spx-gui/src/main.ts
@@ -11,7 +11,7 @@ import App from "./App.vue";
 
 import Loading from "@/components/loading/Loading.vue"
 import { initAssets, initCodeEditor } from './plugins';
-import { initRouter } from "@/router/index.ts";
+import { initRouter } from "@/router/index";
 import { initStore } from "./store";
 import { initI18n } from "@/language";
 

--- a/spx-gui/src/plugins/code-editor/index.ts
+++ b/spx-gui/src/plugins/code-editor/index.ts
@@ -5,9 +5,9 @@
  * @Description: 
  */
 import * as monaco from 'monaco-editor'
-import { keywords, typeKeywords, options, MonarchTokensProviderConfig, LanguageConfig, function_completions } from "./config.ts"
+import { keywords, typeKeywords, options, MonarchTokensProviderConfig, LanguageConfig, function_completions } from "./config"
 
-import wasmModuleUrl from '/wasm/format.wasm?url&wasmModule';
+import wasmModuleUrl from '/wasm/format.wasm?url';
 
 
 const initFormat = async () => {

--- a/spx-gui/src/router/index.ts
+++ b/spx-gui/src/router/index.ts
@@ -6,8 +6,8 @@
  * @FilePath: /builder/spx-gui/src/router/index.ts
  * @Description:
  */
-import { App } from "vue";
-import { createRouter, createWebHistory, RouteRecordRaw } from "vue-router";
+import type { App } from "vue";
+import { createRouter, createWebHistory, type RouteRecordRaw } from "vue-router";
 
 const routes: Array<RouteRecordRaw> = [
     { path: '/', redirect: '/editor/homepage' },

--- a/spx-gui/src/store/index.ts
+++ b/spx-gui/src/store/index.ts
@@ -7,7 +7,7 @@
  * @Description: 
  */
 import { createPinia, defineStore } from "pinia"
-import { App } from "vue";
+import { type App } from "vue";
 import piniaPluginPersist from "pinia-plugin-persist";
 
 export const initStore = async (app: App)=> {

--- a/spx-gui/src/store/modules/project/index.ts
+++ b/spx-gui/src/store/modules/project/index.ts
@@ -7,7 +7,7 @@
  * @Description: The store of project.
  */
 
-import { ref, computed, watch, toRaw, WatchStopHandle, readonly } from 'vue'
+import { ref, computed, watch, toRaw, type WatchStopHandle, readonly } from 'vue'
 import { getMimeFromExt, Content2ArrayBuffer, ArrayBuffer2Content, getPrefix } from '@/util/file'
 import { defineStore, storeToRefs } from 'pinia'
 import JSZip from 'jszip'

--- a/spx-gui/src/util/store.ts
+++ b/spx-gui/src/util/store.ts
@@ -7,7 +7,7 @@
  * @Description: A util to create asset store.
  */
 
-import { ref, Ref, computed } from 'vue'
+import { ref, type Ref, computed } from 'vue'
 import { defineStore } from 'pinia'
 import AssetBase from '@/class/AssetBase'
 

--- a/spx-gui/tsconfig.app.json
+++ b/spx-gui/tsconfig.app.json
@@ -1,0 +1,30 @@
+{
+  "extends": "@vue/tsconfig/tsconfig.dom.json",
+  "include": [
+    "env.d.ts",
+    "src/**/*",
+    "src/**/*.vue"
+  ],
+  "exclude": [
+    "src/**/__tests__/*"
+  ],
+  "compilerOptions": {
+    "composite": true,
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
+    "baseUrl": ".",
+    "paths": {
+      "@/*": [
+        "src/*"
+      ],
+      "comps/*": [
+        "src/components/*"
+      ],
+      "views/*": [
+        "src/views/*"
+      ],
+      "store/*": [
+        "src/store/*"
+      ]
+    }
+  }
+}

--- a/spx-gui/tsconfig.json
+++ b/spx-gui/tsconfig.json
@@ -1,54 +1,11 @@
 {
-  "compilerOptions": {
-    "target": "ES2020",
-    "useDefineForClassFields": true,
-    "module": "ESNext",
-    "lib": [
-      "ES2020",
-      "DOM",
-      "DOM.Iterable"
-    ],
-    "skipLibCheck": true,
-    /* Bundler mode */
-    "moduleResolution": "node",
-    // "moduleResolution": "bundler",
-    // "moduleResolution": "node",
-    // "esModuleInterop": true,
-    "allowImportingTsExtensions": true,
-    "allowSyntheticDefaultImports": true,
-    "resolveJsonModule": true,
-    "isolatedModules": true,
-    "noEmit": true,
-    "jsx": "preserve",
-    "baseUrl": "./",
-    "paths": {
-      "@/*": [
-        "src/*"
-      ],
-      "comps/*": [
-        "src/components/*"
-      ],
-      "views/*": [
-        "src/views/*"
-      ],
-      "store/*": [
-        "src/store/*"
-      ]
-    },
-    /* Linting */
-    "strict": true,
-  },
-  "include": [
-    "src/**/*.ts",
-    "src/**/*.d.ts",
-    "src/**/*.tsx",
-    "src/**/*.vue",
-    "src/test/CommentCom.spec.mjs",
-    "src/test/sum.ts"
-  ],
+  "files": [],
   "references": [
     {
       "path": "./tsconfig.node.json"
+    },
+    {
+      "path": "./tsconfig.app.json"
     }
   ]
 }

--- a/spx-gui/tsconfig.node.json
+++ b/spx-gui/tsconfig.node.json
@@ -1,10 +1,20 @@
 {
-    "compilerOptions": {
-      "composite": true,
-      "skipLibCheck": true,
-      "module": "ESNext",
-      "moduleResolution": "node",
-      "allowSyntheticDefaultImports": true
-    },
-    "include": ["vite.config.ts"]
+  "extends": "@tsconfig/node20/tsconfig.json",
+  "include": [
+    "vite.config.*",
+    "vitest.config.*",
+    "cypress.config.*",
+    "nightwatch.conf.*",
+    "playwright.config.*"
+  ],
+  "compilerOptions": {
+    "composite": true,
+    "noEmit": true,
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "types": [
+      "node"
+    ]
   }
+}


### PR DESCRIPTION
`tsconfig.json` has been updated to match the official Vue template.

There are two main types of issue arose because of the change of compiler rules.
- Imports end with `.ts` which is redundant. Already fixed in the PR.
- Type only imports should be used: `import type ... from ...`

Until the type only imports are fixed, the project will not run (white screen only).