### PR TITLE
Fix ui details

### DIFF
--- a/spx-gui/src/components/asset/library/AssetLibraryModal.vue
+++ b/spx-gui/src/components/asset/library/AssetLibraryModal.vue
@@ -269,7 +269,7 @@ async function handleAssetClick(asset: AssetData) {
 }
 .content {
   height: 513px;
-  padding: 8px 24px 0;
+  padding: 8px 0 0 24px; // no right padding to allow optional scrollbar
   overflow-y: auto;
   overflow-x: visible;
 }

--- a/spx-gui/src/components/editor/code-editor/CodeEditor.vue
+++ b/spx-gui/src/components/editor/code-editor/CodeEditor.vue
@@ -107,7 +107,7 @@ const categories = computed(() => {
   return [
     {
       icon: iconEvent,
-      color: uiVariables.color.yellow.main,
+      color: '#fabd2c',
       ...eventCategory
     },
     {
@@ -122,7 +122,7 @@ const categories = computed(() => {
     },
     {
       icon: iconControl,
-      color: '#67ceff',
+      color: '#3fcdd9',
       ...controlCategory
     },
     {

--- a/spx-gui/src/components/editor/common/EditorItemDetail.vue
+++ b/spx-gui/src/components/editor/common/EditorItemDetail.vue
@@ -34,6 +34,7 @@ const emit = defineEmits<{
   flex-direction: column;
   gap: 20px;
   background-color: var(--ui-color-grey-200);
+  border-bottom-right-radius: var(--ui-border-radius-3);
 }
 
 .name {

--- a/spx-gui/src/components/editor/common/EditorList.vue
+++ b/spx-gui/src/components/editor/common/EditorList.vue
@@ -85,6 +85,10 @@ const cssVars = computed(() => getCssVars('--editor-list-color-', uiVariables.co
   color: var(--ui-color-grey-100);
   background: var(--editor-list-color-main);
 
+  // ensure the button's outline not covered by detail content on the right side
+  position: relative;
+  z-index: 1;
+
   &:hover {
     background: var(--editor-list-color-400);
   }

--- a/spx-gui/src/components/editor/panels/common/PanelList.vue
+++ b/spx-gui/src/components/editor/panels/common/PanelList.vue
@@ -11,7 +11,7 @@
   flex: 1 1 0;
   overflow-y: auto;
   margin: 0;
-  padding: 12px;
+  padding: 12px 0 12px 12px; // no right padding to allow optional scrollbar
   display: flex;
   flex-wrap: wrap;
   align-content: flex-start;

--- a/spx-gui/src/components/editor/sprite/CostumeDetail.vue
+++ b/spx-gui/src/components/editor/sprite/CostumeDetail.vue
@@ -38,6 +38,7 @@ const [imgSrc, imgLoading] = useFileUrl(() => props.costume.img)
 .img-wrapper {
   width: 100%;
   flex: 1 1 0;
+  border-radius: 8px;
   background-image: url(./costume-bg.svg);
 }
 .img {

--- a/spx-gui/src/components/editor/stage/BackdropDetail.vue
+++ b/spx-gui/src/components/editor/stage/BackdropDetail.vue
@@ -1,11 +1,14 @@
 <template>
   <EditorItemDetail :name="backdrop.name" @rename="handleRename">
-    <UIImg class="img" :src="imgSrc" :loading="imgLoading" />
+    <div class="img-wrapper">
+      <img v-if="imgSrc != null" class="img" :src="imgSrc" />
+      <UILoading :visible="imgLoading" cover />
+    </div>
   </EditorItemDetail>
 </template>
 
 <script setup lang="ts">
-import { UIImg, useModal } from '@/components/ui'
+import { useModal } from '@/components/ui'
 import { useFileUrl } from '@/utils/file'
 import type { Backdrop } from '@/models/backdrop'
 import { useEditorCtx } from '../EditorContextProvider.vue'
@@ -30,9 +33,16 @@ const [imgSrc, imgLoading] = useFileUrl(() => props.backdrop.img)
 </script>
 
 <style lang="scss" scoped>
-.img {
+.img-wrapper {
   width: 100%;
   flex: 1 1 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.img {
+  max-width: 100%;
+  max-height: 100%;
   border-radius: 8px;
 }
 </style>

--- a/spx-gui/src/components/project/ProjectList.vue
+++ b/spx-gui/src/components/project/ProjectList.vue
@@ -112,6 +112,7 @@ const handleProjectRemoved = (project: ProjectData) => {
 
 <style lang="scss" scoped>
 .project-list {
+  margin-right: -20px; // negative right margin to allow optional scrollbar
   flex: 1 1 0;
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
* Fix scrollbar for list

    通过省略容器的右 padding 来容纳可能占据空间的 scrollbar，这样当 scrollbar 占据空间（如 windows 或配置了总是显示 scrollbar 的 macos）时，列表元素不会被挤下去，我们可以总是在单行展示固定数量的列表元素

    <img width="656" alt="image" src="https://github.com/goplus/builder/assets/1492263/fd210d1e-f5c9-4d96-8bb4-d843738a6fa5">

* Fix color for category "Event" in tools
* Fix border-radius for backdrop & costume
* Fix outline for backdrop / costume add button
