### PR TITLE
spx-gui: auto save unsaved changes on route change

### DIFF
--- a/spx-gui/src/components/editor/EditorHomepage.vue
+++ b/spx-gui/src/components/editor/EditorHomepage.vue
@@ -51,7 +51,14 @@ import { useMessageHandle, useQuery } from '@/utils/exception'
 import EditorContextProvider from './EditorContextProvider.vue'
 import ProjectEditor from './ProjectEditor.vue'
 import { clear } from '@/models/common/local'
-import { UIButton, UIDivider, UILoading, UIError, useConfirmDialog } from '@/components/ui'
+import {
+  UIButton,
+  UIDivider,
+  UILoading,
+  UIError,
+  useConfirmDialog,
+  useMessage
+} from '@/components/ui'
 import { useI18n } from '@/utils/i18n'
 import { useNetwork } from '@/utils/network'
 
@@ -72,6 +79,7 @@ const createProject = useCreateProject()
 const withConfirm = useConfirmDialog()
 const { t } = useI18n()
 const { isOnline } = useNetwork()
+const m = useMessage()
 
 const projectName = computed(
   () => router.currentRoute.value.params.projectName as string | undefined
@@ -242,9 +250,15 @@ watchEffect((onCleanup) => {
           zh: '保存'
         }),
         async confirmHandler() {
-          if (project.value?.hasUnsyncedChanges) await project.value!.saveToCloud()
-          await clear(LOCAL_CACHE_KEY)
-        }
+          try {
+            if (project.value?.hasUnsyncedChanges) await project.value!.saveToCloud()
+            await clear(LOCAL_CACHE_KEY)
+          } catch (e) {
+            m.error(t({ en: 'Failed to save changes', zh: '保存变更失败' }))
+            throw e
+          }
+        },
+        autoConfirm: true
       })
       return true
     } catch {

--- a/spx-gui/src/components/ui/dialog/UIConfirmDialog.vue
+++ b/spx-gui/src/components/ui/dialog/UIConfirmDialog.vue
@@ -20,7 +20,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue'
+import { onMounted, ref } from 'vue'
 import { useConfig } from '../UIConfigProvider.vue'
 import UIButton from '../UIButton.vue'
 import UIDialog from './UIDialog.vue'
@@ -33,14 +33,15 @@ export type Props = {
   cancelText?: string
   confirmText?: string
   confirmHandler?: () => unknown
+  autoConfirm?: boolean
 }
 
 const props = withDefaults(defineProps<Props>(), {
   type: 'warning',
   cancelText: undefined,
   confirmText: undefined,
-  isConfirmLoading: false,
-  confirmHandler: undefined
+  confirmHandler: undefined,
+  autoConfirm: false
 })
 
 const config = useConfig().confirmDialog
@@ -61,6 +62,10 @@ async function handleConfirm() {
     isConfirmLoading.value = false
   }
 }
+
+onMounted(() => {
+  if (props.autoConfirm) handleConfirm()
+})
 </script>
 <style scoped lang="scss">
 .footer {


### PR DESCRIPTION
We block route changes when there are unsaved changes using `UIConfirmDialog`. For better UX, an automatic save is triggered when the dialog is mounted, reducing the need for users to manually click the `Save` button. If the save failes, users can simply retry by clicking `Save`.

Fixes #665