### PR TITLE
 fix version for node & go

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 20.11.1
           cache: npm
           cache-dependency-path: spx-gui/package-lock.json
 
@@ -49,7 +49,7 @@ jobs:
       - name: Set up Go & Go+
         uses: goplus/setup-goplus@v1
         with:
-          go-version: '1.21.0'
+          go-version: '1.21.3'
           gop-version: '1.2.5'
 
       - name: Run unit test cases

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN bash -c ' echo "deb [trusted=yes] https://pkgs.goplus.org/apt/ /" > /etc/apt
 WORKDIR /app/spx-backend/cmd
 RUN gop build -o spx-backend .
 
-FROM node:latest as frontend-builder
+FROM node:20.11.1 as frontend-builder
 
 WORKDIR /app/spx-gui
 

--- a/spx-gui/package-lock.json
+++ b/spx-gui/package-lock.json
@@ -8,7 +8,6 @@
       "name": "spx-gui",
       "version": "0.0.0",
       "dependencies": {
-        "@rollup/pluginutils": "^5.1.0",
         "axios": "^1.6.5",
         "file-saver": "^2.0.5",
         "js-pkce": "^1.4.0",
@@ -56,6 +55,10 @@
         "vite-plugin-vue-devtools": "^7.0.7",
         "vite-plugin-wasm": "^3.3.0",
         "vue-tsc": "^1.8.27"
+      },
+      "engines": {
+        "node": "^20.11.1",
+        "npm": "^10.2.4"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -1500,6 +1503,7 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.1.0.tgz",
       "integrity": "sha512-XTIWOPPcpvyKI6L1NHo0lFlCyznUEyPmPY1mc3KpPVDYulHSTvyeLNVW00QTLIAFNhR3kYnJTQHeGqU4M3n09g==",
+      "dev": true,
       "dependencies": {
         "@types/estree": "^1.0.0",
         "estree-walker": "^2.0.2",
@@ -1941,7 +1945,8 @@
     "node_modules/@types/estree": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
-      "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw=="
+      "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
+      "dev": true
     },
     "node_modules/@types/file-saver": {
       "version": "2.0.7",
@@ -7353,6 +7358,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
       "engines": {
         "node": ">=8.6"
       },
@@ -7626,7 +7632,7 @@
       "version": "4.9.6",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.9.6.tgz",
       "integrity": "sha512-05lzkCS2uASX0CiLFybYfVkwNbKZG5NFQ6Go0VWyogFTXXbR039UVsegViTntkk4OglHBdF54ccApXRRuXRbsg==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "@types/estree": "1.0.5"
       },

--- a/spx-gui/package.json
+++ b/spx-gui/package.json
@@ -59,5 +59,9 @@
     "vite-plugin-vue-devtools": "^7.0.7",
     "vite-plugin-wasm": "^3.3.0",
     "vue-tsc": "^1.8.27"
+  },
+  "engines": {
+    "node": "^20.11.1",
+    "npm": "^10.2.4"
   }
 }


### PR DESCRIPTION
Same tool version for dev, CI & CD:

* Node.js: `^20.11.1` (Latest LTS)
* Go: `^1.21.3` (Currently using version)

TODO:

- [ ] Configure vercel project to use Node.js 20.x