### PR TITLE
monaco i18n

### DIFF
--- a/spx-gui/package-lock.json
+++ b/spx-gui/package-lock.json
@@ -8,6 +8,7 @@
       "name": "spx-gui",
       "version": "0.0.0",
       "dependencies": {
+        "@monaco-editor/loader": "^1.4.0",
         "dayjs": "^1.11.10",
         "file-saver": "^2.0.5",
         "js-pkce": "^1.4.0",
@@ -1457,6 +1458,17 @@
       "resolved": "https://registry.npmjs.org/@juggle/resize-observer/-/resize-observer-3.4.0.tgz",
       "integrity": "sha512-dfLbk+PwWvFzSxwk3n5ySL0hfBog779o8h68wK/7/APo/7cgyWp5jcXockbxdk5kFRkbeXWm4Fbi9FrdN381sA==",
       "dev": true
+    },
+    "node_modules/@monaco-editor/loader": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@monaco-editor/loader/-/loader-1.4.0.tgz",
+      "integrity": "sha512-00ioBig0x642hytVspPl7DbQyaSWRaolYie/UFNjoTdvoKPzo6xrXLhTk9ixgIKcLH5b5vDOjVNiGyY+uDCUlg==",
+      "dependencies": {
+        "state-local": "^1.0.6"
+      },
+      "peerDependencies": {
+        "monaco-editor": ">= 0.21.0 < 1"
+      }
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -8351,6 +8363,11 @@
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true
+    },
+    "node_modules/state-local": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/state-local/-/state-local-1.0.7.tgz",
+      "integrity": "sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w=="
     },
     "node_modules/std-env": {
       "version": "3.7.0",

--- a/spx-gui/package.json
+++ b/spx-gui/package.json
@@ -13,6 +13,7 @@
     "test": "vitest"
   },
   "dependencies": {
+    "@monaco-editor/loader": "^1.4.0",
     "dayjs": "^1.11.10",
     "file-saver": "^2.0.5",
     "js-pkce": "^1.4.0",

--- a/spx-gui/src/components/editor/code-editor/code-text-editor/initialization.ts
+++ b/spx-gui/src/components/editor/code-editor/code-text-editor/initialization.ts
@@ -1,15 +1,15 @@
-import { onMounted } from 'vue'
-import * as monaco from 'monaco-editor'
 import EditorWorker from 'monaco-editor/esm/vs/editor/editor.worker?worker'
 import { keywords, brackets, typeKeywords, operators } from '@/utils/spx'
 import type { FormatResponse } from '@/apis/util'
 import formatWasm from '@/assets/format.wasm?url'
 import { allSnippets } from './snippets'
 import { useUIVariables } from '@/components/ui'
+import type { IRange, languages } from 'monaco-editor'
 
 function completionItem(
-  range: monaco.IRange | monaco.languages.CompletionItemRanges
-): monaco.languages.CompletionItem[] {
+  range: IRange | languages.CompletionItemRanges,
+  monaco: typeof import('monaco-editor')
+): languages.CompletionItem[] {
   return [
     ...keywords.map((keyword) => ({
       label: keyword,
@@ -47,7 +47,10 @@ async function initFormatWasm() {
 export const defaultThemeName = 'spx-default-theme'
 
 /** Global initializations for monaco editor */
-function init({ color }: ReturnType<typeof useUIVariables>) {
+export function initMonaco(
+  monaco: typeof import('monaco-editor'),
+  { color }: ReturnType<typeof useUIVariables>
+) {
   self.MonacoEnvironment = {
     getWorker() {
       return new EditorWorker()
@@ -216,24 +219,11 @@ function init({ color }: ReturnType<typeof useUIVariables>) {
         startColumn: word.startColumn,
         endColumn: word.endColumn
       }
-      const suggestions: monaco.languages.CompletionItem[] = completionItem(range)
+      const suggestions: languages.CompletionItem[] = completionItem(range, monaco)
       return { suggestions }
     }
   })
 
   // tempararily disable in-browser format
   // initFormat()
-}
-
-let inited = false
-
-/** Ensure global initializations for monaco editor */
-export function useMonacoInitialization() {
-  const uiVariables = useUIVariables()
-
-  onMounted(() => {
-    if (inited) return
-    init(uiVariables)
-    inited = true
-  })
 }

--- a/spx-gui/src/components/top-nav/TopNav.vue
+++ b/spx-gui/src/components/top-nav/TopNav.vue
@@ -196,6 +196,8 @@ const langContent = computed(() => (i18n.lang.value === 'en' ? enSvg : zhSvg))
 
 function toggleLang() {
   i18n.setLang(i18n.lang.value === 'en' ? 'zh' : 'en')
+  // Refresh the page to apply the new language for monaco editor
+  location.reload()
 }
 
 const handleSave = useMessageHandle(


### PR DESCRIPTION
通过`@monaco-editor/loader`从CDN导入monaco代码，在导入前配置及下载语言包。导入只会跑一次，导致语言初始化后不会更新。