### PR TITLE
update vscode ext recommendations

### DIFF
--- a/spx-gui/.vscode/extensions.json
+++ b/spx-gui/.vscode/extensions.json
@@ -1,7 +1,6 @@
 {
   "recommendations": [
     "Vue.volar",
-    "Vue.vscode-typescript-vue-plugin",
     "dbaeumer.vscode-eslint",
     "esbenp.prettier-vscode"
   ]


### PR DESCRIPTION
`vscode-typescript-vue-plugin` has been deprecated as `volar` is updated to v2.