### PR TITLE
fix:hide the scrollbar when the area does not overflow

### DIFF
--- a/spx-gui/src/components/sprite-list/SpriteList.vue
+++ b/spx-gui/src/components/sprite-list/SpriteList.vue
@@ -148,22 +148,13 @@ watchEffect(() => {
   }
   @mixin libraryRightBase {
     max-height: calc(60vh - 60px - 24px);
-    overflow-y: auto;
-  }
-  .asset-library-right {
-    @include libraryRightBase;
-    background: white;
-    border-left:2px dashed #8f98a1
-  }
-  .asset-library-right-click {
-    @include libraryRightBase;
-    background: #f7f7f7;
+    overflow: scroll;
   }
 
   .asset-library-left {
     margin-top: 30px;
     max-height: calc(60vh - 60px - 24px - 40px);
-    overflow: scroll;
+    overflow: auto;
     padding: 10px;
   }
 }


### PR DESCRIPTION
![image](https://github.com/goplus/builder/assets/51194195/fd9c4b57-50ef-4c3a-a058-a8aa2cfa4753)
