### PR TITLE
feat: add sound detail display

### DIFF
--- a/spx-gui/src/components/asset/library/AssetList.vue
+++ b/spx-gui/src/components/asset/library/AssetList.vue
@@ -90,10 +90,7 @@ import { TipsAndUpdatesOutlined } from '@vicons/material'
 
 const FORBIDDEN_AI_CATEGORIES = ['liked', 'history', 'imported']
 const aiGenerationDisabled = computed(() => {
-  if (typeof searchCtx.category === 'string') {
-    return FORBIDDEN_AI_CATEGORIES.includes(searchCtx.category)
-  }
-  return searchCtx.category.some((c) => FORBIDDEN_AI_CATEGORIES.includes(c))
+  return FORBIDDEN_AI_CATEGORIES.includes(searchCtx.tabCategory)
 })
 
 const props = defineProps<{

--- a/spx-gui/src/components/asset/library/details/BackdropDetailDisplay.vue
+++ b/spx-gui/src/components/asset/library/details/BackdropDetailDisplay.vue
@@ -20,54 +20,12 @@
             '--translate-y': `${translateY}px`
           }"
         ></div>
-        <div class="preview-controller">
-          <NTooltip placement="right">
-            <template #trigger>
-              <div
-                role="button"
-                class="preview-action zoom-in"
-                aria-label="zoom in"
-                @click="handleZoomIn"
-              >
-                <NIcon :size="18">
-                  <ZoomInOutlined />
-                </NIcon>
-              </div>
-            </template>
-            <span>
-              {{ $t({ en: 'Zoom In', zh: '放大' }) }}
-            </span>
-          </NTooltip>
-          <NTooltip placement="right">
-            <template #trigger>
-              <div
-                role="button"
-                class="preview-action zoom-out"
-                aria-label="zoom out"
-                @click="handleZoomOut"
-              >
-                <NIcon :size="18">
-                  <ZoomOutOutlined />
-                </NIcon>
-              </div>
-            </template>
-            <span>
-              {{ $t({ en: 'Zoom Out', zh: '缩小' }) }}
-            </span>
-          </NTooltip>
-          <NTooltip placement="right">
-            <template #trigger>
-              <div role="button" class="preview-action fit" aria-label="fit" @click="handleFit">
-                <NIcon :size="18">
-                  <FullscreenOutlined />
-                </NIcon>
-              </div>
-            </template>
-            <span>
-              {{ $t({ en: 'Fit', zh: '适应' }) }}
-            </span>
-          </NTooltip>
-        </div>
+        <PreviewController
+          class="preview-controller"
+          @zoom-in="handleZoomIn"
+          @zoom-out="handleZoomOut"
+          @fit="handleFit"
+        />
         <div ref="scaleInfo" class="scale-info">
           {{ $t({ en: 'Scale', zh: '缩放' }) }}: {{ scale.toFixed(1) }}x
         </div>
@@ -83,10 +41,8 @@ import { UILoading } from '@/components/ui'
 import { cachedConvertAssetData } from '@/models/common/asset'
 import { useFileUrl } from '@/utils/file'
 import { useAsyncComputed } from '@/utils/utils'
-import { NIcon, NTooltip } from 'naive-ui'
-import { ZoomInOutlined, ZoomOutOutlined } from '@vicons/antd'
-import { FullscreenOutlined } from '@vicons/material'
 import { onMounted, onUnmounted, ref } from 'vue'
+import PreviewController from './PreviewController.vue'
 
 const props = defineProps<{
   asset: AssetData<AssetType.Backdrop>
@@ -222,10 +178,7 @@ onUnmounted(() => {
 }
 
 .preview-controller {
-  display: flex;
-  gap: 10px;
   position: absolute;
-  flex-direction: column;
   bottom: 10px;
   right: 10px;
   opacity: 0;
@@ -234,25 +187,6 @@ onUnmounted(() => {
 
 .image-container:hover .preview-controller {
   opacity: 1;
-} 
-
-.preview-action {
-  cursor: pointer;
-  background-color: var(--ui-color-grey-100, #ffffff);
-  box-shadow: var(--ui-box-shadow-big);
-  opacity: 0.8;
-  border-radius: 50%;
-  width: 28px;
-  height: 28px;
-  padding: 4px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  transition: opacity 0.2s;
-
-  &:hover {
-    opacity: 1;
-  }
 }
 
 .backdrop-preview-img {

--- a/spx-gui/src/components/asset/library/details/DetailModal.vue
+++ b/spx-gui/src/components/asset/library/details/DetailModal.vue
@@ -12,6 +12,11 @@
           :asset="props.asset as AssetData<AssetType.Backdrop>"
           class="backdrop-detail"
         />
+        <SoundDetailDisplay
+          v-else-if="asset.assetType === AssetType.Sound"
+          :asset="props.asset as AssetData<AssetType.Sound>"
+          class="sound-detail"
+        />
       </div>
       <div class="detail">
       </div>
@@ -112,6 +117,7 @@ import { template } from 'lodash'
 import type { LocaleMessage } from '@/utils/i18n'
 import BackdropDetailDisplay from './BackdropDetailDisplay.vue'
 import { addAssetToFavorites, removeAssetFromFavorites } from '@/apis/user'
+import SoundDetailDisplay from './SoundDetailDisplay.vue'
 
 // Define component props
 const props = defineProps<{

--- a/spx-gui/src/components/asset/library/details/PreviewController.vue
+++ b/spx-gui/src/components/asset/library/details/PreviewController.vue
@@ -1,0 +1,101 @@
+<template>
+  <div class="preview-controller">
+    <NTooltip placement="right">
+      <template #trigger>
+        <div
+          role="button"
+          class="preview-action zoom-in"
+          aria-label="zoom in"
+          @click="handleZoomIn"
+        >
+          <NIcon :size="18">
+            <ZoomInOutlined />
+          </NIcon>
+        </div>
+      </template>
+      <span>
+        {{ $t({ en: 'Zoom In', zh: '放大' }) }}
+      </span>
+    </NTooltip>
+    <NTooltip placement="right">
+      <template #trigger>
+        <div
+          role="button"
+          class="preview-action zoom-out"
+          aria-label="zoom out"
+          @click="handleZoomOut"
+        >
+          <NIcon :size="18">
+            <ZoomOutOutlined />
+          </NIcon>
+        </div>
+      </template>
+      <span>
+        {{ $t({ en: 'Zoom Out', zh: '缩小' }) }}
+      </span>
+    </NTooltip>
+    <NTooltip placement="right">
+      <template #trigger>
+        <div role="button" class="preview-action fit" aria-label="fit" @click="handleFit">
+          <NIcon :size="18">
+            <FullscreenOutlined />
+          </NIcon>
+        </div>
+      </template>
+      <span>
+        {{ $t({ en: 'Fit', zh: '适应' }) }}
+      </span>
+    </NTooltip>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { NIcon, NTooltip } from 'naive-ui'
+import { ZoomInOutlined, ZoomOutOutlined } from '@vicons/antd'
+import { FullscreenOutlined } from '@vicons/material'
+
+const emit = defineEmits<{
+  zoomIn: [],
+  zoomOut: [],
+  fit: [],
+}>()
+
+const handleZoomIn = () => {
+  emit('zoomIn')
+}
+
+const handleZoomOut = () => {
+  emit('zoomOut')
+}
+
+const handleFit = () => {
+  emit('fit')
+}
+</script>
+
+<style scoped>
+.preview-controller {
+  display: flex;
+  gap: 10px;
+  flex-direction: column;
+}
+
+.preview-action {
+  cursor: pointer;
+  background-color: var(--ui-color-grey-100, #ffffff);
+  box-shadow: var(--ui-box-shadow-big);
+  opacity: 0.8;
+  border-radius: 50%;
+  width: 28px;
+  height: 28px;
+  padding: 4px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: opacity 0.2s;
+
+  &:hover {
+    opacity: 1;
+  }
+}
+</style>

--- a/spx-gui/src/components/asset/library/details/SoundDetailDisplay.vue
+++ b/spx-gui/src/components/asset/library/details/SoundDetailDisplay.vue
@@ -1,0 +1,281 @@
+<template>
+  <div class="container">
+    <div class="sound-container">
+      <div v-if="audioUrl && !audioLoading" class="sound-preview">
+        <audio
+          ref="audioElement"
+          :src="audioUrl"
+          preload="auto"
+          hidden
+          @timeupdate="updateProgress"
+          @loadedmetadata="handleAudioLoaded"
+        />
+        <div ref="waveformContainer" class="waveform-container">
+          <WaveformDisplay
+            v-if="waveformData"
+            ref="waveform"
+            class="waveform"
+            :points="waveformData.data"
+            :scale="gain"
+            :draw-padding-right="waveformData.paddingRight"
+            :style="{
+              transform: `translateX(-${wavePosition}px)`,
+              width: `${(1 / visiblePercent) * 100}%`
+            }"
+          />
+          <div
+            class="progress-cursor"
+            :style="{
+              transform: `translateX(${cursorPosition * (waveformContainer?.clientWidth ?? 0)}px)`
+            }"
+          ></div>
+          <PreviewController
+            class="preview-controller"
+            @zoom-in="handleZoomIn"
+            @zoom-out="handleZoomOut"
+            @fit="handleFit"
+          />
+        </div>
+        <div class="sound-play-controller">
+          <DumbSoundPlayer
+            class="dumb-sound-player"
+            :playing="playing"
+            :progress="progress"
+            color="primary"
+            :play-handler="handlePlay"
+            :loading="audioLoading"
+            @stop="handlePlay"
+          />
+          <VolumeSlider v-model:value="volume" />
+          <div class="spacer" style="flex: 1" />
+          <div class="time-display">{{ displayTime(current) }} / {{ displayTime(duration) }}</div>
+        </div>
+      </div>
+      <UILoading v-else class="sound-preview-loading" />
+    </div>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import type { AssetData, AssetType } from '@/apis/asset'
+import DumbSoundPlayer from '@/components/editor/sound/DumbSoundPlayer.vue'
+import VolumeSlider from '@/components/editor/sound/VolumeSlider.vue'
+import WaveformDisplay from '@/components/editor/sound/waveform/WaveformDisplay.vue'
+import { getWaveformData } from '@/components/editor/sound/waveform/WaveformPlayer.vue'
+import { UILoading } from '@/components/ui'
+import { cachedConvertAssetData } from '@/models/common/asset'
+import { getAudioContext } from '@/utils/audio'
+import { useFileUrl } from '@/utils/file'
+import { useAsyncComputed } from '@/utils/utils'
+import { throttle } from 'lodash'
+import { computed, ref } from 'vue'
+import PreviewController from './PreviewController.vue'
+
+const gain = ref(0.5)
+const props = defineProps<{
+  asset: AssetData<AssetType.Sound>
+}>()
+
+const waveformContainer = ref<HTMLDivElement | null>(null)
+const waveform = ref<HTMLDivElement | null>(null)
+
+const sound = useAsyncComputed(() => {
+  return cachedConvertAssetData(props.asset)
+})
+
+const [audioUrl, audioLoading] = useFileUrl(() => sound.value?.file)
+
+const audioElement = ref<HTMLAudioElement | null>(null)
+
+const playing = ref(false)
+const current = ref(0)
+const duration = ref(0)
+const progress = computed(() => current.value / (duration.value || 1))
+const volume = ref(1)
+
+const scale = ref(0)
+const scaleRate = 0.2
+
+const visiblePercent = computed(() => {
+  return Math.exp(-scaleRate * scale.value)
+})
+const visibleDuration = computed(() => {
+  return duration.value * visiblePercent.value
+})
+
+const visiblePoints = ref(512)
+const pointsRate = computed(() => visiblePoints.value / visibleDuration.value)
+
+const audioBuffer = useAsyncComputed(async () => {
+  if (!audioUrl.value) return null
+  const audioContext = getAudioContext()
+  const arrayBuffer = await fetch(audioUrl.value).then((res) => res.arrayBuffer())
+  return await audioContext.decodeAudioData(arrayBuffer)
+})
+
+const waveformData = computed(() => {
+  if (!audioBuffer.value) return null
+  const targetPoints = Math.floor(audioBuffer.value.duration * pointsRate.value)
+  return getWaveformData(audioBuffer.value, targetPoints)
+})
+
+const cursorPosition = computed(() => {
+  if (current.value < visibleDuration.value / 2) {
+    return current.value / visibleDuration.value
+  }
+  if (current.value > duration.value - visibleDuration.value / 2) {
+    return 1 - (duration.value - current.value) / visibleDuration.value
+  }
+  return 0.5
+})
+
+const wavePosition = computed(() => {
+  const containerWidth = waveformContainer.value?.clientWidth ?? 0
+  const waveformWidth = containerWidth / visiblePercent.value
+  if (current.value < visibleDuration.value / 2) {
+    return 0
+  }
+  if (current.value > duration.value - visibleDuration.value / 2) {
+    return (waveformWidth - containerWidth)
+  }
+  return (current.value - visibleDuration.value / 2) / duration.value * waveformWidth
+})
+
+const handleZoomIn = () => {
+  scale.value += 1
+}
+
+const handleZoomOut = () => {
+  if (scale.value <= 1) {
+    handleFit()
+    return
+  }
+  scale.value -= 1
+}
+
+const handleFit = () => {
+  scale.value = 0
+}
+
+const handleAudioLoaded = () => {
+  if (!audioElement.value) return
+  duration.value = audioElement.value.duration
+  scale.value = 0
+  current.value = 0
+}
+
+const handlePlay = async () => {
+  if (playing.value) {
+    audioElement.value?.pause()
+    playing.value = false
+  } else {
+    audioElement.value?.play()
+    playing.value = true
+  }
+}
+
+const autoUpdateProgress = () => {
+  if (playing.value) {
+    current.value += 0.05
+  }
+  setTimeout(autoUpdateProgress, 50)
+}
+autoUpdateProgress()
+
+const updateProgress = throttle(() => {
+  if (!audioElement.value) return
+  current.value = audioElement.value.currentTime
+}, 500)
+
+const displayTime = (time: number) => {
+  const minutes = Math.floor(time / 60)
+  const seconds = Math.floor(time % 60)
+  return `${minutes.toString().padStart(2, '0')}:${seconds.toString().padStart(2, '0')}`
+}
+</script>
+
+<style lang="scss" scoped>
+.container {
+  --container-width: 95%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.sound-container {
+  width: var(--container-width);
+  height: 0;
+  overflow: visible;
+  padding-bottom: calc(var(--container-width) * 0.5625);
+  position: relative;
+}
+
+.sound-preview,
+.sound-preview-loading {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  border-radius: 8px;
+  box-shadow: 0 0 10px 0 rgba(0, 0, 0, 0.1);
+}
+
+.sound-preview {
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+
+  .waveform-container {
+    background: var(--ui-color-grey-300, #f6f8fa);
+    flex: 1;
+    position: relative;
+    overflow: hidden;
+  }
+
+  .waveform {
+    width: 100%;
+    height: 100%;
+    transition: transform 0.2s linear;
+  }
+
+  .progress-cursor {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    width: 1px;
+    background-color: var(--ui-color-primary-500);
+    transition: transform 0.2s linear;
+    pointer-events: none;
+  }
+
+  .preview-controller {
+    position: absolute;
+    bottom: 10px;
+    right: 10px;
+    opacity: 0;
+    transition: opacity 0.2s;
+  }
+
+  .waveform-container:hover .preview-controller {
+    opacity: 1;
+  }
+
+  .sound-play-controller {
+    display: flex;
+    justify-content: flex-start;
+    align-items: center;
+    padding: 10px 16px;
+    gap: 10px;
+
+    .dumb-sound-player {
+      width: 50px;
+      height: 50px;
+    }
+
+    .volume-slider {
+      width: 30%;
+    }
+  }
+}
+</style>

--- a/spx-gui/src/components/editor/sound/waveform/WaveformDisplay.vue
+++ b/spx-gui/src/components/editor/sound/waveform/WaveformDisplay.vue
@@ -47,16 +47,13 @@ onMounted(() => {
   })
 })
 
-const drawSmoothCurve = (ctx: CanvasRenderingContext2D, points: number[], flip = false) => {
+const drawSmoothCurve = (ctx: CanvasRenderingContext2D, points: number[]) => {
   const halfHeight = ctx.canvas.height / 2
   const paddedWidth = ctx.canvas.width * (1 - (props.drawPaddingRight || 0))
   const segmentLength = paddedWidth / (points.length - 1)
 
   const getPoint = (i: number) => {
-    if (flip) {
-      return halfHeight - points[i] * halfHeight * props.scale
-    }
-    return halfHeight + points[i] * halfHeight * props.scale
+    return halfHeight - points[i] * halfHeight * props.scale
   }
 
   ctx.beginPath()
@@ -86,13 +83,20 @@ const drawSmoothCurve = (ctx: CanvasRenderingContext2D, points: number[], flip =
   ctx.fill()
 }
 
+const mirrorCanvasVertically = (ctx: CanvasRenderingContext2D) => {
+  ctx.save()
+  ctx.scale(1, -1)
+  ctx.drawImage(ctx.canvas, 0, -ctx.canvas.height)
+  ctx.restore()
+}
+
 const draw = () => {
   if (canvas.value) {
     const ctx = canvas.value.getContext('2d')
     if (ctx) {
       ctx.clearRect(0, 0, ctx.canvas.width, ctx.canvas.height)
       drawSmoothCurve(ctx, props.points)
-      drawSmoothCurve(ctx, props.points, true)
+      mirrorCanvasVertically(ctx)
     }
   }
 }

--- a/spx-gui/src/components/editor/sound/waveform/WaveformPlayer.vue
+++ b/spx-gui/src/components/editor/sound/waveform/WaveformPlayer.vue
@@ -159,7 +159,7 @@ const waveformDataFromSrc = useAsyncComputed(async () => {
 </script>
 
 <script lang="ts">
-export async function getWaveformData(audioBuffer: AudioBuffer, targetPointLength = 80) {
+export function getWaveformData(audioBuffer: AudioBuffer, targetPointLength = 80) {
   const scale = 5
   const channelData = audioBuffer.getChannelData(0)
 

--- a/spx-gui/src/components/editor/sound/waveform/WaveformPlayer.vue
+++ b/spx-gui/src/components/editor/sound/waveform/WaveformPlayer.vue
@@ -150,10 +150,17 @@ watch(
 
 const waveformDataFromSrc = useAsyncComputed(async () => {
   if (!props.audioSrc) return null
-  const scale = 5
   const audioContext = getAudioContext()
   const arrayBuffer = await (await fetch(props.audioSrc)).arrayBuffer()
   const audioBuffer = await audioContext.decodeAudioData(arrayBuffer)
+
+  return getWaveformData(audioBuffer)
+})
+</script>
+
+<script lang="ts">
+export async function getWaveformData(audioBuffer: AudioBuffer, targetPointLength = 80) {
+  const scale = 5
   const channelData = audioBuffer.getChannelData(0)
 
   // First, we group the data into blocks by a fixed block size of 128 samples
@@ -168,8 +175,7 @@ const waveformDataFromSrc = useAsyncComputed(async () => {
     preProcessedData[i] = sum / 128
   }
 
-  // We want the final waveform to have a length of about 80 points.
-  const targetPointLength = 80
+  // We want the final waveform to have a length of about `targetPointLength` points.
   // We use floor(x / 20) * 20 to make the block size a multiple of 20.
   // Thus it changes less frequently and the waveform is more stable.
   const blockSize = Math.max(Math.floor(preProcessedData.length / targetPointLength / 20) * 20, 10)
@@ -187,5 +193,5 @@ const waveformDataFromSrc = useAsyncComputed(async () => {
     data: points,
     paddingRight: (preProcessedData.length % blockSize) / blockSize / points.length
   }
-})
+}
 </script>


### PR DESCRIPTION
This pull request provides waveform preview for sound assets.

## Changes:
- Added sound asset preview.
- Improved waveform display with dynamic scrolling and zooming.
- Provided playback controls for volume and progress.

![Peek 2024-08-14 11-54](https://github.com/user-attachments/assets/9c33f4b0-4e42-4757-a5d9-4754a7e93762)
