### PR TITLE
Fix some todos

### DIFF
--- a/spx-gui/.eslintrc.cjs
+++ b/spx-gui/.eslintrc.cjs
@@ -19,6 +19,7 @@ module.exports = {
         shallowOnly: true
       }
     ],
-    'no-console': ['warn', { allow: ['warn', 'error'] }]
+    'no-console': ['warn', { allow: ['warn', 'error'] }],
+    'no-redeclare': 'off'
   }
 }

--- a/spx-gui/src/components/editor/EditorContextProvider.vue
+++ b/spx-gui/src/components/editor/EditorContextProvider.vue
@@ -49,14 +49,12 @@ const props = defineProps<{
 
 const selectedRef = ref<Selected | null>(null)
 
-/* eslint-disable no-redeclare */ // TODO: there should be no need to configure this
 function select(selected: null): void
 function select(type: 'stage'): void
 function select(type: 'sprite' | 'sound', name: string): void
 function select(type: any, name?: string) {
   selectedRef.value = name == null ? { type } : { type, name }
 }
-/* eslint-enable no-redeclare */
 
 // When sprite name changed, we lose the selected state
 // TODO: consider moving selected to model Project, so we can deal with renaming easily

--- a/spx-gui/src/components/editor/EditorHomepage.vue
+++ b/spx-gui/src/components/editor/EditorHomepage.vue
@@ -5,10 +5,16 @@
     </header>
     <main v-if="userStore.userInfo" class="editor-main">
       <template v-if="projectName">
-        <EditorContextProvider v-if="project" :project="project" :user-info="userStore.userInfo">
+        <div v-if="isLoading" class="loading-wrapper">
+          <NSpin size="large" />
+        </div>
+        <div v-else-if="error != null">
+          {{ _t(error.userMessage) }}
+        </div>
+        <EditorContextProvider v-else-if="project != null" :project="project" :user-info="userStore.userInfo">
           <ProjectEditor />
         </EditorContextProvider>
-        <NSpin v-else size="large" />
+        <div v-else>TODO</div>
       </template>
       <template v-else>
         <ProjectList @selected="handleSelected" />
@@ -19,7 +25,7 @@
 </template>
 
 <script setup lang="ts">
-import { watchEffect, ref, watch } from 'vue'
+import { watchEffect, computed, watch } from 'vue'
 import { useRouter } from 'vue-router'
 import { NButton, NSpin } from 'naive-ui'
 import type { ProjectData } from '@/apis/project'
@@ -28,10 +34,10 @@ import { Project } from '@/models/project'
 import TopNav from '@/components/top-nav/TopNav.vue'
 import ProjectList from '@/components/project/ProjectList.vue'
 import { useCreateProject } from '@/components/project'
-import ProjectEditor from './ProjectEditor.vue'
 import { getProjectEditorRoute } from '@/router'
-import { computed } from 'vue'
+import { useQuery } from '@/utils/exception'
 import EditorContextProvider from './EditorContextProvider.vue'
+import ProjectEditor from './ProjectEditor.vue'
 
 const localCacheKey = 'TODO_GOPLUS_BUILDER_CACHED_PROJECT'
 
@@ -46,26 +52,21 @@ watchEffect(() => {
 
 const router = useRouter()
 const createProject = useCreateProject()
-const project = ref<Project | null>(null)
 const projectName = computed(
   () => router.currentRoute.value.params.projectName as string | undefined
 )
 
-watch(
-  () => projectName.value,
-  async (projectName) => {
-    if (userStore.userInfo == null) return
-    if (projectName == null) {
-      project.value = null
-      return
-    }
+const { data: project, isFetching: isLoading, error } = useQuery(
+  async () => {
+    if (userStore.userInfo == null) return null
+    if (projectName.value == null) return null
     // TODO: UI logic to handle conflicts when there are local cache
     const newProject = new Project()
-    await newProject.loadFromCloud(userStore.userInfo.name, projectName)
+    await newProject.loadFromCloud(userStore.userInfo.name, projectName.value)
     newProject.syncToLocalCache(localCacheKey)
-    project.value = newProject
+    return newProject
   },
-  { immediate: true }
+  { en: 'Load project failed', zh: '加载项目失败' }
 )
 
 watch(

--- a/spx-gui/src/components/editor/EditorHomepage.vue
+++ b/spx-gui/src/components/editor/EditorHomepage.vue
@@ -11,7 +11,11 @@
         <div v-else-if="error != null">
           {{ _t(error.userMessage) }}
         </div>
-        <EditorContextProvider v-else-if="project != null" :project="project" :user-info="userStore.userInfo">
+        <EditorContextProvider
+          v-else-if="project != null"
+          :project="project"
+          :user-info="userStore.userInfo"
+        >
           <ProjectEditor />
         </EditorContextProvider>
         <div v-else>TODO</div>
@@ -56,7 +60,11 @@ const projectName = computed(
   () => router.currentRoute.value.params.projectName as string | undefined
 )
 
-const { data: project, isFetching: isLoading, error } = useQuery(
+const {
+  data: project,
+  isFetching: isLoading,
+  error
+} = useQuery(
   async () => {
     if (userStore.userInfo == null) return null
     if (projectName.value == null) return null

--- a/spx-gui/src/components/editor/panels/sprite/SpriteItem.vue
+++ b/spx-gui/src/components/editor/panels/sprite/SpriteItem.vue
@@ -7,7 +7,8 @@
 </template>
 
 <script setup lang="ts">
-import { ref, effect, computed } from 'vue'
+import { computed } from 'vue'
+import { useFileUrl } from '@/utils/file'
 import { Sprite } from '@/models/sprite'
 
 const props = defineProps<{
@@ -19,13 +20,7 @@ const emit = defineEmits<{
   remove: []
 }>()
 
-const imgSrc = ref<string | null>(null)
-
-effect(async () => {
-  const img = props.sprite.costume?.img
-  imgSrc.value = img != null ? await img.url() : null // TODO: race condition
-})
-
+const imgSrc = useFileUrl(() => props.sprite.costume?.img)
 const imgStyle = computed(() => imgSrc.value && { backgroundImage: `url("${imgSrc.value}")` })
 </script>
 

--- a/spx-gui/src/components/editor/panels/stage/StagePanel.vue
+++ b/spx-gui/src/components/editor/panels/stage/StagePanel.vue
@@ -18,13 +18,13 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref, effect } from 'vue'
+import { computed } from 'vue'
 import { NDropdown, NButton } from 'naive-ui'
 import { useAddAssetFromLibrary, useAddAssetToLibrary } from '@/components/library'
 import { useMessageHandle } from '@/utils/exception'
 import { useI18n } from '@/utils/i18n'
 import { AssetType } from '@/apis/asset'
-import { selectImg } from '@/utils/file'
+import { selectImg, useFileUrl } from '@/utils/file'
 import { fromNativeFile } from '@/models/common/file'
 import { Backdrop } from '@/models/backdrop'
 import { stripExt } from '@/utils/path'
@@ -40,15 +40,7 @@ function select() {
 }
 
 const backdrop = computed(() => editorCtx.project.stage.backdrop)
-
-// TODO: we may need a special img component for [File](src/models/common/file.ts)
-const imgSrc = ref<string | null>(null)
-
-effect(async () => {
-  const img = backdrop.value?.img
-  imgSrc.value = img != null ? await img.url() : null // TODO: race condition
-})
-
+const imgSrc = useFileUrl(() => backdrop.value?.img)
 const imgStyle = computed(() => imgSrc.value && { backgroundImage: `url("${imgSrc.value}")` })
 
 const handleUpload = useMessageHandle(

--- a/spx-gui/src/components/editor/panels/todo/AssetAddBtn.vue
+++ b/spx-gui/src/components/editor/panels/todo/AssetAddBtn.vue
@@ -259,7 +259,7 @@ const beforeUpload = async (
   if (uploadFile.file != null) {
     const file = await fromNativeFile(uploadFile.file)
     let fileName = uploadFile.name
-    let assetName = stripExt(fileName) // TODO: naming conflict
+    let assetName = stripExt(fileName)
 
     switch (fileType) {
       case 'backdrop': {

--- a/spx-gui/src/components/editor/preview/stage-viewer/BackdropLayer.vue
+++ b/spx-gui/src/components/editor/preview/stage-viewer/BackdropLayer.vue
@@ -25,7 +25,8 @@
   </v-layer>
 </template>
 <script setup lang="ts">
-import { defineProps, watch, ref } from 'vue'
+import { defineProps } from 'vue'
+import { useImgFile } from '@/utils/file'
 import type { Stage } from '@/models/stage'
 import type { Size } from '@/models/common'
 
@@ -35,18 +36,5 @@ const props = defineProps<{
   stage: Stage
 }>()
 
-const image = ref<HTMLImageElement>()
-
-watch(
-  () => props.stage.backdrop?.img,
-  async (backdropImg) => {
-    image.value?.remove()
-    if (backdropImg != null) {
-      const _image = new window.Image()
-      _image.src = await backdropImg.url()
-      image.value = _image
-    }
-  },
-  { immediate: true }
-)
+const image = useImgFile(() => props.stage.backdrop?.img)
 </script>

--- a/spx-gui/src/components/editor/preview/stage-viewer/Costume.vue
+++ b/spx-gui/src/components/editor/preview/stage-viewer/Costume.vue
@@ -35,6 +35,8 @@ import type { Sprite } from '@/models/sprite'
 import type { SpriteDragMoveEvent, SpriteApperanceChangeEvent } from './common'
 import type { Rect } from 'konva/lib/shapes/Rect'
 import type { Size } from '@/models/common'
+import { useImgFile } from '@/utils/file'
+
 // ----------props & emit------------------------------------
 const props = defineProps<{
   sprite: Sprite
@@ -57,7 +59,7 @@ const displayScale = computed(
 )
 
 // ----------data related -----------------------------------
-const image = ref<HTMLImageElement>()
+const image = useImgFile(() => currentCostume.value?.img)
 const costume = ref()
 // ----------computed properties-----------------------------
 // Computed spx's sprite position to konva's relative position by about changing sprite postion
@@ -85,24 +87,6 @@ watch(
   },
   {
     deep: true
-  }
-)
-
-watch(
-  () => currentCostume.value,
-  async (new_costume) => {
-    if (new_costume != null) {
-      const _image = new window.Image()
-      _image.src = await new_costume.img.url()
-      _image.onload = () => {
-        image.value = _image
-      }
-    } else {
-      image.value?.remove()
-    }
-  },
-  {
-    immediate: true
   }
 )
 

--- a/spx-gui/src/components/project/ProjectCreate.vue
+++ b/spx-gui/src/components/project/ProjectCreate.vue
@@ -72,7 +72,8 @@ async function validateName(name: string): Promise<ValidationResult> {
     }
 
   // check naming conflict
-  const username = userStore.userInfo!.name // TODO: remove `!` here
+  if (userStore.userInfo == null) throw new Error('login required')
+  const username = userStore.userInfo.name
   const existedProject = await getProject(username, name).catch((e) => {
     if (e instanceof ApiException && e.code === ApiExceptionCode.errorNotFound) return null
     throw e

--- a/spx-gui/src/models/common/cloud.ts
+++ b/spx-gui/src/models/common/cloud.ts
@@ -31,12 +31,12 @@ function parseProjectData({ files: fileUrls, ...metadata }: ProjectData) {
 
 export async function uploadFiles(files: Files): Promise<FileCollection> {
   const fileUrls: FileCollection = {}
-  await Promise.all(
-    Object.keys(files).map(async (path) => {
-      // TODO: keep the files' order
-      fileUrls[path] = await uploadFile(files[path]!)
-    })
+  const entries = await Promise.all(
+    Object.keys(files).map(async (path) => [path, await uploadFile(files[path]!)] as const)
   )
+  for (const [path, fileUrl] of entries) {
+    fileUrls[path] = fileUrl
+  }
   return fileUrls
 }
 

--- a/spx-gui/src/models/common/disposable.ts
+++ b/spx-gui/src/models/common/disposable.ts
@@ -5,7 +5,7 @@
 
 export type Disposer = () => void
 
-export abstract class Disposble {
+export class Disposble {
   _disposers: Disposer[] = []
 
   addDisposer(disposer: Disposer) {

--- a/spx-gui/src/models/common/file.ts
+++ b/spx-gui/src/models/common/file.ts
@@ -49,7 +49,7 @@ export class File {
     })
     const ab = await this.arrayBuffer()
     if (cancelled) throw new Cancelled()
-    const url = URL.createObjectURL(new Blob([ab]))
+    const url = URL.createObjectURL(new Blob([ab], { type: this.type }))
     onCleanup(() => URL.revokeObjectURL(url))
     return url
   }

--- a/spx-gui/src/models/common/file.ts
+++ b/spx-gui/src/models/common/file.ts
@@ -5,6 +5,8 @@
 
 import { getMimeFromExt } from '@/utils/file'
 import { extname } from '@/utils/path'
+import type { Disposer } from './disposable'
+import { Cancelled } from '@/utils/exception'
 
 export type Options = {
   /** MIME type of file */
@@ -40,10 +42,16 @@ export class File {
     }))
   }
 
-  // TODO: remember to do URL.revokeObjectURL
-  async url() {
+  async url(onCleanup: (disposer: Disposer) => void) {
+    let cancelled = false
+    onCleanup(() => {
+      cancelled = true
+    })
     const ab = await this.arrayBuffer()
-    return URL.createObjectURL(new Blob([ab]))
+    if (cancelled) throw new Cancelled()
+    const url = URL.createObjectURL(new Blob([ab]))
+    onCleanup(() => URL.revokeObjectURL(url))
+    return url
   }
 }
 

--- a/spx-gui/src/models/costume.ts
+++ b/spx-gui/src/models/costume.ts
@@ -91,10 +91,7 @@ export class Costume {
   static load(
     { name, path, ...inits }: RawCostumeConfig,
     files: Files,
-    /**
-     * Path of directory which contains the config file
-     * TODO: remove me?
-     */
+    /** Path of directory which contains the config file */
     basePath: string
   ) {
     if (name == null) throw new Error(`name expected for costume`)
@@ -105,10 +102,7 @@ export class Costume {
   }
 
   export(
-    /**
-     * Path of directory which contains the config file
-     * TODO: remove me?
-     */
+    /** Path of directory which contains the config file */
     basePath: string
   ): [RawCostumeConfig, Files] {
     const filename = this.name + extname(this.img.name)

--- a/spx-gui/src/models/costume.ts
+++ b/spx-gui/src/models/costume.ts
@@ -5,6 +5,7 @@ import { File, type Files } from './common/file'
 import { type Size } from './common'
 import type { Sprite } from './sprite'
 import { getCostumeName, validateCostumeName } from './common/asset'
+import { Disposble } from './common/disposable'
 
 export type CostumeInits = {
   x?: number
@@ -57,21 +58,23 @@ export class Costume {
   }
 
   async getSize() {
-    const imgUrl = await this.img.url()
+    const d = new Disposble()
+    const imgUrl = await this.img.url((fn) => d.addDisposer(fn))
     return new Promise<Size>((resolve, reject) => {
       const img = new window.Image()
+      d.addDisposer(() => img.remove())
       img.src = imgUrl
       img.onload = () => {
         resolve({
           width: img.width / this.bitmapResolution,
           height: img.height / this.bitmapResolution
         })
-        img.remove()
       }
       img.onerror = (e) => {
         reject(new Error(`load image failed: ${e.toString()}`))
-        img.remove()
       }
+    }).finally(() => {
+      d.dispose()
     })
   }
 

--- a/spx-gui/src/models/sound.ts
+++ b/spx-gui/src/models/sound.ts
@@ -65,17 +65,13 @@ export class Sound {
 
   static async loadAll(files: Files) {
     const soundNames = listDirs(files, soundAssetPath)
-    const sounds: Sound[] = []
-    await Promise.all(
+    const sounds = (await Promise.all(
       soundNames.map(async (soundName) => {
         const sound = await Sound.load(soundName, files)
-        if (sound == null) {
-          console.warn('failed to load sound:', soundName)
-          return
-        }
-        sounds.push(sound)
+        if (sound == null) console.warn('failed to load sound:', soundName)
+        return sound
       })
-    )
+    )).filter(s => !!s) as Sound[]
     return sounds
   }
 

--- a/spx-gui/src/models/sound.ts
+++ b/spx-gui/src/models/sound.ts
@@ -65,13 +65,15 @@ export class Sound {
 
   static async loadAll(files: Files) {
     const soundNames = listDirs(files, soundAssetPath)
-    const sounds = (await Promise.all(
-      soundNames.map(async (soundName) => {
-        const sound = await Sound.load(soundName, files)
-        if (sound == null) console.warn('failed to load sound:', soundName)
-        return sound
-      })
-    )).filter(s => !!s) as Sound[]
+    const sounds = (
+      await Promise.all(
+        soundNames.map(async (soundName) => {
+          const sound = await Sound.load(soundName, files)
+          if (sound == null) console.warn('failed to load sound:', soundName)
+          return sound
+        })
+      )
+    ).filter((s) => !!s) as Sound[]
     return sounds
   }
 

--- a/spx-gui/src/models/sprite.ts
+++ b/spx-gui/src/models/sprite.ts
@@ -40,6 +40,11 @@ export type RawSpriteConfig = SpriteInits & {
 }
 
 export const spriteAssetPath = 'assets/sprites'
+
+export function getSpriteAssetPath(name: string) {
+  return join(spriteAssetPath, name)
+}
+
 export const spriteConfigFileName = 'index.json'
 
 export class Sprite extends Disposble {
@@ -137,7 +142,7 @@ export class Sprite extends Disposble {
   }
 
   static async load(name: string, files: Files) {
-    const pathPrefix = join(spriteAssetPath, name)
+    const pathPrefix = getSpriteAssetPath(name)
     const configFile = files[join(pathPrefix, spriteConfigFileName)]
     if (configFile == null) return null
     const { costumes: costumeConfigs, ...inits } = (await toConfig(configFile)) as RawSpriteConfig
@@ -156,22 +161,18 @@ export class Sprite extends Disposble {
 
   static async loadAll(files: Files) {
     const spriteNames = listDirs(files, spriteAssetPath)
-    const sprites: Sprite[] = []
-    await Promise.all(
+    const sprites = (await Promise.all(
       spriteNames.map(async (spriteName) => {
         const sprite = await Sprite.load(spriteName, files)
-        if (sprite == null) {
-          console.warn('failed to load sprite:', spriteName)
-          return
-        }
-        sprites.push(sprite)
+        if (sprite == null) console.warn('failed to load sprite:', spriteName)
+        return sprite
       })
-    )
+    )).filter(s => !!s) as Sprite[]
     return sprites
   }
 
   export(): Files {
-    const assetPath = join(spriteAssetPath, this.name)
+    const assetPath = getSpriteAssetPath(this.name)
     const costumeConfigs: RawCostumeConfig[] = []
     const files: Files = {}
     for (const c of this.costumes) {

--- a/spx-gui/src/models/sprite.ts
+++ b/spx-gui/src/models/sprite.ts
@@ -161,13 +161,15 @@ export class Sprite extends Disposble {
 
   static async loadAll(files: Files) {
     const spriteNames = listDirs(files, spriteAssetPath)
-    const sprites = (await Promise.all(
-      spriteNames.map(async (spriteName) => {
-        const sprite = await Sprite.load(spriteName, files)
-        if (sprite == null) console.warn('failed to load sprite:', spriteName)
-        return sprite
-      })
-    )).filter(s => !!s) as Sprite[]
+    const sprites = (
+      await Promise.all(
+        spriteNames.map(async (spriteName) => {
+          const sprite = await Sprite.load(spriteName, files)
+          if (sprite == null) console.warn('failed to load sprite:', spriteName)
+          return sprite
+        })
+      )
+    ).filter((s) => !!s) as Sprite[]
     return sprites
   }
 

--- a/spx-gui/src/utils/path.test.ts
+++ b/spx-gui/src/utils/path.test.ts
@@ -32,7 +32,9 @@ describe('stripExt', () => {
   })
   it('should work well with url', () => {
     expect(stripExt('https://test.com/abc.txt')).toBe('https://test.com/abc')
-    expect(stripExt('https://test.com/foo/%E4%B8%AD%E6%96%87.png')).toBe('https://test.com/foo/%E4%B8%AD%E6%96%87')
+    expect(stripExt('https://test.com/foo/%E4%B8%AD%E6%96%87.png')).toBe(
+      'https://test.com/foo/%E4%B8%AD%E6%96%87'
+    )
   })
   it('should work well with no ext', () => {
     expect(stripExt('abc')).toBe('abc')

--- a/spx-gui/src/utils/path.test.ts
+++ b/spx-gui/src/utils/path.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest'
+import { filename, stripExt } from './path'
+
+describe('filename', () => {
+  it('should work well with path', () => {
+    expect(filename('abc.txt')).toBe('abc.txt')
+    expect(filename('abc///def.txt')).toBe('def.txt')
+    expect(filename('你好/世界.png')).toBe('世界.png')
+    expect(filename('src/你好/世界.png')).toBe('世界.png')
+  })
+  it('should work well with url', () => {
+    expect(filename('https://test.com/abc.txt')).toBe('abc.txt')
+    expect(filename('https://test.com/foo/%E4%B8%AD%E6%96%87.png')).toBe('%E4%B8%AD%E6%96%87.png')
+  })
+  it('should work well with no ext', () => {
+    expect(filename('abc')).toBe('abc')
+    expect(filename('/foo/.git/a')).toBe('a')
+    expect(filename('https://test.com/project/foo')).toBe('foo')
+  })
+  it('should work well with complex ext', () => {
+    expect(filename('foo/abc.d.ts')).toBe('abc.d.ts')
+    expect(filename('foo/.cache/abc.d.ts')).toBe('abc.d.ts')
+    expect(filename('/foo/bar/.gitignore')).toBe('.gitignore')
+  })
+})
+
+describe('stripExt', () => {
+  it('should work well with path', () => {
+    expect(stripExt('abc.txt')).toBe('abc')
+    expect(stripExt('中文.png')).toBe('中文')
+    expect(stripExt('src/你好/世界.png')).toBe('src/你好/世界')
+  })
+  it('should work well with url', () => {
+    expect(stripExt('https://test.com/abc.txt')).toBe('https://test.com/abc')
+    expect(stripExt('https://test.com/foo/%E4%B8%AD%E6%96%87.png')).toBe('https://test.com/foo/%E4%B8%AD%E6%96%87')
+  })
+  it('should work well with no ext', () => {
+    expect(stripExt('abc')).toBe('abc')
+    expect(stripExt('/foo/.git/a')).toBe('/foo/.git/a')
+    expect(stripExt('https://test.com/project/foo')).toBe('https://test.com/project/foo')
+  })
+  it('should work well with complex ext', () => {
+    expect(stripExt('abc.d.ts')).toBe('abc.d')
+    expect(stripExt('foo/.cache/abc.d.ts')).toBe('foo/.cache/abc.d')
+    expect(stripExt('/foo/bar/.gitignore')).toBe('/foo/bar/.gitignore')
+  })
+})

--- a/spx-gui/src/utils/path.ts
+++ b/spx-gui/src/utils/path.ts
@@ -9,24 +9,15 @@ export function resolve(base: string, ...paths: string[]) {
 }
 
 export function filename(urlOrPath: string) {
-  // TODO
   const slashPos = urlOrPath.lastIndexOf('/')
   if (slashPos >= 0) urlOrPath = urlOrPath.slice(slashPos + 1)
   return urlOrPath
 }
 
-export function dirname(urlOrPath: string) {
-  // TODO
-  const slashPos = urlOrPath.lastIndexOf('/')
-  if (slashPos >= 0) urlOrPath = urlOrPath.slice(0, slashPos)
-  return urlOrPath
-}
-
 export function stripExt(urlOrPath: string) {
-  // TODO
   const slashPos = urlOrPath.lastIndexOf('/')
   const dotPos = urlOrPath.lastIndexOf('.')
-  if (dotPos > slashPos) return urlOrPath.slice(0, dotPos)
+  if (dotPos > slashPos + 1) return urlOrPath.slice(0, dotPos)
   return urlOrPath
 }
 


### PR DESCRIPTION
### Hooks for File

Hooks to help consume URL of class `File`, taking care of:

* Async procedure
* Object URL revoke

### Disable eslint rule `no-redeclare`

It is already disabled for `.ts` files, while not disabled for `.vue` files. Related:

* `@vue/eslint-config-typescript` extends `plugin:@typescript-eslint/eslint-recommended`: [code](https://github.com/vuejs/eslint-config-typescript/blob/e0bf9da6f8a7980f33b6ee4558cc0199fe9eae2c/index.js#L29)
* `plugin:@typescript-eslint/eslint-recommended` disables `no-redeclare` (and other rules which are not needed for Typescript code): [code](https://github.com/typescript-eslint/typescript-eslint/blob/074310029694f92323d4d91f0fd31df39698d0e7/packages/eslint-plugin/src/configs/eslint-recommended-raw.ts#L33)
* while `@vue/eslint-config-typescript` didn't disable `no-redeclare`: [code](https://github.com/vuejs/eslint-config-typescript/blob/e0bf9da6f8a7980f33b6ee4558cc0199fe9eae2c/index.js#L34-L43)

We may need to disable more such rules manually later. Before that we better first check if `@vue/eslint-config-typescript` has fixed it. Related issue: https://github.com/vuejs/eslint-config-typescript/issues/18

### Timeout for api client

Support timeout for request, with default timeout: 10s

### Keep consistent order for sprites & sounds

So that each time project is saved or reloaded, the order for sprites & sounds keeps stable.

### Others

* remove some useless TODOs
* remove userInfo assertion in `validateName`
* optimization & test cases for `utils/path` > `filename` & `stripExt`