### PR TITLE
Update code-editor for animation

### DIFF
--- a/spx-gui/src/components/asset/preprocessing/PreprocessModal.vue
+++ b/spx-gui/src/components/asset/preprocessing/PreprocessModal.vue
@@ -171,13 +171,11 @@ const selectedCostumes = shallowReactive<Costume[]>([])
 
 /** Update costumes based on current process output */
 async function updateCostumes(files: File[]) {
-  costumes.value = []
-  selectedCostumes.splice(0)
   const newCostumes = await Promise.all(
     files.map((file) => Costume.create(stripExt(file.name), file))
   )
   costumes.value = newCostumes
-  selectedCostumes.push(...newCostumes)
+  selectedCostumes.splice(0, selectedCostumes.length, ...newCostumes)
 }
 
 function isCostumeSelected(costume: Costume) {
@@ -196,10 +194,8 @@ function handleConfirm() {
 
 watch(
   () => props.files,
-  async (files) => {
-    cancelMethod(supportedMethods[0].value)
-    await updateCostumes(files)
-  },
+  // The first method cancelled, all methods cancelled
+  () => cancelMethod(supportedMethods[0].value),
   { immediate: true }
 )
 </script>

--- a/spx-gui/src/components/editor/code-editor/code-text-editor/tools/index.ts
+++ b/spx-gui/src/components/editor/code-editor/code-text-editor/tools/index.ts
@@ -103,7 +103,8 @@ export const lookCategory: ToolCategory = {
     },
     {
       label: { en: 'Costume', zh: '造型' },
-      tools: [spx.costumeName, spx.costumeIndex, spx.setCostume, spx.nextCostume, spx.prevCostume]
+      // index-related tools are excluded, as they are not recommended to use (animation is prefered)
+      tools: [spx.costumeName, spx.setCostume]
     },
     {
       label: { en: 'Animation', zh: '动画' },

--- a/spx-gui/src/components/editor/code-editor/code-text-editor/tools/index.ts
+++ b/spx-gui/src/components/editor/code-editor/code-text-editor/tools/index.ts
@@ -51,7 +51,7 @@ export const motionCategory: ToolCategory = {
   groups: [
     {
       label: { en: 'Move', zh: '移动' },
-      tools: [spx.move, spx.goto, spx.glide]
+      tools: [spx.step, spx.move, spx.goto, spx.glide]
     },
     {
       label: { en: 'Position', zh: '位置' },
@@ -104,6 +104,10 @@ export const lookCategory: ToolCategory = {
     {
       label: { en: 'Costume', zh: '造型' },
       tools: [spx.costumeName, spx.costumeIndex, spx.setCostume, spx.nextCostume, spx.prevCostume]
+    },
+    {
+      label: { en: 'Animation', zh: '动画' },
+      tools: [spx.animate]
     },
     {
       label: { en: 'Backdrop', zh: '背景' },
@@ -258,6 +262,25 @@ export function getVariableCategory(project: Project): ToolCategory {
   })
 
   if (project.selectedSprite != null) {
+    groups.push({
+      label: {
+        en: `Animations of "${project.selectedSprite.name}"`,
+        zh: `${project.selectedSprite.name} 的动画`
+      },
+      tools: project.selectedSprite.animations.map((animation) => {
+        const keyword = `"${animation.name}"`
+        return {
+          type: ToolType.variable,
+          target: ToolContext.sprite,
+          keyword,
+          desc: { en: `Animation "${animation.name}"`, zh: `动画 ${animation.name}` },
+          usage: {
+            sample: keyword,
+            insertText: keyword
+          }
+        }
+      })
+    })
     groups.push({
       label: {
         en: `Costumes of "${project.selectedSprite.name}"`,

--- a/spx-gui/src/components/editor/code-editor/code-text-editor/tools/spx.ts
+++ b/spx-gui/src/components/editor/code-editor/code-text-editor/tools/spx.ts
@@ -171,12 +171,13 @@ export const setCostume: Tool = {
   target: ToolContext.sprite,
   keyword: 'setCostume',
   desc: {
-    en: 'Set the current costume by specifying name or index',
-    zh: '通过指定名称或索引设置当前造型'
+    en: 'Set the current costume by specifying name',
+    zh: '通过指定名称设置当前造型'
   },
+  // index-related usages are excluded, as they are not recommended to use (animation is prefered)
   usage: {
-    sample: 'setCostume 0',
-    insertText: 'setCostume ${1:nameOrIndex}'
+    sample: 'setCostume "happy"',
+    insertText: 'setCostume ${1:name}'
   }
 }
 

--- a/spx-gui/src/components/editor/code-editor/code-text-editor/tools/spx.ts
+++ b/spx-gui/src/components/editor/code-editor/code-text-editor/tools/spx.ts
@@ -95,7 +95,10 @@ export const die: Tool = {
   callEffect: ToolCallEffect.write,
   target: ToolContext.sprite,
   keyword: 'die',
-  desc: { en: 'Let current sprite die', zh: '让当前精灵死亡' },
+  desc: {
+    en: 'Let current sprite die. Animation bound to state "die" will be played.',
+    zh: '让当前精灵死亡，绑定到“死亡”状态的动画会被播放'
+  },
   usage: {
     sample: 'die',
     insertText: 'die'
@@ -201,6 +204,18 @@ export const prevCostume: Tool = {
   }
 }
 
+export const animate: Tool = {
+  type: ToolType.method,
+  callEffect: ToolCallEffect.write,
+  target: ToolContext.sprite,
+  keyword: 'animate',
+  desc: { en: 'Play animation with given name', zh: '通过指定名称播放动画' },
+  usage: {
+    sample: 'animate "jump"',
+    insertText: 'animate ${1:name}'
+  }
+}
+
 export const say: Tool = {
   type: ToolType.method,
   callEffect: ToolCallEffect.write,
@@ -261,10 +276,25 @@ export const move: Tool = {
   callEffect: ToolCallEffect.write,
   target: ToolContext.sprite,
   keyword: 'move',
-  desc: { en: 'Move given steps, toward current heading', zh: '向当前朝向移动指定的步数' },
+  desc: { en: 'Move given distance, toward current heading', zh: '向当前朝向移动指定的距离' },
   usage: {
     sample: 'move 10',
-    insertText: 'move ${1:steps}'
+    insertText: 'move ${1:distance}'
+  }
+}
+
+export const step: Tool = {
+  type: ToolType.method,
+  callEffect: ToolCallEffect.write,
+  target: ToolContext.sprite,
+  keyword: 'step',
+  desc: {
+    en: 'Step given distance, toward current heading. Animation bound to state "step" will be played',
+    zh: '向当前朝向行走指定的距离，绑定到“行走”状态的动画会被播放'
+  },
+  usage: {
+    sample: 'step 10',
+    insertText: 'step ${1:distance}'
   }
 }
 


### PR DESCRIPTION
* Update code-editor for animation, update #543 

    1. Add animation-related tools, e.g. `step`, & update description for existed tools
    2. Add animation definitions of current sprite in `Variable` tools
    3. Exclude costume-index related tools or usages

* Fix costume add problem introduced in #614 