### PR TITLE
use `.gbp` instead of `.zip` for exported projects

### DIFF
--- a/spx-gui/src/components/project/runner/ProjectRunner.vue
+++ b/spx-gui/src/components/project/runner/ProjectRunner.vue
@@ -21,7 +21,7 @@ const handleConsole = (type: 'log' | 'warn', args: unknown[]) => {
 
 defineExpose({
   run: async () => {
-    const zipFile = await props.project.exportZipFile()
+    const zipFile = await props.project.exportGbpFile()
     zipData.value = await zipFile.arrayBuffer()
   },
   stop: () => {

--- a/spx-gui/src/components/project/runner/ProjectRunner.vue
+++ b/spx-gui/src/components/project/runner/ProjectRunner.vue
@@ -21,8 +21,8 @@ const handleConsole = (type: 'log' | 'warn', args: unknown[]) => {
 
 defineExpose({
   run: async () => {
-    const zipFile = await props.project.exportGbpFile()
-    zipData.value = await zipFile.arrayBuffer()
+    const gbpFile = await props.project.exportGbpFile()
+    zipData.value = await gbpFile.arrayBuffer()
   },
   stop: () => {
     zipData.value = null

--- a/spx-gui/src/components/top-nav/TopNav.vue
+++ b/spx-gui/src/components/top-nav/TopNav.vue
@@ -179,12 +179,12 @@ async function handleImportProjectFile() {
     confirmText: i18n.t({ en: 'Continue', zh: '继续' })
   })
   const file = await selectFile({ accept: '.gbp' })
-  await props.project!.loadZipFile(file)
+  await props.project!.loadGbpFile(file)
 }
 
 async function handleExportProjectFile() {
-  const zipFile = await props.project!.exportGbpFile()
-  saveAs(zipFile, zipFile.name) // TODO: what if user cancelled download?
+  const gbpFile = await props.project!.exportGbpFile()
+  saveAs(gbpFile, gbpFile.name) // TODO: what if user cancelled download?
 }
 
 async function handleImportFromScratch() {

--- a/spx-gui/src/components/top-nav/TopNav.vue
+++ b/spx-gui/src/components/top-nav/TopNav.vue
@@ -178,12 +178,12 @@ async function handleImportProjectFile() {
     }),
     confirmText: i18n.t({ en: 'Continue', zh: '继续' })
   })
-  const file = await selectFile({ accept: '.zip' })
+  const file = await selectFile({ accept: '.gbp' })
   await props.project!.loadZipFile(file)
 }
 
 async function handleExportProjectFile() {
-  const zipFile = await props.project!.exportZipFile()
+  const zipFile = await props.project!.exportGbpFile()
   saveAs(zipFile, zipFile.name) // TODO: what if user cancelled download?
 }
 

--- a/spx-gui/src/models/common/gbp.ts
+++ b/spx-gui/src/models/common/gbp.ts
@@ -8,11 +8,11 @@ import { filename, stripExt } from '@/utils/path'
 import { File as LazyFile, type Files as LazyFiles } from './file'
 import type { Metadata } from '../project'
 
-export async function load(zipFile: File) {
+export async function load(gbpFile: File) {
   const metadata: Metadata = {
-    name: stripExt(zipFile.name)
+    name: stripExt(gbpFile.name)
   }
-  const jszip = await JSZip.loadAsync(zipFile)
+  const jszip = await JSZip.loadAsync(gbpFile)
   const files: LazyFiles = {}
   await Promise.all(
     Object.keys(jszip.files).map(async (path) => {

--- a/spx-gui/src/models/common/gbp.ts
+++ b/spx-gui/src/models/common/gbp.ts
@@ -1,6 +1,9 @@
 /**
- * @file Zip file related helper
- * @desc load-from & export-to zip file
+ * @file Gbp file related helper
+ * @desc load-from & export-to gbp file
+ * Gbp file is a zip file with a specific structure that contains
+ * metadata and files for a Go+ builder project.
+ * https://github.com/goplus/builder/issues/464
  */
 
 import JSZip from 'jszip'

--- a/spx-gui/src/models/common/zip.ts
+++ b/spx-gui/src/models/common/zip.ts
@@ -32,5 +32,5 @@ export async function save({ name }: Metadata, files: LazyFiles) {
     })
   )
   const blob = await zip.generateAsync({ type: 'blob' })
-  return new File([blob], (name || 'Untitled') + '.zip')
+  return new File([blob], (name || 'Untitled') + '.gbp')
 }

--- a/spx-gui/src/models/project.ts
+++ b/spx-gui/src/models/project.ts
@@ -15,7 +15,7 @@ import { Sprite } from './sprite'
 import { Sound } from './sound'
 import * as cloudHelper from './common/cloud'
 import * as localHelper from './common/local'
-import * as zipHelper from './common/zip'
+import * as gbpHelper from './common/gbp'
 import { assign } from './common'
 import { ensureValidSpriteName, ensureValidSoundName } from './common/asset'
 
@@ -201,9 +201,8 @@ export class Project extends Disposble {
     return [metadata, files]
   }
 
-  /** Load from a zip file */
-  async loadZipFile(zipFile: globalThis.File) {
-    const { metadata, files } = await zipHelper.load(zipFile)
+  async loadGbpFile(file: globalThis.File) {
+    const { metadata, files } = await gbpHelper.load(file)
     this.load(
       {
         // name is the only metadata we need when load from file
@@ -213,10 +212,9 @@ export class Project extends Disposble {
     )
   }
 
-  /** Export to a zip file */
   async exportGbpFile() {
     const [metadata, files] = this.export()
-    return await zipHelper.save(metadata, files)
+    return await gbpHelper.save(metadata, files)
   }
 
   // TODO: Some go+-builder-specific file format (instead of zip) support?

--- a/spx-gui/src/models/project.ts
+++ b/spx-gui/src/models/project.ts
@@ -214,7 +214,7 @@ export class Project extends Disposble {
   }
 
   /** Export to a zip file */
-  async exportZipFile() {
+  async exportGbpFile() {
     const [metadata, files] = this.export()
     return await zipHelper.save(metadata, files)
   }


### PR DESCRIPTION
https://github.com/goplus/builder/issues/464
