### PR TITLE
Hide tool `onTouched` for code-editor

### DIFF
--- a/spx-gui/src/components/editor/code-editor/code-text-editor/tools/index.ts
+++ b/spx-gui/src/components/editor/code-editor/code-text-editor/tools/index.ts
@@ -25,7 +25,7 @@ export const eventCategory: ToolCategory = {
     },
     {
       label: { en: 'Sensing Events', zh: '感知事件' },
-      tools: [spx.onClick, spx.onKey, spx.onAnyKey, spx.onTouched]
+      tools: [spx.onClick, spx.onKey, spx.onAnyKey]
     },
     {
       label: { en: 'Motion Events', zh: '运动事件' },

--- a/spx-gui/src/components/editor/code-editor/code-text-editor/tools/spx.ts
+++ b/spx-gui/src/components/editor/code-editor/code-text-editor/tools/spx.ts
@@ -32,6 +32,8 @@ export const onCloned: Tool = {
   }
 }
 
+// For now `onTouched` is not exposed to the user
+// As it behaves strangely in the current implementation, see details in https://github.com/goplus/spx/issues/298
 export const onTouched: Tool = {
   type: ToolType.method,
   callEffect: ToolCallEffect.listen,
@@ -54,7 +56,7 @@ export const onTouched: Tool = {
     },
     {
       desc: { en: 'By some given sprites', zh: '指定的某些精灵' },
-      sample: 'onTouched [S1, S2] => {}',
+      sample: 'onTouched [S1, S2], => {}',
       insertText: 'onTouched [${1:}], => {\n\t${2}\n}'
     }
   ]


### PR DESCRIPTION
We will keep `onTouched` hidden as it behaves strangely, until https://github.com/goplus/spx/issues/298 is resolved