### PR TITLE
Button Shadow Details

### DIFF
--- a/spx-gui/src/components/editor/code-editor/FormatButton.vue
+++ b/spx-gui/src/components/editor/code-editor/FormatButton.vue
@@ -1,6 +1,5 @@
 <template>
   <UIButton
-    size="small"
     type="boring"
     :loading="handleFormat.isLoading.value"
     @click="handleFormat.fn"

--- a/spx-gui/src/components/editor/preview/EditorPreview.vue
+++ b/spx-gui/src/components/editor/preview/EditorPreview.vue
@@ -4,7 +4,7 @@
       <div class="header">
         {{ $t({ en: 'Preview', zh: '预览' }) }}
       </div>
-      <UIButton class="run-button" size="small" type="primary" icon="play" @click="show = true">
+      <UIButton class="run-button" type="primary" icon="play" @click="show = true">
         {{ $t({ en: 'Run', zh: '运行' }) }}
       </UIButton>
     </UICardHeader>

--- a/spx-gui/src/components/ui/UIButton.vue
+++ b/spx-gui/src/components/ui/UIButton.vue
@@ -5,9 +5,11 @@
     :disabled="disabled"
     :type="htmlType"
   >
-    <UIIcon v-if="icon != null" class="icon" :type="icon" />
-    <slot v-else name="icon"></slot>
-    <slot></slot>
+    <div class="content">
+      <UIIcon v-if="icon != null" class="icon" :type="icon" />
+      <slot v-else name="icon"></slot>
+      <slot></slot>
+    </div>
   </button>
 </template>
 
@@ -44,29 +46,45 @@ const icon = computed(() => (props.loading ? 'loading' : props.icon))
 <style lang="scss" scoped>
 .ui-button {
   display: flex;
-  height: calc(var(--ui-line-height-2) + 4px);
-  padding: 0 16px;
-  align-items: center;
-  gap: 4px;
-
+  align-items: stretch;
+  height: var(--ui-line-height-2);
+  padding: 0 0 4px 0;
+  background: none;
   border: none;
-  border-bottom-width: 4px;
-  border-bottom-style: solid;
   border-radius: var(--ui-border-radius-2);
   cursor: pointer;
 
+  --ui-button-color: var(--ui-color-grey-100);
+  --ui-button-bg-color: var(--ui-color-primary-main);
+  --ui-button-shadow-color: var(--ui-color-primary-700);
+
+  .content {
+    display: flex;
+    padding: 0 16px;
+    align-items: center;
+    gap: 4px;
+    border-radius: var(--ui-border-radius-2);
+
+    color: var(--ui-button-color);
+    background-color: var(--ui-button-bg-color);
+    box-shadow: 0 4px var(--ui-button-shadow-color);
+  }
+
   &:not(:disabled):active,
   &.loading {
-    border-bottom-width: 0;
+    padding-bottom: 0;
+    .content {
+      box-shadow: none;
+    }
   }
 
   &:disabled {
     cursor: not-allowed;
 
     &:not(.loading) {
-      color: var(--ui-color-disabled-text);
-      background-color: var(--ui-color-disabled-bg);
-      border-bottom-color: var(--ui-color-grey-500);
+      --ui-button-color: var(--ui-color-disabled-text);
+      --ui-button-bg-color: var(--ui-color-disabled-bg);
+      --ui-button-shadow-color: var(--ui-color-grey-500);
     }
   }
 
@@ -81,61 +99,64 @@ const icon = computed(() => (props.loading ? 'loading' : props.icon))
 }
 
 .type-primary {
-  color: var(--ui-color-grey-100);
-  background-color: var(--ui-color-primary-main);
-  border-bottom-color: var(--ui-color-primary-700);
+  --ui-button-color: var(--ui-color-grey-100);
+  --ui-button-bg-color: var(--ui-color-primary-main);
+  --ui-button-shadow-color: var(--ui-color-primary-700);
 
   &:hover:not(:active, :disabled) {
-    background-color: var(--ui-color-primary-400);
+    --ui-button-bg-color: var(--ui-color-primary-400);
   }
 }
 
 .type-secondary {
-  color: var(--ui-color-primary-main);
-  background-color: var(--ui-color-primary-200);
-  border-bottom-color: var(--ui-color-primary-300);
+  --ui-button-color: var(--ui-color-primary-main);
+  --ui-button-bg-color: var(--ui-color-primary-200);
+  --ui-button-shadow-color: var(--ui-color-primary-300);
 
   &:hover:not(:active, :disabled) {
-    background-color: var(--ui-color-primary-100);
+    --ui-button-bg-color: var(--ui-color-primary-100);
   }
 }
 
 .type-boring {
-  color: var(--ui-color-text);
-  background-color: var(--ui-color-grey-300);
-  border-bottom-color: var(--ui-color-grey-600);
+  --ui-button-color: var(--ui-color-text);
+  --ui-button-bg-color: var(--ui-color-grey-300);
+  --ui-button-shadow-color: var(--ui-color-grey-600);
 
   &:hover:not(:active, :disabled) {
-    background-color: var(--ui-color-grey-200);
+    --ui-button-bg-color: var(--ui-color-grey-200);
   }
 }
 
 .type-danger {
-  color: var(--ui-color-grey-100);
-  background-color: var(--ui-color-danger-main);
-  border-bottom-color: var(--ui-color-danger-300);
+  --ui-button-color: var(--ui-color-grey-100);
+  --ui-button-bg-color: var(--ui-color-danger-main);
+  --ui-button-shadow-color: var(--ui-color-danger-300);
 
   &:hover:not(:active, :disabled) {
-    background-color: var(--ui-color-danger-100);
+    --ui-button-bg-color: var(--ui-color-danger-100);
   }
 }
 
 .type-success {
-  color: var(--ui-color-grey-100);
-  background-color: var(--ui-color-success-main);
-  border-bottom-color: var(--ui-color-success-300);
+  --ui-button-color: var(--ui-color-grey-100);
+  --ui-button-bg-color: var(--ui-color-success-main);
+  --ui-button-shadow-color: var(--ui-color-success-300);
 
   &:hover:not(:active, :disabled) {
-    background-color: var(--ui-color-success-100);
+    --ui-button-bg-color: var(--ui-color-success-100);
   }
 }
 
 .size-large {
-  font-size: 15px;
-  line-height: 1.6;
-  height: calc(var(--ui-line-height-3) + 4px);
-  padding: 0 24px;
-  gap: 8px;
+  height: var(--ui-line-height-3);
+
+  .content {
+    font-size: 15px;
+    line-height: 1.6;
+    padding: 0 24px;
+    gap: 8px;
+  }
 
   .icon {
     width: 15px;
@@ -144,11 +165,14 @@ const icon = computed(() => (props.loading ? 'loading' : props.icon))
 }
 
 .size-small {
-  font-size: 13px;
-  line-height: 1.5;
-  height: calc(var(--ui-line-height-1) + 4px);
-  padding: 0 12px;
-  gap: 4px;
+  height: var(--ui-line-height-1);
+
+  .content {
+    font-size: 13px;
+    line-height: 1.5;
+    padding: 0 12px;
+    gap: 4px;
+  }
 
   .icon {
     width: 13px;

--- a/spx-gui/src/components/ui/UIButtonGroupItem.vue
+++ b/spx-gui/src/components/ui/UIButtonGroupItem.vue
@@ -26,7 +26,7 @@ const handleClick = () => {
 
 <style scoped lang="scss">
 .ui-button-group-item {
-  height: 30px;
+  height: var(--ui-line-height-2);
   min-width: 32px;
   display: flex;
   align-items: center;

--- a/spx-gui/src/components/ui/UIIconButton.vue
+++ b/spx-gui/src/components/ui/UIIconButton.vue
@@ -7,9 +7,11 @@
     type="button"
     :disabled="disabled"
   >
-    <div class="icon">
-      <UIIcon v-if="icon != null" class="ui-icon" :type="icon" />
-      <slot v-else name="default"></slot>
+    <div class="content">
+      <div class="icon">
+        <UIIcon v-if="icon != null" class="ui-icon" :type="icon" />
+        <slot v-else name="default"></slot>
+      </div>
     </div>
   </button>
 </template>
@@ -47,18 +49,36 @@ const icon = computed(() => (props.loading ? 'loading' : props.icon))
   display: flex;
   width: 42px;
   height: 42px;
-  align-items: center;
-  justify-content: center;
+  align-items: stretch;
 
+  padding: 0 0 4px 0;
+  background: none;
   border: none;
-  border-bottom-width: 4px;
-  border-bottom-style: solid;
-  border-radius: 42px;
+  border-radius: 100%;
   cursor: pointer;
+
+  --ui-button-color: var(--ui-color-grey-100);
+  --ui-button-bg-color: var(--ui-color-primary-main);
+  --ui-button-shadow-color: var(--ui-color-primary-700);
+
+  .content {
+    width: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 100%;
+
+    color: var(--ui-button-color);
+    background-color: var(--ui-button-bg-color);
+    box-shadow: 0 4px var(--ui-button-shadow-color);
+  }
 
   &:not(:disabled):active,
   &.loading {
-    border-bottom-width: 0;
+    padding-bottom: 0;
+    .content {
+      box-shadow: none;
+    }
   }
 
   &:disabled,
@@ -66,9 +86,9 @@ const icon = computed(() => (props.loading ? 'loading' : props.icon))
     cursor: not-allowed;
 
     &:not(.loading) {
-      color: var(--ui-color-disabled-text);
-      background-color: var(--ui-color-disabled-bg);
-      border-bottom-color: var(--ui-color-grey-500);
+      --ui-button-color: var(--ui-color-disabled-text);
+      --ui-button-bg-color: var(--ui-color-disabled-bg);
+      --ui-button-shadow-color: var(--ui-color-grey-500);
     }
   }
 
@@ -89,12 +109,12 @@ const icon = computed(() => (props.loading ? 'loading' : props.icon))
 }
 
 .type-primary {
-  color: var(--ui-color-grey-100);
-  background-color: var(--ui-color-primary-main);
-  border-bottom-color: var(--ui-color-primary-700);
+  --ui-button-color: var(--ui-color-grey-100);
+  --ui-button-bg-color: var(--ui-color-primary-main);
+  --ui-button-shadow-color: var(--ui-color-primary-700);
 
-  &:hover:not(:active) {
-    background-color: var(--ui-color-primary-400);
+  &:hover:not(:active, :disabled) {
+    --ui-button-bg-color: var(--ui-color-primary-400);
   }
 }
 
@@ -109,52 +129,52 @@ const icon = computed(() => (props.loading ? 'loading' : props.icon))
 }
 
 .type-secondary {
-  color: var(--ui-color-grey-100);
-  background-color: var(--ui-color-blue-500);
-  border-bottom-color: var(--ui-color-blue-700);
+  --ui-button-color: var(--ui-color-grey-100);
+  --ui-button-bg-color: var(--ui-color-blue-500);
+  --ui-button-shadow-color: var(--ui-color-blue-700);
 
   &:hover:not(:active) {
-    background-color: var(--ui-color-blue-400);
+    --ui-button-bg-color: var(--ui-color-blue-400);
   }
 }
 
 .type-boring {
-  color: var(--ui-color-text);
-  background-color: var(--ui-color-grey-300);
-  border-bottom-color: var(--ui-color-grey-600);
+  --ui-button-color: var(--ui-color-text);
+  --ui-button-bg-color: var(--ui-color-grey-300);
+  --ui-button-shadow-color: var(--ui-color-grey-600);
 
   &:hover:not(:active) {
-    background-color: var(--ui-color-grey-200);
+    --ui-button-bg-color: var(--ui-color-grey-200);
   }
 }
 
 .type-danger {
-  color: var(--ui-color-grey-100);
-  background-color: var(--ui-color-danger-main);
-  border-bottom-color: var(--ui-color-danger-300);
+  --ui-button-color: var(--ui-color-grey-100);
+  --ui-button-bg-color: var(--ui-color-danger-main);
+  --ui-button-shadow-color: var(--ui-color-danger-300);
 
   &:hover:not(:active) {
-    background-color: var(--ui-color-danger-100);
+    --ui-button-bg-color: var(--ui-color-danger-100);
   }
 }
 
 .type-success {
-  color: var(--ui-color-grey-100);
-  background-color: var(--ui-color-success-main);
-  border-bottom-color: var(--ui-color-success-300);
+  --ui-button-color: var(--ui-color-grey-100);
+  --ui-button-bg-color: var(--ui-color-success-main);
+  --ui-button-shadow-color: var(--ui-color-success-300);
 
   &:hover:not(:active) {
-    background-color: var(--ui-color-success-100);
+    --ui-button-bg-color: var(--ui-color-success-100);
   }
 }
 
 .type-info {
-  color: var(--ui-color-grey-100);
-  background-color: var(--ui-color-purple-500);
-  border-bottom-color: var(--ui-color-purple-700);
+  --ui-button-color: var(--ui-color-grey-100);
+  --ui-button-bg-color: var(--ui-color-purple-500);
+  --ui-button-shadow-color: var(--ui-color-purple-700);
 
   &:hover:not(:active) {
-    background-color: var(--ui-color-purple-400);
+    --ui-button-bg-color: var(--ui-color-purple-400);
   }
 }
 </style>


### PR DESCRIPTION
close #572 （详见 https://github.com/goplus/builder/issues/572#issuecomment-2151780134 ）

* button 整体高度使用跟其它控件一致的高度（40/32/26px），把 #569 中添加的 4px 去掉
* 对于面板右上角的 button（如 Format、Run），使用 size=medium 而不是 size=small
* 对于 `UIButtonGroupItem`，使用与其它输入控件一致的高度（32px）

此外使用 box-shadow + padding 替代原来的 border 实现，解决 https://github.com/goplus/builder/issues/572#issue-2337298602 这里提到的视觉感受上厚度不一致的问题