### PR TITLE
Exclude code when sprite added to asset-library

### DIFF
--- a/spx-gui/src/models/common/asset.ts
+++ b/spx-gui/src/models/common/asset.ts
@@ -19,7 +19,7 @@ export type AssetModel<T extends AssetType = AssetType> = T extends AssetType.So
       : never
 
 export async function sprite2Asset(sprite: Sprite): Promise<PartialAssetData> {
-  const fileCollection = await uploadFiles(sprite.export())
+  const fileCollection = await uploadFiles(sprite.export(false))
   return {
     displayName: sprite.name,
     assetType: AssetType.Sprite,

--- a/spx-gui/src/models/sprite.ts
+++ b/spx-gui/src/models/sprite.ts
@@ -245,7 +245,7 @@ export class Sprite extends Disposble {
     return sprites
   }
 
-  export(): Files {
+  export(includeCode = true): Files {
     const assetPath = getSpriteAssetPath(this.name)
     const costumeConfigs: RawCostumeConfig[] = []
     const files: Files = {}
@@ -265,7 +265,9 @@ export class Sprite extends Disposble {
       isDraggable: this.isDraggable,
       costumes: costumeConfigs
     }
-    files[this.codeFileName] = this.codeFile ?? fromText(this.codeFileName, '')
+    if (includeCode) {
+      files[this.codeFileName] = this.codeFile ?? fromText(this.codeFileName, '')
+    }
     files[`${assetPath}/${spriteConfigFileName}`] = fromConfig(spriteConfigFileName, config)
     return files
   }


### PR DESCRIPTION
Exclude code when sprite added to asset-library

* Code reuse is more complex than image / audio files
* Privacy leak may happen unintentionally

So we exclude code from asset-library by default. Code-reuse for sprites requires further design.
