### PR TITLE
fix required prop warnings

### DIFF
--- a/spx-gui/src/components/ui/block-items/UIEditorSoundItem.vue
+++ b/spx-gui/src/components/ui/block-items/UIEditorSoundItem.vue
@@ -21,7 +21,7 @@ import UIBlockItemTitle from './UIBlockItemTitle.vue'
 
 withDefaults(
   defineProps<{
-    color: 'sound' | 'primary'
+    color?: 'sound' | 'primary'
     name: string
     selected: boolean
   }>(),

--- a/spx-gui/src/components/ui/block-items/UIEditorSpriteItem.vue
+++ b/spx-gui/src/components/ui/block-items/UIEditorSpriteItem.vue
@@ -18,7 +18,7 @@ withDefaults(
     imgLoading: boolean
     name: string
     selected: boolean
-    color: 'sprite' | 'primary'
+    color?: 'sprite' | 'primary'
   }>(),
   {
     color: 'sprite'


### PR DESCRIPTION
There is a wall of warnings in console from Vue saying that the `color` prop of `UlEditorSpriteltem` is required but not provided, even if we have already defined the defaults with `withDefaults`.