### PR TITLE
Integrates asset history api for asset and ai-asset

### DIFF
--- a/spx-gui/src/apis/aigc.ts
+++ b/spx-gui/src/apis/aigc.ts
@@ -12,6 +12,10 @@ export async function matting(imageUrl: string) {
   return result.imageUrl
 }
 
+/**
+ * AI asset data
+ * It is a subset of `AssetData`.
+ */
 export type AIAssetData<T extends AssetType = AssetType> = {
   /** Globally unique ID */
   id: string
@@ -32,14 +36,44 @@ export type AIAssetData<T extends AssetType = AssetType> = {
   status: AIGCStatus
 }
 
+/**
+ * Flag to indicate the asset is an AI-generated asset.
+ * It could be used to narrow down the `AssetOrAIAsset` type.
+ */
 export const isAiAsset = Symbol('isAiAsset')
+
+/**
+ * Flag to indicate the preview image of the asset is ready.
+ */
 export const isPreviewReady = Symbol('isPreviewReady')
+
+/**
+ * Flag to indicate the content of the asset is ready.
+ * For sprite, it means the sprite has been generated from the preview image.
+ */
 export const isContentReady = Symbol('isContentReady')
+
+/**
+ * When the asset is exported, the backend will return an ID for the exported asset.
+ * This ID can be used to retrieve the exported asset.
+ * 
+ * Store the exported ID in the asset data to prevent exporting the same asset multiple times.
+ */
+export const exportedId = Symbol('isExported')
+
+/**
+ * AI asset data with some additional flags and data.
+ */
 export type TaggedAIAssetData<T extends AssetType = AssetType> = AIAssetData<T> & {
   [isAiAsset]: true
   [isPreviewReady]: boolean
   [isContentReady]: boolean
+  [exportedId]?: string
 }
+
+/**
+ * Type for an public asset or an AI-generated asset.
+ */
 export type AssetOrAIAsset = AssetData | TaggedAIAssetData
 
 export interface CreateAIImageParams {
@@ -193,5 +227,27 @@ export async function getAIGCStatus(jobId: string) {
     {},
     { timeout: 20 * 1000 }
   )) as AIGCStatusResponse
+  return result
+}
+
+/**
+ * WARNING: This API is not implemented in the backend yet.
+ * The parameter has not been determined yet.
+ * As some ai-generated asset may be edited by user or js code, 
+ * the backend may need to get the partial asset instead of the jobId.
+ */
+export async function exportAIGCAsset(asset: TaggedAIAssetData): Promise<{ assetId: string }>;
+export async function exportAIGCAsset(jobId: string): Promise<{ assetId: string }>;
+export async function exportAIGCAsset(param: any) {
+  return new Promise<{ assetId: string }>((resolve) => {
+    setTimeout(() => {
+      resolve({ assetId: '21' })
+    }, 1000)
+  })
+  const result = (await client.post(`/aigc/export`,
+    typeof param === 'string' ? { jobId: param } : { ...param }
+  )) as {
+    assetId: string
+  }
   return result
 }

--- a/spx-gui/src/components/asset/library/AssetLibrary.vue
+++ b/spx-gui/src/components/asset/library/AssetLibrary.vue
@@ -94,7 +94,7 @@
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue'
 import { UITextInput, UIIcon, UIModalClose, UIDivider } from '@/components/ui'
-import { AssetType, getAssetSearchSuggestion, type AssetData } from '@/apis/asset'
+import { addAssetToHistory, AssetType, getAssetSearchSuggestion, type AssetData } from '@/apis/asset'
 import { debounce, useAsyncComputed } from '@/utils/utils'
 import { useMessageHandle } from '@/utils/exception'
 import { type Project } from '@/models/project'
@@ -218,7 +218,10 @@ const handleAddToProject = useMessageHandle(
     const action = {
       name: { en: `Add ${entityMessage.value.en}`, zh: `添加${entityMessage.value.zh}` }
     }
-    const assetModel = await props.project.history.doAction(action, () => addAssetToProject(asset))
+    const [, assetModel] = await Promise.all([
+      addAssetToHistory(asset.id),
+      props.project.history.doAction(action, () => addAssetToProject(asset))
+    ])
     addedModels.push(assetModel)
   },
   { en: 'Failed to add asset', zh: '素材添加失败' },

--- a/spx-gui/src/components/asset/library/AssetLibrary.vue
+++ b/spx-gui/src/components/asset/library/AssetLibrary.vue
@@ -77,6 +77,7 @@
           :ai-assets="currentAIAssetList"
           class="asset-page"
           :add-to-project-pending="handleAddToProject.isLoading.value"
+          @add-to-project="handleAddToProject.fn"
           @select-ai="handleSelectAiAsset"
         />
       </section>

--- a/spx-gui/src/components/asset/library/AssetList.vue
+++ b/spx-gui/src/components/asset/library/AssetList.vue
@@ -84,6 +84,14 @@ import {
 import AIAssetItem from './AIAssetItem.vue'
 import { TipsAndUpdatesOutlined } from '@vicons/material'
 
+const FORBIDDEN_AI_CATEGORIES = ['liked', 'history', 'imported']
+const aiGenerationDisabled = computed(() => {
+  if (typeof searchCtx.category === 'string') {
+    return FORBIDDEN_AI_CATEGORIES.includes(searchCtx.category)
+  }
+  return searchCtx.category.some((c) => FORBIDDEN_AI_CATEGORIES.includes(c))
+})
+
 const props = defineProps<{
   addToProjectPending: boolean
 }>()
@@ -225,7 +233,7 @@ watch(
     if (!hasMoreAssets.value) {
       // Fill the last row with AI assets
       const count = COLUMN_COUNT - (assetList.value.length % COLUMN_COUNT)
-      if (count <= COLUMN_COUNT) {
+      if (count <= COLUMN_COUNT && !aiGenerationDisabled.value) {
         generateMultipleAIImages(count, false)
       }
     } else if (searchCtx.page === 1) {

--- a/spx-gui/src/components/asset/library/SearchContextProvider.vue
+++ b/spx-gui/src/components/asset/library/SearchContextProvider.vue
@@ -94,7 +94,8 @@ const {
   {
     en: 'Failed to list',
     zh: '获取列表失败'
-  }
+  },
+  true
 )
 
 const searchResultCtx = reactive<SearchResultCtx>({

--- a/spx-gui/src/components/asset/library/ai/AIPreviewModal.vue
+++ b/spx-gui/src/components/asset/library/ai/AIPreviewModal.vue
@@ -13,18 +13,18 @@
         <UIButton
           size="large"
           class="insert-button"
-          :disabled="!contentReady || addToProjectPending"
+          :disabled="!contentReady || addToProjectPending || exportPending"
           @click="handleAddButton"
         >
           <span style="white-space: nowrap">
             {{
-              addToProjectPending
+              addToProjectPending || exportPending
                 ? $t({ en: 'Pending...', zh: '正在添加...' })
                 : $t({ en: 'Add to project', zh: '添加到项目' })
             }}
           </span>
         </UIButton>
-        <UIButton size="large" :disabled="!contentReady" @click="handleToggleFav">
+        <UIButton size="large" :disabled="!contentReady || exportPending" @click="handleToggleFav">
           <span style="white-space: nowrap">
             {{
               isFavorite
@@ -119,7 +119,7 @@
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue'
 import { NIcon, NSpin } from 'naive-ui'
-import { addAssetToFavorites, AssetType, removeAssetFromFavorites } from '@/apis/asset'
+import { addAssetToFavorites, AssetType, getAsset, removeAssetFromFavorites, type AssetData } from '@/apis/asset'
 import UIButton from '@/components/ui/UIButton.vue'
 import AIAssetItem from '../AIAssetItem.vue'
 import { NScrollbar } from 'naive-ui'
@@ -130,7 +130,9 @@ import {
   type AIGCFiles,
   isContentReady,
   isPreviewReady,
-  type TaggedAIAssetData
+  type TaggedAIAssetData,
+  exportAIGCAsset,
+  exportedId
 } from '@/apis/aigc'
 import { debounce } from '@/utils/utils'
 import { getFiles } from '@/models/common/cloud'
@@ -150,7 +152,7 @@ const props = defineProps<{
 }>()
 
 const emit = defineEmits<{
-  addToProject: [asset: TaggedAIAssetData]
+  addToProject: [asset: AssetData]
   selectAi: [asset: TaggedAIAssetData]
 }>()
 
@@ -244,12 +246,40 @@ const pollStatus = async () => {
 }
 
 const isFavorite = ref(false)
-
-const handleAddButton = () => {
-  emit('addToProject', props.asset)
+const exportPending = ref(false)
+/**
+ * Get the public asset data from the asset data
+ * If the asset data is not exported, export it first
+ */
+const exportAssetDataToPublic = async () => {
+  if (!props.asset[isContentReady]) {
+    throw new Error('Could not export an incomplete asset')
+  }
+  exportPending.value = true
+  const assetId = props.asset[exportedId] ?? (await exportAIGCAsset(props.asset)).assetId
+  const publicAsset = await getAsset(assetId)
+  exportPending.value = false
+  return publicAsset
 }
 
-const handleToggleFav = () => {
+const publicAsset = ref<AssetData | null>(null)
+
+const handleAddButton = async () => {
+  if (props.addToProjectPending) {
+    return
+  }
+  if (!publicAsset.value) {
+    const exportedAsset = await exportAssetDataToPublic()
+    publicAsset.value = exportedAsset
+  }
+  emit('addToProject', publicAsset.value)
+}
+
+const handleToggleFav = async () => {
+  if (!publicAsset.value) {
+    const exportedAsset = await exportAssetDataToPublic()
+    publicAsset.value = exportedAsset
+  }
   isFavorite.value = !isFavorite.value
   if (isFavorite.value) {
     removeAssetFromFavorites(props.asset.id)

--- a/spx-gui/src/components/asset/library/ai/AISpriteEditor.vue
+++ b/spx-gui/src/components/asset/library/ai/AISpriteEditor.vue
@@ -5,6 +5,7 @@
       :costumes="selectedAnimation.costumes"
       :duration="selectedAnimation.duration"
       :sound="null"
+      :style="{ width: '100%', height: '100%' }"
     />
   </div>
 </template>


### PR DESCRIPTION
This pull request integrates asset history api and did some bug fixes for asset list component.

## Changes:
- Introduced asset history tracking to allow users to view their asset history.
- Disabled AI generation for specific categories such as 'liked', 'history', and 'imported' to prevent unnecessary AI-generated assets.
- Implemented a mechanism to abort AI generation and asset search when search parameters are changed quickly, ensuring outdated data is not displayed.
- Added functionality to export AI assets and integrate them into projects, including mock API for exporting and features to `add to project` and `favorite` AI assets.

## Notes:
- Export API has not been implemented yet. It will return a mock result.
- The `preventing race condition` feature in the `useQuery` hook is disabled by default for compatibility with the existing codebase.