### PR TITLE
Expand `SpriteBasicConfig` by default

### DIFF
--- a/spx-gui/src/components/editor/panels/sprite/SpritesPanel.vue
+++ b/spx-gui/src/components/editor/panels/sprite/SpritesPanel.vue
@@ -92,7 +92,7 @@ const emit = defineEmits<{
 
 const editorCtx = useEditorCtx()
 
-const footerExpanded = ref(false)
+const footerExpanded = ref(true)
 
 const sprites = computed(() => editorCtx.project.sprites)
 const summaryList = ref<InstanceType<typeof PanelSummaryList>>()


### PR DESCRIPTION
Expand `SpriteBasicConfig` by default to make it easy to find sprite "rename" button, close #537 