### PR TITLE
Enhance asset detail page with carousel and style updates

### DIFF
--- a/spx-gui/src/components/asset/library/SpritePreview.vue
+++ b/spx-gui/src/components/asset/library/SpritePreview.vue
@@ -1,15 +1,84 @@
 <template>
-  <UIImg class="sprite-preview" :src="imgSrc" :loading="imgLoading" />
+  <div class="container" @mouseenter="() => setPlay(true)" @mouseleave="() => setPlay(false)">
+    <Transition name="fade" mode="out-in" appear>
+      <UIImg
+        v-if="!play || animations.length === 0"
+        class="sprite-preview"
+        :src="imgSrc"
+        :loading="imgLoading"
+      />
+      <div v-else class="sprite-preview">
+        <AnimationPlayer
+          :costumes="animations[currentIndex].costumes"
+          :duration="animations[currentIndex].duration"
+          :sound="null"
+          :style="{ width: '100%', height: '100%' }"
+        />
+        <div class="animation-play-info">{{ currentIndex + 1 }}/{{ animations.length }}</div>
+      </div>
+    </Transition>
+  </div>
 </template>
 
 <script setup lang="ts">
+import AnimationPlayer from '@/components/editor/sprite/animation/AnimationPlayer.vue'
 import { UIImg } from '@/components/ui'
 import type { Sprite } from '@/models/sprite'
 import { useFileUrl } from '@/utils/file'
+import { computed, ref } from 'vue'
 
 const props = defineProps<{
   sprite: Sprite
 }>()
 
 const [imgSrc, imgLoading] = useFileUrl(() => props.sprite.defaultCostume?.img)
+
+const animations = computed(() => props.sprite.animations)
+const currentIndex = ref(0)
+const play = ref(false)
+
+const INTERVAL = 5000
+let timer: number
+
+const next = () => {
+  currentIndex.value = (currentIndex.value + 1) % animations.value.length
+}
+
+const setPlay = (value: boolean) => {
+  play.value = value
+  clearInterval(timer)
+  if (value) {
+    timer = setInterval(next, INTERVAL) as any
+  }
+}
 </script>
+
+<style lang="scss" scoped>
+.sprite-preview {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+}
+
+.animation-play-info {
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  background-color: rgba(0, 0, 0, 0.4);
+  color: white;
+  padding: 2px 4px;
+  font-size: 10px;
+  border-radius: 2px;
+}
+
+.fade-enter-active {
+  transition: all 0.25s ease;
+}
+.fade-leave-active {
+  display: none;
+}
+
+.fade-enter-from {
+  opacity: 0;
+}
+</style>

--- a/spx-gui/src/components/asset/library/details/BackdropDetailDisplay.vue
+++ b/spx-gui/src/components/asset/library/details/BackdropDetailDisplay.vue
@@ -1,0 +1,294 @@
+<template>
+  <div class="container">
+    <div class="image-container">
+      <div
+        v-if="imgSrc && !imgLoading"
+        class="backdrop-preview"
+        :class="{ dragging }"
+        @wheel="handleWheel"
+        @dragstart.prevent
+        @mousedown="handleMouseDown"
+      >
+        <div
+          class="backdrop-preview-img"
+          role="img"
+          aria-label="backdrop preview"
+          :style="{
+            '--img-src': `url(${imgSrc})`,
+            '--scale': scale,
+            '--translate-x': `${translateX}px`,
+            '--translate-y': `${translateY}px`
+          }"
+        ></div>
+        <div class="preview-controller">
+          <NTooltip placement="right">
+            <template #trigger>
+              <div
+                role="button"
+                class="preview-action zoom-in"
+                aria-label="zoom in"
+                @click="handleZoomIn"
+              >
+                <NIcon :size="18">
+                  <ZoomInOutlined />
+                </NIcon>
+              </div>
+            </template>
+            <span>
+              {{ $t({ en: 'Zoom In', zh: '放大' }) }}
+            </span>
+          </NTooltip>
+          <NTooltip placement="right">
+            <template #trigger>
+              <div
+                role="button"
+                class="preview-action zoom-out"
+                aria-label="zoom out"
+                @click="handleZoomOut"
+              >
+                <NIcon :size="18">
+                  <ZoomOutOutlined />
+                </NIcon>
+              </div>
+            </template>
+            <span>
+              {{ $t({ en: 'Zoom Out', zh: '缩小' }) }}
+            </span>
+          </NTooltip>
+          <NTooltip placement="right">
+            <template #trigger>
+              <div role="button" class="preview-action fit" aria-label="fit" @click="handleFit">
+                <NIcon :size="18">
+                  <FullscreenOutlined />
+                </NIcon>
+              </div>
+            </template>
+            <span>
+              {{ $t({ en: 'Fit', zh: '适应' }) }}
+            </span>
+          </NTooltip>
+        </div>
+        <div ref="scaleInfo" class="scale-info">
+          {{ $t({ en: 'Scale', zh: '缩放' }) }}: {{ scale.toFixed(1) }}x
+        </div>
+      </div>
+      <UILoading v-if="imgLoading" class="backdrop-preview-loading" />
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import type { AssetData, AssetType } from '@/apis/asset'
+import { UILoading } from '@/components/ui'
+import { cachedConvertAssetData } from '@/models/common/asset'
+import { useFileUrl } from '@/utils/file'
+import { useAsyncComputed } from '@/utils/utils'
+import { NIcon, NTooltip } from 'naive-ui'
+import { ZoomInOutlined, ZoomOutOutlined } from '@vicons/antd'
+import { FullscreenOutlined } from '@vicons/material'
+import { onMounted, onUnmounted, ref } from 'vue'
+
+const props = defineProps<{
+  asset: AssetData<AssetType.Backdrop>
+}>()
+
+const backdrop = useAsyncComputed(() => {
+  return cachedConvertAssetData(props.asset)
+})
+
+const [imgSrc, imgLoading] = useFileUrl(() => backdrop.value?.img)
+
+const scale = ref(1)
+const translateX = ref(0)
+const translateY = ref(0)
+
+const scaleInfo = ref<HTMLElement | null>(null)
+let infoTimer: number
+
+const adjustScale = (delta: number) => {
+  scale.value = Math.max(0.1, scale.value + delta)
+  scaleInfo.value?.classList.add('active')
+  clearTimeout(infoTimer)
+  infoTimer = setTimeout(() => {
+    scaleInfo.value?.classList.remove('active')
+  }, 500) as any
+}
+
+const handleZoomIn = () => {
+  adjustScale(0.2)
+}
+
+const handleZoomOut = () => {
+  adjustScale(-0.2)
+}
+
+const handleFit = () => {
+  adjustScale(1 - scale.value)
+  translateX.value = 0
+  translateY.value = 0
+}
+
+const handleWheel = (e: WheelEvent) => {
+  e.preventDefault()
+  // move horizontally when shift key is pressed
+  if (e.shiftKey) {
+    translateX.value -= e.deltaY
+    return
+  }
+  // move vertically when alt key is pressed
+  if (e.altKey) {
+    translateY.value -= e.deltaY
+    return
+  }
+  if (e.deltaY > 0) {
+    handleZoomOut()
+  } else {
+    handleZoomIn()
+  }
+}
+
+const dragging = ref(false)
+const lastX = ref(0)
+const lastY = ref(0)
+
+const handleMouseDown = (e: MouseEvent) => {
+  dragging.value = true
+  lastX.value = e.clientX
+  lastY.value = e.clientY
+}
+
+const handleMouseMove = (e: MouseEvent) => {
+  if (dragging.value) {
+    // divide by scale to keep the movement consistent
+    // otherwise, the image will move too slow when zoomed out
+    translateX.value += (e.clientX - lastX.value) / scale.value
+    translateY.value += (e.clientY - lastY.value) / scale.value
+    lastX.value = e.clientX
+    lastY.value = e.clientY
+  }
+}
+
+const handleMouseUp = () => {
+  dragging.value = false
+}
+
+onMounted(() => {
+  window.addEventListener('mousemove', handleMouseMove)
+  window.addEventListener('mouseup', handleMouseUp)
+})
+
+onUnmounted(() => {
+  window.removeEventListener('mousemove', handleMouseMove)
+  window.removeEventListener('mouseup', handleMouseUp)
+})
+</script>
+
+<style lang="scss" scoped>
+.container {
+  --container-width: 95%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.image-container {
+  width: var(--container-width);
+  height: 0;
+  overflow: visible;
+  padding-bottom: calc(var(--container-width) * 0.5625);
+  position: relative;
+}
+
+.backdrop-preview,
+.backdrop-preview-loading {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border-radius: 8px;
+  box-shadow: 0 0 10px 0 rgba(0, 0, 0, 0.1);
+}
+
+.backdrop-preview {
+  overflow: hidden;
+  background-color: var(--ui-color-grey-200, #f5f7fa);
+  cursor: grab;
+
+  &.dragging {
+    cursor: grabbing;
+  }
+}
+
+.preview-controller {
+  display: flex;
+  gap: 10px;
+  position: absolute;
+  flex-direction: column;
+  bottom: 10px;
+  right: 10px;
+  opacity: 0;
+  transition: opacity 0.2s;
+}
+
+.image-container:hover .preview-controller {
+  opacity: 1;
+} 
+
+.preview-action {
+  cursor: pointer;
+  background-color: var(--ui-color-grey-100, #ffffff);
+  box-shadow: var(--ui-box-shadow-big);
+  opacity: 0.8;
+  border-radius: 50%;
+  width: 28px;
+  height: 28px;
+  padding: 4px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: opacity 0.2s;
+
+  &:hover {
+    opacity: 1;
+  }
+}
+
+.backdrop-preview-img {
+  background-image: var(--img-src);
+  width: 100%;
+  height: 100%;
+  background-size: contain;
+  background-position: center;
+  background-repeat: no-repeat;
+  transition: transform 0.2s;
+  transform: scale(var(--scale)) translate(var(--translate-x), var(--translate-y));
+}
+
+.backdrop-preview.dragging .backdrop-preview-img {
+  // prevent lagging when dragging
+  transition: none;
+}
+
+.scale-info {
+  position: absolute;
+  bottom: 10px;
+  left: 10px;
+  color: var(--ui-color-grey-800, #4b5563);
+  font-size: 14px;
+  font-weight: bold;
+  background-color: var(--ui-color-grey-100, #ffffff);
+  padding: 4px 8px;
+  border-radius: 4px;
+  box-shadow: var(--ui-box-shadow-small);
+  opacity: 0;
+  transition: opacity 0.3s;
+  pointer-events: none;
+  user-select: none;
+}
+
+.scale-info.active {
+  opacity: 0.9;
+}
+</style>

--- a/spx-gui/src/components/asset/library/details/DetailModal.vue
+++ b/spx-gui/src/components/asset/library/details/DetailModal.vue
@@ -141,7 +141,7 @@ const handleToggleFav = () => {
   }
 }
 
-const displayTime = (date: Date | string, options?: Intl.NumberFormatOptions) => {
+const displayTime = (date: Date | string, options?: Intl.DateTimeFormatOptions) => {
   if (typeof date === 'string') {
     date = new Date(date)
   }

--- a/spx-gui/src/components/asset/library/details/DetailModal.vue
+++ b/spx-gui/src/components/asset/library/details/DetailModal.vue
@@ -2,10 +2,15 @@
   <main>
     <div class="content">
       <div class="display">
-        <DetailDisplay
+        <SpriteDetailDisplay
           v-if="asset.assetType === AssetType.Sprite"
           :asset="props.asset as AssetData<AssetType.Sprite>"
           class="sprite-detail"
+        />
+        <BackdropDetailDisplay
+          v-else-if="asset.assetType === AssetType.Backdrop"
+          :asset="props.asset as AssetData<AssetType.Backdrop>"
+          class="backdrop-detail"
         />
       </div>
       <div class="detail">
@@ -103,11 +108,12 @@ import {
 import UIButton from '@/components/ui/UIButton.vue'
 import UIModal from '@/components/ui/modal/UIModal.vue'
 import LibraryTab from '../LibraryTab.vue'
-import DetailDisplay from './SpriteDetailDisplay.vue'
+import SpriteDetailDisplay from './SpriteDetailDisplay.vue'
 import AssetRate from '../reviews/AssetRate.vue'
 import { StarOutlined, HeartOutlined, HeartFilled } from '@vicons/antd'
 import { template } from 'lodash'
 import type { LocaleMessage } from '@/utils/i18n'
+import BackdropDetailDisplay from './BackdropDetailDisplay.vue'
 
 // Define component props
 const props = defineProps<{

--- a/spx-gui/src/components/asset/library/details/DetailModal.vue
+++ b/spx-gui/src/components/asset/library/details/DetailModal.vue
@@ -153,7 +153,7 @@ const displayTime = (date: Date | string, options?: Intl.DateTimeFormatOptions) 
           dateStyle: 'medium',
           timeStyle: 'short',
           ...options
-        }).format(date)
+        }).format(date as Date)
       }
       return undefined
     }
@@ -207,7 +207,7 @@ main {
   }
 
   .detail {
-    margin-top: 20px;
+    margin-top: 0px;
     height: 100%;
     padding: 0 20px;
   }

--- a/spx-gui/src/components/asset/library/details/DetailModal.vue
+++ b/spx-gui/src/components/asset/library/details/DetailModal.vue
@@ -9,7 +9,6 @@
         />
       </div>
       <div class="detail">
-        <LibraryTab />
       </div>
     </div>
     <div class="sider">
@@ -201,11 +200,10 @@ main {
   flex: 3;
   padding: 10px;
   border-right: 1px solid var(--ui-color-border, #cbd2d8);
-  overflow: hidden;
+  overflow: auto;
 
   .display {
     width: 100%;
-    min-height: 50vh;
   }
 
   .detail {

--- a/spx-gui/src/components/asset/library/details/SpriteDetailDisplay.vue
+++ b/spx-gui/src/components/asset/library/details/SpriteDetailDisplay.vue
@@ -3,6 +3,7 @@
     <div class="carousel-container">
       <NCarousel
         show-arrow
+        :show-dots="false"
         autoplay
         class="carousel"
         :interval="5000"
@@ -27,6 +28,14 @@
           />
           <UILoading v-else-if="custom[imgLoading].value" />
         </NCarouselItem>
+        <template #arrow="{ prev, next }">
+          <div type="button" class="custom-arrow custom-arrow--left" role="button" @click="prev">
+            <NIcon :size="32" color="var(--n-text-color, #57606a)"><ChevronLeftFilled /></NIcon>
+          </div>
+          <div type="button" class="custom-arrow custom-arrow--right" role="button" @click="next">
+            <NIcon :size="32" color="var(--n-text-color, #57606a)"><ChevronRightFilled /></NIcon>
+          </div>
+        </template>
       </NCarousel>
     </div>
     <div class="thumbnail-switcher-container">
@@ -139,9 +148,8 @@ const handleThumbnailScroll = (direction: number) => {
     } else if (direction < 0 && scrollLeft <= 0) {
       targetLeft = maxLeft
       currentDotIndex.value = dotCount.value - 1
-    }
-    else {
-      currentDotIndex.value = Math.floor(targetLeft / clientWidth)
+    } else {
+      currentDotIndex.value = Math.max(0, Math.floor(targetLeft / clientWidth))
     }
 
     thumbnailContainer.value.scrollTo({
@@ -247,6 +255,39 @@ const currentDotIndex = ref(0)
   box-shadow: var(--ui-box-shadow-small, 0px 2px 8px 0px rgba(51, 51, 51, 0.08));
 }
 
+.custom-arrow {
+  cursor: pointer;
+  background-color: var(--ui-color-grey-100, #ffffff);
+  width: 40px;
+  height: 40px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  border-radius: 50%;
+  transition: background-color 0.3s;
+  box-shadow: var(--ui-box-shadow-big);
+  z-index: 1;
+  opacity: 0;
+  transition: opacity 0.3s;
+  position: absolute;
+}
+
+.carousel-container:hover .custom-arrow {
+  opacity: 1;
+}
+
+.custom-arrow--left {
+  left: 5px;
+  top: 50%;
+  transform: translateY(-50%);
+}
+
+.custom-arrow--right {
+  right: 5px;
+  top: 50%;
+  transform: translateY(-50%);
+}
+
 .thumbnail-switcher-container {
   display: flex;
   flex-direction: column;
@@ -265,7 +306,7 @@ const currentDotIndex = ref(0)
     margin: 5px 10px;
     width: var(--container-width);
   }
-  
+
   .switcher-scroll-btn {
     cursor: pointer;
     display: flex;
@@ -355,7 +396,9 @@ const currentDotIndex = ref(0)
   height: 5px;
   border-radius: 5px;
   background-color: var(--ui-color-grey-500);
-  transition: background-color 0.3s, width 0.3s;
+  transition:
+    background-color 0.3s,
+    width 0.3s;
 
   &.active {
     background-color: var(--ui-color-primary-main, #0bc0cf);

--- a/spx-gui/src/components/asset/library/details/SpriteDetailDisplay.vue
+++ b/spx-gui/src/components/asset/library/details/SpriteDetailDisplay.vue
@@ -1,14 +1,105 @@
 <template>
-  <NImage
-    v-if="imgSrc"
-    class="sprite-preview"
-    :src="imgSrc"
-    :loading="imgLoading"
-    width="100%"
-    object-fit="contain"
-    style="width: 100%"
-  />
-  <UILoading v-else cover :mask="false" />
+  <div class="container">
+    <div class="carousel-container">
+      <NCarousel
+        show-arrow
+        autoplay
+        class="carousel"
+        :interval="5000"
+        :current-index="currentIndex"
+        @update:current-index="handleCarouselSwitch"
+      >
+        <NCarouselItem v-for="anim in animations" :key="anim.name">
+          <AnimationPlayer
+            :costumes="anim.costumes"
+            :duration="anim.duration"
+            :sound="null"
+            :style="{ width: '100%', height: '100%' }"
+          />
+        </NCarouselItem>
+        <NCarouselItem v-for="custom in customs" :key="custom.name">
+          <NImage
+            v-if="custom[imgSrc].value"
+            :src="custom[imgSrc].value ?? undefined"
+            width="100%"
+            object-fit="contain"
+            style="width: 100%"
+          />
+          <UILoading v-else-if="custom[imgLoading].value" />
+        </NCarouselItem>
+      </NCarousel>
+    </div>
+    <div class="carousel-switcher-container">
+      <div class="switcher-scroll-btn left" role="button">
+        <NIcon :size="28">
+          <ChevronLeftFilled />
+        </NIcon>
+      </div>
+      <div class="carousel-switcher">
+        <div
+          v-for="(anim, index) in animations"
+          :key="anim.name"
+          class="switcher"
+          @click="currentIndex = index"
+        >
+          <NTooltip trigger="hover" placement="bottom">
+            <template #trigger>
+              <NImage
+                v-if="anim[imgSrc].value"
+                :src="anim[imgSrc].value ?? undefined"
+                width="100%"
+                object-fit="contain"
+                style="width: 100%"
+                preview-disabled
+              />
+              <UILoading v-else-if="anim[imgLoading].value" />
+            </template>
+            <span
+              >{{
+                $t({
+                  en: `Animation: ${anim.name}`,
+                  zh: `动画: ${anim.name}`
+                })
+              }}
+            </span>
+          </NTooltip>
+        </div>
+        <div
+          v-for="(custom, index) in customs"
+          :key="custom.name"
+          class="switcher"
+          @click="currentIndex = index + animations.length"
+        >
+          <NTooltip trigger="hover" placement="bottom">
+            <template #trigger>
+              <NImage
+                v-if="custom[imgSrc].value"
+                :src="custom[imgSrc].value ?? undefined"
+                width="100%"
+                object-fit="contain"
+                style="width: 100%"
+                preview-disabled
+              />
+              <UILoading v-else-if="custom[imgLoading].value" />
+            </template>
+            <span
+              >{{
+                $t({
+                  en: `Custom: ${custom.name}`,
+                  zh: `造型: ${custom.name}`
+                })
+              }}
+            </span>
+          </NTooltip>
+        </div>
+      </div>
+      <div class="switcher-scroll-btn right" role="button">
+        <NIcon :size="28">
+          <ChevronRightFilled />
+        </NIcon>
+      </div>
+    </div>
+  </div>
 </template>
 
 <script setup lang="ts">
@@ -16,13 +107,128 @@ import { useFileUrl } from '@/utils/file'
 import { cachedConvertAssetData } from '@/models/common/asset'
 import { useAsyncComputed } from '@/utils/utils'
 import type { AssetData, AssetType } from '@/apis/asset'
-import { NImage } from 'naive-ui'
+import { NImage, NCarousel, NCarouselItem, NTooltip, NIcon } from 'naive-ui'
+import { ChevronLeftFilled, ChevronRightFilled } from '@vicons/material'
 import { UILoading } from '@/components/ui'
+import { computed, ref } from 'vue'
+import AnimationPlayer from '@/components/editor/sprite/animation/AnimationPlayer.vue'
 
 const props = defineProps<{
   asset: AssetData<AssetType.Sprite>
 }>()
 
-const sprite = useAsyncComputed(() => cachedConvertAssetData(props.asset))
-const [imgSrc, imgLoading] = useFileUrl(() => sprite.value?.defaultCostume?.img)
+const currentIndex = ref(0)
+
+const handleCarouselSwitch = (index: number) => {
+  currentIndex.value = index
+}
+
+const sprite = useAsyncComputed(() => {
+  return cachedConvertAssetData(props.asset)
+})
+
+const imgSrc = Symbol('imgSrc')
+const imgLoading = Symbol('imgLoading')
+
+// get animations and load the first costume image as the preview
+const animations = computed(() => {
+  return (
+    sprite.value?.animations.map((a) => {
+      const [url, loading] = useFileUrl(() => a.costumes[0].img)
+      return {
+        ...a,
+        [imgSrc]: url,
+        [imgLoading]: loading
+      }
+    }) ?? []
+  )
+})
+
+// get customs that are not in the animations
+// and load the images
+const customs = computed(() => {
+  return (
+    sprite.value?.costumes
+      .filter((c) => {
+        return animations.value.every((a) => {
+          return a.costumes.every((ac) => ac !== c)
+        })
+      })
+      .map((c) => {
+        const [url, loading] = useFileUrl(() => c.img)
+        return {
+          ...c,
+          [imgSrc]: url,
+          [imgLoading]: loading
+        }
+      }) ?? []
+  )
+})
 </script>
+
+<style scoped>
+.carousel-container {
+  width: 100%;
+  height: 0;
+  overflow: visible;
+  padding-bottom: 61.8%;
+  position: relative;
+}
+
+.carousel {
+  position: absolute;
+  width: calc(100% - 20px);
+  height: calc(100% - 10px);
+  top: 5px;
+  left: 10px;
+
+  border-radius: var(--ui-border-radius-1, 8px);
+  box-shadow: var(--ui-box-shadow-small, 0px 2px 8px 0px rgba(51, 51, 51, 0.08));
+}
+
+.carousel-switcher-container {
+  --width: 150px;
+  --height: calc(var(--width) * 0.618);
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 10px;
+  padding-top: 10px;
+  margin: 5px 10px;
+}
+
+.switcher-scroll-btn {
+  cursor: pointer;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  border-radius: var(--ui-border-radius-1, 8px);
+  height: var(--height);
+  padding: 0 5px;
+}
+
+.switcher-scroll-btn:hover {
+  background-color: var(--ui-color-grey-300);
+}
+
+.carousel-switcher {
+  display: flex;
+  overflow-x: auto;
+  gap: 10px;
+  gap: 10px;
+
+  scrollbar-width: none;
+}
+
+.switcher {
+  cursor: pointer;
+  border-radius: var(--ui-border-radius-1, 8px);
+  overflow: hidden;
+  width: var(--width);
+  flex: 0 0 var(--width);
+  height: var(--height);
+  border: 1px solid var(--ui-color-border, #cbd2d8);
+
+  box-shadow: var(--ui-box-shadow-small, 0px 2px 8px 0px rgba(51, 51, 51, 0.08));
+}
+</style>


### PR DESCRIPTION
This pull request adjusted the style of the asset detail page, and provided a preview of the sprite asset with carousel.

## Changes:
- Updated styles of the asset detail page.
- Updated i18n text for asset info.
- Replaced the single image preview with a carousel component. And added carousel items for animations and custom costumes.
- Implemented thumbnail navigation for the carousel.
- Implemented backdrop preview component and provided image preview, zoom in/out, and drag functionality.

![image](https://github.com/user-attachments/assets/9e2d7490-09ed-44a3-8f92-3b9a69ff42db)

![image](https://github.com/user-attachments/assets/f754386c-72a9-41dc-af59-b520c93c6b98)


