### PR TITLE
refactor(spx-gui): remove "codeFile" concept and optimize project saving

### DIFF
--- a/spx-gui/src/components/editor/sprite/SpriteEditor.vue
+++ b/spx-gui/src/components/editor/sprite/SpriteEditor.vue
@@ -23,7 +23,6 @@
 
 <script setup lang="ts">
 import { computed, ref } from 'vue'
-import { useAsyncComputed } from '@/utils/utils'
 import type { Sprite } from '@/models/sprite'
 import { UITabs, UITab } from '@/components/ui'
 import CodeEditor from '../code-editor/CodeEditor.vue'
@@ -39,7 +38,7 @@ const props = defineProps<{
 const editorCtx = useEditorCtx()
 const selectedTab = ref<'code' | 'costumes'>('code')
 const codeEditor = ref<InstanceType<typeof CodeEditor>>()
-const code = useAsyncComputed(() => props.sprite.getCode())
+const code = computed(() => props.sprite.code)
 
 // use `computed` to keep reference-equal for `mergeable`, see details in project history
 const actionUpdateCode = computed(() => ({

--- a/spx-gui/src/components/editor/stage/StageEditor.vue
+++ b/spx-gui/src/components/editor/stage/StageEditor.vue
@@ -23,8 +23,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue'
-import { useAsyncComputed } from '@/utils/utils'
+import { computed, ref } from 'vue'
 import type { Stage } from '@/models/stage'
 import { UITabs, UITab } from '@/components/ui'
 import CodeEditor from '../code-editor/CodeEditor.vue'
@@ -41,7 +40,7 @@ const props = defineProps<{
 const editorCtx = useEditorCtx()
 const selectedTab = ref<'code' | 'backdrops'>('code')
 const codeEditor = ref<InstanceType<typeof CodeEditor>>()
-const code = useAsyncComputed(() => props.stage.getCode())
+const code = computed(() => props.stage.code)
 
 const action = {
   name: { en: 'Update stage code', zh: '修改舞台代码' },

--- a/spx-gui/src/models/project/history.test.ts
+++ b/spx-gui/src/models/project/history.test.ts
@@ -109,7 +109,7 @@ describe('History', () => {
 
     expect(history.getRedoAction()).toBeNull()
     expect(history.getUndoAction()).toBe(actionUpdateCode)
-    expect(await project.sprites[0].getCode()).toBe('code')
+    expect(project.sprites[0].code).toBe('code')
 
     await history.doAction(actionUpdateCode, () => {
       project.sprites[0].setCode('code2')
@@ -117,17 +117,17 @@ describe('History', () => {
 
     expect(history.getRedoAction()).toBeNull()
     expect(history.getUndoAction()).toBe(actionUpdateCode)
-    expect(await project.sprites[0].getCode()).toBe('code2')
+    expect(project.sprites[0].code).toBe('code2')
 
     await history.undo()
     expect(history.getRedoAction()).toBe(actionUpdateCode)
     expect(history.getUndoAction()).toBeNull()
-    expect(await project.sprites[0].getCode()).toBe('')
+    expect(project.sprites[0].code).toBe('')
 
     await history.redo()
     expect(history.getRedoAction()).toBeNull()
     expect(history.getUndoAction()).toBe(actionUpdateCode)
-    expect(await project.sprites[0].getCode()).toBe('code2')
+    expect(project.sprites[0].code).toBe('code2')
   })
 
   it('should work well with concurrent actions', async () => {


### PR DESCRIPTION
- Removed the "codeFile" concept from sprite and stage models introduced in #508. Since #617, lazy-loading for plain text files is no longer needed.
- Avoided redundant `parseProjectData` in `@/models/common/cloud.save`.

Fixes #369