### PR TITLE
feat(spx-gui): Add AI-generated results to search result

### DIFF
--- a/spx-gui/src/apis/aigc.ts
+++ b/spx-gui/src/apis/aigc.ts
@@ -42,11 +42,11 @@ export interface CreateAIImageParams {
 }
 
 const mockAIImage = {
-  imageUri:
-    ['kodo://goplus-builder-static-test/files/FvEYel08GXL60vuviffq9sW-9xZs/IMG20230406220355.jpg',
-      'kodo://goplus-builder-static-test/files/FtzNex_e0lYKKn7S52HTG42d9Mm9-6906',
-      'kodo://goplus-builder-static-test/files/FvbBWmTdYLqyx_Mn_wCF6KAhfZXn-5443'
-    ]
+  imageUri: [
+    'kodo://goplus-builder-static-test/files/FvEYel08GXL60vuviffq9sW-9xZs/IMG20230406220355.jpg',
+    'kodo://goplus-builder-static-test/files/FtzNex_e0lYKKn7S52HTG42d9Mm9-6906',
+    'kodo://goplus-builder-static-test/files/FvbBWmTdYLqyx_Mn_wCF6KAhfZXn-5443'
+  ]
 }
 
 /**
@@ -105,7 +105,7 @@ export enum AIGCStatus {
   Waiting,
   Generating,
   Finished,
-  Failed,
+  Failed
 }
 
 export type AIGCFiles = {
@@ -140,13 +140,13 @@ export async function getAIGCStatus(jobId: string) {
   return new Promise<AIGCStatusResponse>((resolve) => {
     setTimeout(() => {
       const timestamp = mockAIGCStatusMap.get(jobId)
+      const random = Math.random()
       if (timestamp === undefined) {
         mockAIGCStatusMap.set(jobId, Date.now())
         resolve({ status: AIGCStatus.Waiting })
-      } else if (
-        Date.now() - timestamp > Math.random() * 2000 &&
-        Date.now() - timestamp < 5000 + Math.random() * 2000
-      ) {
+      } else if (Date.now() - timestamp < 2000 + random * 2000) {
+        resolve({ status: AIGCStatus.Waiting })
+      } else if (Date.now() - timestamp < 7000 + random * 2000) {
         resolve({ status: AIGCStatus.Generating })
       } else {
         resolve({
@@ -155,7 +155,7 @@ export async function getAIGCStatus(jobId: string) {
             jobId,
             type: AIGCType.Image,
             files: {
-              imageUrl: mockAIImage.imageUri[Math.floor(Math.random() * mockAIImage.imageUri.length)]
+              imageUrl: mockAIImage.imageUri[Math.floor(random * mockAIImage.imageUri.length)]
             }
           }
         })

--- a/spx-gui/src/apis/aigc.ts
+++ b/spx-gui/src/apis/aigc.ts
@@ -43,7 +43,10 @@ export interface CreateAIImageParams {
 
 const mockAIImage = {
   imageUri:
-    'kodo://goplus-builder-static-test/files/Fr1MD9ALY59z1OQj7GlY-tKbLTjh/TotK_Ganondorf.png'
+    ['kodo://goplus-builder-static-test/files/FvEYel08GXL60vuviffq9sW-9xZs/IMG20230406220355.jpg',
+      'kodo://goplus-builder-static-test/files/FtzNex_e0lYKKn7S52HTG42d9Mm9-6906',
+      'kodo://goplus-builder-static-test/files/FvbBWmTdYLqyx_Mn_wCF6KAhfZXn-5443'
+    ]
 }
 
 /**
@@ -101,7 +104,17 @@ export enum AIGCType {
 export enum AIGCStatus {
   Waiting,
   Generating,
-  Finished
+  Finished,
+  Failed,
+}
+
+export type AIGCFiles = {
+  imageUrl?: string
+  skeletonUrl?: string
+  animMeshUrl?: string
+  frameDataUrl?: string
+  backdropImageUrl?: string
+  [key: string]: string | undefined
 }
 
 export interface AIGCStatusResponse {
@@ -109,14 +122,7 @@ export interface AIGCStatusResponse {
   result?: {
     jobId: string
     type: AIGCType
-    files: {
-      imageUrl?: string
-      skeletonUrl?: string
-      animMeshUrl?: string
-      frameDataUrl?: string
-      backdropImageUrl?: string
-      [key: string]: string | undefined
-    }
+    files: AIGCFiles
   }
 }
 
@@ -149,7 +155,7 @@ export async function getAIGCStatus(jobId: string) {
             jobId,
             type: AIGCType.Image,
             files: {
-              imageUrl: mockAIImage.imageUri
+              imageUrl: mockAIImage.imageUri[Math.floor(Math.random() * mockAIImage.imageUri.length)]
             }
           }
         })

--- a/spx-gui/src/apis/aigc.ts
+++ b/spx-gui/src/apis/aigc.ts
@@ -2,11 +2,164 @@
  * @desc AI-related APIs of spx-backend
  */
 
-import { client } from './common'
+import type { AssetData, AssetType } from './asset'
+import { client, type FileCollection } from './common'
 
 export async function matting(imageUrl: string) {
   const result = (await client.post('/aigc/matting', { imageUrl }, { timeout: 20 * 1000 })) as {
     imageUrl: string
   }
   return result.imageUrl
+}
+
+export type AIAssetData<T extends AssetType = AssetType> = {
+  /** Globally unique ID */
+  id: string
+  // /** Asset Category */
+  // category: string
+  /** Asset Type */
+  assetType: T
+  /** Files the asset contains */
+  files?: FileCollection
+  /** Preview URL for the asset, e.g., a gif for a sprite */
+  preview?: string
+  /** Creation time */
+  cTime: string
+  status: AIGCStatus
+}
+
+export const AssetSourceKey = Symbol('AssetSource')
+export type AssetOrAIAsset =
+  | (AssetData & { [AssetSourceKey]?: 'public' })
+  | (AIAssetData & { [AssetSourceKey]?: 'ai' })
+
+export interface CreateAIImageParams {
+  keyword: string
+  category: string | string[]
+  assetType: AssetType
+  width?: number
+  height?: number
+}
+
+const mockAIImage = {
+  imageUri:
+    'kodo://goplus-builder-static-test/files/Fr1MD9ALY59z1OQj7GlY-tKbLTjh/TotK_Ganondorf.png'
+}
+
+/**
+ * Generate AI image with given keyword and category
+ *
+ * WARNING: This API has not been implemented yet. It will return a mock result.
+ */
+export async function generateAIImage({
+  keyword,
+  category,
+  assetType,
+  width,
+  height
+}: CreateAIImageParams) {
+  return new Promise<{ imageJobId: string }>((resolve) => {
+    setTimeout(() => {
+      resolve({ imageJobId: `mock-${keyword}-${Math.random().toString(36).slice(2)}` })
+    }, 1000)
+  })
+  // const result = (await client.post(
+  //   '/aigc/image',
+  //   { keyword, category, assetType, width, height },
+  //   { timeout: 20 * 1000 }
+  // )) as {
+  //   imageJobId: string
+  // }
+  // return result.imageJobId
+}
+
+/**
+ * Generate AI sprite from image
+ *
+ * @param imageJobId The image job ID given by `generateAIImage`
+ *
+ * WARNING: This API has not been implemented yet. It will return a mock result.
+ */
+export async function generateAISprite(imageJobId: string) {
+  return new Promise<{ spriteJobId: string }>((resolve) => {
+    setTimeout(() => {
+      resolve({ spriteJobId: `mock-${imageJobId}-${Math.random().toString(36).slice(2)}` })
+    }, 1000)
+  })
+  // const result = (await client.post('/aigc/sprite', { imageJobId }, { timeout: 20 * 1000 })) as {
+  //   spriteJobId: string
+  // }
+  // return result.spriteJobId
+}
+
+export enum AIGCType {
+  Image,
+  Sprite,
+  Backdrop
+}
+
+export enum AIGCStatus {
+  Waiting,
+  Generating,
+  Finished
+}
+
+export interface AIGCStatusResponse {
+  status: AIGCStatus
+  result?: {
+    jobId: string
+    type: AIGCType
+    files: {
+      imageUrl?: string
+      skeletonUrl?: string
+      animMeshUrl?: string
+      frameDataUrl?: string
+      backdropImageUrl?: string
+      [key: string]: string | undefined
+    }
+  }
+}
+
+const mockAIGCStatusMap: Map<string, number> = new Map()
+
+/**
+ * Get AI image generation status
+ *
+ * @param jobId The job ID returned by `generateAIXxx`
+ * @returns
+ *
+ * WARNING: This API has not been implemented yet. It will return a mock result.
+ */
+export async function getAIGCStatus(jobId: string) {
+  return new Promise<AIGCStatusResponse>((resolve) => {
+    setTimeout(() => {
+      const timestamp = mockAIGCStatusMap.get(jobId)
+      if (timestamp === undefined) {
+        mockAIGCStatusMap.set(jobId, Date.now())
+        resolve({ status: AIGCStatus.Waiting })
+      } else if (
+        Date.now() - timestamp > Math.random() * 2000 &&
+        Date.now() - timestamp < 5000 + Math.random() * 2000
+      ) {
+        resolve({ status: AIGCStatus.Generating })
+      } else {
+        resolve({
+          status: AIGCStatus.Finished,
+          result: {
+            jobId,
+            type: AIGCType.Image,
+            files: {
+              imageUrl: mockAIImage.imageUri
+            }
+          }
+        })
+      }
+    }, 300)
+  })
+  // const result = (await client.get(
+  //   `/aigc/status/${jobId}`,
+  //   {},
+  //   { timeout: 20 * 1000 }
+  // )) as AIGCStatusResponse
+  // return result
 }

--- a/spx-gui/src/apis/aigc.ts
+++ b/spx-gui/src/apis/aigc.ts
@@ -66,14 +66,14 @@ export async function generateAIImage({
       resolve({ imageJobId: `mock-${keyword}-${Math.random().toString(36).slice(2)}` })
     }, 1000)
   })
-  // const result = (await client.post(
-  //   '/aigc/image',
-  //   { keyword, category, assetType, width, height },
-  //   { timeout: 20 * 1000 }
-  // )) as {
-  //   imageJobId: string
-  // }
-  // return result.imageJobId
+  const result = (await client.post(
+    '/aigc/image',
+    { keyword, category, assetType, width, height },
+    { timeout: 20 * 1000 }
+  )) as {
+    imageJobId: string
+  }
+  return result
 }
 
 /**
@@ -89,10 +89,10 @@ export async function generateAISprite(imageJobId: string) {
       resolve({ spriteJobId: `mock-${imageJobId}-${Math.random().toString(36).slice(2)}` })
     }, 1000)
   })
-  // const result = (await client.post('/aigc/sprite', { imageJobId }, { timeout: 20 * 1000 })) as {
-  //   spriteJobId: string
-  // }
-  // return result.spriteJobId
+  const result = (await client.post('/aigc/sprite', { imageJobId }, { timeout: 20 * 1000 })) as {
+    spriteJobId: string
+  }
+  return result
 }
 
 export enum AIGCType {
@@ -162,10 +162,10 @@ export async function getAIGCStatus(jobId: string) {
       }
     }, 300)
   })
-  // const result = (await client.get(
-  //   `/aigc/status/${jobId}`,
-  //   {},
-  //   { timeout: 20 * 1000 }
-  // )) as AIGCStatusResponse
-  // return result
+  const result = (await client.get(
+    `/aigc/status/${jobId}`,
+    {},
+    { timeout: 20 * 1000 }
+  )) as AIGCStatusResponse
+  return result
 }

--- a/spx-gui/src/components/asset/library/AIAssetItem.vue
+++ b/spx-gui/src/components/asset/library/AIAssetItem.vue
@@ -1,0 +1,200 @@
+<template>
+  <div class="asset-item ai-asset-item">
+    <div class="asset-preview-container">
+      <div class="asset-preview">
+        <template v-if="status !== AIGCStatus.Finished">
+          <NSpin>
+            <template #description>
+              <Transition name="slide-fade" mode="out-in" appear>
+                <span v-if="status === AIGCStatus.Waiting" class="generating-text">
+                  {{ $t({ en: `Pending...`, zh: `排队中...` }) }}
+                </span>
+                <span v-else-if="status === AIGCStatus.Generating" class="generating-text">
+                  {{ $t({ en: `Generating...`, zh: `生成中...` }) }}
+                </span>
+              </Transition>
+            </template>
+          </NSpin>
+        </template>
+        <template v-else>
+          <UIImg class="preview" :src="previewImageSrc" :loading="previewImageLoading" />
+        </template>
+      </div>
+    </div>
+    <div class="asset-name">
+      <NIcon size="14" color="var(--text-color)">
+        <BulbOutlined />
+      </NIcon>
+      <span class="ai-asset-tip">
+        {{ $t({ en: `Created by AI`, zh: `AI 创作` }) }}
+      </span>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { UIImg } from '@/components/ui'
+import { NIcon, NSpin } from 'naive-ui'
+import { BulbOutlined } from '@vicons/antd'
+import { ref } from 'vue'
+import { AIGCStatus, getAIGCStatus, type AIAssetData, type AIGCFiles } from '@/apis/aigc'
+import { useFileUrl } from '@/utils/file'
+import { getFiles } from '@/models/common/cloud'
+import type { File } from '@/models/common/file'
+
+const props = defineProps<{
+  asset: AIAssetData
+}>()
+
+const emit = defineEmits<{
+  ready: [asset: AIAssetData]
+}>()
+
+const status = ref<AIGCStatus>(AIGCStatus.Waiting)
+
+let previewImageFile = ref<File | undefined>(undefined)
+const [previewImageSrc, previewImageLoading] = useFileUrl(() => previewImageFile.value as File)
+
+const POLLING_INTERVAL = 500
+
+const POLLING_MAX_COUNT = (5 * 60 * 1000) / POLLING_INTERVAL
+
+let pollingCount = 0
+type RequiredAIGCFiles = Required<AIGCFiles> & { [key: string]: string }
+const pollStatus = async () => {
+  if (status.value === AIGCStatus.Finished) {
+    return
+  }
+  if (pollingCount >= POLLING_MAX_COUNT) {
+    status.value = AIGCStatus.Failed
+    return
+  }
+
+  pollingCount++
+
+  const newStatus = await getAIGCStatus(props.asset.id)
+  status.value = newStatus.status
+
+  if (newStatus.status === AIGCStatus.Finished) {
+    const cloudFiles = newStatus.result?.files
+    if (!cloudFiles) {
+      status.value = AIGCStatus.Failed
+      return
+    }
+    // const files = await getFiles(cloudFiles as Required<AIGCFiles>)
+    const files = (await getFiles(cloudFiles as RequiredAIGCFiles)) as {
+      [key in keyof AIGCFiles]: File
+    }
+
+    if (!files) {
+      status.value = AIGCStatus.Failed
+      return
+    }
+    props.asset.preview = cloudFiles.imageUrl
+    previewImageFile.value = files.imageUrl
+    emit('ready', props.asset)
+  }
+
+  if (newStatus.status !== AIGCStatus.Failed) {
+    setTimeout(pollStatus, POLLING_INTERVAL)
+  }
+}
+
+pollStatus()
+</script>
+
+<style lang="scss" scoped>
+$COLUMN_COUNT: 4;
+$FLEX_BASIS: calc(90% / $COLUMN_COUNT);
+
+.asset-item {
+  flex: 0 1 $FLEX_BASIS;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: center;
+  cursor: pointer;
+  user-select: none;
+  color: var(--text-color);
+  font-size: 12px;
+  text-align: center;
+  padding: 0;
+  border-radius: 8px;
+  background-color: var(--bg-color);
+  transition: background-color 0.2s;
+}
+
+.asset-item:hover {
+  background-color: var(--bg-color-hover);
+}
+
+.asset-preview-container {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+  width: 100%;
+
+  border-color: var(--ui-color-grey-300);
+  background-color: var(--ui-color-grey-300);
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.asset-preview {
+  width: 100%;
+  /* calculate the height based on the aspect ratio */
+  /* and the child element should be absolutely positioned */
+  padding-bottom: 61.8%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+}
+
+.asset-preview > * {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  top: 0;
+  left: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.asset-name {
+  margin-top: 8px;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 6px;
+
+  //   .ai-asset-tip {
+  // 	font-style: italic;
+  //   }
+}
+
+.generating-text {
+  display: inline-block;
+  color: var(--ui-color-turquoise-400, #3fcdd9);
+}
+
+.slide-fade-enter-active,
+.slide-fade-leave-active {
+  transition: all 0.3s;
+}
+
+.slide-fade-enter-from,
+.slide-fade-leave-to {
+  opacity: 0;
+}
+
+.slide-fade-enter-from {
+  transform: translateY(10px);
+}
+
+.slide-fade-leave-to {
+  transform: translateY(-10px);
+}
+</style>

--- a/spx-gui/src/components/asset/library/AssetList.vue
+++ b/spx-gui/src/components/asset/library/AssetList.vue
@@ -21,7 +21,7 @@
     <template #default="{ item }: { item: GroupedAssetItem }">
       <div v-if="item.type === 'asset-group'" class="asset-list-row">
         <template v-for="asset in item.assets" :key="asset.id">
-          <div v-if="isAiAsset in asset" :asset="asset">{{asset.id}}</div>
+          <AIAssetItem v-if="isAiAsset in asset" :asset="asset" />
           <AssetItem
             v-else
             :asset="asset"
@@ -58,6 +58,7 @@ import emptyImg from '@/components/ui/empty/empty.svg'
 import errorImg from '@/components/ui/error/default-error.svg'
 import AssetItem from './AssetItem.vue'
 import { AIGCStatus, generateAIImage, type AIAssetData } from '@/apis/aigc'
+import AIAssetItem from './AIAssetItem.vue'
 
 const props = defineProps<{
   addToProjectPending: boolean


### PR DESCRIPTION
This pull request introduces the AIAssetItem component for displaying AI-generated assets.
The component shows the generating status and preview for AI assets and polls for the AI asset generation status. 

## Changes:
1. AIAssetItem.vue
  - Added AIAssetItem.vue for displaying AI assets.
  - Shows generating status and preview for AI assets.
  - Polls for AI asset generation status.
2. AssetList.vue
  - Call generate AI image when search result is not enough.
  - Use AIAssetItem component for AI assets.
3. aigc.ts
  - Add AI-related APIs and types for asset generation
    - Add AiAssetData and other AIGC-related types.
    - Add new APIs for AI image and sprite generation (Mock).
    - Add new APIs for retrieving AI image generation job status (Mock).
        
## Notes:
  - AIGC API has not been implemented yet. All related API will return a mock result.

## TODO:
  - [x] Add AIGC API and types.
  - [x] Add mock data.
  - [x] Call AIGC when search result is not enough.
  - [x] Introduce AIAssetItem.
  - [x] Improve status display.
  - [x] Improve AIGC related interactions.
    
 