### PR TITLE
feat: Complete the lexical analysis section of the monaco editor and configure code highlighting

### DIFF
--- a/spx-gui/src/components/code-editor/language.ts
+++ b/spx-gui/src/components/code-editor/language.ts
@@ -103,7 +103,7 @@ const brackets = [
 // editor options
 export const editorOptions: monaco.editor.IStandaloneEditorConstructionOptions = {
     language: "spx", // define the language mode
-    theme: "vs", // choose vs, hc-black, or vs-dark
+    // theme: "vs", // choose vs, hc-black, or vs-dark
     minimap: { enabled: true },
     selectOnLineNumbers: true, // select the line number's of the code
     roundedSelection: true, // rounded selection
@@ -115,10 +115,14 @@ export const editorOptions: monaco.editor.IStandaloneEditorConstructionOptions =
     renderControlCharacters: false, // render control characters
     fontSize: 16, // font size
     quickSuggestionsDelay: 100, // quick suggestions
-    folding: true, // code folding
     wordWrap: "on", // word wrap
     wordWrapColumn: 40,
     tabSize: 4, // tab size
+    folding: true, // code folding
+    foldingHighlight: true, // 折叠等高线
+    foldingStrategy: "indentation", // 折叠方式  auto | indentation
+    showFoldingControls: "mouseover", // 是否一直显示折叠 always | mouseover
+    disableLayerHinting: true, // 等宽优 
 };
 export const MonarchTokensProviderConfig:
     | monaco.languages.IMonarchLanguage
@@ -129,48 +133,87 @@ export const MonarchTokensProviderConfig:
     operators,
     functions: function_completions.map((e) => e.label),
     brackets,
+    symbols: /[=><!~?:&|+\-*\/\^%]+/,
+    escapes: /\\(?:[abfnrtv\\"']|x[0-9A-Fa-f]{1,4}|u[0-9A-Fa-f]{4}|U[0-9A-Fa-f]{8})/,
+    // digits
+    digits: /\d+(_+\d+)*/,
+    octaldigits: /[0-7]+(_+[0-7]+)*/,
+    binarydigits: /[0-1]+(_+[0-1]+)*/,
+    hexdigits: /[[0-9a-fA-F]+(_+[0-9a-fA-F]+)*/,
+    // The main tokenizer for our languages 
     tokenizer: {
         root: [
             [
                 /[a-z_$][\w$]*/,
                 {
                     cases: {
-                        "@typeKeywords": "keyword",
+                        "@typeKeywords": "typeKeywords",
                         "@keywords": "keyword",
-                        "@functions": "keyword",
-                        "@default": "variable",
+                        "@functions": "functions",
+                        "@default": "identifier",
                     },
                 },
             ],
             [/[A-Z][\w$]*/, "type.identifier"],
-            [/[{}[\]()]/, "@brackets"],
 
-            [/\d*\.\d+([eE][-+]?\d+)?/, "number.float"],
-            [/0[xX][0-9a-fA-F]+/, "number.hex"],
-            [/\d+/, "number"],
+            // whitespace
+            { include: '@whitespace' },
 
+            // delimiters and operators
+            [/[{}()\[\]]/, '@brackets'],
+            [/[<>](?!@symbols)/, '@brackets'],
+            [/@symbols/, {
+                cases: {
+                    '@operators': 'operator',
+                    '@default': ''
+                }
+            }],
+
+            // numbers
+            [/(@digits)[eE]([\-+]?(@digits))?/, 'number.float'],
+            [/(@digits)\.(@digits)([eE][\-+]?(@digits))?/, 'number.float'],
+            [/0[xX](@hexdigits)/, 'number.hex'],
+            [/0[oO]?(@octaldigits)/, 'number.octal'],
+            [/0[bB](@binarydigits)/, 'number.binary'],
+            [/(@digits)/, 'number'],
+
+            // delimiter: after number because of .\d floats
             [/[;,.]/, "delimiter"],
             [/[=><!~?:&|+\-*/^%]+/, "operator"],
 
             [/"([^"\\]|\\.)*$/, "string.invalid"],
             [/"/, { token: "string.quote", bracket: "@open", next: "@string" }],
-            [/'[^\\']'/, "string"],
-            [/'/, "string.invalid"],
+
+            // characters
+            [/'[^\\']'/, 'string'],
+            [/(')(@escapes)(')/, ['string', 'string.escape', 'string']],
+            [/'/, 'string.invalid']
+
+
         ],
         comment: [
-            [/[^/*]+/, "comment"],
-            [/\/\*/, "comment", "@push"],
-            ["\\*/", "comment", "@pop"],
-            [/[/*]/, "comment"],
+            [/[^\/*]+/, 'comment'],
+            [/\/\*/, 'comment', '@push'],
+            ["\\*/", 'comment', '@pop'],
+            [/[\/*]/, 'comment']
         ],
+
         string: [
-            [/[^\\"]+/, "string"],
-            [/"/, { token: "string.quote", bracket: "@close", next: "@pop" }],
+            [/[^\\"]+/, 'string'],
+            [/@escapes/, 'string.escape'],
+            [/\\./, 'string.escape.invalid'],
+            [/"/, { token: 'string.quote', bracket: '@close', next: '@pop' }]
         ],
+
         whitespace: [
-            [/[ \t\r\n]+/, "white"],
-            [/\/\*/, "comment", "@comment"],
-            [/\/\/.*$/, "comment"],
+            [/[ \t\r\n]+/, 'white'],
+            [/\/\*/, 'comment', '@comment'],
+            [/\/\/.*$/, 'comment'],
+        ],
+
+        bracketCounting: [
+            [/\{/, 'delimiter.bracket', '@bracketCounting'],
+            [/\}/, 'delimiter.bracket', '@pop'],
         ],
     },
 };

--- a/spx-gui/src/components/code-editor/register.ts
+++ b/spx-gui/src/components/code-editor/register.ts
@@ -55,7 +55,7 @@ const initFormat = async () => {
     go.run(result.instance)
 }
 
-export const register=()=>{
+export const register = () => {
     monaco.languages.register({
         id: 'spx',
     })
@@ -63,23 +63,32 @@ export const register=()=>{
     monaco.editor.defineTheme("myTransparentTheme", {
         base: "vs",
         inherit: true,
-        rules: [],
+        rules: [
+            { token: 'comment', foreground: '#ffbdb398', fontStyle: 'italic' },
+            { token: 'string', foreground: '#F96B6B' },
+            { token: 'operator', foreground: '#FF8C00' },
+            { token: 'number', foreground: '#3AA6D4' },
+            { token: 'keyword', foreground: '#fa81a899' },
+            { token: 'typeKeywords', foreground: '#fa81a899' },
+            { token: 'functions', foreground: '#000000' },
+            { token: 'brackets', foreground: '#000000' },
+        ],
         colors: {
-          "editor.background": "#FFFFFF", // 透明背景
-          "scrollbar.shadow": "#FFFFFF00", // 滚动条阴影颜色
-          "scrollbarSlider.background": "#fa81a833", // 滚动条背景颜色
-          "scrollbarSlider.hoverBackground": "#fa81a866", // 鼠标悬停时滚动条背景颜色
-          "scrollbarSlider.activeBackground": "#fa81a899", // 激活时滚动条背景颜色
-          "scrollbarSlider.width": "8px !important", // 激活时滚动条背景颜色
-          "minimap.background": "#fa81a810", // 小地图背景颜色
-          "minimapSlider.background": "#fa81a833", // 小地图滑块背景颜色
-          "minimapSlider.hoverBackground": "#FFFFFF66", // 小地图滑块鼠标悬停背景颜色
-          "minimapSlider.activeBackground": "#FFFFFF99", // 小地图滑块激活背景颜色
+            "editor.background": "#FFFFFF", // 透明背景
+            "scrollbar.shadow": "#FFFFFF00", // 滚动条阴影颜色
+            "scrollbarSlider.background": "#fa81a833", // 滚动条背景颜色
+            "scrollbarSlider.hoverBackground": "#fa81a866", // 鼠标悬停时滚动条背景颜色
+            "scrollbarSlider.activeBackground": "#fa81a899", // 激活时滚动条背景颜色
+            "scrollbarSlider.width": "8px !important", // 激活时滚动条背景颜色
+            "minimap.background": "#fa81a810", // 小地图背景颜色
+            "minimapSlider.background": "#fa81a833", // 小地图滑块背景颜色
+            "minimapSlider.hoverBackground": "#FFFFFF66", // 小地图滑块鼠标悬停背景颜色
+            "minimapSlider.activeBackground": "#FFFFFF99", // 小地图滑块激活背景颜色
         },
-      });
+    });
 
     monaco.languages.setLanguageConfiguration('spx', LanguageConfig)
-    
+
     // Match token and highlight
     monaco.languages.setMonarchTokensProvider('spx', MonarchTokensProviderConfig);
     // Code hint


### PR DESCRIPTION
#33 Configure the tokenizer for the monaco editor and match it with spx syntax, which can recognize multiple types such as numbers, strings, keywords, etc
<img width="499" alt="Secure Image" src="https://github.com/goplus/builder/assets/93132738/28c6691f-802d-4327-a0df-a39761858099">
