### PR TITLE
Debug animation sound on project load

### DIFF
--- a/spx-gui/src/components/editor/sprite/animation/AnimationSettings.vue
+++ b/spx-gui/src/components/editor/sprite/animation/AnimationSettings.vue
@@ -110,6 +110,7 @@ function handleClickOutside(e: MouseEvent) {
   gap: 4px;
   border-radius: var(--ui-border-radius-1);
   box-shadow: var(--ui-box-shadow-small);
+  background-color: var(--ui-color-grey-100);
 }
 
 .setting {

--- a/spx-gui/src/models/animation.test.ts
+++ b/spx-gui/src/models/animation.test.ts
@@ -1,6 +1,7 @@
 import { nextTick } from 'vue'
 import { describe, expect, it } from 'vitest'
-import { fromText } from './common/file'
+import { delayFile } from '@/utils/test'
+import { fromText, type Files } from './common/file'
 import { Project } from './project'
 import { Sprite } from './sprite'
 import { Costume } from './costume'
@@ -78,5 +79,18 @@ describe('Animation', () => {
     project.removeSound(project.sounds[0].name)
     await nextTick()
     expect(animation.sound).toBeNull()
+  })
+
+  it('should load correctly', async () => {
+    const project = makeProject()
+    project.sprites[0].animations[0].setSound(project.sounds[0].name)
+
+    const [metadata, files] = project.export()
+    const delayedFiles: Files = Object.fromEntries(
+      Object.entries(files).map(([path, file]) => [path, delayFile(file!, 50)])
+    )
+    const newProject = new Project()
+    await newProject.load(metadata, delayedFiles)
+    expect(newProject.sprites[0].animations[0].sound).toBe(newProject.sounds[0].name)
   })
 })

--- a/spx-gui/src/models/project/index.ts
+++ b/spx-gui/src/models/project/index.ts
@@ -161,16 +161,34 @@ export class Project extends Disposble {
     sound.addDisposer(() => sound.setProject(null))
     this.sounds.push(sound)
     sound.addDisposer(
-      // update selected when sound renamed
+      // update animation.sound & selected when sound renamed
+      // TODO: there are quite some similar logic to deal with such references among models, we may introduce model `ID` to simplify that
       watch(
         () => sound.name,
         (newName, originalName) => {
+          for (const sprite of this.sprites) {
+            for (const animation of sprite.animations) {
+              if (animation.sound === originalName) {
+                animation.setSound(newName)
+              }
+            }
+          }
           if (this.selected?.type === 'sound' && this.selected.name === originalName) {
             this.select({ type: 'sound', name: newName })
           }
         }
       )
     )
+    sound.addDisposer(() => {
+      // TODO: it may be better to do `setSound(null)` in `Animation`, but for now it is difficult for `Animation` to know when sound is removed
+      for (const sprite of this.sprites) {
+        for (const animation of sprite.animations) {
+          if (animation.sound === sound.name) {
+            animation.setSound(null)
+          }
+        }
+      }
+    })
   }
 
   setPublic(isPublic: IsPublic) {

--- a/spx-gui/src/models/sprite.ts
+++ b/spx-gui/src/models/sprite.ts
@@ -75,7 +75,7 @@ function getSpriteCodeFileName(name: string) {
 export const spriteConfigFileName = 'index.json'
 
 export class Sprite extends Disposble {
-  project: Project | null = null
+  private project: Project | null = null
   setProject(project: Project | null) {
     this.project = project
   }

--- a/spx-gui/src/utils/test.ts
+++ b/spx-gui/src/utils/test.ts
@@ -2,6 +2,14 @@
  * @desc Helpers for testing
  */
 
+import { File } from '@/models/common/file'
+
 export function sleep(duration = 1000) {
   return new Promise<void>((resolve) => setTimeout(() => resolve(), duration))
+}
+
+export function delayFile(file: File, duration = 1000) {
+  return new File(file!.name, () => sleep(duration).then(() => file!.arrayBuffer()), {
+    type: file!.type
+  })
 }


### PR DESCRIPTION
* Fix animation sound loss on project load

    In #634, we tried to

    > Fix animation sound issues when sound removed / renamed

    by clear field `sound` when we can't find it in `project.sounds`.

    While we load animations (in sprites) & sounds concurrently, if animation loaded before corresponding sound, the field `sound` will be cleared by mistake.

    We move the logic to model `Project` (just like what we do with sprite removing & renaming) to fix that.

* Fix `AnimationSettings` bg color