### PR TITLE
fix normalizeAssetName

### DIFF
--- a/spx-gui/src/models/common/asset-name.test.ts
+++ b/spx-gui/src/models/common/asset-name.test.ts
@@ -1,9 +1,26 @@
 import { describe, it, expect } from 'vitest'
-import { getSoundName, getSpriteName, normalizeGopIdentifierAssetName } from './asset-name'
+import { getSoundName, getSpriteName, normalizeAssetName, normalizeGopIdentifierAssetName } from './asset-name'
 import { Project } from '../project'
 import { Sprite } from '../sprite'
 import { Sound } from '../sound'
 import { fromText } from './file'
+
+describe('normalizeAssetName', () => {
+  it('should work well with camel case', () => {
+    expect(normalizeAssetName('abc', 'camel')).toBe('abc')
+  })
+  it('should work well with pascal case', () => {
+    expect(normalizeAssetName('abc', 'pascal')).toBe('Abc')
+  })
+  it('should work well with empty string', () => {
+    expect(normalizeAssetName('', 'camel')).toBe('')
+    expect(normalizeAssetName('', 'pascal')).toBe('')
+  })
+  it('should work well with non-ascii chars', () => {
+    expect(normalizeAssetName('中文-1', 'camel')).toBe('中文-1')
+    expect(normalizeAssetName('中文 2', 'pascal')).toBe('中文 2')
+  })
+})
 
 describe('normalizeGopIdentifierAssetName', () => {
   it('should work well with camel case', () => {

--- a/spx-gui/src/models/common/asset-name.ts
+++ b/spx-gui/src/models/common/asset-name.ts
@@ -98,6 +98,7 @@ function lowFirst(str: string) {
 
 /** Convert any string to valid asset name, empty string may be returned */
 export function normalizeAssetName(src: string, cas: 'camel' | 'pascal') {
+  if (src === '') return ''
   const result = cas === 'pascal' ? upFirst(src) : lowFirst(src)
   return result.slice(0, 20) // 20 should be enough, it will be hard to read with too long name
 }


### PR DESCRIPTION
In #614, we updated asset name normalization (`normalizeAssetName`), which causes error when creating new projects —— `normalizeAssetName` will be called with empty `src`.

In this PR we update `normalizeAssetName` to avoid the above error.