### PR TITLE
Add duplicate asset check when adding to library

### DIFF
--- a/spx-backend/cmd/spx-backend/get_assets_list.yap
+++ b/spx-backend/cmd/spx-backend/get_assets_list.yap
@@ -44,6 +44,10 @@ if assetTypeParam := ${assetType}; assetTypeParam != "" {
 	params.AssetType = &assetType
 }
 
+if filesHash := ${filesHash}; filesHash != "" {
+	params.FilesHash = &filesHash
+}
+
 if isPublicParam := ${isPublic}; isPublicParam != "" {
 	isPublicInt, err := strconv.Atoi(isPublicParam)
 	if err != nil {

--- a/spx-backend/cmd/spx-backend/gop_autogen.go
+++ b/spx-backend/cmd/spx-backend/gop_autogen.go
@@ -228,51 +228,58 @@ func (this *get_assets_list) Main(_gop_arg0 *yap.Context) {
 //line cmd/spx-backend/get_assets_list.yap:47:1
 	if
 //line cmd/spx-backend/get_assets_list.yap:47:1
-	isPublicParam := this.Gop_Env("isPublic"); isPublicParam != "" {
+	filesHash := this.Gop_Env("filesHash"); filesHash != "" {
 //line cmd/spx-backend/get_assets_list.yap:48:1
-		isPublicInt, err := strconv.Atoi(isPublicParam)
-//line cmd/spx-backend/get_assets_list.yap:49:1
-		if err != nil {
-//line cmd/spx-backend/get_assets_list.yap:50:1
-			replyWithCode(ctx, errorInvalidArgs)
+		params.FilesHash = &filesHash
+	}
 //line cmd/spx-backend/get_assets_list.yap:51:1
+	if
+//line cmd/spx-backend/get_assets_list.yap:51:1
+	isPublicParam := this.Gop_Env("isPublic"); isPublicParam != "" {
+//line cmd/spx-backend/get_assets_list.yap:52:1
+		isPublicInt, err := strconv.Atoi(isPublicParam)
+//line cmd/spx-backend/get_assets_list.yap:53:1
+		if err != nil {
+//line cmd/spx-backend/get_assets_list.yap:54:1
+			replyWithCode(ctx, errorInvalidArgs)
+//line cmd/spx-backend/get_assets_list.yap:55:1
 			return
 		}
-//line cmd/spx-backend/get_assets_list.yap:53:1
+//line cmd/spx-backend/get_assets_list.yap:57:1
 		isPublic := model.IsPublic(isPublicInt)
-//line cmd/spx-backend/get_assets_list.yap:54:1
+//line cmd/spx-backend/get_assets_list.yap:58:1
 		params.IsPublic = &isPublic
 	}
-//line cmd/spx-backend/get_assets_list.yap:57:1
+//line cmd/spx-backend/get_assets_list.yap:61:1
 	if
-//line cmd/spx-backend/get_assets_list.yap:57:1
+//line cmd/spx-backend/get_assets_list.yap:61:1
 	orderBy := this.Gop_Env("orderBy"); orderBy != "" {
-//line cmd/spx-backend/get_assets_list.yap:58:1
+//line cmd/spx-backend/get_assets_list.yap:62:1
 		params.OrderBy = controller.ListAssetsOrderBy(orderBy)
 	}
-//line cmd/spx-backend/get_assets_list.yap:61:1
-	params.Pagination.Index = ctx.ParamInt("pageIndex", firstPageIndex)
-//line cmd/spx-backend/get_assets_list.yap:62:1
-	params.Pagination.Size = ctx.ParamInt("pageSize", defaultPageSize)
-//line cmd/spx-backend/get_assets_list.yap:63:1
-	if
-//line cmd/spx-backend/get_assets_list.yap:63:1
-	ok, msg := params.Validate(); !ok {
-//line cmd/spx-backend/get_assets_list.yap:64:1
-		replyWithCodeMsg(ctx, errorInvalidArgs, msg)
 //line cmd/spx-backend/get_assets_list.yap:65:1
-		return
-	}
+	params.Pagination.Index = ctx.ParamInt("pageIndex", firstPageIndex)
+//line cmd/spx-backend/get_assets_list.yap:66:1
+	params.Pagination.Size = ctx.ParamInt("pageSize", defaultPageSize)
+//line cmd/spx-backend/get_assets_list.yap:67:1
+	if
+//line cmd/spx-backend/get_assets_list.yap:67:1
+	ok, msg := params.Validate(); !ok {
 //line cmd/spx-backend/get_assets_list.yap:68:1
-	assets, err := this.ctrl.ListAssets(ctx.Context(), params)
+		replyWithCodeMsg(ctx, errorInvalidArgs, msg)
 //line cmd/spx-backend/get_assets_list.yap:69:1
-	if err != nil {
-//line cmd/spx-backend/get_assets_list.yap:70:1
-		replyWithInnerError(ctx, err)
-//line cmd/spx-backend/get_assets_list.yap:71:1
 		return
 	}
+//line cmd/spx-backend/get_assets_list.yap:72:1
+	assets, err := this.ctrl.ListAssets(ctx.Context(), params)
 //line cmd/spx-backend/get_assets_list.yap:73:1
+	if err != nil {
+//line cmd/spx-backend/get_assets_list.yap:74:1
+		replyWithInnerError(ctx, err)
+//line cmd/spx-backend/get_assets_list.yap:75:1
+		return
+	}
+//line cmd/spx-backend/get_assets_list.yap:77:1
 	this.Json__1(assets)
 }
 func (this *get_assets_list) Classfname() string {

--- a/spx-backend/init.sql
+++ b/spx-backend/init.sql
@@ -14,6 +14,7 @@ CREATE TABLE `asset`  (
                           `category` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NULL DEFAULT NULL,
                           `asset_type` int NULL DEFAULT NULL,
                           `files` json NULL,
+                          `files_hash` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NULL DEFAULT NULL,
                           `preview` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NULL,
                           `click_count` int NULL DEFAULT 0,
                           `is_public` tinyint NULL DEFAULT NULL,

--- a/spx-backend/internal/controller/asset.go
+++ b/spx-backend/internal/controller/asset.go
@@ -58,6 +58,9 @@ type ListAssetsParams struct {
 	// AccessType is the access type filter, applied only if non-nil.
 	AssetType *model.AssetType
 
+	// FilesHash is the files hash filter, applied only if non-nil.
+	FilesHash *string
+
 	// IsPublic is the visibility filter, applied only if non-nil.
 	IsPublic *model.IsPublic
 
@@ -96,6 +99,9 @@ func (ctrl *Controller) ListAssets(ctx context.Context, params *ListAssetsParams
 	if params.AssetType != nil {
 		wheres = append(wheres, model.FilterCondition{Column: "asset_type", Operation: "=", Value: *params.AssetType})
 	}
+	if params.FilesHash != nil {
+		wheres = append(wheres, model.FilterCondition{Column: "files_hash", Operation: "=", Value: *params.FilesHash})
+	}
 	if params.IsPublic != nil {
 		wheres = append(wheres, model.FilterCondition{Column: "is_public", Operation: "=", Value: *params.IsPublic})
 	}
@@ -123,6 +129,7 @@ type AddAssetParams struct {
 	Category    string               `json:"category"`
 	AssetType   model.AssetType      `json:"assetType"`
 	Files       model.FileCollection `json:"files"`
+	FilesHash   string               `json:"filesHash"`
 	Preview     string               `json:"preview"`
 	IsPublic    model.IsPublic       `json:"isPublic"`
 }
@@ -144,6 +151,9 @@ func (p *AddAssetParams) Validate() (ok bool, msg string) {
 	case model.AssetTypeSprite, model.AssetTypeBackdrop, model.AssetTypeSound:
 	default:
 		return false, "invalid assetType"
+	}
+	if p.FilesHash == "" {
+		return false, "missing filesHash"
 	}
 	switch p.IsPublic {
 	case model.Personal, model.Public:
@@ -168,6 +178,7 @@ func (ctrl *Controller) AddAsset(ctx context.Context, params *AddAssetParams) (*
 		Category:    params.Category,
 		AssetType:   params.AssetType,
 		Files:       params.Files,
+		FilesHash:   params.FilesHash,
 		Preview:     params.Preview,
 		IsPublic:    params.IsPublic,
 	})
@@ -184,6 +195,7 @@ type UpdateAssetParams struct {
 	Category    string               `json:"category"`
 	AssetType   model.AssetType      `json:"assetType"`
 	Files       model.FileCollection `json:"files"`
+	FilesHash   string               `json:"filesHash"`
 	Preview     string               `json:"preview"`
 	IsPublic    model.IsPublic       `json:"isPublic"`
 }
@@ -202,6 +214,9 @@ func (p *UpdateAssetParams) Validate() (ok bool, msg string) {
 	case model.AssetTypeSprite, model.AssetTypeBackdrop, model.AssetTypeSound:
 	default:
 		return false, "invalid assetType"
+	}
+	if p.FilesHash == "" {
+		return false, "missing filesHash"
 	}
 	switch p.IsPublic {
 	case model.Personal, model.Public:
@@ -225,6 +240,7 @@ func (ctrl *Controller) UpdateAsset(ctx context.Context, id string, updates *Upd
 		Category:    updates.Category,
 		AssetType:   updates.AssetType,
 		Files:       updates.Files,
+		FilesHash:   updates.FilesHash,
 		Preview:     updates.Preview,
 		IsPublic:    updates.IsPublic,
 	})

--- a/spx-backend/internal/controller/asset_test.go
+++ b/spx-backend/internal/controller/asset_test.go
@@ -151,22 +151,24 @@ func TestControllerListAssets(t *testing.T) {
 		paramsOwner := "fake-name"
 		paramsCategory := "fake-category"
 		paramsAssetType := model.AssetTypeSprite
+		paramsFilesHash := "fake-files-hash"
 		paramsIsPublic := model.Personal
 		params := &ListAssetsParams{
 			Keyword:    "fake",
 			Owner:      &paramsOwner,
 			Category:   &paramsCategory,
 			AssetType:  &paramsAssetType,
+			FilesHash:  &paramsFilesHash,
 			IsPublic:   &paramsIsPublic,
 			OrderBy:    DefaultOrder,
 			Pagination: model.Pagination{Index: 1, Size: 10},
 		}
-		mock.ExpectQuery(`SELECT COUNT\(\*\) FROM asset WHERE display_name LIKE \? AND owner = \? AND category = \? AND asset_type = \? AND is_public = \? AND status != \?`).
-			WithArgs("%"+params.Keyword+"%", params.Owner, params.Category, model.AssetTypeSprite, model.Personal, model.StatusDeleted).
+		mock.ExpectQuery(`SELECT COUNT\(\*\) FROM asset WHERE display_name LIKE \? AND owner = \? AND category = \? AND asset_type = \? AND files_hash = \? AND is_public = \? AND status != \?`).
+			WithArgs("%"+params.Keyword+"%", params.Owner, params.Category, model.AssetTypeSprite, params.FilesHash, model.Personal, model.StatusDeleted).
 			WillReturnRows(mock.NewRows([]string{"COUNT(1)"}).
 				AddRow(1))
-		mock.ExpectQuery(`SELECT \* FROM asset WHERE display_name LIKE \? AND owner = \? AND category = \? AND asset_type = \? AND is_public = \? AND status != \? ORDER BY id ASC LIMIT \?, \? `).
-			WithArgs("%"+params.Keyword+"%", params.Owner, params.Category, model.AssetTypeSprite, model.Personal, model.StatusDeleted, 0, 10).
+		mock.ExpectQuery(`SELECT \* FROM asset WHERE display_name LIKE \? AND owner = \? AND category = \? AND asset_type = \? AND files_hash = \? AND is_public = \? AND status != \? ORDER BY id ASC LIMIT \?, \? `).
+			WithArgs("%"+params.Keyword+"%", params.Owner, params.Category, model.AssetTypeSprite, params.FilesHash, model.Personal, model.StatusDeleted, 0, 10).
 			WillReturnRows(mock.NewRows([]string{"id", "display_name", "owner"}).
 				AddRow(1, "fake-asset", "fake-name"))
 		assets, err := ctrl.ListAssets(ctx, params)
@@ -184,22 +186,24 @@ func TestControllerListAssets(t *testing.T) {
 		paramsOwner := "fake-name"
 		paramsCategory := "fake-category"
 		paramsAssetType := model.AssetTypeSprite
+		paramsFilesHash := "fake-files-hash"
 		paramsIsPublic := model.Personal
 		params := &ListAssetsParams{
 			Keyword:    "fake",
 			Owner:      &paramsOwner,
 			Category:   &paramsCategory,
 			AssetType:  &paramsAssetType,
+			FilesHash:  &paramsFilesHash,
 			IsPublic:   &paramsIsPublic,
 			OrderBy:    TimeDesc,
 			Pagination: model.Pagination{Index: 1, Size: 10},
 		}
-		mock.ExpectQuery(`SELECT COUNT\(\*\) FROM asset WHERE display_name LIKE \? AND owner = \? AND category = \? AND asset_type = \? AND is_public = \? AND status != \?`).
-			WithArgs("%"+params.Keyword+"%", params.Owner, params.Category, model.AssetTypeSprite, model.Public, model.StatusDeleted).
+		mock.ExpectQuery(`SELECT COUNT\(\*\) FROM asset WHERE display_name LIKE \? AND owner = \? AND category = \? AND asset_type = \? AND files_hash = \? AND is_public = \? AND status != \?`).
+			WithArgs("%"+params.Keyword+"%", params.Owner, params.Category, model.AssetTypeSprite, params.FilesHash, model.Public, model.StatusDeleted).
 			WillReturnRows(mock.NewRows([]string{"COUNT(1)"}).
 				AddRow(1))
-		mock.ExpectQuery(`SELECT \* FROM asset WHERE display_name LIKE \? AND owner = \? AND category = \? AND asset_type = \? AND is_public = \? AND status != \? ORDER BY c_time DESC LIMIT \?, \? `).
-			WithArgs("%"+params.Keyword+"%", params.Owner, params.Category, model.AssetTypeSprite, model.Public, model.StatusDeleted, 0, 10).
+		mock.ExpectQuery(`SELECT \* FROM asset WHERE display_name LIKE \? AND owner = \? AND category = \? AND asset_type = \? AND files_hash = \? AND is_public = \? AND status != \? ORDER BY c_time DESC LIMIT \?, \? `).
+			WithArgs("%"+params.Keyword+"%", params.Owner, params.Category, model.AssetTypeSprite, params.FilesHash, model.Public, model.StatusDeleted, 0, 10).
 			WillReturnRows(mock.NewRows([]string{"id", "display_name", "owner"}).
 				AddRow(1, "fake-asset", "fake-name"))
 		assets, err := ctrl.ListAssets(ctx, params)
@@ -216,21 +220,23 @@ func TestControllerListAssets(t *testing.T) {
 		ctx := newContextWithTestUser(context.Background())
 		paramsCategory := "fake-category"
 		paramsAssetType := model.AssetTypeSprite
+		paramsFilesHash := "fake-files-hash"
 		paramsIsPublic := model.Personal
 		params := &ListAssetsParams{
 			Keyword:    "fake",
 			Category:   &paramsCategory,
 			AssetType:  &paramsAssetType,
+			FilesHash:  &paramsFilesHash,
 			IsPublic:   &paramsIsPublic,
 			OrderBy:    ClickCountDesc,
 			Pagination: model.Pagination{Index: 1, Size: 10},
 		}
-		mock.ExpectQuery(`SELECT COUNT\(\*\) FROM asset WHERE display_name LIKE \? AND category = \? AND asset_type = \? AND is_public = \? AND status != \?`).
-			WithArgs("%"+params.Keyword+"%", params.Category, model.AssetTypeSprite, model.Public, model.StatusDeleted).
+		mock.ExpectQuery(`SELECT COUNT\(\*\) FROM asset WHERE display_name LIKE \? AND category = \? AND asset_type = \? AND files_hash = \? AND is_public = \? AND status != \?`).
+			WithArgs("%"+params.Keyword+"%", params.Category, model.AssetTypeSprite, params.FilesHash, model.Public, model.StatusDeleted).
 			WillReturnRows(mock.NewRows([]string{"COUNT(1)"}).
 				AddRow(1))
-		mock.ExpectQuery(`SELECT \* FROM asset WHERE display_name LIKE \? AND category = \? AND asset_type = \? AND is_public = \? AND status != \? ORDER BY click_count DESC LIMIT \?, \? `).
-			WithArgs("%"+params.Keyword+"%", params.Category, model.AssetTypeSprite, model.Public, model.StatusDeleted, 0, 10).
+		mock.ExpectQuery(`SELECT \* FROM asset WHERE display_name LIKE \? AND category = \? AND asset_type = \? AND files_hash = \? AND is_public = \? AND status != \? ORDER BY click_count DESC LIMIT \?, \? `).
+			WithArgs("%"+params.Keyword+"%", params.Category, model.AssetTypeSprite, params.FilesHash, model.Public, model.StatusDeleted, 0, 10).
 			WillReturnRows(mock.NewRows([]string{"id", "display_name", "owner"}).
 				AddRow(1, "fake-asset", "fake-name"))
 		assets, err := ctrl.ListAssets(ctx, params)
@@ -248,22 +254,24 @@ func TestControllerListAssets(t *testing.T) {
 		paramsOwner := "another-fake-name"
 		paramsCategory := "fake-category"
 		paramsAssetType := model.AssetTypeSprite
+		paramsFilesHash := "fake-files-hash"
 		paramsIsPublic := model.Personal
 		params := &ListAssetsParams{
 			Keyword:    "fake",
 			Owner:      &paramsOwner,
 			Category:   &paramsCategory,
 			AssetType:  &paramsAssetType,
+			FilesHash:  &paramsFilesHash,
 			IsPublic:   &paramsIsPublic,
 			OrderBy:    DefaultOrder,
 			Pagination: model.Pagination{Index: 1, Size: 10},
 		}
-		mock.ExpectQuery(`SELECT COUNT\(\*\) FROM asset WHERE display_name LIKE \? AND owner = \? AND category = \? AND asset_type = \? AND is_public = \? AND status != \?`).
-			WithArgs("%"+params.Keyword+"%", params.Owner, params.Category, model.AssetTypeSprite, model.Public, model.StatusDeleted).
+		mock.ExpectQuery(`SELECT COUNT\(\*\) FROM asset WHERE display_name LIKE \? AND owner = \? AND category = \? AND asset_type = \? AND files_hash = \? AND is_public = \? AND status != \?`).
+			WithArgs("%"+params.Keyword+"%", params.Owner, params.Category, model.AssetTypeSprite, params.FilesHash, model.Public, model.StatusDeleted).
 			WillReturnRows(mock.NewRows([]string{"COUNT(1)"}).
 				AddRow(1))
-		mock.ExpectQuery(`SELECT \* FROM asset WHERE display_name LIKE \? AND owner = \? AND category = \? AND asset_type = \? AND is_public = \? AND status != \? ORDER BY id ASC LIMIT \?, \? `).
-			WithArgs("%"+params.Keyword+"%", params.Owner, params.Category, model.AssetTypeSprite, model.Public, model.StatusDeleted, 0, 10).
+		mock.ExpectQuery(`SELECT \* FROM asset WHERE display_name LIKE \? AND owner = \? AND category = \? AND asset_type = \? AND files_hash = \? AND is_public = \? AND status != \? ORDER BY id ASC LIMIT \?, \? `).
+			WithArgs("%"+params.Keyword+"%", params.Owner, params.Category, model.AssetTypeSprite, params.FilesHash, model.Public, model.StatusDeleted, 0, 10).
 			WillReturnRows(mock.NewRows([]string{"id", "display_name", "owner"}).
 				AddRow(1, "fake-asset", "another-fake-name"))
 		assets, err := ctrl.ListAssets(ctx, params)
@@ -282,12 +290,14 @@ func TestControllerListAssets(t *testing.T) {
 		paramsOwner := "fake-name"
 		paramsCategory := "fake-category"
 		paramsAssetType := model.AssetTypeSprite
+		paramsFilesHash := "fake-files-hash"
 		paramsIsPublic := model.Personal
 		params := &ListAssetsParams{
 			Keyword:    "fake",
 			Owner:      &paramsOwner,
 			Category:   &paramsCategory,
 			AssetType:  &paramsAssetType,
+			FilesHash:  &paramsFilesHash,
 			IsPublic:   &paramsIsPublic,
 			OrderBy:    DefaultOrder,
 			Pagination: model.Pagination{Index: 1, Size: 10},
@@ -306,6 +316,7 @@ func TestAddAssetParamsValidate(t *testing.T) {
 			Category:    "fake-category",
 			AssetType:   model.AssetTypeSprite,
 			Files:       model.FileCollection{},
+			FilesHash:   "fake-files-hash",
 			Preview:     "fake-preview",
 			IsPublic:    model.Personal,
 		}
@@ -321,6 +332,7 @@ func TestAddAssetParamsValidate(t *testing.T) {
 			Category:    "fake-category",
 			AssetType:   model.AssetTypeSprite,
 			Files:       model.FileCollection{},
+			FilesHash:   "fake-files-hash",
 			Preview:     "fake-preview",
 			IsPublic:    model.Personal,
 		}
@@ -336,6 +348,7 @@ func TestAddAssetParamsValidate(t *testing.T) {
 			Category:    "fake-category",
 			AssetType:   model.AssetTypeSprite,
 			Files:       model.FileCollection{},
+			FilesHash:   "fake-files-hash",
 			Preview:     "fake-preview",
 			IsPublic:    model.Personal,
 		}
@@ -351,6 +364,7 @@ func TestAddAssetParamsValidate(t *testing.T) {
 			Category:    "fake-category",
 			AssetType:   model.AssetTypeSprite,
 			Files:       model.FileCollection{},
+			FilesHash:   "fake-files-hash",
 			Preview:     "fake-preview",
 			IsPublic:    model.Personal,
 		}
@@ -366,6 +380,7 @@ func TestAddAssetParamsValidate(t *testing.T) {
 			Category:    "",
 			AssetType:   model.AssetTypeSprite,
 			Files:       model.FileCollection{},
+			FilesHash:   "fake-files-hash",
 			Preview:     "fake-preview",
 			IsPublic:    model.Personal,
 		}
@@ -381,12 +396,29 @@ func TestAddAssetParamsValidate(t *testing.T) {
 			Category:    "fake-category",
 			AssetType:   -1,
 			Files:       model.FileCollection{},
+			FilesHash:   "fake-files-hash",
 			Preview:     "fake-preview",
 			IsPublic:    model.Personal,
 		}
 		ok, msg := params.Validate()
 		assert.False(t, ok)
 		assert.Equal(t, "invalid assetType", msg)
+	})
+
+	t.Run("EmptyFilesHash", func(t *testing.T) {
+		params := &AddAssetParams{
+			DisplayName: "fake-display-name",
+			Owner:       "fake-owner",
+			Category:    "fake-category",
+			AssetType:   model.AssetTypeSprite,
+			Files:       model.FileCollection{},
+			FilesHash:   "",
+			Preview:     "fake-preview",
+			IsPublic:    model.Personal,
+		}
+		ok, msg := params.Validate()
+		assert.False(t, ok)
+		assert.Equal(t, "missing filesHash", msg)
 	})
 
 	t.Run("InvalidIsPublic", func(t *testing.T) {
@@ -396,6 +428,7 @@ func TestAddAssetParamsValidate(t *testing.T) {
 			Category:    "fake-category",
 			AssetType:   model.AssetTypeSprite,
 			Files:       model.FileCollection{},
+			FilesHash:   "fake-files-hash",
 			Preview:     "fake-preview",
 			IsPublic:    -1,
 		}
@@ -417,10 +450,11 @@ func TestControllerAddAsset(t *testing.T) {
 			Category:    "fake-category",
 			AssetType:   model.AssetTypeSprite,
 			Files:       model.FileCollection{},
+			FilesHash:   "fake-files-hash",
 			Preview:     "fake-preview",
 			IsPublic:    model.Personal,
 		}
-		mock.ExpectExec(`INSERT INTO asset \(c_time, u_time, display_name, owner, category, asset_type, files, preview, click_count, is_public, status\) VALUES \(\?,\?,\?,\?,\?,\?,\?,\?,\?,\?,\?\)`).
+		mock.ExpectExec(`INSERT INTO asset \(c_time, u_time, display_name, owner, category, asset_type, files, files_hash, preview, click_count, is_public, status\) VALUES \(\?,\?,\?,\?,\?,\?,\?,\?,\?,\?,\?,\?\)`).
 			WillReturnResult(sqlmock.NewResult(1, 1))
 		mock.ExpectQuery(`SELECT \* FROM asset WHERE id = \? AND status != \? ORDER BY id ASC LIMIT 1`).
 			WillReturnRows(mock.NewRows([]string{"id", "display_name", "owner"}).
@@ -442,6 +476,7 @@ func TestControllerAddAsset(t *testing.T) {
 			Category:    "fake-category",
 			AssetType:   model.AssetTypeSprite,
 			Files:       model.FileCollection{},
+			FilesHash:   "fake-files-hash",
 			Preview:     "fake-preview",
 			IsPublic:    model.Personal,
 		}
@@ -461,6 +496,7 @@ func TestControllerAddAsset(t *testing.T) {
 			Category:    "fake-category",
 			AssetType:   model.AssetTypeSprite,
 			Files:       model.FileCollection{},
+			FilesHash:   "fake-files-hash",
 			Preview:     "fake-preview",
 			IsPublic:    model.Personal,
 		}
@@ -481,6 +517,7 @@ func TestControllerAddAsset(t *testing.T) {
 			Category:    "fake-category",
 			AssetType:   model.AssetTypeSprite,
 			Files:       model.FileCollection{},
+			FilesHash:   "fake-files-hash",
 			Preview:     "fake-preview",
 			IsPublic:    model.Personal,
 		}
@@ -497,6 +534,7 @@ func TestUpdateAssetParamsValidate(t *testing.T) {
 			Category:    "fake-category",
 			AssetType:   model.AssetTypeSprite,
 			Files:       model.FileCollection{},
+			FilesHash:   "fake-files-hash",
 			Preview:     "fake-preview",
 			IsPublic:    model.Personal,
 		}
@@ -511,6 +549,7 @@ func TestUpdateAssetParamsValidate(t *testing.T) {
 			Category:    "fake-category",
 			AssetType:   model.AssetTypeSprite,
 			Files:       model.FileCollection{},
+			FilesHash:   "fake-files-hash",
 			Preview:     "fake-preview",
 			IsPublic:    model.Personal,
 		}
@@ -525,6 +564,7 @@ func TestUpdateAssetParamsValidate(t *testing.T) {
 			Category:    "fake-category",
 			AssetType:   model.AssetTypeSprite,
 			Files:       model.FileCollection{},
+			FilesHash:   "fake-files-hash",
 			Preview:     "fake-preview",
 			IsPublic:    model.Personal,
 		}
@@ -539,6 +579,7 @@ func TestUpdateAssetParamsValidate(t *testing.T) {
 			Category:    "",
 			AssetType:   model.AssetTypeSprite,
 			Files:       model.FileCollection{},
+			FilesHash:   "fake-files-hash",
 			Preview:     "fake-preview",
 			IsPublic:    model.Personal,
 		}
@@ -553,6 +594,7 @@ func TestUpdateAssetParamsValidate(t *testing.T) {
 			Category:    "fake-category",
 			AssetType:   -1,
 			Files:       model.FileCollection{},
+			FilesHash:   "fake-files-hash",
 			Preview:     "fake-preview",
 			IsPublic:    model.Personal,
 		}
@@ -561,12 +603,28 @@ func TestUpdateAssetParamsValidate(t *testing.T) {
 		assert.Equal(t, "invalid assetType", msg)
 	})
 
+	t.Run("EmptyFilesHash", func(t *testing.T) {
+		params := &UpdateAssetParams{
+			DisplayName: "fake-asset",
+			Category:    "fake-category",
+			AssetType:   model.AssetTypeSprite,
+			Files:       model.FileCollection{},
+			FilesHash:   "",
+			Preview:     "fake-preview",
+			IsPublic:    model.Personal,
+		}
+		ok, msg := params.Validate()
+		assert.False(t, ok)
+		assert.Equal(t, "missing filesHash", msg)
+	})
+
 	t.Run("InvalidIsPublic", func(t *testing.T) {
 		params := &UpdateAssetParams{
 			DisplayName: "fake-asset",
 			Category:    "fake-category",
 			AssetType:   model.AssetTypeSprite,
 			Files:       model.FileCollection{},
+			FilesHash:   "fake-files-hash",
 			Preview:     "fake-preview",
 			IsPublic:    -1,
 		}
@@ -587,17 +645,18 @@ func TestControllerUpdateAsset(t *testing.T) {
 			Category:    "fake-category",
 			AssetType:   model.AssetTypeSprite,
 			Files:       model.FileCollection{},
+			FilesHash:   "fake-files-hash",
 			Preview:     "fake-preview",
 			IsPublic:    model.Personal,
 		}
 		mock.ExpectQuery(`SELECT \* FROM asset WHERE id = \? AND status != \? ORDER BY id ASC LIMIT 1`).
-			WillReturnRows(mock.NewRows([]string{"id", "display_name", "owner", "files", "is_public"}).
-				AddRow(1, "fake-asset", "fake-name", []byte("{}"), model.Personal))
-		mock.ExpectExec(`UPDATE asset SET u_time = \?, display_name = \?, category = \?, asset_type = \?, files = \?, preview = \?, is_public = \? WHERE id = \?`).
+			WillReturnRows(mock.NewRows([]string{"id", "display_name", "owner", "files", "files_hash", "is_public"}).
+				AddRow(1, "fake-asset", "fake-name", []byte("{}"), "fake-files-hash", model.Personal))
+		mock.ExpectExec(`UPDATE asset SET u_time = \?, display_name = \?, category = \?, asset_type = \?, files = \?, files_hash = \?, preview = \?, is_public = \? WHERE id = \?`).
 			WillReturnResult(sqlmock.NewResult(1, 1))
 		mock.ExpectQuery(`SELECT \* FROM asset WHERE id = \? AND status != \? ORDER BY id ASC LIMIT 1`).
-			WillReturnRows(mock.NewRows([]string{"id", "display_name", "owner", "files", "is_public"}).
-				AddRow(1, "fake-asset", "fake-name", []byte("{}"), model.Public))
+			WillReturnRows(mock.NewRows([]string{"id", "display_name", "owner", "files", "files_hash", "is_public"}).
+				AddRow(1, "fake-asset", "fake-name", []byte("{}"), "fake-files-hash", model.Public))
 		asset, err := ctrl.UpdateAsset(ctx, "1", params)
 		require.NoError(t, err)
 		require.NotNil(t, asset)
@@ -615,12 +674,13 @@ func TestControllerUpdateAsset(t *testing.T) {
 			Category:    "fake-category",
 			AssetType:   model.AssetTypeSprite,
 			Files:       model.FileCollection{},
+			FilesHash:   "fake-files-hash",
 			Preview:     "fake-preview",
 			IsPublic:    model.Personal,
 		}
 		mock.ExpectQuery(`SELECT \* FROM asset WHERE id = \? AND status != \? ORDER BY id ASC LIMIT 1`).
-			WillReturnRows(mock.NewRows([]string{"id", "display_name", "owner", "files", "is_public"}).
-				AddRow(1, "fake-asset", "fake-name", []byte("{}"), model.Personal))
+			WillReturnRows(mock.NewRows([]string{"id", "display_name", "owner", "files", "files_hash", "is_public"}).
+				AddRow(1, "fake-asset", "fake-name", []byte("{}"), "fake-files-hash", model.Personal))
 		_, err = ctrl.UpdateAsset(ctx, "1", params)
 		require.Error(t, err)
 		assert.ErrorIs(t, err, ErrUnauthorized)
@@ -636,12 +696,13 @@ func TestControllerUpdateAsset(t *testing.T) {
 			Category:    "fake-category",
 			AssetType:   model.AssetTypeSprite,
 			Files:       model.FileCollection{},
+			FilesHash:   "fake-files-hash",
 			Preview:     "fake-preview",
 			IsPublic:    model.Personal,
 		}
 		mock.ExpectQuery(`SELECT \* FROM asset WHERE id = \? AND status != \? ORDER BY id ASC LIMIT 1`).
-			WillReturnRows(mock.NewRows([]string{"id", "display_name", "owner", "files", "is_public"}).
-				AddRow(1, "fake-asset", "another-fake-name", []byte("{}"), model.Personal))
+			WillReturnRows(mock.NewRows([]string{"id", "display_name", "owner", "files", "files_hash", "is_public"}).
+				AddRow(1, "fake-asset", "another-fake-name", []byte("{}"), "fake-files-hash", model.Personal))
 		_, err = ctrl.UpdateAsset(ctx, "1", params)
 		require.Error(t, err)
 		assert.ErrorIs(t, err, ErrForbidden)
@@ -657,6 +718,7 @@ func TestControllerUpdateAsset(t *testing.T) {
 			Category:    "fake-category",
 			AssetType:   model.AssetTypeSprite,
 			Files:       model.FileCollection{},
+			FilesHash:   "fake-files-hash",
 			Preview:     "fake-preview",
 			IsPublic:    model.Personal,
 		}
@@ -677,13 +739,14 @@ func TestControllerUpdateAsset(t *testing.T) {
 			Category:    "fake-category",
 			AssetType:   model.AssetTypeSprite,
 			Files:       model.FileCollection{},
+			FilesHash:   "fake-files-hash",
 			Preview:     "fake-preview",
 			IsPublic:    model.Personal,
 		}
 		mock.ExpectQuery(`SELECT \* FROM asset WHERE id = \? AND status != \? ORDER BY id ASC LIMIT 1`).
-			WillReturnRows(mock.NewRows([]string{"id", "display_name", "owner", "files", "is_public"}).
-				AddRow(1, "fake-asset", "fake-name", []byte("{}"), model.Personal))
-		mock.ExpectExec(`UPDATE asset SET u_time = \?, display_name = \?, category = \?, asset_type = \?, files = \?, preview = \?, is_public = \? WHERE id = \?`).
+			WillReturnRows(mock.NewRows([]string{"id", "display_name", "owner", "files", "files_hash", "is_public"}).
+				AddRow(1, "fake-asset", "fake-name", []byte("{}"), "fake-files-hash", model.Personal))
+		mock.ExpectExec(`UPDATE asset SET u_time = \?, display_name = \?, category = \?, asset_type = \?, files = \?, files_hash = \?, preview = \?, is_public = \? WHERE id = \?`).
 			WillReturnError(sql.ErrConnDone)
 		_, err = ctrl.UpdateAsset(ctx, "1", params)
 		require.Error(t, err)
@@ -698,8 +761,8 @@ func TestControllerIncreaseAssetClickCount(t *testing.T) {
 
 		ctx := newContextWithTestUser(context.Background())
 		mock.ExpectQuery(`SELECT \* FROM asset WHERE id = \? AND status != \? ORDER BY id ASC LIMIT 1`).
-			WillReturnRows(mock.NewRows([]string{"id", "display_name", "owner", "files", "is_public"}).
-				AddRow(1, "fake-asset", "fake-name", []byte("{}"), model.Personal))
+			WillReturnRows(mock.NewRows([]string{"id", "display_name", "owner", "files", "files_hash", "is_public"}).
+				AddRow(1, "fake-asset", "fake-name", []byte("{}"), "fake-files-hash", model.Personal))
 		mock.ExpectExec(`UPDATE asset SET u_time = \?, click_count = click_count \+ 1 WHERE id = \?`).
 			WillReturnResult(sqlmock.NewResult(1, 1))
 		err = ctrl.IncreaseAssetClickCount(ctx, "1")
@@ -712,8 +775,8 @@ func TestControllerIncreaseAssetClickCount(t *testing.T) {
 
 		ctx := context.Background()
 		mock.ExpectQuery(`SELECT \* FROM asset WHERE id = \? AND status != \? ORDER BY id ASC LIMIT 1`).
-			WillReturnRows(mock.NewRows([]string{"id", "display_name", "owner", "files", "is_public"}).
-				AddRow(1, "fake-asset", "fake-name", []byte("{}"), model.Personal))
+			WillReturnRows(mock.NewRows([]string{"id", "display_name", "owner", "files", "files_hash", "is_public"}).
+				AddRow(1, "fake-asset", "fake-name", []byte("{}"), "fake-files-hash", model.Personal))
 		err = ctrl.IncreaseAssetClickCount(ctx, "1")
 		require.Error(t, err)
 		assert.ErrorIs(t, err, ErrUnauthorized)
@@ -725,8 +788,8 @@ func TestControllerIncreaseAssetClickCount(t *testing.T) {
 
 		ctx := newContextWithTestUser(context.Background())
 		mock.ExpectQuery(`SELECT \* FROM asset WHERE id = \? AND status != \? ORDER BY id ASC LIMIT 1`).
-			WillReturnRows(mock.NewRows([]string{"id", "display_name", "owner", "files", "is_public"}).
-				AddRow(1, "fake-asset", "another-fake-name", []byte("{}"), model.Personal))
+			WillReturnRows(mock.NewRows([]string{"id", "display_name", "owner", "files", "files_hash", "is_public"}).
+				AddRow(1, "fake-asset", "another-fake-name", []byte("{}"), "fake-files-hash", model.Personal))
 		err = ctrl.IncreaseAssetClickCount(ctx, "1")
 		require.Error(t, err)
 		assert.ErrorIs(t, err, ErrForbidden)
@@ -750,8 +813,8 @@ func TestControllerIncreaseAssetClickCount(t *testing.T) {
 
 		ctx := newContextWithTestUser(context.Background())
 		mock.ExpectQuery(`SELECT \* FROM asset WHERE id = \? AND status != \? ORDER BY id ASC LIMIT 1`).
-			WillReturnRows(mock.NewRows([]string{"id", "display_name", "owner", "files", "is_public"}).
-				AddRow(1, "fake-asset", "fake-name", []byte("{}"), model.Personal))
+			WillReturnRows(mock.NewRows([]string{"id", "display_name", "owner", "files", "files_hash", "is_public"}).
+				AddRow(1, "fake-asset", "fake-name", []byte("{}"), "fake-files-hash", model.Personal))
 		mock.ExpectExec(`UPDATE asset SET u_time = \?, click_count = click_count \+ 1 WHERE id = \?`).
 			WillReturnError(sql.ErrConnDone)
 		err = ctrl.IncreaseAssetClickCount(ctx, "1")
@@ -767,8 +830,8 @@ func TestControllerDeleteAsset(t *testing.T) {
 
 		ctx := newContextWithTestUser(context.Background())
 		mock.ExpectQuery(`SELECT \* FROM asset WHERE id = \? AND status != \? ORDER BY id ASC LIMIT 1`).
-			WillReturnRows(mock.NewRows([]string{"id", "display_name", "owner", "files", "is_public"}).
-				AddRow(1, "fake-asset", "fake-name", []byte("{}"), model.Personal))
+			WillReturnRows(mock.NewRows([]string{"id", "display_name", "owner", "files", "files_hash", "is_public"}).
+				AddRow(1, "fake-asset", "fake-name", []byte("{}"), "fake-files-hash", model.Personal))
 		mock.ExpectExec(`UPDATE asset SET u_time = \?, status = \? WHERE id = \?`).
 			WillReturnResult(sqlmock.NewResult(1, 1))
 		err = ctrl.DeleteAsset(ctx, "1")
@@ -781,8 +844,8 @@ func TestControllerDeleteAsset(t *testing.T) {
 
 		ctx := context.Background()
 		mock.ExpectQuery(`SELECT \* FROM asset WHERE id = \? AND status != \? ORDER BY id ASC LIMIT 1`).
-			WillReturnRows(mock.NewRows([]string{"id", "display_name", "owner", "files", "is_public"}).
-				AddRow(1, "fake-asset", "fake-name", []byte("{}"), model.Personal))
+			WillReturnRows(mock.NewRows([]string{"id", "display_name", "owner", "files", "files_hash", "is_public"}).
+				AddRow(1, "fake-asset", "fake-name", []byte("{}"), "fake-files-hash", model.Personal))
 		err = ctrl.DeleteAsset(ctx, "1")
 		require.Error(t, err)
 		assert.ErrorIs(t, err, ErrUnauthorized)
@@ -794,8 +857,8 @@ func TestControllerDeleteAsset(t *testing.T) {
 
 		ctx := newContextWithTestUser(context.Background())
 		mock.ExpectQuery(`SELECT \* FROM asset WHERE id = \? AND status != \? ORDER BY id ASC LIMIT 1`).
-			WillReturnRows(mock.NewRows([]string{"id", "display_name", "owner", "files", "is_public"}).
-				AddRow(1, "fake-asset", "another-fake-name", []byte("{}"), model.Personal))
+			WillReturnRows(mock.NewRows([]string{"id", "display_name", "owner", "files", "files_hash", "is_public"}).
+				AddRow(1, "fake-asset", "another-fake-name", []byte("{}"), "fake-files-hash", model.Personal))
 		err = ctrl.DeleteAsset(ctx, "1")
 		require.Error(t, err)
 		assert.ErrorIs(t, err, ErrForbidden)
@@ -819,8 +882,8 @@ func TestControllerDeleteAsset(t *testing.T) {
 
 		ctx := newContextWithTestUser(context.Background())
 		mock.ExpectQuery(`SELECT \* FROM asset WHERE id = \? AND status != \? ORDER BY id ASC LIMIT 1`).
-			WillReturnRows(mock.NewRows([]string{"id", "display_name", "owner", "files", "is_public"}).
-				AddRow(1, "fake-asset", "fake-name", []byte("{}"), model.Personal))
+			WillReturnRows(mock.NewRows([]string{"id", "display_name", "owner", "files", "files_hash", "is_public"}).
+				AddRow(1, "fake-asset", "fake-name", []byte("{}"), "fake-files-hash", model.Personal))
 		mock.ExpectExec(`UPDATE asset SET u_time = \?, status = \? WHERE id = \?`).
 			WillReturnError(sql.ErrConnDone)
 		err = ctrl.DeleteAsset(ctx, "1")

--- a/spx-backend/internal/model/asset.go
+++ b/spx-backend/internal/model/asset.go
@@ -36,6 +36,9 @@ type Asset struct {
 	// Files contains the asset's files.
 	Files FileCollection `db:"files" json:"files"`
 
+	// FilesHash is the hash of the asset's files.
+	FilesHash string `db:"files_hash" json:"filesHash"`
+
 	// Preview is the URL for the asset preview, e.g., a gif for a sprite.
 	Preview string `db:"preview" json:"preview"`
 
@@ -77,8 +80,8 @@ func AddAsset(ctx context.Context, db *sql.DB, a *Asset) (*Asset, error) {
 	logger := log.GetReqLogger(ctx)
 
 	now := time.Now().UTC()
-	query := fmt.Sprintf("INSERT INTO %s (c_time, u_time, display_name, owner, category, asset_type, files, preview, click_count, is_public, status) VALUES (?,?,?,?,?,?,?,?,?,?,?)", TableAsset)
-	result, err := db.ExecContext(ctx, query, now, now, a.DisplayName, a.Owner, a.Category, a.AssetType, a.Files, a.Preview, a.ClickCount, a.IsPublic, StatusNormal)
+	query := fmt.Sprintf("INSERT INTO %s (c_time, u_time, display_name, owner, category, asset_type, files, files_hash, preview, click_count, is_public, status) VALUES (?,?,?,?,?,?,?,?,?,?,?,?)", TableAsset)
+	result, err := db.ExecContext(ctx, query, now, now, a.DisplayName, a.Owner, a.Category, a.AssetType, a.Files, a.FilesHash, a.Preview, a.ClickCount, a.IsPublic, StatusNormal)
 	if err != nil {
 		logger.Printf("db.ExecContext failed: %v", err)
 		return nil, err
@@ -96,8 +99,8 @@ func AddAsset(ctx context.Context, db *sql.DB, a *Asset) (*Asset, error) {
 func UpdateAssetByID(ctx context.Context, db *sql.DB, id string, a *Asset) (*Asset, error) {
 	logger := log.GetReqLogger(ctx)
 
-	query := fmt.Sprintf("UPDATE %s SET u_time = ?, display_name = ?, category = ?, asset_type = ?, files = ?, preview = ?, is_public = ? WHERE id = ?", TableAsset)
-	result, err := db.ExecContext(ctx, query, time.Now().UTC(), a.DisplayName, a.Category, a.AssetType, a.Files, a.Preview, a.IsPublic, id)
+	query := fmt.Sprintf("UPDATE %s SET u_time = ?, display_name = ?, category = ?, asset_type = ?, files = ?, files_hash = ?, preview = ?, is_public = ? WHERE id = ?", TableAsset)
+	result, err := db.ExecContext(ctx, query, time.Now().UTC(), a.DisplayName, a.Category, a.AssetType, a.Files, a.FilesHash, a.Preview, a.IsPublic, id)
 	if err != nil {
 		logger.Printf("db.ExecContext failed: %v", err)
 		return nil, err

--- a/spx-backend/internal/model/asset_test.go
+++ b/spx-backend/internal/model/asset_test.go
@@ -79,7 +79,7 @@ func TestAddAsset(t *testing.T) {
 		require.NoError(t, err)
 		defer db.Close()
 
-		mock.ExpectExec(`INSERT INTO asset \(c_time, u_time, display_name, owner, category, asset_type, files, preview, click_count, is_public, status\) VALUES \(\?,\?,\?,\?,\?,\?,\?,\?,\?,\?,\?\)`).
+		mock.ExpectExec(`INSERT INTO asset \(c_time, u_time, display_name, owner, category, asset_type, files, files_hash, preview, click_count, is_public, status\) VALUES \(\?,\?,\?,\?,\?,\?,\?,\?,\?,\?,\?,\?\)`).
 			WillReturnResult(sqlmock.NewResult(1, 1))
 		mock.ExpectQuery(`SELECT \* FROM asset WHERE id = \? AND status != \? ORDER BY id ASC LIMIT 1`).
 			WillReturnRows(mock.NewRows([]string{"display_name"}).
@@ -95,7 +95,7 @@ func TestAddAsset(t *testing.T) {
 		require.NoError(t, err)
 		defer db.Close()
 
-		mock.ExpectExec(`INSERT INTO asset \(c_time, u_time, display_name, owner, category, asset_type, files, preview, click_count, is_public, status\) VALUES \(\?,\?,\?,\?,\?,\?,\?,\?,\?,\?,\?\)`).
+		mock.ExpectExec(`INSERT INTO asset \(c_time, u_time, display_name, owner, category, asset_type, files, files_hash, preview, click_count, is_public, status\) VALUES \(\?,\?,\?,\?,\?,\?,\?,\?,\?,\?,\?,\?\)`).
 			WillReturnError(sql.ErrConnDone)
 		asset, err := AddAsset(context.Background(), db, &Asset{DisplayName: "foo"})
 		require.Error(t, err)
@@ -108,7 +108,7 @@ func TestAddAsset(t *testing.T) {
 		require.NoError(t, err)
 		defer db.Close()
 
-		mock.ExpectExec(`INSERT INTO asset \(c_time, u_time, display_name, owner, category, asset_type, files, preview, click_count, is_public, status\) VALUES \(\?,\?,\?,\?,\?,\?,\?,\?,\?,\?,\?\)`).
+		mock.ExpectExec(`INSERT INTO asset \(c_time, u_time, display_name, owner, category, asset_type, files, files_hash, preview, click_count, is_public, status\) VALUES \(\?,\?,\?,\?,\?,\?,\?,\?,\?,\?,\?,\?\)`).
 			WillReturnResult(sqlmock.NewErrorResult(sql.ErrConnDone))
 		asset, err := AddAsset(context.Background(), db, &Asset{DisplayName: "foo"})
 		require.Error(t, err)
@@ -122,7 +122,7 @@ func TestUpdateAssetByID(t *testing.T) {
 		require.NoError(t, err)
 		defer db.Close()
 
-		mock.ExpectExec(`UPDATE asset SET u_time = \?, display_name = \?, category = \?, asset_type = \?, files = \?, preview = \?, is_public = \? WHERE id = \?`).
+		mock.ExpectExec(`UPDATE asset SET u_time = \?, display_name = \?, category = \?, asset_type = \?, files = \?, files_hash = \?, preview = \?, is_public = \? WHERE id = \?`).
 			WillReturnResult(sqlmock.NewResult(1, 1))
 		mock.ExpectQuery(`SELECT \* FROM asset WHERE id = \? AND status != \? ORDER BY id ASC LIMIT 1`).
 			WillReturnRows(mock.NewRows([]string{"display_name"}).
@@ -138,7 +138,7 @@ func TestUpdateAssetByID(t *testing.T) {
 		require.NoError(t, err)
 		defer db.Close()
 
-		mock.ExpectExec(`UPDATE asset SET u_time = \?, display_name = \?, category = \?, asset_type = \?, files = \?, preview = \?, is_public = \? WHERE id = \?`).
+		mock.ExpectExec(`UPDATE asset SET u_time = \?, display_name = \?, category = \?, asset_type = \?, files = \?, files_hash = \?, preview = \?, is_public = \? WHERE id = \?`).
 			WillReturnResult(sqlmock.NewResult(1, 0))
 		asset, err := UpdateAssetByID(context.Background(), db, "1", &Asset{DisplayName: "foo"})
 		require.Error(t, err)
@@ -151,7 +151,7 @@ func TestUpdateAssetByID(t *testing.T) {
 		require.NoError(t, err)
 		defer db.Close()
 
-		mock.ExpectExec(`UPDATE asset SET u_time = \?, display_name = \?, category = \?, asset_type = \?, files = \?, preview = \?, is_public = \? WHERE id = \?`).
+		mock.ExpectExec(`UPDATE asset SET u_time = \?, display_name = \?, category = \?, asset_type = \?, files = \?, files_hash = \?, preview = \?, is_public = \? WHERE id = \?`).
 			WillReturnError(sql.ErrConnDone)
 		asset, err := UpdateAssetByID(context.Background(), db, "1", &Asset{DisplayName: "foo"})
 		require.Error(t, err)
@@ -164,7 +164,7 @@ func TestUpdateAssetByID(t *testing.T) {
 		require.NoError(t, err)
 		defer db.Close()
 
-		mock.ExpectExec(`UPDATE asset SET u_time = \?, display_name = \?, category = \?, asset_type = \?, files = \?, preview = \?, is_public = \? WHERE id = \?`).
+		mock.ExpectExec(`UPDATE asset SET u_time = \?, display_name = \?, category = \?, asset_type = \?, files = \?, files_hash = \?, preview = \?, is_public = \? WHERE id = \?`).
 			WillReturnResult(sqlmock.NewErrorResult(sql.ErrConnDone))
 		asset, err := UpdateAssetByID(context.Background(), db, "1", &Asset{DisplayName: "foo"})
 		require.Error(t, err)

--- a/spx-gui/src/apis/asset.ts
+++ b/spx-gui/src/apis/asset.ts
@@ -18,21 +18,23 @@ export type AssetData = {
   owner: string
   /** Asset Category */
   category: string
-  /** Public status */
-  isPublic: IsPublic
-  /** Files the asset contains */
-  files: FileCollection
-  /** Preview URL for the asset, e.g., a gif for a sprite */
-  preview: string
   /** Asset Type */
   assetType: AssetType
+  /** Files the asset contains */
+  files: FileCollection
+  /** Hash of the files */
+  filesHash: string
+  /** Preview URL for the asset, e.g., a gif for a sprite */
+  preview: string
   /** Click count of the asset */
   clickCount: number
+  /** Public status */
+  isPublic: IsPublic
 }
 
 export type AddAssetParams = Pick<
   AssetData,
-  'displayName' | 'category' | 'isPublic' | 'files' | 'preview' | 'assetType'
+  'displayName' | 'category' | 'assetType' | 'files' | 'filesHash' | 'preview' | 'isPublic'
 >
 
 export function addAsset(params: AddAssetParams) {
@@ -57,10 +59,11 @@ export enum ListAssetParamOrderBy {
 
 export type ListAssetParams = PaginationParams & {
   keyword?: string
-  assetType?: AssetType
-  category?: string
-  isPublic?: IsPublic
   owner?: string
+  category?: string
+  assetType?: AssetType
+  filesHash?: string
+  isPublic?: IsPublic
   orderBy?: ListAssetParamOrderBy
 }
 

--- a/spx-gui/src/components/asset/library/AssetAddModal.vue
+++ b/spx-gui/src/components/asset/library/AssetAddModal.vue
@@ -58,9 +58,17 @@ import {
   UIRadio,
   UIRadioGroup,
   UICheckbox,
-  useForm
+  useForm,
+  useConfirmDialog
 } from '@/components/ui'
-import { type AssetData, addAsset, IsPublic } from '@/apis/asset'
+import {
+  type AssetData,
+  addAsset,
+  listAsset,
+  IsPublic,
+  ListAssetParamOrderBy,
+  AssetType
+} from '@/apis/asset'
 import { useMessageHandle } from '@/utils/exception'
 import { Backdrop } from '@/models/backdrop'
 import { Sound } from '@/models/sound'
@@ -95,6 +103,8 @@ const form = useForm({
   isPublic: [false]
 })
 
+const withConfirm = useConfirmDialog()
+
 const nameTip = {
   en: 'A good name makes it easy to be found in asset library.',
   zh: '起一个准确的名字，可以帮助你下次更快地找到它'
@@ -112,12 +122,46 @@ const handleSubmit = useMessageHandle(
     } else {
       throw new Error(`unknown asset type ${props.asset}`)
     }
+
+    const { data: assets } = await listAsset({
+      pageSize: 1, // we only need to know if the asset with the same filesHash exists
+      pageIndex: 1,
+      assetType: params.assetType,
+      filesHash: params.filesHash,
+      orderBy: ListAssetParamOrderBy.TimeDesc
+    })
+    if (assets.length) {
+      let assetTypeName = t({ en: 'asset', zh: '素材' })
+      switch (params.assetType) {
+        case AssetType.Sprite:
+          assetTypeName = t({ en: 'sprite', zh: '精灵' })
+          break
+        case AssetType.Backdrop:
+          assetTypeName = t({ en: 'backdrop', zh: '背景' })
+          break
+        case AssetType.Sound:
+          assetTypeName = t({ en: 'sound', zh: '声音' })
+          break
+      }
+      await withConfirm({
+        type: 'warning',
+        title: t({
+          en: `Duplicate ${assetTypeName} confirmation`,
+          zh: `${assetTypeName}重复确认`
+        }),
+        content: t({
+          en: `The ${assetTypeName} you uploaded [${form.value.name}] is the same as the existing ${assetTypeName} [${assets[0].displayName}] in the asset library. Are you sure you want to add this ${assetTypeName} to the asset library?`,
+          zh: `您上传的${assetTypeName}「${form.value.name}」与已存在于素材库中的${assetTypeName}「${assets[0].displayName}」内容相同。是否确认需要将此${assetTypeName}添加到素材库中？`
+        })
+      })
+    }
+
     const assetData = await addAsset({
       ...params,
       displayName: form.value.name,
-      isPublic: form.value.isPublic ? IsPublic.public : IsPublic.personal,
       category: form.value.category,
-      preview: 'TODO'
+      preview: 'TODO',
+      isPublic: form.value.isPublic ? IsPublic.public : IsPublic.personal
     })
     emit('resolved')
     return assetData

--- a/spx-gui/src/components/project/ProjectCreateModal.vue
+++ b/spx-gui/src/components/project/ProjectCreateModal.vue
@@ -106,7 +106,7 @@ const handleSubmit = useMessageHandle(
     await sprite.autoFit()
     // upload project content & call API addProject, TODO: maybe this should be extracted to `@/models`?
     const files = project.export()[1]
-    const fileCollection = await uploadFiles(files)
+    const { fileCollection } = await uploadFiles(files)
     const projectData = await addProject({
       name: form.value.name,
       isPublic: IsPublic.personal,

--- a/spx-gui/src/models/common/asset.ts
+++ b/spx-gui/src/models/common/asset.ts
@@ -5,7 +5,7 @@ import { Sprite } from '../sprite'
 import { Backdrop, type BackdropInits } from '../backdrop'
 import { getFiles, uploadFiles } from './cloud'
 
-export type PartialAssetData = Pick<AssetData, 'displayName' | 'assetType' | 'files'>
+export type PartialAssetData = Pick<AssetData, 'displayName' | 'assetType' | 'files' | 'filesHash'>
 
 export type AssetModel<T extends AssetType = AssetType> = T extends AssetType.Sound
   ? Sound
@@ -16,11 +16,12 @@ export type AssetModel<T extends AssetType = AssetType> = T extends AssetType.So
       : never
 
 export async function sprite2Asset(sprite: Sprite): Promise<PartialAssetData> {
-  const fileCollection = await uploadFiles(sprite.export(false))
+  const { fileCollection, fileCollectionHash } = await uploadFiles(sprite.export(false))
   return {
     displayName: sprite.name,
     assetType: AssetType.Sprite,
-    files: fileCollection
+    files: fileCollection,
+    filesHash: fileCollectionHash
   }
 }
 
@@ -37,11 +38,12 @@ const virtualBackdropConfigFileName = 'assets/__backdrop__.json'
 export async function backdrop2Asset(backdrop: Backdrop): Promise<PartialAssetData> {
   const [config, files] = backdrop.export()
   files[virtualBackdropConfigFileName] = fromConfig(virtualBackdropConfigFileName, config)
-  const fileColleciton = await uploadFiles(files)
+  const { fileCollection, fileCollectionHash } = await uploadFiles(files)
   return {
     displayName: backdrop.name,
     assetType: AssetType.Backdrop,
-    files: fileColleciton
+    files: fileCollection,
+    filesHash: fileCollectionHash
   }
 }
 
@@ -54,11 +56,12 @@ export async function asset2Backdrop(assetData: PartialAssetData) {
 }
 
 export async function sound2Asset(sound: Sound): Promise<PartialAssetData> {
-  const fileCollection = await uploadFiles(sound.export())
+  const { fileCollection, fileCollectionHash } = await uploadFiles(sound.export())
   return {
     displayName: sound.name,
     assetType: AssetType.Sound,
-    files: fileCollection
+    files: fileCollection,
+    filesHash: fileCollectionHash
   }
 }
 

--- a/spx-gui/src/models/common/cloud.test.ts
+++ b/spx-gui/src/models/common/cloud.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest'
+import { hashFiles } from './cloud'
+
+describe('hashFiles', () => {
+  it('should return correct hash', async () => {
+    const fileCollection = {
+      file1: 'url1',
+      file2: 'url2',
+      file3: 'url3'
+    }
+    const want = 'h1:hJGLZftaDTsyPWv/2/cDCULE87c=' // {"file1":"url1","file2":"url2","file3":"url3"}
+    const got = await hashFiles(fileCollection)
+    expect(got).toBe(want)
+  })
+
+  it('should handle disordered file collection', async () => {
+    const fileCollection = {
+      file2: 'url2',
+      file1: 'url1',
+      file3: 'url3'
+    }
+    const want = 'h1:hJGLZftaDTsyPWv/2/cDCULE87c=' // {"file1":"url1","file2":"url2","file3":"url3"}
+    const got = await hashFiles(fileCollection)
+    expect(got).toBe(want)
+  })
+
+  it('should handle empty file collection', async () => {
+    const fileCollection = {}
+    const want = 'h1:vyGp6PvFo4RvsFtPoIWeCReyIC8=' // {}
+    const got = await hashFiles(fileCollection)
+    expect(got).toBe(want)
+  })
+})


### PR DESCRIPTION
Fixes #520

---

Execute the following SQL in the test env DB for migration before merging:

```sql
ALTER TABLE `asset` ADD COLUMN `files_hash` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NULL DEFAULT NULL;
```