### PR TITLE
feat:prevent unexpected sprite naming

### DIFF
--- a/spx-gui/src/components/sprite-list/AssetAddBtn.vue
+++ b/spx-gui/src/components/sprite-list/AssetAddBtn.vue
@@ -192,7 +192,8 @@ const spriteNameAllow = computed(() => {
 // ----------methods-----------------------------------------
 // check if the name is legal.
 const isAllowName = (name: string) => {
-  // name rules of spx
+  // spx code is go+ code, and the sprite name will compiled to an identifier of go+
+  // so sprite name rules is depend on the identifier rules of go+.
   let regex = /^[\u4e00-\u9fa5a-zA-Z_][\u4e00-\u9fa5a-zA-Z0-9_]*$/
   return regex.test(name) && !typeKeywords.includes(name) && !keywords.includes(name)
 }

--- a/spx-gui/src/components/sprite-list/AssetAddBtn.vue
+++ b/spx-gui/src/components/sprite-list/AssetAddBtn.vue
@@ -111,7 +111,7 @@
       />
     </div>
     <div style="width: 100%; text-align: center">
-      <n-button @click="handleSubmitSprite()">
+      <n-button :disabled="!spriteNameAllow" @click="handleSubmitSprite()">
         {{ $t('list.submit') }}
       </n-button>
     </div>
@@ -121,6 +121,7 @@
 
 <script setup lang="ts">
 // ----------Import required packages / components-----------
+import { typeKeywords, keywords } from '../code-editor/language'
 import { ref, defineProps, computed } from 'vue'
 import type { UploadFileInfo } from 'naive-ui'
 import { NIcon, NUpload, NButton, useMessage, NModal, NInput } from 'naive-ui'
@@ -183,7 +184,19 @@ const addBtnClassName = computed(() => {
   }
 })
 
+// Computed  spritename is legal or not
+const spriteNameAllow = computed(() => {
+  return isAllowName(uploadSpriteName.value)
+})
+
 // ----------methods-----------------------------------------
+// check if the name is legal.
+const isAllowName = (name: string) => {
+  // name rules of spx
+  let regex = /^[\u4e00-\u9fa5a-zA-Z_][\u4e00-\u9fa5a-zA-Z0-9_]*$/
+  return regex.test(name) && !typeKeywords.includes(name) && !keywords.includes(name)
+}
+
 /**
  * @description: A Function about clicking add button to change button style.
  * @Author: Xu Ning


### PR DESCRIPTION
#135

- [x] prevent incorrect sprite name 
 spx code is go+ code, and the sprite name will compiled to an identifier of go+, so sprite name rules is depend on the identifier rules of go+.

