### PR TITLE
Success feedback for name input

### DIFF
--- a/spx-gui/src/components/editor/panels/sprite/SpriteRenameModal.vue
+++ b/spx-gui/src/components/editor/panels/sprite/SpriteRenameModal.vue
@@ -1,6 +1,6 @@
 <template>
   <RenameModal :visible="visible" @cancel="handleCancel">
-    <UIForm :form="form" @submit="handleSubmit">
+    <UIForm :form="form" has-success-feedback @submit="handleSubmit">
       <UIFormItem path="name">
         <UITextInput v-model:value="form.value.name" />
         <template #tip>{{ $t(spriteNameTip) }}</template>
@@ -41,7 +41,9 @@ function handleCancel() {
 }
 
 function handleSubmit() {
-  props.sprite.setName(form.value.name)
+  if (form.value.name !== props.sprite.name) {
+    props.sprite.setName(form.value.name)
+  }
   emit('resolved')
 }
 

--- a/spx-gui/src/components/editor/sound/SoundRenameModal.vue
+++ b/spx-gui/src/components/editor/sound/SoundRenameModal.vue
@@ -1,6 +1,6 @@
 <template>
   <RenameModal :visible="visible" @cancel="handleCancel">
-    <UIForm :form="form" @submit="handleSubmit">
+    <UIForm :form="form" has-success-feedback @submit="handleSubmit">
       <UIFormItem path="name">
         <UITextInput v-model:value="form.value.name" />
         <template #tip>{{ $t(soundNameTip) }}</template>
@@ -41,7 +41,9 @@ function handleCancel() {
 }
 
 function handleSubmit() {
-  props.sound.setName(form.value.name)
+  if (form.value.name !== props.sound.name) {
+    props.sound.setName(form.value.name)
+  }
   emit('resolved')
 }
 

--- a/spx-gui/src/components/project/ProjectCreateModal.vue
+++ b/spx-gui/src/components/project/ProjectCreateModal.vue
@@ -5,7 +5,7 @@
     :visible="props.visible"
     @update:visible="handleCancel"
   >
-    <UIForm :form="form" @submit="handleSubmit.fn">
+    <UIForm :form="form" has-success-feedback @submit="handleSubmit.fn">
       <div class="alert">
         {{
           $t({

--- a/spx-gui/src/components/ui/UITextInput.vue
+++ b/spx-gui/src/components/ui/UITextInput.vue
@@ -25,23 +25,15 @@ const slots = useSlots()
 .ui-text-input {
   // it's not possible to control input's hovered-bg-color with themeOverrides,
   // so we do background color control here
-  &:not(.n-input--focus, .n-input--error-status) {
+  &:not(.n-input--focus, .n-input--error-status, .n-input--success-status) {
     background-color: var(--ui-color-grey-300);
-    &:hover {
-      background-color: var(--ui-color-grey-400);
-    }
   }
-
-  &.n-input--error-status {
-    background-color: #feefef; // TODO: uiVars?
-    &:not(.n-input--focus) :deep(.n-input__state-border) {
-      visibility: hidden;
-    }
-    &:hover {
-      background-color: #fdc7c7; // TODO: uiVars?
-    }
-    &.n-input--focus {
-      background-color: var(--ui-color-grey-100);
+  &:not(.n-input--focus):hover {
+    background-color: var(--ui-color-grey-400);
+  }
+  &.n-input--success-status {
+    :deep(.n-input__state-border) {
+      border: 1px solid var(--ui-color-success-main);
     }
   }
 }

--- a/spx-gui/src/components/ui/form/UIForm.vue
+++ b/spx-gui/src/components/ui/form/UIForm.vue
@@ -1,25 +1,44 @@
 <template>
-  <NForm
-    :ref="form._nFormRef"
-    :rules="form._nFormRules"
-    :model="form.value"
-    @submit.prevent="handleSubmit"
-  >
+  <NForm @submit.prevent="handleSubmit">
     <slot></slot>
   </NForm>
 </template>
 
+<script lang="ts">
+export type FormInjection = {
+  form: FormCtrl
+  hasSuccessFeedback: boolean
+}
+
+const formInjectionKey: InjectionKey<FormInjection> = Symbol('form')
+
+export function useForm() {
+  const injected = inject(formInjectionKey)
+  if (injected == null) throw new Error('useForm should be called inside of UIForm')
+  return injected
+}
+</script>
+
 <script setup lang="ts">
+import { inject, provide, type InjectionKey } from 'vue'
 import { NForm } from 'naive-ui'
 import type { FormCtrl } from './ctrl'
 
-const props = defineProps<{
-  form: FormCtrl
-}>()
+const props = withDefaults(
+  defineProps<{
+    form: FormCtrl
+    hasSuccessFeedback?: boolean
+  }>(),
+  {
+    hasSuccessFeedback: false
+  }
+)
 
 const emit = defineEmits<{
   submit: []
 }>()
+
+provide(formInjectionKey, props)
 
 async function handleSubmit() {
   const { hasError } = await props.form.validate()

--- a/spx-gui/src/components/ui/form/UIFormItem.vue
+++ b/spx-gui/src/components/ui/form/UIFormItem.vue
@@ -1,39 +1,58 @@
 <template>
   <!-- TODO: margin among multiple FormItems -->
-  <NFormItem ref="formItem" class="ui-form-item" :show-label="!!label" :label="label" :path="path">
-    <UIFormItemInternal>
+  <NFormItem
+    class="ui-form-item"
+    :show-label="!!label"
+    :label="label"
+    :path="path"
+    v-bind="nFormItemProps"
+  >
+    <UIFormItemInternal
+      :handle-content-blur="handleContentBlur"
+      :handle-content-input="handleContentInput"
+    >
       <slot></slot>
     </UIFormItemInternal>
   </NFormItem>
   <p v-if="!!slots.tip" class="tip"><slot name="tip"></slot></p>
 </template>
 
-<script lang="ts">
-export type FormItemInjection = () => InstanceType<typeof NFormItem> | undefined
-
-const formItemInjectionKey: InjectionKey<FormItemInjection> = Symbol('form-item')
-
-export function useFormItem() {
-  const injection = inject(formItemInjectionKey)
-  if (injection == null) throw new Error('useFormItem should be used inside of UIFormItem')
-  return injection
-}
-</script>
-
 <script setup lang="ts">
-import { ref, useSlots, provide, type InjectionKey, inject } from 'vue'
+import { useSlots, computed } from 'vue'
 import { NFormItem } from 'naive-ui'
+import { debounce } from '@/utils/utils'
 import UIFormItemInternal from './UIFormItemInternal.vue'
+import { useForm } from './UIForm.vue'
 
-defineProps<{
+const props = defineProps<{
   label?: string
   path?: string
 }>()
 
 const slots = useSlots()
+const form = useForm()
 
-const formItem = ref<InstanceType<typeof NFormItem>>()
-provide(formItemInjectionKey, () => formItem.value)
+const validated = computed(() => (props.path != null ? form.form.validated[props.path] : null))
+const nFormItemProps = computed(() => {
+  if (validated.value == null) return undefined
+  if (validated.value.hasError)
+    return { validationStatus: 'error' as const, feedback: validated.value.error }
+  return form.hasSuccessFeedback ? { validationStatus: 'success' as const } : undefined
+})
+
+function handleContentBlur() {
+  const path = props.path
+  if (path == null) return
+  setTimeout(() => {
+    form.form.validateWithPath(path)
+  }, 200)
+}
+
+const handleContentInput = debounce(() => {
+  const path = props.path
+  if (path == null) return
+  form.form.validateWithPath(path)
+}, 300)
 </script>
 
 <style lang="scss" scoped>

--- a/spx-gui/src/components/ui/form/UIFormItemInternal.vue
+++ b/spx-gui/src/components/ui/form/UIFormItemInternal.vue
@@ -5,13 +5,10 @@
 <script setup lang="ts">
 import { inject, provide } from 'vue'
 import { formItemInjectionKey as nFormItemInjectionKey } from 'naive-ui/es/_mixins/use-form-item'
-import { debounce } from '@/utils/utils'
-import { useFormItem } from './UIFormItem.vue'
-import { FormTrigger } from './ctrl'
 
-defineProps<{
-  label?: string
-  path?: string
+const props = defineProps<{
+  handleContentBlur: () => void
+  handleContentInput: () => void
 }>()
 
 const nFormItemInjection = inject(nFormItemInjectionKey)
@@ -21,25 +18,6 @@ if (nFormItemInjection == null)
 // hijack injection of NFormItem to get notified when content blur/input
 provide(nFormItemInjectionKey, {
   ...nFormItemInjection,
-  handleContentBlur,
-  handleContentInput
+  ...props
 })
-
-const getNFormItem = useFormItem()
-
-function handleContentBlur() {
-  nFormItemInjection?.handleContentBlur()
-  setTimeout(() => {
-    getNFormItem()?.validate(FormTrigger.delayedBlur)
-  }, 200)
-}
-
-const validateForDebouncedInput = debounce(() => {
-  getNFormItem()?.validate(FormTrigger.debouncedInput)
-}, 300)
-
-function handleContentInput() {
-  nFormItemInjection?.handleContentInput()
-  validateForDebouncedInput()
-}
 </script>


### PR DESCRIPTION
* Add success feedback for name input, close #471 
* Implement form validation instead of relying on validation of `NForm` (Validation of `NForm` does not support success feedback)
* Update `UITextInput` error style for design change
