### PR TITLE
fix error on `npm run lint` & format

### DIFF
--- a/spx-gui/.eslintrc.cjs
+++ b/spx-gui/.eslintrc.cjs
@@ -1,19 +1,19 @@
+/* eslint-disable @typescript-eslint/naming-convention */
 /* eslint-env node */
-require("@rushstack/eslint-patch/modern-module-resolution");
+require('@rushstack/eslint-patch/modern-module-resolution')
 
 module.exports = {
   extends: [
-    "eslint:recommended",
-    "plugin:vue/vue3-recommended",
-    // "plugin:@typescript-eslint/recommended",
-    "@vue/eslint-config-typescript",
-    "@vue/eslint-config-prettier/skip-formatting",
+    'eslint:recommended',
+    'plugin:vue/vue3-recommended',
+    '@vue/eslint-config-typescript',
+    '@vue/eslint-config-prettier/skip-formatting'
   ],
   parserOptions: {
-    ecmaVersion: "latest",
+    ecmaVersion: 'latest'
   },
   rules: {
-    "no-useless-escape": "warn",
-    "@typescript-eslint/naming-convention": "warn",
-  },
-};
+    'no-useless-escape': 'warn',
+    '@typescript-eslint/naming-convention': 'warn'
+  }
+}

--- a/spx-gui/package.json
+++ b/spx-gui/package.json
@@ -8,7 +8,7 @@
     "build": "vite build",
     "preview": "vite preview",
     "type-check": "vue-tsc --build --force",
-    "lint": "eslint . --ext .vue,.js,.jsx,.cjs,.mjs,.ts,.tsx,.cts,.mts --ignore-path .gitignore"
+    "lint": "eslint . --ext .vue,.ts --ignore-path .gitignore"
   },
   "dependencies": {
     "@rollup/pluginutils": "^5.1.0",


### PR DESCRIPTION
Fix error on running `npm run lint`:
```
Error: Error while loading rule '@typescript-eslint/naming-convention': You have used a rule which requires parserServices to be generated. You must therefore provide a value for the "parserOptions.project" property for @typescript-eslint/parser.
Note: detected a parser other than @typescript-eslint/parser. Make sure the parser is configured to forward "parserOptions.project" to @typescript-eslint/parser.
```