### PR TITLE
Introduce AssetItem Component 

### DIFF
--- a/spx-gui/src/apis/asset.ts
+++ b/spx-gui/src/apis/asset.ts
@@ -30,6 +30,10 @@ export type AssetData<T extends AssetType = AssetType> = {
   clickCount: number
   /** Public status */
   isPublic: IsPublic
+  /** Favorite status */
+  isFavorite: boolean
+  /** Favorite count */
+  favoriteCount: number
 }
 
 export type AddAssetParams = Pick<
@@ -77,4 +81,25 @@ export function getAsset(id: string) {
 
 export function increaseAssetClickCount(id: string) {
   return client.post(`/asset/${encodeURIComponent(id)}/click`) as Promise<void>
+}
+
+/**
+ * WARNING: This API is not implemented in the backend yet.
+ */
+export function addAssetToHistory(id: string) {
+  return client.post('/asset/history', { assetId: id }) as Promise<void>
+}
+
+/**
+ * WARNING: This API is not implemented in the backend yet.
+ */
+export function addAssetToFavorites(id: string) {
+  return client.post('/asset/favorites', { assetId: id }) as Promise<void>
+}
+
+/**
+ * WARNING: This API is not implemented in the backend yet.
+ */
+export function removeAssetFromFavorites(id: string) {
+  return client.delete('/asset/favorites', { assetId: id }) as Promise<void>
 }

--- a/spx-gui/src/components/asset/library/AssetItem.vue
+++ b/spx-gui/src/components/asset/library/AssetItem.vue
@@ -37,12 +37,21 @@
             }}
           </div>
         </div>
-        <div class="asset-operation">
+        <div
+          class="asset-operation"
+          :class="{ disabled: addToProjectPending }"
+          @click="handleAddToProject"
+        >
           <NIcon :size="14" color="#ffffff">
             <PlusOutlined />
           </NIcon>
           <div class="operation-title">
-            {{ $t({ en: `Add to project`, zh: `添加到项目` }) }}
+            <!-- {{ $t({ en: `Add to project`, zh: `添加到项目` }) }} -->
+            {{
+              addToProjectPending
+                ? $t({ en: `Adding to project...`, zh: `正在添加..` })
+                : $t({ en: `Add to project`, zh: `添加到项目` })
+            }}
           </div>
         </div>
       </div>
@@ -93,6 +102,11 @@ import { ref } from 'vue'
 const props = defineProps<{
   asset: AssetData
   selected: boolean
+  addToProjectPending: boolean
+}>()
+
+const emit = defineEmits<{
+  addToProject: [asset: AssetData]
 }>()
 
 const assetModel = useAsyncComputed(() => cachedConvertAssetData(props.asset))
@@ -109,6 +123,13 @@ const handleFavorite = () => {
     favoriteCount.value--
     addAssetToFavorites(props.asset.id)
   }
+}
+
+const handleAddToProject = () => {
+  if (props.addToProjectPending) {
+    return
+  }
+  emit('addToProject', props.asset)
 }
 </script>
 
@@ -200,6 +221,11 @@ $FLEX_BASIS: calc(90% / $COLUMN_COUNT);
   grid-template-columns: 14px 0fr;
   align-items: center;
   transition: grid-template-columns 0.25s ease;
+}
+
+.asset-operation.disabled {
+  background-color: #2f2f2f77;
+  color: #cbd2d8;
 }
 
 .asset-operation .operation-title {

--- a/spx-gui/src/components/asset/library/AssetItem.vue
+++ b/spx-gui/src/components/asset/library/AssetItem.vue
@@ -3,8 +3,8 @@
   <SpritePreview v-if="sprite" :sprite="sprite" style="display: flex; flex-direction: column; align-items: center; justify-content: center; width: 100px; height: 100px"/>
   </div> -->
   <div class="asset-item">
-    <div class="asset-preview">
-      <div class="asset-preview-img">
+    <div class="asset-preview-container">
+      <div class="asset-preview">
         <UILoading v-if="!assetModel" cover :mask="false" />
         <SpritePreview
           v-else-if="asset.assetType === AssetType.Sprite"
@@ -22,6 +22,43 @@
           class="preview sound-preview"
         />
       </div>
+      <!-- shown when hovered -->
+      <div class="asset-operations">
+        <div class="asset-operation">
+          <NIcon :size="14" color="#ffffff">
+            <HeartOutlined />
+          </NIcon>
+          <div class="operation-title">
+            {{ $t({ en: `Favorite`, zh: `添加到收藏` }) }}
+          </div>
+        </div>
+        <div class="asset-operation">
+          <NIcon :size="14" color="#ffffff">
+            <PlusOutlined />
+          </NIcon>
+          <div class="operation-title">
+            {{ $t({ en: `Add to project`, zh: `添加到项目` }) }}
+          </div>
+        </div>
+      </div>
+      <!-- hidden when hovered -->
+      <div class="asset-info">
+        <div class="asset-info-left">
+          <div class="asset-info-item">
+            <NIcon color="#ffffff">
+              <HeartFilled />
+            </NIcon>
+            {{ 0 }}
+          </div>
+          <div class="asset-info-item">
+            <NIcon color="#ffffff">
+              <StarOutlined />
+            </NIcon>
+            {{ 0 }}
+          </div>
+        </div>
+        <!-- <div class="asset-info-right">{{ $t({ en: `FREE`, zh: `免费` }) }}</div> -->
+      </div>
     </div>
     <div class="asset-name">
       {{ asset.displayName }}
@@ -30,14 +67,15 @@
 </template>
 
 <script setup lang="ts">
-import { UILoading, UISpriteItem } from '@/components/ui'
-import { useFileUrl } from '@/utils/file'
+import { UILoading } from '@/components/ui'
 import { cachedConvertAssetData, type AssetModel } from '@/models/common/asset'
 import { useAsyncComputed } from '@/utils/utils'
 import { type AssetData, AssetType } from '@/apis/asset'
 import SpritePreview from './SpritePreview.vue'
 import BackdropPreview from './BackdropPreview.vue'
 import SoundPreview from './SoundPreview.vue'
+import { NIcon } from 'naive-ui'
+import { HeartOutlined, HeartFilled, PlusOutlined, StarOutlined } from '@vicons/antd'
 
 const props = defineProps<{
   asset: AssetData
@@ -49,19 +87,20 @@ const assetModel = useAsyncComputed(() => cachedConvertAssetData(props.asset))
 
 <style lang="scss" scoped>
 $COLUMN_COUNT: 4;
-$FLEX_BASIS: calc(100% / $COLUMN_COUNT);
+$FLEX_BASIS: calc(90% / $COLUMN_COUNT);
+
 .asset-item {
   flex: 0 1 $FLEX_BASIS;
   display: flex;
   flex-direction: column;
-  align-items: center;
+  align-items: flex-start;
   justify-content: center;
   cursor: pointer;
   user-select: none;
   color: var(--text-color);
   font-size: 12px;
   text-align: center;
-  padding: 8px;
+  padding: 0;
   border-radius: 8px;
   background-color: var(--bg-color);
   transition: background-color 0.2s;
@@ -71,15 +110,20 @@ $FLEX_BASIS: calc(100% / $COLUMN_COUNT);
   background-color: var(--bg-color-hover);
 }
 
-.asset-preview {
+.asset-preview-container {
   display: flex;
   align-items: center;
   justify-content: center;
   position: relative;
   width: 100%;
+
+  border-color: var(--ui-color-grey-300);
+  background-color: var(--ui-color-grey-300);
+  border-radius: 8px;
+  overflow: hidden;
 }
 
-.asset-preview-img {
+.asset-preview {
   width: 100%;
   /* calculate the height based on the aspect ratio */
   /* and the child element should be absolutely positioned */
@@ -90,7 +134,7 @@ $FLEX_BASIS: calc(100% / $COLUMN_COUNT);
   position: relative;
 }
 
-.asset-preview-img > * {
+.asset-preview > * {
   position: absolute;
   width: 100%;
   height: 100%;
@@ -103,5 +147,99 @@ $FLEX_BASIS: calc(100% / $COLUMN_COUNT);
 
 .asset-name {
   margin-top: 8px;
+}
+
+.asset-operations {
+  display: flex;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  align-items: center;
+  justify-content: space-between;
+  opacity: 0;
+  transition: opacity 0.25s ease;
+  pointer-events: none;
+  padding: 8px;
+}
+
+.asset-operation {
+  height: 24px;
+  background-color: #00000077;
+  color: #ffffff;
+  padding: 0 5px;
+  border-radius: 5px;
+  display: grid;
+  grid-template-columns: 14px 0fr;
+  align-items: center;
+  transition: grid-template-columns 0.25s ease;
+}
+
+.asset-operation .operation-title {
+  overflow: hidden;
+  white-space: nowrap;
+  min-width: 0;
+}
+
+.asset-operation:hover {
+  grid-template-columns: 24px 1fr;
+}
+
+.asset-item:hover .asset-operations {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.asset-info {
+  display: flex;
+  flex-direction: row;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  align-items: flex-end;
+  justify-content: space-between;
+  z-index: 0;
+  color: #ffffff;
+  padding: 4px 8px;
+  opacity: 1;
+  transition: opacity 0.25s ease;
+  // pointer-events: auto;
+  pointer-events: none;
+}
+
+.asset-info-right,
+.asset-info-left {
+  height: 1rem;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.asset-info-item {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.asset-info::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: linear-gradient(
+    180deg,
+    rgba(0, 0, 0, 0) calc(100% - 1rem - 16px),
+    rgba(0, 0, 0, 0.5) 100%
+  );
+  z-index: -1;
+}
+
+.asset-item:hover .asset-info {
+  opacity: 0;
+  pointer-events: none;
 }
 </style>

--- a/spx-gui/src/components/asset/library/AssetItem.vue
+++ b/spx-gui/src/components/asset/library/AssetItem.vue
@@ -101,7 +101,6 @@ import { ref } from 'vue'
 
 const props = defineProps<{
   asset: AssetData
-  selected: boolean
   addToProjectPending: boolean
 }>()
 

--- a/spx-gui/src/components/asset/library/AssetItem.vue
+++ b/spx-gui/src/components/asset/library/AssetItem.vue
@@ -24,12 +24,17 @@
       </div>
       <!-- shown when hovered -->
       <div class="asset-operations">
-        <div class="asset-operation">
-          <NIcon :size="14" color="#ffffff">
+        <div class="asset-operation" @click="handleFavorite">
+          <NIcon v-if="!isFavorite" :size="14" color="#ffffff">
             <HeartOutlined />
           </NIcon>
+          <NIcon v-else :size="14" color="#f44336">
+            <HeartFilled />
+          </NIcon>
           <div class="operation-title">
-            {{ $t({ en: `Favorite`, zh: `添加到收藏` }) }}
+            {{
+              $t(isFavorite ? { en: `Unfavorite`, zh: `取消收藏` } : { en: `Favorite`, zh: `收藏` })
+            }}
           </div>
         </div>
         <div class="asset-operation">
@@ -48,15 +53,17 @@
             <NIcon color="#ffffff">
               <HeartFilled />
             </NIcon>
-            {{ 0 }}
+            {{ favoriteCount }}
           </div>
-          <div class="asset-info-item">
+          <!-- Rating is not implemented yet -->
+          <!-- <div class="asset-info-item">
             <NIcon color="#ffffff">
               <StarOutlined />
             </NIcon>
             {{ 0 }}
-          </div>
+          </div> -->
         </div>
+        <!-- Maybe we will introduce a marketplace in the future -->
         <!-- <div class="asset-info-right">{{ $t({ en: `FREE`, zh: `免费` }) }}</div> -->
       </div>
     </div>
@@ -70,12 +77,18 @@
 import { UILoading } from '@/components/ui'
 import { cachedConvertAssetData, type AssetModel } from '@/models/common/asset'
 import { useAsyncComputed } from '@/utils/utils'
-import { type AssetData, AssetType } from '@/apis/asset'
+import {
+  addAssetToFavorites,
+  type AssetData,
+  AssetType,
+  removeAssetFromFavorites
+} from '@/apis/asset'
 import SpritePreview from './SpritePreview.vue'
 import BackdropPreview from './BackdropPreview.vue'
 import SoundPreview from './SoundPreview.vue'
 import { NIcon } from 'naive-ui'
-import { HeartOutlined, HeartFilled, PlusOutlined, StarOutlined } from '@vicons/antd'
+import { HeartOutlined, HeartFilled, PlusOutlined /** , StarOutlined */ } from '@vicons/antd'
+import { ref } from 'vue'
 
 const props = defineProps<{
   asset: AssetData
@@ -83,6 +96,20 @@ const props = defineProps<{
 }>()
 
 const assetModel = useAsyncComputed(() => cachedConvertAssetData(props.asset))
+
+const isFavorite = ref(props.asset.isFavorite ?? false)
+const favoriteCount = ref(props.asset.favoriteCount ?? 0)
+
+const handleFavorite = () => {
+  isFavorite.value = !isFavorite.value
+  if (isFavorite.value) {
+    favoriteCount.value++
+    removeAssetFromFavorites(props.asset.id)
+  } else {
+    favoriteCount.value--
+    addAssetToFavorites(props.asset.id)
+  }
+}
 </script>
 
 <style lang="scss" scoped>

--- a/spx-gui/src/components/asset/library/AssetItem.vue
+++ b/spx-gui/src/components/asset/library/AssetItem.vue
@@ -1,0 +1,107 @@
+<template>
+  <!-- <div style="display: flex; flex-direction: column; align-items: center; justify-content: center; width: 100px; height: 100px">
+  <SpritePreview v-if="sprite" :sprite="sprite" style="display: flex; flex-direction: column; align-items: center; justify-content: center; width: 100px; height: 100px"/>
+  </div> -->
+  <div class="asset-item">
+    <div class="asset-preview">
+      <div class="asset-preview-img">
+        <UILoading v-if="!assetModel" cover :mask="false" />
+        <SpritePreview
+          v-else-if="asset.assetType === AssetType.Sprite"
+          :sprite="assetModel as AssetModel<AssetType.Sprite>"
+          class="preview sprite-preview"
+        />
+        <BackdropPreview
+          v-else-if="asset.assetType === AssetType.Backdrop"
+          :backdrop="assetModel as AssetModel<AssetType.Backdrop>"
+          class="preview backdrop-preview"
+        />
+        <SoundPreview
+          v-else-if="asset.assetType === AssetType.Sound"
+          :sound="assetModel as AssetModel<AssetType.Sound>"
+          class="preview sound-preview"
+        />
+      </div>
+    </div>
+    <div class="asset-name">
+      {{ asset.displayName }}
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { UILoading, UISpriteItem } from '@/components/ui'
+import { useFileUrl } from '@/utils/file'
+import { cachedConvertAssetData, type AssetModel } from '@/models/common/asset'
+import { useAsyncComputed } from '@/utils/utils'
+import { type AssetData, AssetType } from '@/apis/asset'
+import SpritePreview from './SpritePreview.vue'
+import BackdropPreview from './BackdropPreview.vue'
+import SoundPreview from './SoundPreview.vue'
+
+const props = defineProps<{
+  asset: AssetData
+  selected: boolean
+}>()
+
+const assetModel = useAsyncComputed(() => cachedConvertAssetData(props.asset))
+</script>
+
+<style lang="scss" scoped>
+$COLUMN_COUNT: 4;
+$FLEX_BASIS: calc(100% / $COLUMN_COUNT);
+.asset-item {
+  flex: 0 1 $FLEX_BASIS;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  user-select: none;
+  color: var(--text-color);
+  font-size: 12px;
+  text-align: center;
+  padding: 8px;
+  border-radius: 8px;
+  background-color: var(--bg-color);
+  transition: background-color 0.2s;
+}
+
+.asset-item:hover {
+  background-color: var(--bg-color-hover);
+}
+
+.asset-preview {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+  width: 100%;
+}
+
+.asset-preview-img {
+  width: 100%;
+  /* calculate the height based on the aspect ratio */
+  /* and the child element should be absolutely positioned */
+  padding-bottom: 61.8%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+}
+
+.asset-preview-img > * {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  top: 0;
+  left: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.asset-name {
+  margin-top: 8px;
+}
+</style>

--- a/spx-gui/src/components/asset/library/AssetLibrary.vue
+++ b/spx-gui/src/components/asset/library/AssetLibrary.vue
@@ -27,42 +27,18 @@
         <div class="content">
           <AssetList
             :add-to-project-pending="handleAddToProject.isLoading.value"
-            @update:selected="handleAssetSelectedChange"
             @add-to-project="handleAddToProject.fn"
           />
         </div>
-        <footer class="footer">
-          <span v-show="selected.length > 0">
-            {{
-              $t({
-                en: `${selected.length} ${entityMessage.en}${selected.length > 1 ? 's' : ''} selected`,
-                zh: `已选中 ${selected.length} 个${entityMessage.zh}`
-              })
-            }}
-          </span>
-          <UIButton
-            size="large"
-            :disabled="selected.length === 0"
-            :loading="handleConfirm.isLoading.value"
-            @click="handleConfirm.fn"
-          >
-            {{ $t({ en: 'Confirm', zh: '确认' }) }}
-          </UIButton>
-        </footer>
       </main>
     </section>
   </div>
 </template>
 <script setup lang="ts">
-import { computed, ref, shallowReactive, watch } from 'vue'
+import { computed, ref, watch } from 'vue'
 import {
   UITextInput,
   UIIcon,
-  UITag,
-  UILoading,
-  UIEmpty,
-  UIError,
-  UIButton,
   UIModalClose,
   UIDivider
 } from '@/components/ui'
@@ -94,6 +70,12 @@ const handleUpdateShow = (visible: boolean) => {
 }
 
 const handleCloseButton = () => {
+  if (addedModels.length > 0) {
+    emit('resolved', addedModels)
+  }
+  else {
+    emit('cancelled')
+  }
   handleUpdateShow(false)
 }
 
@@ -129,8 +111,6 @@ function handleChangeType(t: AssetType) {
   searchCtx.type = t
 }
 
-const selected = shallowReactive<AssetData[]>([])
-
 async function addAssetToProject(asset: AssetData) {
   switch (asset.assetType) {
     case AssetType.Sprite: {
@@ -154,33 +134,20 @@ async function addAssetToProject(asset: AssetData) {
   }
 }
 
-const handleConfirm = useMessageHandle(
-  async () => {
-    const action = {
-      name: { en: `Add ${entityMessage.value.en}`, zh: `添加${entityMessage.value.zh}` }
-    }
-    const assetModels = await props.project.history.doAction(action, () =>
-      Promise.all(selected.map(addAssetToProject))
-    )
-    emit('resolved', assetModels)
-  },
-  { en: 'Failed to add asset', zh: '素材添加失败' }
-)
+const addedModels:AssetModel[] = []
 
 const handleAddToProject = useMessageHandle(
   async (asset: AssetData) => {
     const action = {
       name: { en: `Add ${entityMessage.value.en}`, zh: `添加${entityMessage.value.zh}` }
     }
-    await props.project.history.doAction(action, () => addAssetToProject(asset))
+    const assetModel = await props.project.history.doAction(action, () => addAssetToProject(asset))
+    addedModels.push(assetModel)
   },
   { en: 'Failed to add asset', zh: '素材添加失败' },
   { en: 'Asset added successfully', zh: '素材添加成功' }
 )
 
-async function handleAssetSelectedChange(assets: AssetData[]) {
-  selected.splice(0, selected.length, ...assets)
-}
 </script>
 
 <style scoped lang="scss">

--- a/spx-gui/src/components/asset/library/AssetLibrary.vue
+++ b/spx-gui/src/components/asset/library/AssetLibrary.vue
@@ -19,14 +19,17 @@
     <UIDivider />
     <section class="body">
       <div class="sider">
-        <LibraryMenu @update:value="handleSelectCategory"/>
+        <LibraryMenu @update:value="handleSelectCategory" />
         <UIDivider />
-        <LibraryTree :type="type" @update="handleSelectCategory"/>
+        <LibraryTree :type="type" @update="handleSelectCategory" />
       </div>
       <main class="main">
         <div class="content">
-          
-          <AssetList @update:selected="handleAssetSelectedChange"/>
+          <AssetList
+            :add-to-project-pending="handleAddToProject.isLoading.value"
+            @update:selected="handleAssetSelectedChange"
+            @add-to-project="handleAddToProject.fn"
+          />
         </div>
         <footer class="footer">
           <span v-show="selected.length > 0">
@@ -104,7 +107,7 @@ const searchInput = ref('')
 const searchCtx = useSearchCtx()
 const searchResultCtx = useSearchResultCtx()
 const entityMessage = computed(() => entityMessages[searchCtx.type])
-const type = ref(searchCtx.type)//just for display
+const type = ref(searchCtx.type) //just for display
 
 // do search (with a delay) when search-input changed
 watch(
@@ -114,12 +117,11 @@ watch(
   }, 500)
 )
 
-
 function handleSearch() {
   searchCtx.keyword = searchInput.value
 }
 
-function handleSelectCategory(c: string|string[]) {
+function handleSelectCategory(c: string | string[]) {
   searchCtx.category = c
 }
 
@@ -165,6 +167,16 @@ const handleConfirm = useMessageHandle(
   { en: 'Failed to add asset', zh: '素材添加失败' }
 )
 
+const handleAddToProject = useMessageHandle(
+  async (asset: AssetData) => {
+    const action = {
+      name: { en: `Add ${entityMessage.value.en}`, zh: `添加${entityMessage.value.zh}` }
+    }
+    await props.project.history.doAction(action, () => addAssetToProject(asset))
+  },
+  { en: 'Failed to add asset', zh: '素材添加失败' },
+  { en: 'Asset added successfully', zh: '素材添加成功' }
+)
 
 async function handleAssetSelectedChange(assets: AssetData[]) {
   selected.splice(0, selected.length, ...assets)

--- a/spx-gui/src/components/asset/library/AssetLibraryModal.vue
+++ b/spx-gui/src/components/asset/library/AssetLibraryModal.vue
@@ -5,7 +5,6 @@
         :project="props.project"
         @resolved="emit('resolved', $event)"
         @cancelled="emit('cancelled')"
-        @update:visible="emit('cancelled')"
       />
     </UIModal>
   </SearchContextProvider>

--- a/spx-gui/src/components/asset/library/AssetList.vue
+++ b/spx-gui/src/components/asset/library/AssetList.vue
@@ -11,30 +11,17 @@
     ref="virtualList"
     class="asset-list"
     :items="groupedAssetItems"
-    :item-size="140"
+    :item-size="148"
     :key-field="'id'"
-    :item-resizable="true"
+    :item-resizable="false"
     @scroll="handleScroll"
     @wheel="handleScroll"
   >
     <template #default="{ item }: { item: GroupedAssetItem }">
       <div v-if="item.type === 'asset-group'" class="asset-list-row">
         <template v-for="asset in item.assets" :key="asset.id">
-          <SoundItem
-            v-if="asset.assetType === AssetType.Sound"
-            :asset="(asset as AssetData<AssetType.Sound>)"
-            :selected="isSelected(asset)"
-            @click="handleAssetClick(asset)"
-          />
-          <SpriteItem
-            v-else-if="asset.assetType === AssetType.Sprite"
-            :asset="(asset as AssetData<AssetType.Sprite>)"
-            :selected="isSelected(asset)"
-            @click="handleAssetClick(asset)"
-          />
-          <BackdropItem
-            v-else-if="asset.assetType === AssetType.Backdrop"
-            :asset="(asset as AssetData<AssetType.Backdrop>)"
+          <AssetItem
+            :asset="asset"
             :selected="isSelected(asset)"
             @click="handleAssetClick(asset)"
           />
@@ -61,13 +48,11 @@ import { computed, ref, shallowReactive, watch } from 'vue'
 import { useSearchCtx, useSearchResultCtx, type SearchCtx } from './SearchContextProvider.vue'
 import { UILoading, UIEmpty, UIError } from '@/components/ui'
 import { NVirtualList, NSpin } from 'naive-ui'
-import { AssetType, type AssetData } from '@/apis/asset'
-import SoundItem from './SoundItem.vue'
-import SpriteItem from './SpriteItem.vue'
-import BackdropItem from './BackdropItem.vue'
+import { type AssetData } from '@/apis/asset'
 import type { ActionException } from '@/utils/exception'
 import emptyImg from '@/components/ui/empty/empty.svg'
 import errorImg from '@/components/ui/error/default-error.svg'
+import AssetItem from './AssetItem.vue'
 
 const emit = defineEmits<{
   'update:selected': [selected: AssetData[]]
@@ -76,7 +61,7 @@ const emit = defineEmits<{
 const searchCtx = useSearchCtx()
 const searchResultCtx = useSearchResultCtx()
 
-const COLUMN_COUNT = 6
+const COLUMN_COUNT = 4
 const assetList = ref<AssetData[]>([])
 
 type GroupedAssetItem =
@@ -201,9 +186,12 @@ watch(
 
 .asset-list-row {
   display: flex;
-  gap: 8px;
+  gap: 2.5%;
   flex-wrap: nowrap;
+  align-items: center;
+  margin: 10px 2.5%;
 }
+
 .asset-list-row:not(:last-child) {
   margin-bottom: 8px;
 }

--- a/spx-gui/src/components/asset/library/AssetList.vue
+++ b/spx-gui/src/components/asset/library/AssetList.vue
@@ -196,7 +196,7 @@ watch(
 }
 
 .asset-list-row:not(:last-child) {
-  margin-bottom: 8px;
+  margin-bottom: 20px;
 }
 
 .more-info {

--- a/spx-gui/src/components/asset/library/AssetList.vue
+++ b/spx-gui/src/components/asset/library/AssetList.vue
@@ -29,11 +29,11 @@
       </div>
       <div v-else-if="item.type === 'loading-more'" class="more-info loading-more">
         <NSpin />
-        {{ $t({ en: 'Loading more...', zh: '加载更多...' }) }}
+        {{ $t({ en: 'Loading more assets...', zh: '正在加载更多素材...' }) }}
       </div>
       <div v-else-if="item.type === 'no-more'" size="small" class="more-info no-more">
         <img :src="emptyImg" alt="empty" />
-        {{ $t({ en: 'No more', zh: '没有更多了' }) }}
+        {{ $t({ en: 'No more assets', zh: '没有更多素材了' }) }}
       </div>
       <div v-else-if="item.type === 'loading-more-error'" class="more-info loading-more-error">
         <img :src="errorImg" alt="error" />
@@ -206,12 +206,12 @@ watch(
   gap: 8px;
   padding: 16px;
   padding-right: 40px;
-  font-size: 14px;
+  font-size: 18px;
   color: var(--ui-color-grey-600);
 }
 
 .more-info img {
-  width: 18px;
-  height: 18px;
+  width: 36px;
+  height: 36px;
 }
 </style>

--- a/spx-gui/src/components/asset/library/AssetList.vue
+++ b/spx-gui/src/components/asset/library/AssetList.vue
@@ -22,9 +22,7 @@
         <template v-for="asset in item.assets" :key="asset.id">
           <AssetItem
             :asset="asset"
-            :selected="isSelected(asset)"
             :add-to-project-pending="props.addToProjectPending"
-            @click="handleAssetClick(asset)"
             @add-to-project="(asset) => emit('addToProject', asset)"
           />
         </template>
@@ -61,7 +59,6 @@ const props = defineProps<{
 }>()
 
 const emit = defineEmits<{
-  'update:selected': [selected: AssetData[]]
   addToProject: [asset: AssetData]
 }>()
 
@@ -143,20 +140,6 @@ const handleScroll = (e: Event) => {
   if (target.scrollHeight - target.scrollTop === target.clientHeight) {
     loadMore()
   }
-}
-
-const selected = shallowReactive<AssetData[]>([])
-
-function isSelected(asset: AssetData) {
-  return selected.some((a) => a.id === asset.id)
-}
-
-async function handleAssetClick(asset: AssetData) {
-  const index = selected.findIndex((a) => a.id === asset.id)
-  if (index < 0) selected.push(asset)
-  else selected.splice(index, 1)
-
-  emit('update:selected', selected)
 }
 
 // Append search result to assetList

--- a/spx-gui/src/components/asset/library/AssetList.vue
+++ b/spx-gui/src/components/asset/library/AssetList.vue
@@ -23,7 +23,9 @@
           <AssetItem
             :asset="asset"
             :selected="isSelected(asset)"
+            :add-to-project-pending="props.addToProjectPending"
             @click="handleAssetClick(asset)"
+            @add-to-project="(asset) => emit('addToProject', asset)"
           />
         </template>
       </div>
@@ -54,8 +56,13 @@ import emptyImg from '@/components/ui/empty/empty.svg'
 import errorImg from '@/components/ui/error/default-error.svg'
 import AssetItem from './AssetItem.vue'
 
+const props = defineProps<{
+  addToProjectPending: boolean
+}>()
+
 const emit = defineEmits<{
   'update:selected': [selected: AssetData[]]
+  addToProject: [asset: AssetData]
 }>()
 
 const searchCtx = useSearchCtx()

--- a/spx-gui/src/components/asset/library/AssetList.vue
+++ b/spx-gui/src/components/asset/library/AssetList.vue
@@ -125,7 +125,7 @@ const groupedAssetItems = computed(() => {
 })
 
 const loadMore = () => {
-  if (assetList.value.length >= (searchResultCtx.assets?.total ?? 0)) {
+  if (searchCtx.page * searchCtx.pageSize >= (searchResultCtx.assets?.total ?? 0)) {
     return
   }
   searchCtx.page++
@@ -157,6 +157,9 @@ watch(
   () => searchResultCtx.assets,
   (result) => {
     assetList.value.push(...(result?.data ?? []))
+    if (searchCtx.page === 1) {
+      loadMore()
+    }
   }
 )
 


### PR DESCRIPTION
This PR introduces the AssetItem component to replace the three existing asset items in the asset library.

## Feat
- Added AssetItem component to replace the existing asset items.
- Implemented `Add to Project` button, allowing users to add assets directly from the asset list.
- Added a favorite functionality to the `AssetItem` component.
- Added functionality to show/hide information and actions on the asset item.
- Removed the `select and add asset` functionality from the AssetLibrary.
![image](https://github.com/user-attachments/assets/511643cd-3d94-40bb-ae26-d39f12e3f840)


## Notes
- The backend API for the favorite functionality has not been implemented yet.