### PR TITLE
load audio after recording

### DIFF
--- a/spx-gui/src/utils/wavesurfer-record.ts
+++ b/spx-gui/src/utils/wavesurfer-record.ts
@@ -179,6 +179,7 @@ export class RecordPlugin extends BasePlugin<RecordPluginEvents, RecordPluginOpt
       this.emit(ev, blob)
       if (this.options.renderRecordedAudio) {
         this.applyOriginalOptionsIfNeeded()
+        this.wavesurfer?.loadBlob(blob)
       }
     }
 


### PR DESCRIPTION
在 #589 我们为了解决波形在停止录制时改变的问题，不在结束时使用`loadBlob`重新加载音频，这导致了以下问题：

* 录制停止后（还没有保存）点击播放不会播放
* 录制停止后选择特定范围再保存，保存的依然是原音频，而不是选定的范围
* 录制停止后调整音量，对应的波形变化不符合预期，另外波形图下方会多出来一个滚动条

这里加回去作为临时解决方案