### PR TITLE
Fix state loss when sprite / sound renamed

### DIFF
--- a/spx-gui/src/components/editor/EditorContextProvider.vue
+++ b/spx-gui/src/components/editor/EditorContextProvider.vue
@@ -8,7 +8,7 @@ import type { Sprite } from '@/models/sprite'
 import type { Sound } from '@/models/sound'
 
 type Selected =
-| {
+  | {
       type: 'sprite'
       value: Sprite
     }
@@ -42,7 +42,15 @@ export function useEditorCtx() {
 </script>
 
 <script setup lang="ts">
-import { provide, type InjectionKey, watch, shallowReactive, computed, watchEffect, shallowRef } from 'vue'
+import {
+  provide,
+  type InjectionKey,
+  watch,
+  shallowReactive,
+  computed,
+  watchEffect,
+  shallowRef
+} from 'vue'
 import { Project } from '@/models/project'
 import type { UserInfo } from '@/stores/user'
 
@@ -62,13 +70,13 @@ function select(type: unknown, name?: string) {
     return
   }
   if (type === 'sprite') {
-    const sprite = props.project.sprites.find(s => s.name === name)
+    const sprite = props.project.sprites.find((s) => s.name === name)
     if (sprite == null) throw new Error(`sprite ${name} not found`)
     selectedRef.value = { type, value: sprite }
     return
   }
   if (type === 'sound') {
-    const sound = props.project.sounds.find(s => s.name === name)
+    const sound = props.project.sounds.find((s) => s.name === name)
     if (sound == null) throw new Error(`sound ${name} not found`)
     selectedRef.value = { type, value: sound }
     return

--- a/spx-gui/src/components/editor/EditorContextProvider.vue
+++ b/spx-gui/src/components/editor/EditorContextProvider.vue
@@ -49,7 +49,8 @@ import {
   shallowReactive,
   computed,
   watchEffect,
-  shallowRef
+  shallowRef,
+  effect
 } from 'vue'
 import { Project } from '@/models/project'
 import type { UserInfo } from '@/stores/user'
@@ -92,14 +93,39 @@ const selectedSound = computed(() => {
   return selectedRef.value?.type === 'sound' ? selectedRef.value.value : null
 })
 
+function selectSprite() {
+  if (props.project.sprites.length > 0) {
+    select('sprite', props.project.sprites[0].name)
+  } else {
+    select(null)
+  }
+}
+
+function selectSound() {
+  if (props.project.sounds.length > 0) {
+    select('sound', props.project.sounds[0].name)
+  } else {
+    select(null)
+  }
+}
+
+// selected sprite / sound removed
+// TODO: consider moving selected to model Project, so we can deal with renaming easily
+effect(() => {
+  if (selectedSprite.value != null && !props.project.sprites.includes(selectedSprite.value)) {
+    selectSprite()
+    return
+  }
+  if (selectedSound.value != null && !props.project.sounds.includes(selectedSound.value)) {
+    selectSound()
+    return
+  }
+})
+
 watch(
   () => props.project,
-  (project) => {
-    if (project.sprites.length > 0) {
-      select('sprite', project.sprites[0].name)
-    } else {
-      select(null)
-    }
+  () => {
+    selectSprite()
   },
   { immediate: true }
 )

--- a/spx-gui/src/components/top-nav/TopNav.vue
+++ b/spx-gui/src/components/top-nav/TopNav.vue
@@ -212,7 +212,8 @@ const handleSave = useMessageHandle(
   height: 50px;
 }
 
-.left, .right {
+.left,
+.right {
   flex-basis: 30%;
   display: flex;
 }

--- a/spx-gui/src/components/ui/UIButton.vue
+++ b/spx-gui/src/components/ui/UIButton.vue
@@ -55,7 +55,8 @@ const icon = computed(() => (props.loading ? 'loading' : props.icon))
   border-radius: var(--ui-border-radius-2);
   cursor: pointer;
 
-  &:not(:disabled):active, &.loading {
+  &:not(:disabled):active,
+  &.loading {
     border-bottom-width: 0;
   }
 

--- a/spx-gui/src/components/ui/UIIconButton.vue
+++ b/spx-gui/src/components/ui/UIIconButton.vue
@@ -56,7 +56,8 @@ const icon = computed(() => (props.loading ? 'loading' : props.icon))
   border-radius: 42px;
   cursor: pointer;
 
-  &:not(:disabled):active, &.loading {
+  &:not(:disabled):active,
+  &.loading {
     border-bottom-width: 0;
   }
 

--- a/spx-gui/src/components/ui/global.scss
+++ b/spx-gui/src/components/ui/global.scss
@@ -5,3 +5,7 @@
 ::after {
   box-sizing: border-box;
 }
+
+button {
+  font-family: inherit;
+}

--- a/spx-gui/src/components/ui/menu/UIMenuItem.vue
+++ b/spx-gui/src/components/ui/menu/UIMenuItem.vue
@@ -69,7 +69,7 @@ function handleClick(e: MouseEvent) {
       margin-top: 16px;
       position: relative;
       &:before {
-        content: "";
+        content: '';
         position: absolute;
         top: -8px;
         left: 0;

--- a/spx-gui/src/components/ui/modal/UIFormModal.vue
+++ b/spx-gui/src/components/ui/modal/UIFormModal.vue
@@ -58,11 +58,11 @@ const handleCloseButton = () => {
   line-height: 26px;
   flex: 1;
   color: var(--ui-color-title);
-  padding-left: 24px;
 }
 
 .center {
   text-align: center;
+  padding-left: 24px; // take a offset of the same size with close btn, to make the title content correctly centered
 }
 
 .body {


### PR DESCRIPTION
* Fix state loss when sprite / sound renamed, close #373 
* Fix non-centered modal title, related: #394
* Fix default `font-family` for `button`