### PR TITLE
UI: Fix bug where Monaco Editor fails to load 'en' language pack

### DIFF
--- a/spx-gui/src/components/editor/code-editor/code-text-editor/CodeTextEditor.vue
+++ b/spx-gui/src/components/editor/code-editor/code-text-editor/CodeTextEditor.vue
@@ -26,13 +26,19 @@ const monacoEditor = shallowRef<editor.IStandaloneCodeEditor>()
 const uiVariables = useUIVariables()
 const { t, lang } = useI18n()
 
-loader.config({
-  'vs/nls': {
-    availableLanguages: {
-      '*': lang.value === 'zh' ? 'zh-cn' : 'en'
-    }
+if (lang.value !== 'en') {
+  const langOverride = {
+    zh: 'zh-cn'
   }
-})
+  const locale = langOverride[lang.value] || lang.value
+  loader.config({
+    'vs/nls': {
+      availableLanguages: {
+        '*': locale
+      }
+    }
+  })
+}
 
 watchEffect(async (onClenaup) => {
   const monaco_ = await loader.init()


### PR DESCRIPTION
```
Failed to load message bundle for language en. Falling back to the default language: Error: [object Event]
```

<img width="668" alt="Screenshot 2024-05-06 at 15 16 53" src="https://github.com/goplus/builder/assets/5037285/2010fec3-61ef-48ae-be2f-b7bc1de16310">
