### PR TITLE
Fix audio & image support

### DIFF
--- a/spx-gui/src/components/asset/scratch/LoadFromScratch.vue
+++ b/spx-gui/src/components/asset/scratch/LoadFromScratch.vue
@@ -142,9 +142,9 @@ const scratchToSpxFile = (scratchFile: ExportedScratchFile) => {
 }
 
 const importSprite = async (asset: ExportedScratchSprite) => {
-  const costumes = asset.costumes.map((costume) =>
+  const costumes = await Promise.all(asset.costumes.map((costume) =>
     Costume.create(costume.name, scratchToSpxFile(costume))
-  )
+  ))
   const sprite = Sprite.create(asset.name)
   for (const costume of costumes) {
     sprite.addCostume(costume)
@@ -160,9 +160,9 @@ const importSound = async (asset: ExportedScratchFile) => {
   props.project.addSound(sound)
 }
 
-const importBackdrop = (asset: ExportedScratchFile) => {
+const importBackdrop = async (asset: ExportedScratchFile) => {
   const file = scratchToSpxFile(asset)
-  const backdrop = Backdrop.create(asset.name, file)
+  const backdrop = await Backdrop.create(asset.name, file)
   props.project.stage.setBackdrop(backdrop)
 }
 

--- a/spx-gui/src/components/asset/scratch/LoadFromScratch.vue
+++ b/spx-gui/src/components/asset/scratch/LoadFromScratch.vue
@@ -70,7 +70,7 @@ import { Sprite } from '@/models/sprite'
 import { type ExportedScratchAssets, type ExportedScratchFile } from '@/utils/scratch'
 import { Backdrop } from '@/models/backdrop'
 import { Costume } from '@/models/costume'
-import { File as LazyFile } from '@/models/common/file'
+import { fromBlob } from '@/models/common/file'
 import { useMessageHandle } from '@/utils/exception'
 import BlobImage from '../BlobImage.vue'
 import type { ExportedScratchSprite } from '@/utils/scratch'
@@ -138,16 +138,12 @@ const selectBackdrop = (backdrop: ExportedScratchFile) => {
 }
 
 const scratchToSpxFile = (scratchFile: ExportedScratchFile) => {
-  return new LazyFile(
-    `${scratchFile.name}.${scratchFile.extension}`,
-    () => scratchFile.blob.arrayBuffer(),
-    {}
-  )
+  return fromBlob(`${scratchFile.name}.${scratchFile.extension}`, scratchFile.blob)
 }
 
 const importSprite = async (asset: ExportedScratchSprite) => {
   const costumes = asset.costumes.map((costume) =>
-    Costume.create(costume.name, new LazyFile(costume.name, () => costume.blob.arrayBuffer()))
+    Costume.create(costume.name, scratchToSpxFile(costume))
   )
   const sprite = Sprite.create(asset.name)
   for (const costume of costumes) {
@@ -158,9 +154,9 @@ const importSprite = async (asset: ExportedScratchSprite) => {
   return sprite
 }
 
-const importSound = (asset: ExportedScratchFile) => {
+const importSound = async (asset: ExportedScratchFile) => {
   const file = scratchToSpxFile(asset)
-  const sound = Sound.create(asset.name, file)
+  const sound = await Sound.create(asset.name, file)
   props.project.addSound(sound)
 }
 

--- a/spx-gui/src/components/asset/scratch/SoundItem.vue
+++ b/spx-gui/src/components/asset/scratch/SoundItem.vue
@@ -6,7 +6,7 @@
       </div>
     </div>
     <div class="asset-name">{{ asset.name }}</div>
-    <div class="duration">{{ formattedDuration }}</div>
+    <div class="duration">{{ formattedDuration || '&nbsp;' }}</div>
   </ScratchItemContainer>
 </template>
 <script setup lang="ts">

--- a/spx-gui/src/components/editor/panels/sound/SoundsPanel.vue
+++ b/spx-gui/src/components/editor/panels/sound/SoundsPanel.vue
@@ -88,8 +88,7 @@ function handleSoundClick(sound: Sound) {
 const handleUpload = useMessageHandle(
   async () => {
     const audio = await selectAudio()
-    const file = fromNativeFile(audio)
-    const sound = Sound.create(stripExt(audio.name), file)
+    const sound = await Sound.create(stripExt(audio.name), fromNativeFile(audio))
     editorCtx.project.addSound(sound)
     editorCtx.select('sound', sound.name)
   },

--- a/spx-gui/src/components/editor/panels/sprite/SpritesPanel.vue
+++ b/spx-gui/src/components/editor/panels/sprite/SpritesPanel.vue
@@ -97,7 +97,7 @@ const handleUpload = useMessageHandle(
     // When we support costume list & edit, we should allow user to choose multiple images (for multiple costumes) here
     const img = await selectImg()
     const sprite = Sprite.create(stripExt(img.name))
-    const costume = Costume.create('default', fromNativeFile(img))
+    const costume = await Costume.create('default', fromNativeFile(img))
     sprite.addCostume(costume)
     editorCtx.project.addSprite(sprite)
     await sprite.autoFit()

--- a/spx-gui/src/components/editor/panels/stage/StagePanel.vue
+++ b/spx-gui/src/components/editor/panels/stage/StagePanel.vue
@@ -61,7 +61,7 @@ const handleUpload = useMessageHandle(
   async () => {
     const img = await selectImg()
     const file = fromNativeFile(img)
-    const backdrop = Backdrop.create(stripExt(img.name), file)
+    const backdrop = await Backdrop.create(stripExt(img.name), file)
     editorCtx.project.stage.setBackdrop(backdrop)
   },
   { en: 'Upload failed', zh: '上传失败' }

--- a/spx-gui/src/components/editor/sound/DumbSoundPlayer.vue
+++ b/spx-gui/src/components/editor/sound/DumbSoundPlayer.vue
@@ -2,7 +2,7 @@
 
 <template>
   <div class="sound-play" :style="colorCssVars">
-    <div v-show="!playing" class="play" @click.stop="emit('play')">
+    <div v-show="!playing" class="play" @click.stop="handlePlay.fn">
       <UIIcon class="icon" type="play" />
     </div>
     <div v-show="playing" class="stop" @click.stop="emit('stop')">
@@ -17,6 +17,7 @@
 
 <script setup lang="ts">
 import { computed } from 'vue'
+import { useMessageHandle } from '@/utils/exception'
 import { UIIcon } from '@/components/ui'
 import type { Color } from '@/components/ui/tokens/colors'
 
@@ -24,12 +25,17 @@ const props = defineProps<{
   playing: boolean
   progress: number
   color: Color
+  playHandler: () => Promise<void>
 }>()
 
 const emit = defineEmits<{
-  play: []
   stop: []
 }>()
+
+const handlePlay = useMessageHandle(
+  () => props.playHandler(),
+  { en: 'Play audio failed', zh: '无法播放音频' }
+)
 
 const playCssVars = computed(() => ({
   '--progress': props.progress ?? 0

--- a/spx-gui/src/components/editor/sound/SoundEditor.vue
+++ b/spx-gui/src/components/editor/sound/SoundEditor.vue
@@ -21,7 +21,7 @@
         class="play-button"
         :playing="playing != null"
         :progress="playing?.progress ?? 0"
-        @play="handlePlay"
+        :play-handler="handlePlay"
         @stop="handleStop"
       />
     </div>

--- a/spx-gui/src/components/editor/sound/SoundPlayer.vue
+++ b/spx-gui/src/components/editor/sound/SoundPlayer.vue
@@ -5,7 +5,7 @@
     :playing="playing != null"
     :progress="playing?.progress ?? 0"
     :color="color"
-    @play="handlePlay"
+    :play-handler="handlePlay"
     @stop="handleStop"
   />
 </template>

--- a/spx-gui/src/components/editor/sound/SoundRecorder.vue
+++ b/spx-gui/src/components/editor/sound/SoundRecorder.vue
@@ -165,7 +165,7 @@ const stopRecording = () => {
 
 const saveRecording = async () => {
   const file = fromBlob(`Recording_${dayjs().format('YYYY-MM-DD_HH:mm:ss')}.webm`, audioBlob.value!)
-  const sound = Sound.create('recording', file)
+  const sound = await Sound.create('recording', file)
   editorCtx.project.addSound(sound)
   emit('saved', sound)
 }

--- a/spx-gui/src/components/project/ProjectCreateModal.vue
+++ b/spx-gui/src/components/project/ProjectCreateModal.vue
@@ -97,9 +97,11 @@ const handleSubmit = useMessageHandle(
   async () => {
     // make default project
     const sprite = Sprite.create('')
-    sprite.addCostume(Costume.create('', createFile(defaultSpritePng)))
+    const costume = await Costume.create('', createFile(defaultSpritePng))
+    sprite.addCostume(costume)
     const project = new Project()
-    project.stage.setBackdrop(Backdrop.create('', createFile(defaultBackdropImg)))
+    const backdrop = await Backdrop.create('', createFile(defaultBackdropImg))
+    project.stage.setBackdrop(backdrop)
     project.addSprite(sprite)
     await sprite.autoFit()
     // upload project content & call API addProject, TODO: maybe this should be extracted to `@/models`?

--- a/spx-gui/src/components/ui/UIButton.vue
+++ b/spx-gui/src/components/ui/UIButton.vue
@@ -75,20 +75,6 @@ const icon = computed(() => (props.loading ? 'loading' : props.icon))
     height: var(--ui-font-size-text);
   }
 
-  &.loading .icon {
-    animation: button-icon-spin 1s linear infinite;
-    @keyframes button-icon-spin {
-      from {
-        transform-origin: 50% 50%;
-        transform: rotate(0);
-      }
-      to {
-        transform-origin: 50% 50%;
-        transform: rotate(360deg);
-      }
-    }
-  }
-
   &:focus {
     outline: 2px solid var(--ui-color-primary-700);
   }

--- a/spx-gui/src/components/ui/UIIconButton.vue
+++ b/spx-gui/src/components/ui/UIIconButton.vue
@@ -83,20 +83,6 @@ const icon = computed(() => (props.loading ? 'loading' : props.icon))
     }
   }
 
-  &.loading .icon {
-    animation: button-icon-spin 1s linear infinite;
-    @keyframes button-icon-spin {
-      from {
-        transform-origin: 50% 50%;
-        transform: rotate(0);
-      }
-      to {
-        transform-origin: 50% 50%;
-        transform: rotate(360deg);
-      }
-    }
-  }
-
   &:focus {
     outline: 2px solid var(--ui-color-primary-700);
   }

--- a/spx-gui/src/components/ui/icons/UIIcon.vue
+++ b/spx-gui/src/components/ui/icons/UIIcon.vue
@@ -1,7 +1,7 @@
 <template v-html="typeIconMap[type]">
   <!-- TODO: is there any way to avoid the wrapper `<div>`? -->
   <!-- eslint-disable-next-line vue/no-lone-template, vue/no-v-html -->
-  <div class="ui-icon" v-html="typeIconMap[type]"></div>
+  <div class="ui-icon" :class="{ spinning: type === 'loading' }" v-html="typeIconMap[type]"></div>
 </template>
 
 <script setup lang="ts">
@@ -69,6 +69,20 @@ defineProps<{
   :deep(svg) {
     width: 100%;
     height: 100%;
+  }
+}
+
+.spinning {
+  animation: ui-icon-spinning 1s linear infinite;
+  @keyframes ui-icon-spinning {
+    from {
+      transform-origin: 50% 50%;
+      transform: rotate(0);
+    }
+    to {
+      transform-origin: 50% 50%;
+      transform: rotate(360deg);
+    }
   }
 }
 </style>

--- a/spx-gui/src/components/ui/modal/UIFormModal.vue
+++ b/spx-gui/src/components/ui/modal/UIFormModal.vue
@@ -1,5 +1,5 @@
 <template>
-  <UIModal :visible="visible" auto-focus @update:visible="handleUpdateShow">
+  <UIModal :visible="visible" auto-focus mask-closable @update:visible="handleUpdateShow">
     <div class="container">
       <div class="header">
         <div :class="['title', { center: centerTitle }]">

--- a/spx-gui/src/components/ui/modal/UISearchableModal.vue
+++ b/spx-gui/src/components/ui/modal/UISearchableModal.vue
@@ -3,7 +3,7 @@
 -->
 
 <template>
-  <UIModal :visible="visible" :auto-focus="false" @update:visible="handleUpdateShow">
+  <UIModal :visible="visible" :auto-focus="false" mask-closable @update:visible="handleUpdateShow">
     <div class="container">
       <div class="header">
         <h4 class="title">

--- a/spx-gui/src/models/backdrop.ts
+++ b/spx-gui/src/models/backdrop.ts
@@ -4,6 +4,7 @@ import type { File, Files } from './common/file'
 import { resolve } from '@/utils/path'
 import { getBackdropName, validateBackdropName } from './common/asset'
 import type { Stage } from './stage'
+import { adaptImg } from '@/utils/spx'
 
 export type BackdropInits = CostumeInits
 export type RawBackdropConfig = RawCostumeConfig
@@ -32,8 +33,9 @@ export class Backdrop extends Costume {
    * Create instance with default inits
    * Note that the "default" means default behavior for builder, not the default behavior of spx
    */
-  static create(nameBase: string, file: File, inits?: BackdropInits) {
-    return new Backdrop(getBackdropName(null, nameBase), file, inits)
+  static async create(nameBase: string, file: File, inits?: BackdropInits) {
+    const adaptedFile = await adaptImg(file)
+    return new Backdrop(getBackdropName(null, nameBase), adaptedFile, inits)
   }
 
   static load({ name, path, ...inits }: RawBackdropConfig, files: Files) {

--- a/spx-gui/src/models/costume.ts
+++ b/spx-gui/src/models/costume.ts
@@ -1,6 +1,7 @@
 import { reactive } from 'vue'
 
 import { extname, resolve } from '@/utils/path'
+import { adaptImg } from '@/utils/spx'
 import { File, type Files } from './common/file'
 import { type Size } from './common'
 import type { Sprite } from './sprite'
@@ -91,8 +92,9 @@ export class Costume {
    * Create instance with default inits
    * Note that the "default" means default behavior for builder, not the default behavior of spx
    */
-  static create(nameBase: string, file: File, inits?: CostumeInits) {
-    return new Costume(getCostumeName(null, nameBase), file, inits)
+  static async create(nameBase: string, file: File, inits?: CostumeInits) {
+    const adaptedFile = await adaptImg(file)
+    return new Costume(getCostumeName(null, nameBase), adaptedFile, inits)
   }
 
   static load(

--- a/spx-gui/src/models/sound.ts
+++ b/spx-gui/src/models/sound.ts
@@ -1,5 +1,6 @@
 import { reactive } from 'vue'
 import { extname, join, resolve } from '@/utils/path'
+import { adaptAudio } from '@/utils/spx'
 import { File, fromConfig, type Files, listDirs, toConfig } from './common/file'
 import { getSoundName, validateSoundName } from './common/asset'
 import type { Project } from './project'
@@ -56,8 +57,9 @@ export class Sound {
    * Create instance with default inits
    * Note that the "default" means default behavior for builder, not the default behavior of spx
    */
-  static create(nameBase: string, file: File, inits?: SoundInits) {
-    return new Sound(getSoundName(null, nameBase), file, inits)
+  static async create(nameBase: string, file: File, inits?: SoundInits) {
+    const adaptedFile = await adaptAudio(file)
+    return new Sound(getSoundName(null, nameBase), adaptedFile, inits)
   }
 
   static async load(name: string, files: Files) {

--- a/spx-gui/src/utils/audio.ts
+++ b/spx-gui/src/utils/audio.ts
@@ -1,10 +1,18 @@
 import { computed, ref, watchEffect } from 'vue'
 
-const audioContext = new AudioContext()
+let audioContext: AudioContext
+
+// Reuse single AudioContext instance, see details in https://developer.mozilla.org/en-US/docs/Web/API/AudioContext
+// > It's recommended to create one AudioContext and reuse it instead of initializing a new one each time,
+// > and it's OK to use a single AudioContext for several different audio sources and pipeline concurrently.
+function getAudioContext() {
+  if (audioContext == null) audioContext = new AudioContext()
+  return audioContext
+}
 
 /** Convert arbitrary-type (supported by current browser) audio content to type-`audio/wav` content. */
 export async function toWav(ab: ArrayBuffer): Promise<ArrayBuffer> {
-  const audioBuffer = await audioContext.decodeAudioData(ab)
+  const audioBuffer = await getAudioContext().decodeAudioData(ab)
   const numOfChan = audioBuffer.numberOfChannels
   const length = audioBuffer.length * numOfChan * 2 + 44
   const buffer = new ArrayBuffer(length)

--- a/spx-gui/src/utils/img.ts
+++ b/spx-gui/src/utils/img.ts
@@ -1,0 +1,28 @@
+import { Disposble } from "@/models/common/disposable"
+
+/** Convert arbitrary-type (supported by current browser) image content to type-`image/jpeg` content. */
+export async function toJpeg(blob: Blob) {
+  const d = new Disposble()
+  return new Promise<Blob>((resolve, reject) => {
+    const img = new Image()
+    img.onload = () => {
+        const canvas = document.createElement('canvas')
+        canvas.width = img.naturalWidth
+        canvas.height = img.naturalHeight
+        canvas.getContext('2d')?.drawImage(img, 0, 0)
+        canvas.toBlob(newBlob => {
+          if (newBlob == null) {
+            reject(new Error('toBlob failed'))
+            return
+          }
+          resolve(newBlob)
+        }, 'image/jpeg')
+    }
+    img.onerror = (e) => reject(new Error(`load image failed: ${e.toString()}`))
+    const url = URL.createObjectURL(blob)
+    d.addDisposer(() => URL.revokeObjectURL(url))
+    img.src = url
+  }).finally(() => {
+    d.dispose()
+  })
+}

--- a/spx-gui/src/utils/scratch.ts
+++ b/spx-gui/src/utils/scratch.ts
@@ -83,12 +83,9 @@ export const parseScratchFileAssets = async (file: File): Promise<ExportedScratc
   }
 
   for (const target of projectData.targets) {
-    const imageFiles = await convertFiles(
-      target.costumes.filter((costume) => costume.dataFormat !== 'svg')
-      // FIXME: SVG causes error
-    )
-
+    const imageFiles = await convertFiles(target.costumes)
     const soundFiles = await convertFiles(target.sounds)
+
     if (imageFiles.length > 0) {
       if (target.isStage) {
         scratchAssets.backdrops.push(...imageFiles)

--- a/spx-gui/src/utils/spx.ts
+++ b/spx-gui/src/utils/spx.ts
@@ -3,6 +3,11 @@
  * @desc definition or helpers for spx language
  */
 
+import { File } from '@/models/common/file'
+import { getMimeFromExt } from './file'
+import { stripExt } from './path'
+import { toWav } from './audio'
+
 export const keywords = [
   'func',
   'main',
@@ -95,3 +100,22 @@ export const brackets = [
   { open: '[', close: ']', token: 'delimiter.bracket' },
   { open: '(', close: ')', token: 'delimiter.parenthesis' }
 ]
+
+/**
+ * Adapt audio file to fit spx.
+ * 
+ * Currently spx supports `mp3` and `wav` only (see details in https://github.com/goplus/spx/blob/7f46dc7879e2320a9889f1396b9e592efb6d888d/audio.go),
+ * it seems that wav-encoding is simpler than mp3-encoding. So we convert unsupported audio files to wav before added to project.
+ * 
+ * Note: wav with codec `adpcm` is supported by spx, while not natively supported by chrome (& maybe more other browsers).
+ * So it is allowed to add a sound of wav file with codec `adpcm` to project, and it works in the game.
+ * But it does not work as expected with audio element (`SoundPlayer`) & wavesurfer.
+ */
+export async function adaptAudio(file: File): Promise<File> {
+  if (file.type === getMimeFromExt('mp3')) return file
+  if (file.type === getMimeFromExt('wav')) return file
+
+  const wavAb = await toWav(await file.arrayBuffer())
+  const wavFileName = stripExt(file.name) + '.wav'
+  return new File(wavFileName, async () => wavAb)
+}

--- a/spx-gui/src/utils/spx.ts
+++ b/spx-gui/src/utils/spx.ts
@@ -3,10 +3,11 @@
  * @desc definition or helpers for spx language
  */
 
-import { File } from '@/models/common/file'
+import { File, fromBlob, toNativeFile } from '@/models/common/file'
 import { getMimeFromExt } from './file'
 import { stripExt } from './path'
 import { toWav } from './audio'
+import { toJpeg } from './img'
 
 export const keywords = [
   'func',
@@ -102,20 +103,43 @@ export const brackets = [
 ]
 
 /**
+ * Audio file formats supported by spx.
+ * See details in https://github.com/goplus/spx/blob/7f46dc7879e2320a9889f1396b9e592efb6d888d/audio.go
+ */
+const supportedAudioExts = ['mp3', 'wav']
+
+/**
  * Adapt audio file to fit spx.
  * 
- * Currently spx supports `mp3` and `wav` only (see details in https://github.com/goplus/spx/blob/7f46dc7879e2320a9889f1396b9e592efb6d888d/audio.go),
- * it seems that wav-encoding is simpler than mp3-encoding. So we convert unsupported audio files to wav before added to project.
+ * Currently spx supports `mp3` and `wav` only, and it seems that wav-encoding is simpler than mp3-encoding.
+ * So we convert unsupported audio files to wav before added to project.
  * 
  * Note: wav with codec `adpcm` is supported by spx, while not natively supported by chrome (& maybe more other browsers).
  * So it is allowed to add a sound of wav file with codec `adpcm` to project, and it works in the game.
  * But it does not work as expected with audio element (`SoundPlayer`) & wavesurfer.
  */
 export async function adaptAudio(file: File): Promise<File> {
-  if (file.type === getMimeFromExt('mp3')) return file
-  if (file.type === getMimeFromExt('wav')) return file
-
+  for (const ext of supportedAudioExts) {
+    if (file.type === getMimeFromExt(ext)) return file
+  }
   const wavAb = await toWav(await file.arrayBuffer())
   const wavFileName = stripExt(file.name) + '.wav'
   return new File(wavFileName, async () => wavAb)
+}
+
+/**
+ * Image file formats supported by spx. See details in
+ * - https://github.com/goplus/spx/blob/7f46dc7879e2320a9889f1396b9e592efb6d888d/spbase.go#L25-L26
+ * - https://github.com/goplus/spx/blob/7f46dc7879e2320a9889f1396b9e592efb6d888d/internal/svgr/svg.go#L22
+ */
+const supportedImgExts = ['jpg', 'jpeg', 'png', 'svg']
+
+/** Adapt image file to fit spx. Unsupported image files will be converted to jpeg. */
+export async function adaptImg(file: File): Promise<File> {
+  for (const ext of supportedImgExts) {
+    if (file.type === getMimeFromExt(ext)) return file
+  }
+  const jpegBlob = await toJpeg(await toNativeFile(file))
+  const jpegFileName = stripExt(file.name) + '.jpeg'
+  return fromBlob(jpegFileName, jpegBlob)
 }


### PR DESCRIPTION
### 改动

* Fix audio & image support, close #370
* Move spinning animation from `UIButton loading` to `UIIcon type=loading`
* Fix `mask-closable` behavior for `UIFormModal` & `UISearchableModal`

### 整体情况 & 方案

Builder 对于音频 & 图片格式的支持需要考虑两个方面：

1. SPX 的支持情况：决定游戏是否可运行
2. 当前浏览器的支持情况（主要是 decode）：决定资源是否可以在 Builder 中被操作，包括但不限于

    * 通过 `SoundPlayer` 播放音频
    * 通过 wavesurfer 渲染音轨
    * 通过 `StageViewer` 渲染（sprite、backdrop 中的）图片
    * 在 `SpritesPanel`、`StagePanel` 中渲染图片

整体的处理方案是：

* 当向项目中添加资源（包括上传、从 scratch 导入等）时，允许的用户输入以当前浏览器的支持情况为准
* 然后检查资源是否被 SPX 支持；若支持，则直接使用；若不支持，将其转换为 SPX 支持的格式再使用

  注意，因为当前浏览器原生支持 decode 用户输入的资源，因此我们“几乎”总是可以将其低成本地转换为 SPX 支持的格式（自己搞定 encode 过程即可）

对于以下两种“添加资源”的场景：

* 导入项目文件（这个项目文件可以认为是由 Builder 自己生成的）
* 从素材库添加

这两种情况下，资源的源文件可以认为在最初已经被 Builder 处理过（一定是 SPX 已经支持的），因此不需要走上述的处理过程

不难发现，上述的处理过程基本能保证最终项目中使用的资源是 SPX 支持的，但不一定是当前浏览器支持的，因为同一个项目的资源添加可能来自在不同的浏览器中进行操作。

这个问题对图片的影响较小，因为绝大部分浏览器支持的图片格式是 SPX 支持的图片格式的超集。对音频的影响稍大一些，具体体现为项目中存在这样的音频文件，游戏运行时可以正常播放，但不可以被 Builder 操作，比如不能通过 `SoundPlayer` 播放，不能通过 wavesurfer 绘制音轨；等后面我们支持音频的编辑后，这部分音频文件也不能在 Builder 中被编辑。

考虑到这个是低频情况，且造成的不便有限，因此我们这里做了异常反馈（如 `SoundPlayer` 在播放失败时会给予提示），但不去彻底解决；彻底解决可能要引入全功能的音频转码能力（如 [`ffmpeg.wasm`](https://github.com/ffmpegwasm/ffmpeg.wasm) 或云服务），成本会相对高，后面随着功能迭代可以重新评估。

### 录音

录音的情况稍微特殊一点；虽然主流浏览器都支持 mp3、wav 等格式音频的播放，但在进行录制时（`MediaRecorder`）只支持输出（encode）为 webm；因此对于录音功能，几乎总是会先录制为 webm，然后再被我们转为 SPX 支持的格式（默认 wav）

