### PR TITLE
Fix auto-focus for project-runner

### DIFF
--- a/spx-gui/src/components/project/runner/IframeDisplay.vue
+++ b/spx-gui/src/components/project/runner/IframeDisplay.vue
@@ -34,6 +34,9 @@ watch(iframe, () => {
 
   iframeWindow.addEventListener('wasmReady', () => {
     iframeWindow.startWithZipBuffer(zipData)
+    const canvas = iframeWindow.document.querySelector('canvas')
+    if (canvas == null) throw new Error('canvas expected in iframe')
+    canvas.focus() // focus to canvas by default, so the user can interact with the game immediately
   })
   iframeWindow.console.log = function (...args: unknown[]) {
     // eslint-disable-next-line no-console

--- a/spx-gui/src/components/ui/modal/UIFullScreenModal.vue
+++ b/spx-gui/src/components/ui/modal/UIFullScreenModal.vue
@@ -1,5 +1,5 @@
 <template>
-  <NModal :to="attachTo" auto-focus :show="visible" @update:show="handleUpdateShow">
+  <NModal :to="attachTo" :auto-focus="false" :show="visible" @update:show="handleUpdateShow">
     <div class="container">
       <slot></slot>
     </div>


### PR DESCRIPTION
fix #457 

* Disable auto-focus for `UIFullScreenModal`
* In `IframeDisplay`, wait for `wasmReady` & then focus to canvas