### PR TITLE
fix: unable to switch shapes during multi-style sprites runtime

### DIFF
--- a/spx-gui/src/components/sprite-list/AssetAddBtn.vue
+++ b/spx-gui/src/components/sprite-list/AssetAddBtn.vue
@@ -343,9 +343,10 @@ const handleSubmitSprite = async (): Promise<void> => {
       uploadFilesArr.push(fileItem.file)
     }
   })
+  console.log('uploadFilesArr', uploadFilesArr)
   let sprite = new Sprite(uploadSpriteName.value, uploadFilesArr)
   spriteStore.addItem(sprite)
-  message.success(t('message.success', {uploadSpriteName: uploadSpriteName.value}))
+  message.success(t('message.success', { uploadSpriteName: uploadSpriteName.value }))
 
   try {
     let gifRes = undefined
@@ -364,7 +365,7 @@ const handleSubmitSprite = async (): Promise<void> => {
       categoryValue.value || undefined
     )
   } catch (err) {
-    message.error(t('message.fail', {uploadSpriteName: uploadSpriteName.value}))
+    message.error(t('message.fail', { uploadSpriteName: uploadSpriteName.value }))
   }
   uploadSpriteName.value = ''
   showUploadModal.value = false
@@ -400,17 +401,21 @@ async function urlToFile(url: string, filename: string): Promise<File> {
 /**
  * @description: A function to add sprite to list store.
  * @param {*} name - added asset name
- * @param {*} address - added asset file url
+ * @param {*} assetMultiCostumeObj - added asset file obj(name - url)
  * @Author: Xu Ning
  * @Date: 2024-01-30 11:47:25
  */
-const handleAssetAddition = async (name: string, address: string) => {
+const handleAssetAddition = async (name: string, assetMultiCostumeObj: { [key: string]: string }) => {
+  let fileArr: File[] = []
+  for (const [key, value] of Object.entries(assetMultiCostumeObj)) {
+    const file = await urlToFile(value, key)
+    fileArr.push(file)
+  }
   if (props.type === 'sprite') {
-    const file = await urlToFile(address, name)
-    const sprite = new Sprite(name, [file])
+    const sprite = new Sprite(name, fileArr)
     spriteStore.addItem(sprite)
   } else if (props.type === 'backdrop') {
-    const file = await urlToFile(address, name)
+    const file = fileArr[0]
     let fileURL = URL.createObjectURL(file)
     let fileWithUrl = new FileWithUrl(file, fileURL)
     let fileNameWithoutExtension = name.substring(0, name.lastIndexOf('.'))
@@ -418,11 +423,11 @@ const handleAssetAddition = async (name: string, address: string) => {
     backdrop.addScene([{ name: fileNameWithoutExtension, file: fileWithUrl }])
     // backdropStore.backdrop.addFile(file)
   } else if (props.type === 'sounds') {
-    const file = await urlToFile(address, name)
+    const file = fileArr[0]
     const sound = new Sound(name, [file])
     soundStore.addItem(sound)
   }
-  message.success(t('message.addSuccess', {name: name}))
+  message.success(t('message.addSuccess', { name: name }))
 }
 </script>
 

--- a/spx-gui/src/components/spx-library/LibraryModal.vue
+++ b/spx-gui/src/components/spx-library/LibraryModal.vue
@@ -263,12 +263,13 @@ const closeModalFunc = () => {
 /**
  * @description: A function to emit add object.
  * @param {*} name
+ * @param {*} assetMultiCostumeObj
  * @Author: Xu Ning
  * @Date: 2024-01-30 11:51:05
  */
-const handleAddAsset = async (id: number, name: string, address: string) => {
+const handleAddAsset = async (id: number, name: string, assetMultiCostumeObj: {[key: string]: string}) => {
   await addAssetClickCount(id)
-  emits('add-asset', name, address)
+  emits('add-asset', name, assetMultiCostumeObj)
 }
 
 /**

--- a/spx-gui/src/components/spx-library/SpriteCard.vue
+++ b/spx-gui/src/components/spx-library/SpriteCard.vue
@@ -2,7 +2,7 @@
  * @Author: Xu Ning
  * @Date: 2024-01-15 17:18:15
  * @LastEditors: xuning 453594138@qq.com
- * @LastEditTime: 2024-03-11 18:36:02
+ * @LastEditTime: 2024-03-14 15:42:10
  * @FilePath: /builder/spx-gui/src/components/spx-library/SpriteCard.vue
  * @Description: sprite Card
 -->
@@ -10,7 +10,7 @@
   <!-- S Component Sprite Card -->
   <div
     class="sprite-card"
-    @click="addAssetToListFunc(props.assetInfo.id, props.assetInfo.name, assetImageUrl)"
+    @click="addAssetToListFunc(props.assetInfo.id, props.assetInfo.name, assetMultiCostumeObj)"
   >
     <!-- S Component First Static Costume Card -->
     <n-image
@@ -78,6 +78,15 @@ const assetImageUrl = computed(() => {
   }
 })
 
+// get multi costume obj to emit
+const assetMultiCostumeObj = computed(()=>{
+  let addressObj = {}
+  if (props.assetInfo.address != null) {
+      addressObj = JSON.parse(props.assetInfo.address)
+  }
+  return addressObj
+})
+
 // Compute the asset gif url if it has
 const assetImageGifUrl = computed(() => {
   return props.assetInfo.previewAddress
@@ -90,17 +99,18 @@ const shouldShowGif = computed(() => isHovering.value && assetImageGifUrl.value 
 
 /**
  * @description: A function to add sprite to list
+ * @param {*} id
  * @param {*} name
- * @param {*} file
+ * @param {*} assetMultiCostumeObj
  * @Author: Xu Ning
  * @Date: 2024-01-24 12:18:12
  */
 const addAssetToListFunc = (
   id: number,
   name: string,
-  address: string | undefined
+  assetMultiCostumeObj: {[key: string]: string}
 ) => {
-    emits('add-asset', id, name, address)
+    emits('add-asset', id, name, assetMultiCostumeObj)
 }
 </script>
 


### PR DESCRIPTION
Fixed the problem of importing multi-style sprites from the asset library to the sprite list, but unable to switch shapes during runtime.