### PR TITLE
spx-gui: remove unnecessary `defineProps` and `defineEmits` imports

### DIFF
--- a/spx-gui/.eslintrc.cjs
+++ b/spx-gui/.eslintrc.cjs
@@ -31,6 +31,20 @@ module.exports = {
           'v-.*' // for Vue Konva components
         ]
       }
+    ],
+    'no-restricted-imports': [
+      'warn',
+      {
+        paths: [
+          {
+            // Workaround for https://github.com/vuejs/eslint-plugin-vue/issues/2437
+            name: 'vue',
+            importNames: ['defineProps', 'defineEmits'],
+            message:
+              '`defineProps` and `defineEmits` are compiler macros and no longer need to be imported.'
+          }
+        ]
+      }
     ]
   }
 }

--- a/spx-gui/src/components/asset/animation/GroupCostumesModal.vue
+++ b/spx-gui/src/components/asset/animation/GroupCostumesModal.vue
@@ -54,7 +54,7 @@
   </UIFormModal>
 </template>
 <script setup lang="ts">
-import { defineProps, defineEmits, ref, reactive, computed } from 'vue'
+import { ref, reactive, computed } from 'vue'
 import { UIButton, UICheckbox, UIEmpty, UIFormModal } from '@/components/ui'
 import type { Costume } from '@/models/costume'
 import type { Sprite } from '@/models/sprite'

--- a/spx-gui/src/components/asset/library/AssetLibraryModal.vue
+++ b/spx-gui/src/components/asset/library/AssetLibraryModal.vue
@@ -94,7 +94,7 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, defineProps, ref, shallowReactive, watch } from 'vue'
+import { computed, ref, shallowReactive, watch } from 'vue'
 import {
   UITextInput,
   UIIcon,

--- a/spx-gui/src/components/asset/preprocessing/PreprocessModal.vue
+++ b/spx-gui/src/components/asset/preprocessing/PreprocessModal.vue
@@ -77,7 +77,7 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, defineProps, ref, shallowReactive, shallowRef, watch } from 'vue'
+import { computed, ref, shallowReactive, shallowRef, watch } from 'vue'
 import { stripExt } from '@/utils/path'
 import type { LocaleMessage } from '@/utils/i18n'
 import { Costume } from '@/models/costume'

--- a/spx-gui/src/components/editor/preview/stage-viewer/SpriteItem.vue
+++ b/spx-gui/src/components/editor/preview/stage-viewer/SpriteItem.vue
@@ -8,7 +8,7 @@
   />
 </template>
 <script lang="ts" setup>
-import { computed, defineProps, onMounted, ref, watchEffect } from 'vue'
+import { computed, onMounted, ref, watchEffect } from 'vue'
 import type { KonvaEventObject } from 'konva/lib/Node'
 import type { ImageConfig } from 'konva/lib/shapes/Image'
 import type { Action } from '@/models/project'

--- a/spx-gui/src/components/editor/sound/SoundRecorder.vue
+++ b/spx-gui/src/components/editor/sound/SoundRecorder.vue
@@ -95,7 +95,7 @@
 </template>
 
 <script lang="ts" setup>
-import { defineEmits, ref } from 'vue'
+import { ref } from 'vue'
 import { useEditorCtx } from '@/components/editor/EditorContextProvider.vue'
 import dayjs from 'dayjs'
 import { fromBlob } from '@/models/common/file'

--- a/spx-gui/src/components/editor/sound/waveform/WaveformRangeControl.vue
+++ b/spx-gui/src/components/editor/sound/waveform/WaveformRangeControl.vue
@@ -15,7 +15,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, defineProps, defineEmits } from 'vue'
+import { ref } from 'vue'
 
 const props = defineProps<{ value: { left: number; right: number } }>()
 const emit = defineEmits<{

--- a/spx-gui/src/components/editor/sprite/AnimationRemoveModal.vue
+++ b/spx-gui/src/components/editor/sprite/AnimationRemoveModal.vue
@@ -39,7 +39,7 @@ import type { Animation } from '@/models/animation'
 import type { Project } from '@/models/project'
 import type { Sprite } from '@/models/sprite'
 
-import { defineProps, defineEmits, ref } from 'vue'
+import { ref } from 'vue'
 
 const props = defineProps<{
   visible: boolean

--- a/spx-gui/src/widgets/spx-runner/SpxRunner.ce.vue
+++ b/spx-gui/src/widgets/spx-runner/SpxRunner.ce.vue
@@ -30,7 +30,7 @@
 </template>
 <script setup lang="ts">
 import ProjectRunner from '@/components/project/runner/ProjectRunner.vue'
-import { ref, defineProps, watch } from 'vue'
+import { ref, watch } from 'vue'
 import { Project, fullName } from '@/models/project'
 import { shallowRef } from 'vue'
 const props = defineProps<{ owner?: string; name?: string }>()


### PR DESCRIPTION
```bash
$ npm run dev
...

[@vue/compiler-sfc] `defineProps` is a compiler macro and no longer needs to be imported.

[@vue/compiler-sfc] `defineEmits` is a compiler macro and no longer needs to be imported.
```