### PR TITLE
fix: modify body size in nginx.conf for /api

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -2,8 +2,6 @@ server {
     listen 80;
     server_name localhost;
 
-    client_max_body_size 200M;
-
     # Gzip Settings
     gzip on;
     gzip_vary on;
@@ -16,6 +14,8 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
+
+        client_max_body_size 200M;
     }
 
     location ~* \.(js|css|jpg|jpeg|png|gif|ico|woff|woff2|ttf|eot|otf)$ {


### PR DESCRIPTION
Previous config of client_max_body_size in server {} did not seem to take effect. We move the config to location /api block and it worked in local test.