### PR TITLE
Fix file select

### DIFF
--- a/spx-gui/src/utils/file.ts
+++ b/spx-gui/src/utils/file.ts
@@ -53,11 +53,12 @@ function _selectFile({ accept = '', multiple = false }: FileSelectOptions) {
         setTimeout(() => {
           // change event of input not triggered (if triggered, it happens soon after focus event of window)
           if (!settled) reject(new Cancelled())
-        }, 300)
+        }, 1000)
       },
       { once: true }
     )
     input.onchange = async () => {
+      // TODO: we should not check size for `.gbp` or scratch files
       const oversizedFileNames = Array.from(input.files!)
         .filter((file) => file.size > maxFileSize)
         .map((file) => file.name)


### PR DESCRIPTION
300ms is too short, so selecting with file is sometimes considered cancelled.

<img width="511" alt="image" src="https://github.com/goplus/builder/assets/1492263/80d5cd72-5f54-421c-b726-d7465f6586b0">
