### PR TITLE
feat(spx-gui): Add asset rate API and functionality

### DIFF
--- a/spx-gui/src/apis/asset.ts
+++ b/spx-gui/src/apis/asset.ts
@@ -131,9 +131,61 @@ export async function getAssetSearchSuggestion(keyword: string, count = 6) {
     orderBy: ListAssetParamOrderBy.TimeAsc
   })
   return {
-    suggestions: Array.from(new Set(assets.data.map(asset => asset.displayName))).slice(0, count)
+    suggestions: Array.from(new Set(assets.data.map((asset) => asset.displayName))).slice(0, count)
   }
   return client.get('/asset/suggest', { keyword, count }) as Promise<{
     suggestions: string[]
   }>
+}
+
+export interface AssetRate {
+  rate: number
+  detail: number[]
+}
+
+/**
+ * Get the rate of an asset
+ * 
+ * WARNING: This API is not implemented in the backend yet. 
+ * Currently, it returns a random rate that follows a normal distribution.
+ * 
+ * @param id 
+ * @returns 
+ */
+export function getAssetRate(id: string): Promise<AssetRate> {
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      const rateCount = Math.floor(Math.random() * 10000)
+      const calcNormDist = (x: number, mean: number, std: number) => {
+        return Math.exp(-Math.pow(x - mean, 2) / (2 * Math.pow(std, 2))) / (std * Math.sqrt(2 * Math.PI))
+      }
+      const targetRate = Math.random() * 4 + 1
+      const distribution = [1, 2, 3, 4, 5].map((rate) => calcNormDist(rate, targetRate, 1))
+      const rates = distribution.map((rate) => Math.floor(rate * rateCount))
+      if (targetRate > 2.5 && targetRate < 3.5 && Math.random() < 0.5) {
+        rates.unshift(rates.pop()!)
+        rates.unshift(rates.pop()!)
+      }
+      resolve({
+        rate: rates.reduce((acc, cur, i) => acc + cur * (i + 1), 0) / rateCount,
+        detail: rates
+      })
+    }, 100)
+  })
+  return client.get(`/asset/${encodeURIComponent(id)}/rate`) as Promise<AssetRate>
+}
+
+/**
+ * Rate an asset
+ * 
+ * WARNING: This API is not implemented in the backend yet.
+ * @param id asset id
+ * @param rate rate value, 1-5
+ * @returns
+ */
+export function rateAsset(id: string, rate: number) {
+  if ([1, 2, 3, 4, 5].indexOf(rate) === -1) {
+    throw new Error('Invalid rate value')
+  }
+  return client.post(`/asset/${encodeURIComponent(id)}/rate`, { rate }) as Promise<void>
 }

--- a/spx-gui/src/components/asset/library/details/DetailModal.vue
+++ b/spx-gui/src/components/asset/library/details/DetailModal.vue
@@ -51,20 +51,46 @@
         <div class="category-title">{{ $t({ en: 'Category', zh: '类别' }) }}</div>
         <NTag class="category-content">{{ asset.category }}</NTag>
       </div>
-      <div class="more"></div>
+      <div class="reviews">
+        <div class="rate">
+          <div class="rate-title">
+            <span class="rate-title-text">
+              {{ $t({ en: 'Rating', zh: '评分' }) }}
+            </span>
+            <div class="rate-title-action open-rate-modal">
+              <NButton ref="rateButton" size="small" @click="handleOpenRateModal">
+                <template #icon>
+                  <NIcon>
+                    <StarOutlined />
+                  </NIcon>
+                </template>
+                {{ $t({ zh: '打个分', en: 'Rate it' }) }}
+              </NButton>
+            </div>
+          </div>
+          <AssetRate ref="assetRate" :asset="asset" />
+        </div>
+      </div>
     </div>
   </main>
 </template>
 
 <script setup lang="ts">
 import { computed, ref } from 'vue'
-import { NTag } from 'naive-ui'
+import { NButton, NIcon, NTag } from 'naive-ui'
 import { UIModalClose } from '@/components/ui'
-import { addAssetToFavorites, AssetType, removeAssetFromFavorites, type AssetData } from '@/apis/asset'
+import {
+  addAssetToFavorites,
+  AssetType,
+  removeAssetFromFavorites,
+  type AssetData
+} from '@/apis/asset'
 import UIButton from '@/components/ui/UIButton.vue'
 import UIModal from '@/components/ui/modal/UIModal.vue'
 import LibraryTab from '../LibraryTab.vue'
 import DetailDisplay from './SpriteDetailDisplay.vue'
+import AssetRate from '../reviews/AssetRate.vue'
+import { StarOutlined } from '@vicons/antd'
 
 // Define component props
 const props = defineProps<{
@@ -101,6 +127,20 @@ const handleToggleFav = () => {
 const displayTime = computed(() => {
   return new Date(props.asset.cTime).toLocaleString()
 })
+
+const assetRate = ref<InstanceType<typeof AssetRate> | null>(null)
+const rateButton = ref<InstanceType<typeof NButton> | null>(null)
+
+const handleOpenRateModal = () => {
+  assetRate.value?.openRateModal()
+  if (
+    document.activeElement &&
+    'blur' in document.activeElement &&
+    typeof document.activeElement.blur === 'function'
+  ) {
+    document.activeElement.blur()
+  }
+}
 </script>
 
 <style lang="scss" scoped>
@@ -117,78 +157,101 @@ header {
 
 main {
   display: flex;
+}
 
-  .content {
+.content {
+  display: flex;
+  justify-content: space-between;
+  flex-direction: column;
+  align-items: center;
+
+  flex: 3;
+  padding: 10px;
+  border-right: 1px solid var(--ui-color-border, #cbd2d8);
+  overflow: hidden;
+
+  .display {
+    width: 100%;
+    min-height: 50vh;
+  }
+
+  .detail {
+    margin-top: 20px;
+    height: 100%;
+    padding: 0 20px;
+  }
+}
+
+.sider {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+
+  flex: 1;
+  min-width: 275px;
+  max-width: 350px;
+  padding: 10px 15px 10px 15px;
+
+  .title {
+    font-size: 24px;
+    font-weight: bold;
+    color: #000;
+  }
+
+  .button-group {
     display: flex;
-    justify-content: space-between;
-    flex-direction: column;
-    align-items: center;
-    padding: 20px;
-    border-bottom: 1px solid #e0e0e0;
-    flex: 1;
+    gap: 10px;
 
-    .display {
-      width: 100%;
-      min-height: 50vh;
-      border-right: 1px solid #e0e0e0;
-    }
-
-    .detail {
-      margin-top: 20px;
-      height: 100%;
-      padding: 0 20px;
+    .insert-button {
     }
   }
 
-  .sider {
+  .sider-info {
     display: flex;
     flex-direction: column;
-    margin: 20px;
-    gap: 20px;
+    gap: 10px;
+  }
 
-    .title {
-      font-size: 24px;
+  .basic-info {
+    font-size: 14px;
+  }
+
+  .category {
+    margin-top: 20px;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+  }
+
+  .category-title {
+    font-size: 14px;
+    font-weight: bold;
+  }
+
+  .category-content {
+    font-size: 14px;
+    width: fit-content;
+  }
+
+  .rate {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+
+    .rate-title {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+    }
+
+    .rate-title-text {
+      font-size: 16px;
       font-weight: bold;
-      color: #000;
     }
 
-    .button-group {
+    .rate-title-action {
       display: flex;
       gap: 10px;
-
-      .insert-button {
-      }
-    }
-
-    .sider-info {
-      display: flex;
-      flex-direction: column;
-      gap: 10px;
-    }
-
-    .basic-info {
-      font-size: 14px;
-    }
-
-    .category {
-      margin-top: 20px;
-      display: flex;
-      flex-direction: column;
-      gap: 10px;
-    }
-
-    .category-title {
-      font-size: 14px;
-      font-weight: bold;
-    }
-
-    .category-content {
-      font-size: 14px;
-      width: fit-content;
-    }
-
-    .more {
-      margin-top: 20px;
     }
   }
 }

--- a/spx-gui/src/components/asset/library/reviews/AssetRate.vue
+++ b/spx-gui/src/components/asset/library/reviews/AssetRate.vue
@@ -1,0 +1,266 @@
+<template>
+  <div class="container">
+    <div class="left rate-summary">
+      <div class="rate-avg">{{ rate.toFixed(1) ?? 'NaN' }}</div>
+      <div class="rate-avg-star">
+        <NRate
+          :value="halfRoundedRate"
+          allow-half
+          readonly
+          :color="colorSet[halfRoundedRate * 2 - 2]"
+          size="small"
+        />
+      </div>
+      <div class="rate-count">
+        {{
+          $t({
+            en: `${$t(intlCompactNumber(rateCount))} ratings`,
+            zh: `${$t(intlCompactNumber(rateCount))}个评分`
+          })
+        }}
+      </div>
+    </div>
+    <div class="right rate-details">
+      <div v-for="idx in [4, 3, 2, 1, 0]" :key="idx" class="rate-detail">
+        <div class="rate-detail-name">{{ idx + 1 }}</div>
+        <div class="rate-detail-bar">
+          <NTooltip trigger="hover" placement="left">
+            <template #trigger>
+              <NProgress
+                type="line"
+                :percentage="((rateData?.detail[idx] ?? 0) / rateCount) * 100"
+                :show-indicator="false"
+              />
+            </template>
+            <span>
+              {{
+                $t({
+                  en: `${$t(intlCompactNumber(rateData?.detail[idx] ?? 0))} people rated ${idx + 1} star(s)`,
+                  zh: `${$t(intlCompactNumber(rateData?.detail[idx] ?? 0))} 个用户给出了 ${idx + 1} 星评价`
+                })
+              }}
+            </span>
+          </NTooltip>
+        </div>
+      </div>
+    </div>
+  </div>
+  <UIModal v-model:visible="rateModalVisible" size="small">
+    <div class="modal-header">
+      <div class="modal-header-left">
+        <div class="asset-name">
+          {{ asset.displayName }}
+        </div>
+      </div>
+      <div class="modal-header-right">
+        <UIModalClose @click="rateModalVisible = false" />
+      </div>
+    </div>
+    <div class="modal-main">
+      <div class="modal-title">
+        {{ $t({ zh: '为此素材评分', en: 'Rate this asset' }) }}
+      </div>
+      <div class="rate-input">
+        <NRate v-model:value="userRate" :color="colorSet[userRate * 2 - 2]" />
+        <div class="rate-value">{{ userRate }} {{ $t({ zh: '星', en: 'star' }) }}</div>
+      </div>
+      <!-- We may add a text area here for users to leave comments in the future.  -->
+    </div>
+    <div class="modal-footer">
+      <UIButton type="secondary" @click="rateModalVisible = false">
+        {{ $t({ zh: '取消', en: 'Cancel' }) }}
+      </UIButton>
+      <UIButton type="primary" @click="handleRate">
+        {{ $t({ zh: '提交', en: 'Submit' }) }}
+      </UIButton>
+    </div>
+  </UIModal>
+</template>
+
+<script lang="ts" setup>
+import { getAssetRate, rateAsset, type AssetData } from '@/apis/asset'
+import { useAsyncComputed } from '@/utils/utils'
+import { computed, ref } from 'vue'
+import { NRate, NProgress, NTooltip } from 'naive-ui'
+import type { LocaleMessage } from '@/utils/i18n'
+import UIModal from '@/components/ui/modal/UIModal.vue'
+import UIModalClose from '@/components/ui/modal/UIModalClose.vue'
+import UIButton from '@/components/ui/UIButton.vue'
+
+const props = defineProps<{
+  asset: AssetData
+}>()
+
+const rateData = useAsyncComputed(async () => {
+  return await getAssetRate(props.asset.id)
+})
+
+const rate = computed(() => {
+  return rateData.value?.rate ?? NaN
+})
+
+const halfRoundedRate = computed(() => {
+  return Math.round(rate.value * 2) / 2
+})
+
+const rateCount = computed(() => {
+  return rateData.value?.detail.reduce((acc, cur) => acc + cur, 0) ?? 0
+})
+
+const rateModalVisible = ref(false)
+
+const userRate = ref(5)
+
+const handleRate = () => {
+	rateAsset(props.asset.id, userRate.value)
+	if (rateData.value) {
+		rateData.value.detail[userRate.value - 1]++
+		rateData.value.rate = (rateData.value.rate * rateCount.value + userRate.value) / (rateCount.value + 1)
+	}
+	rateModalVisible.value = false
+}
+
+const openRateModal = () => {
+  rateModalVisible.value = true
+}
+
+defineExpose({
+  openRateModal
+})
+
+// Gradient color set for rating stars
+const colorSet = [
+  '#d74a31',
+  '#dc602a',
+  '#e27623',
+  '#e78c1c',
+  '#eda215',
+  '#f2b80e',
+  '#f8ce07',
+  '#fbd904',
+  '#fde300'
+]
+
+/**
+ * Format number to compact notation
+ * Returns a proxy object that can be used to format the number in different locales
+ * @example
+ * ```js
+ * const num = 1234567
+ * const formatter = intlCompactNumber(num)
+ * formatter.en // 1.23M
+ * formatter.zh // 123.46万
+ * ```
+ */
+const intlCompactNumber = (num: number, options?: Intl.NumberFormatOptions) => {
+  return new Proxy({} as LocaleMessage, {
+    get: (_, key) => {
+      if (typeof key === 'string') {
+        return new Intl.NumberFormat(key, {
+          notation: 'compact',
+          maximumFractionDigits: 2,
+          ...options
+        }).format(num)
+      }
+      return undefined
+    }
+  })
+}
+</script>
+
+<style scoped>
+.container {
+  display: flex;
+  flex-direction: row;
+}
+
+.left {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+}
+
+.rate-summary {
+  margin-right: 15px;
+}
+
+.rate-avg {
+  font-size: 24px;
+  font-weight: bold;
+  flex: 1;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.rate-count {
+  font-size: 12px;
+}
+
+.right {
+  display: flex;
+  flex-direction: column;
+  gap: 0px;
+  flex: 1;
+}
+
+.rate-detail {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 8px;
+}
+
+.rate-detail-name {
+  font-size: 12px;
+}
+
+.rate-detail-bar {
+  flex: 1;
+}
+
+.modal-header {
+  display: flex;
+  justify-content: space-between;
+  padding: 10px;
+  border-bottom: 1px solid #e0e0e0;
+}
+
+.modal-header-left {
+  display: flex;
+  align-items: center;
+}
+
+.modal-header-right {
+  display: flex;
+  align-items: center;
+}
+
+.modal-main {
+  padding: 1rem;
+}
+
+.asset-name {
+  font-size: 16px;
+  font-weight: bold;
+}
+
+.modal-title {
+  font-size: 16px;
+  font-weight: bold;
+}
+
+.rate-input {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.modal-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 1rem;
+  padding: 10px;
+}
+</style>


### PR DESCRIPTION
This pull request implements asset rate functionality.

## Changes:
- add `getAssetRate` API to retrieve the rate of an asset and `rateAsset` API to rate an asset (Mock)
- Add `AssetRate` component to display the asset rating and provide an modal to rate the asset
- Update the asset details modal for AssetRate component

## Notes: 
The rating API is not implemented yet.
Currently, it will return a random rating that follows a normal distribution.
![image](https://github.com/user-attachments/assets/734c00b6-7f82-455f-b6e0-82370af621a8)
