### PR TITLE
fix `Cancelled` warning in console

### DIFF
--- a/spx-gui/src/components/editor/EditorHomepage.vue
+++ b/spx-gui/src/components/editor/EditorHomepage.vue
@@ -47,7 +47,7 @@ import TopNav from '@/components/top-nav/TopNav.vue'
 import ProjectList from '@/components/project/ProjectList.vue'
 import { useCreateProject } from '@/components/project'
 import { getProjectEditorRoute } from '@/router'
-import { useQuery } from '@/utils/exception'
+import { useMessageHandle, useQuery } from '@/utils/exception'
 import EditorContextProvider from './EditorContextProvider.vue'
 import ProjectEditor from './ProjectEditor.vue'
 import { clear } from '@/models/common/local'
@@ -258,10 +258,13 @@ function handleSelected(project: ProjectData) {
   openProject(project.name)
 }
 
-async function handleCreate() {
-  const newProject = await createProject()
-  openProject(newProject.name)
-}
+const handleCreate = useMessageHandle(
+  async () => {
+    const newProject = await createProject()
+    openProject(newProject.name)
+  },
+  { en: 'Failed to create project', zh: '创建项目失败' }
+).fn
 </script>
 
 <style scoped lang="scss">

--- a/spx-gui/src/components/editor/panels/sprite/SpriteBasicConfig.vue
+++ b/spx-gui/src/components/editor/panels/sprite/SpriteBasicConfig.vue
@@ -81,6 +81,7 @@ import {
   UIButtonGroup,
   UIButtonGroupItem
 } from '@/components/ui'
+import { useMessageHandle } from '@/utils/exception'
 import { debounce, round } from '@/utils/utils'
 import type { Sprite } from '@/models/sprite'
 import { type Project } from '@/models/project'
@@ -98,12 +99,14 @@ const emit = defineEmits<{
 
 const renameSprite = useModal(SpriteRenameModal)
 
-function handleNameEdit() {
-  renameSprite({
-    sprite: props.sprite,
-    project: props.project
-  })
-}
+const handleNameEdit = useMessageHandle(
+  () =>
+    renameSprite({
+      sprite: props.sprite,
+      project: props.project
+    }),
+  { en: 'Failed to rename sprite', zh: '重命名精灵失败' }
+).fn
 
 const handleXUpdate = wrapUpdateHandler((x: number | null) => props.sprite.setX(x ?? 0))
 const handleYUpdate = wrapUpdateHandler((y: number | null) => props.sprite.setY(y ?? 0))

--- a/spx-gui/src/components/editor/sound/SoundEditor.vue
+++ b/spx-gui/src/components/editor/sound/SoundEditor.vue
@@ -82,12 +82,14 @@ const props = defineProps<{
 const editorCtx = useEditorCtx()
 const renameSound = useModal(SoundRenameModal)
 
-function handleNameEdit() {
-  renameSound({
-    sound: props.sound,
-    project: editorCtx.project
-  })
-}
+const handleNameEdit = useMessageHandle(
+  () =>
+    renameSound({
+      sound: props.sound,
+      project: editorCtx.project
+    }),
+  { en: 'Failed to rename sound', zh: '重命名声音失败' }
+).fn
 
 const waveformPlayerRef = ref<InstanceType<typeof WaveformPlayer> | null>(null)
 const gain = ref(1)

--- a/spx-gui/src/components/editor/sprite/CostumeDetail.vue
+++ b/spx-gui/src/components/editor/sprite/CostumeDetail.vue
@@ -8,6 +8,7 @@
 
 <script setup lang="ts">
 import { UIImg, useModal } from '@/components/ui'
+import { useMessageHandle } from '@/utils/exception'
 import { useFileUrl } from '@/utils/file'
 import type { Costume } from '@/models/costume'
 import type { Sprite } from '@/models/sprite'
@@ -23,13 +24,15 @@ const props = defineProps<{
 const editorCtx = useEditorCtx()
 const renameCostume = useModal(CostumeRenameModal)
 
-function handleRename() {
-  renameCostume({
-    costume: props.costume,
-    sprite: props.sprite,
-    project: editorCtx.project
-  })
-}
+const handleRename = useMessageHandle(
+  () =>
+    renameCostume({
+      costume: props.costume,
+      sprite: props.sprite,
+      project: editorCtx.project
+    }),
+  { en: 'Failed to rename costume', zh: '重命名造型失败' }
+).fn
 
 const [imgSrc, imgLoading] = useFileUrl(() => props.costume.img)
 </script>

--- a/spx-gui/src/components/editor/stage/BackdropDetail.vue
+++ b/spx-gui/src/components/editor/stage/BackdropDetail.vue
@@ -9,6 +9,7 @@
 
 <script setup lang="ts">
 import { useModal, UILoading } from '@/components/ui'
+import { useMessageHandle } from '@/utils/exception'
 import { useFileUrl } from '@/utils/file'
 import type { Backdrop } from '@/models/backdrop'
 import { useEditorCtx } from '../EditorContextProvider.vue'
@@ -22,12 +23,14 @@ const props = defineProps<{
 const editorCtx = useEditorCtx()
 const renameBackdrop = useModal(BackdropRenameModal)
 
-function handleRename() {
-  renameBackdrop({
-    backdrop: props.backdrop,
-    project: editorCtx.project
-  })
-}
+const handleRename = useMessageHandle(
+  () =>
+    renameBackdrop({
+      backdrop: props.backdrop,
+      project: editorCtx.project
+    }),
+  { en: 'Failed to rename backdrop', zh: '重命名背景失败' }
+).fn
 
 const [imgSrc, imgLoading] = useFileUrl(() => props.backdrop.img)
 </script>

--- a/spx-gui/src/components/project/ProjectCreateModal.vue
+++ b/spx-gui/src/components/project/ProjectCreateModal.vue
@@ -44,7 +44,7 @@ import {
   useForm,
   type FormValidationResult
 } from '@/components/ui'
-import { type ProjectData, getProject, addProject as apiAddProject, IsPublic } from '@/apis/project'
+import { type ProjectData, getProject, addProject, IsPublic } from '@/apis/project'
 import { useI18n } from '@/utils/i18n'
 import { useMessageHandle } from '@/utils/exception'
 import { useUserStore } from '@/stores/user'
@@ -74,12 +74,6 @@ const userStore = useUserStore()
 const form = useForm({
   name: ['', validateName]
 })
-
-const addProject = useMessageHandle(
-  apiAddProject,
-  { en: 'Failed to create project', zh: '创建失败' },
-  (project) => ({ en: `Project ${project.name} created`, zh: `项目 ${project.name} 创建成功` })
-).fn
 
 function handleCancel() {
   emit('cancelled')
@@ -113,8 +107,13 @@ const handleSubmit = useMessageHandle(
       files: fileCollection
     })
     emit('resolved', projectData)
+    return projectData
   },
-  { en: 'Failed to create project', zh: '项目创建失败' }
+  { en: 'Failed to create project', zh: '项目创建失败' },
+  (projectData) => ({
+    en: `Project ${projectData.name} created`,
+    zh: `项目 ${projectData.name} 创建成功`
+  })
 )
 
 async function validateName(name: string): Promise<FormValidationResult> {

--- a/spx-gui/src/components/top-nav/TopNav.vue
+++ b/spx-gui/src/components/top-nav/TopNav.vue
@@ -17,7 +17,7 @@
               <template #icon><img :src="newSvg" /></template>
               {{ $t({ en: 'New project', zh: '新建项目' }) }}
             </UIMenuItem>
-            <UIMenuItem @click="openProject">
+            <UIMenuItem @click="handleOpenProject">
               <template #icon><img :src="openSvg" /></template>
               {{ $t({ en: 'Open project...', zh: '打开项目...' }) }}
             </UIMenuItem>
@@ -39,13 +39,13 @@
             </UIMenuItem>
           </UIMenuGroup>
           <UIMenuGroup :disabled="project == null || !isOnline">
-            <UIMenuItem @click="shareProject(project!)">
+            <UIMenuItem @click="handleShareProject">
               <template #icon><img :src="shareSvg" /></template>
               {{ $t({ en: 'Share project', zh: '分享项目' }) }}
             </UIMenuItem>
             <UIMenuItem
               v-if="project?.isPublic === IsPublic.public"
-              @click="stopSharingProject(project!)"
+              @click="handleStopSharingProject"
             >
               <template #icon><img :src="stopSharingSvg" /></template>
               {{ $t({ en: 'Stop sharing', zh: '停止分享' }) }}
@@ -185,16 +185,19 @@ const { isOnline } = useNetwork()
 const router = useRouter()
 
 const createProject = useCreateProject()
-const openProject = useOpenProject()
-const removeProject = useRemoveProject()
-const shareProject = useSaveAndShareProject()
-const stopSharingProject = useStopSharingProject()
-const loadFromScratchModal = useLoadFromScratchModal()
+const handleNewProject = useMessageHandle(
+  async () => {
+    const { name } = await createProject()
+    router.push(getProjectEditorRoute(name))
+  },
+  { en: 'Failed to create new project', zh: '新建项目失败' }
+).fn
 
-async function handleNewProject() {
-  const { name } = await createProject()
-  router.push(getProjectEditorRoute(name))
-}
+const openProject = useOpenProject()
+const handleOpenProject = useMessageHandle(openProject, {
+  en: 'Failed to open project',
+  zh: '打开项目失败'
+}).fn
 
 const confirm = useConfirmDialog()
 
@@ -225,11 +228,26 @@ const handleExportProjectFile = useMessageHandle(
   { en: 'Failed to export project file', zh: '导出项目文件失败' }
 ).fn
 
+const loadFromScratchModal = useLoadFromScratchModal()
 const handleImportFromScratch = useMessageHandle(() => loadFromScratchModal(props.project!), {
   en: 'Failed to import from Scratch file',
   zh: '从 Scratch 项目文件导入失败'
 }).fn
 
+const shareProject = useSaveAndShareProject()
+const handleShareProject = useMessageHandle(() => shareProject(props.project!), {
+  en: 'Failed to share project',
+  zh: '分享项目失败'
+}).fn
+
+const stopSharingProject = useStopSharingProject()
+const handleStopSharingProject = useMessageHandle(
+  () => stopSharingProject(props.project!),
+  { en: 'Failed to stop sharing project', zh: '停止分享项目失败' },
+  { en: 'Project sharing is now stopped', zh: '项目已停止分享' }
+).fn
+
+const removeProject = useRemoveProject()
 const handleRemoveProject = useMessageHandle(
   async () => {
     await removeProject(props.project!.owner!, props.project!.name!)

--- a/spx-gui/src/main.ts
+++ b/spx-gui/src/main.ts
@@ -1,11 +1,3 @@
-/*
- * @Author: Xu Ning
- * @Date: 2024-01-12 11:15:15
- * @LastEditors: Zhang Zhi Yang
- * @LastEditTime: 2024-03-06 14:38:25
- * @FilePath: \spx-gui\src\main.ts
- * @Description:
- */
 import { createApp } from 'vue'
 import VueKonva from 'vue-konva'
 import { VueQueryPlugin } from '@tanstack/vue-query'
@@ -35,4 +27,5 @@ async function initApp() {
 
   app.mount('#app')
 }
+
 initApp()

--- a/spx-gui/src/utils/exception.ts
+++ b/spx-gui/src/utils/exception.ts
@@ -99,7 +99,10 @@ export function useMessageHandle<Args extends any[], T>(
   const { t } = useI18n()
   const action = useAction(fn, failureSummaryMessage)
 
-  function messageHandleFn(...args: Args) {
+  // Typically we should do message handling only in the very end of the action chain,
+  // which means the returned (or resolved) value will not be used by subsequent code (cuz there is supposed to be no subsequent code).
+  // So it's ok to resolve with `void` here, which allows us to swallow exceptions.
+  function messageHandleFn(...args: Args): Promise<void> {
     return action.fn(...args).then(
       (ret) => {
         if (successMessage != null) {
@@ -108,10 +111,18 @@ export function useMessageHandle<Args extends any[], T>(
           )
           m.success(successText)
         }
-        return ret
       },
       (e) => {
-        if (e instanceof ActionException) m.error(t(e.userMessage))
+        // For
+        // - `Cancelled` exceptions: nothing to do
+        // - `ActionException` exceptions: we will notify the user
+        // do `return` (which swallows the exception) instead of `throw`.
+        // It let the runtime (browser, vue, etc.) ignore such exceptions, which is intended.
+        if (e instanceof Cancelled) return
+        if (e instanceof ActionException) {
+          m.error(t(e.userMessage))
+          return
+        }
         throw e
       }
     )


### PR DESCRIPTION
close #475 

* Swallow exceptions (if they are handled) in `useMessageHandle` instead of throw them out. 

    Then the runtime (browser, vue, etc.) will not catch them.

    Typically we should do message handling (`useMessageHandle`) only in the very end of the action chain. So it's ok for `useMessageHandle` to swallow exceptions and there will be no meaningful output to `return`.

* Add missing message handling
