### PR TITLE
feat: edit AI-generated backdrop

### DIFF
--- a/spx-gui/src/components/asset/library/ai/AIBackdropEditor.vue
+++ b/spx-gui/src/components/asset/library/ai/AIBackdropEditor.vue
@@ -1,15 +1,25 @@
 <template>
   <div ref="editorContainer" class="container">
-    <v-stage v-if="stageConfig != null" ref="stage" :config="stageConfig">
+    <v-stage v-if="stageConfig != null && !loading" ref="stage" :config="stageConfig">
       <v-layer ref="layer">
-        <v-image ref="nodeRef" :config="config" />
+        <v-image
+          ref="nodeRef"
+          :config="config"
+          @transformend="handleTransformEnd"
+          @dragend="handleDragEnd"
+        />
+        <v-transformer ref="resizeTransformerRef" :config="resizeTransformerConfig" />
       </v-layer>
     </v-stage>
+    <div v-if="editMode === 'resize'" class="resize-info info-tip">
+      <span>{{ resizedImageSize?.width }} x {{ resizedImageSize?.height }}</span>
+    </div>
+    <CheckerboardBackground class="background" />
   </div>
 </template>
 
 <script lang="ts" setup>
-import { computed, onMounted, ref } from 'vue'
+import { computed, onMounted, ref, watch } from 'vue'
 import { isContentReady, type TaggedAIAssetData } from '@/apis/aigc'
 import type { ImageConfig } from 'konva/lib/shapes/Image'
 import { cachedConvertAssetData } from '@/models/common/asset'
@@ -18,6 +28,17 @@ import type { AssetType } from '@/apis/asset'
 import type { Backdrop } from '@/models/backdrop'
 import { useFileImg } from '@/utils/file'
 import type Konva from 'konva'
+import type { TransformerConfig } from 'konva/lib/shapes/Transformer'
+import CheckerboardBackground from '@/components/editor/sprite/CheckerboardBackground.vue'
+import type { EditorAction } from './AIPreviewModal.vue'
+import type { ButtonType } from '@/components/ui/UIButton.vue'
+import { PhotoSizeSelectLargeFilled } from '@vicons/material'
+
+// `vue-konva` does not provide types for ref to Konva nodes
+interface KonvaNode<T extends Konva.Node = Konva.Node> {
+  getNode(): T
+  getStage(): Konva.Stage
+}
 
 const props = defineProps<{
   asset: TaggedAIAssetData<AssetType.Backdrop>
@@ -30,17 +51,23 @@ const backdrop = useAsyncComputed<Backdrop | undefined>(() => {
   return cachedConvertAssetData(props.asset as Required<TaggedAIAssetData<AssetType.Backdrop>>)
 })
 
+const [image, loading] = useFileImg(() => backdrop.value?.img)
+
 const editorContainer = ref<HTMLElement>()
 const stage = ref<Konva.Stage>()
 const layer = ref<Konva.Layer>()
-const nodeRef = ref<Konva.Image>()
+const nodeRef = ref<KonvaNode<Konva.Image>>()
+const resizeTransformerRef = ref<KonvaNode<Konva.Transformer>>()
+const node = computed(() => nodeRef.value?.getNode())
+const resizeTransformer = computed(() => resizeTransformerRef.value?.getNode())
+const editMode = ref<'resize' | 'preview'>('preview')
 
 const mapWidth = ref(800)
 const mapHeight = ref(600)
 
 const updateMapSize = () => {
   if (!editorContainer.value) {
-	return
+    return
   }
   mapWidth.value = editorContainer.value.clientWidth
   mapHeight.value = editorContainer.value.clientHeight
@@ -65,18 +92,142 @@ const stageConfig = computed(() => {
   }
 })
 
-const [image] = useFileImg(() => backdrop.value?.img)
+const resizeTransformerConfig = computed<TransformerConfig | null>(() => {
+  if (!config.value) {
+    return null
+  }
+  return {
+    anchorStyleFunc: ((anchor: Konva.Rect) => {
+      anchor.cornerRadius(10)
+      anchor.stroke('rgba(11, 192, 207, 1)')
+      if (anchor.hasName('top-center') || anchor.hasName('bottom-center')) {
+        anchor.height(6)
+        anchor.offsetY(3)
+        anchor.width(30)
+        anchor.offsetX(15)
+      }
+      if (anchor.hasName('middle-left') || anchor.hasName('middle-right')) {
+        anchor.height(30)
+        anchor.offsetY(15)
+        anchor.width(6)
+        anchor.offsetX(3)
+      }
+    }) as TransformerConfig['anchorStyleFunc'],
+    borderStroke: 'rgba(11, 192, 207, 1)',
+    rotateEnabled: false
+  }
+})
+
+const showTransformer = () => {
+  if (!resizeTransformer.value) {
+    return
+  }
+  if (!nodeRef.value) {
+    return
+  }
+  if (editMode.value === 'resize') {
+    resizeTransformer.value.visible(true)
+    resizeTransformer.value.nodes([nodeRef.value.getNode()])
+    return
+  }
+  resizeTransformer.value.visible(false)
+}
+
+watch(editMode, () => {
+  showTransformer()
+})
 
 const FILL_PERCENT = 0.8
+// renderScale is used to scale the image to fit the map
+// so that the image is always visible and user can still resize the image 
+// even if it is larger than the map
+const renderScale = ref(1)
+const handleTransformEnd = () => {
+  if (!node.value) {
+    return
+  }
+  // since we are resizing the image, we need to apply the scale to the size
+  // and reset the scale to 1;
+  // the scaleX() and scaleY() contains the renderScale factor,
+  // so we need to remove it
+  const scaleX = node.value.scaleX() / renderScale.value
+  const scaleY = node.value.scaleY() / renderScale.value
+  const width = Math.max(1, Math.round(node.value.width() * scaleX))
+  const height = Math.max(1, Math.round(node.value.height() * scaleY))
+  renderScale.value = 1
+  node.value.scaleX(1)
+  node.value.scaleY(1)
+  resizedImageSize.value = {
+    width: width,
+    height: height
+  }
+  currentPos.value = { x: node.value.x(), y: node.value.y() }
+}
 
-const imageSize = computed(() => {
+const handleDragEnd = () => {
+  if (!node.value || !resizedImageSize.value) {
+    return
+  }
+  currentPos.value = { x: node.value.x(), y: node.value.y() }
+  // trigger a re-render to update the target position
+  resizedImageSize.value = {
+    ...resizedImageSize.value
+  }
+}
+
+const initialImageSize = computed(() => {
   if (!image.value) {
-	return null
+    return null
   }
   const width = image.value.width
   const height = image.value.height
+  return { width: width, height: height }
+})
+
+const resizedImageSize = ref(initialImageSize.value)
+
+watch(
+  initialImageSize,
+  () => {
+    resizedImageSize.value = initialImageSize.value
+  },
+  { immediate: true }
+)
+
+watch(resizedImageSize, () => {
+  const { width, height } = resizedImageSize.value ?? { width: 0, height: 0 }
   const scale = Math.min(mapWidth.value / width, mapHeight.value / height) * FILL_PERCENT
-  return { width: width * scale, height: height * scale, scale }
+  if (scale < 1) {
+    renderScale.value = scale
+  }
+})
+
+const currentPos = ref({ x: 0, y: 0 })
+
+const targetPos = computed(() => {
+  const { width, height } = resizedImageSize.value ??
+    initialImageSize.value ?? { width: 0, height: 0 }
+  return {
+    x: mapWidth.value / 2 - (width * renderScale.value) / 2,
+    y: mapHeight.value / 2 - (height * renderScale.value) / 2
+  }
+})
+
+const animateToTarget = () => {
+  const step = 0.1
+  currentPos.value.x += (targetPos.value.x - currentPos.value.x) * step
+  currentPos.value.y += (targetPos.value.y - currentPos.value.y) * step
+
+  if (
+    Math.abs(targetPos.value.x - currentPos.value.x) >= step ||
+    Math.abs(targetPos.value.y - currentPos.value.y) >= step
+  ) {
+    requestAnimationFrame(animateToTarget)
+  }
+}
+
+watch(targetPos, () => {
+  animateToTarget()
 })
 
 const config = computed<ImageConfig | null>(() => {
@@ -91,14 +242,34 @@ const config = computed<ImageConfig | null>(() => {
     offsetX: 0,
     offsetY: 0,
     visible: true,
-	// center the image
-    x: mapWidth.value / 2 - (imageSize.value?.width ?? 0) / 2,
-	y: mapHeight.value / 2 - (imageSize.value?.height ?? 0) / 2,
-    rotation: 0, 
-    scaleX: imageSize.value?.scale ?? 1,
-    scaleY: imageSize.value?.scale ?? 1,
+    x: currentPos.value.x,
+    y: currentPos.value.y,
+    rotation: 0,
+    width: resizedImageSize.value?.width ?? 0,
+    height: resizedImageSize.value?.height ?? 0,
+    scaleX: renderScale.value ?? 1,
+    scaleY: renderScale.value ?? 1
   } satisfies ImageConfig
   return config
+})
+
+const actions = computed(
+  () =>
+    [
+      {
+        name: 'edit',
+        label: { zh: '缩放', en: 'Resize' },
+        icon: PhotoSizeSelectLargeFilled,
+        type: (editMode.value === 'resize' ? 'primary' : 'secondary') satisfies ButtonType,
+        action: () => {
+          editMode.value = editMode.value === 'resize' ? 'preview' : 'resize'
+        }
+      }
+    ] satisfies EditorAction[]
+)
+
+defineExpose({
+  actions
 })
 </script>
 
@@ -107,5 +278,26 @@ const config = computed<ImageConfig | null>(() => {
   position: relative;
   width: 100%;
   height: 100%;
+  z-index: 0;
+}
+
+.background {
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
+  z-index: -1;
+}
+
+.info-tip {
+  position: absolute;
+  top: 10px;
+  left: 10px;
+  background-color: rgba(0, 0, 0, 0.5);
+  color: white;
+  padding: 5px;
+  border-radius: 5px;
+  z-index: 1;
 }
 </style>

--- a/spx-gui/src/components/asset/library/ai/AIBackdropEditor.vue
+++ b/spx-gui/src/components/asset/library/ai/AIBackdropEditor.vue
@@ -246,22 +246,25 @@ const saveToAsset = async () => {
 }
 
 const exportImage = async () => {
-  if (!activeEditor.value) {
+  if (!node.value) {
     return
   }
-  const img = await activeEditor.value.getImage()
-  const a = document.createElement('a')
-  a.href = img.src
-  a.download = 'backdrop.png'
-  a.click()
+  node.value.toImage({
+    callback: (img) => {
+      const a = document.createElement('a')
+      a.href = img.src
+      a.download = backdrop.value?.img.name ?? 'image.png'
+      a.click()
+    }
+  })
 }
 
 const confirm = useConfirmDialog()
 const i18n = useI18n()
 // TODO: do not upload to kodo when switch mode?
-const actions = computed(
-  () =>
-    ([
+const actions = computed(() =>
+  (
+    [
       {
         name: 'edit',
         label: { zh: '缩放', en: 'Resize' },
@@ -317,10 +320,7 @@ const actions = computed(
         label: { zh: '保存', en: 'Save' },
         icon: SaveFilled,
         type: 'secondary' satisfies ButtonType,
-        action: () => {
-          saveToAsset()
-          editMode.value = 'preview'
-        }
+        action: saveToAsset
       },
       editMode.value === 'preview' && {
         name: 'export',
@@ -329,7 +329,8 @@ const actions = computed(
         type: 'secondary' satisfies ButtonType,
         action: exportImage
       }
-    ] satisfies (EditorAction | false)[]).filter(Boolean)
+    ] satisfies (EditorAction | false)[]
+  ).filter(Boolean)
 )
 
 defineExpose({

--- a/spx-gui/src/components/asset/library/ai/AIBackdropEditor.vue
+++ b/spx-gui/src/components/asset/library/ai/AIBackdropEditor.vue
@@ -116,7 +116,16 @@ const resizeTransformerConfig = computed<TransformerConfig | null>(() => {
       }
     }) as TransformerConfig['anchorStyleFunc'],
     borderStroke: 'rgba(11, 192, 207, 1)',
-    rotateEnabled: false
+    rotateEnabled: false,
+    boundBoxFunc: function (oldBoundBox, newBoundBox) {
+      const MIN_WIDTH = 10
+      const MIN_HEIGHT = 10
+      if (newBoundBox.width < MIN_WIDTH || newBoundBox.height < MIN_HEIGHT) {
+        return oldBoundBox;
+      }
+
+      return newBoundBox;
+    },
   }
 })
 
@@ -154,8 +163,8 @@ const handleTransformEnd = () => {
   // so we need to remove it
   const scaleX = node.value.scaleX() / renderScale.value
   const scaleY = node.value.scaleY() / renderScale.value
-  const width = Math.max(1, Math.round(node.value.width() * scaleX))
-  const height = Math.max(1, Math.round(node.value.height() * scaleY))
+  const width = Math.max(10, Math.round(node.value.width() * scaleX))
+  const height = Math.max(10, Math.round(node.value.height() * scaleY))
   renderScale.value = 1
   node.value.scaleX(1)
   node.value.scaleY(1)

--- a/spx-gui/src/components/asset/library/ai/AIPreviewModal.vue
+++ b/spx-gui/src/components/asset/library/ai/AIPreviewModal.vue
@@ -3,7 +3,18 @@
     <div class="head head-actions">
       <Transition name="slide-fade" mode="out-in" appear>
         <div v-if="contentReady" class="head-left">
-          <!-- Maybe we could put actions of inner editors here? -->
+          <UIButton
+            v-for="action in currentActions"
+            :key="action.name"
+            size="large"
+            :type="action.type"
+            @click="action.action"
+          >
+            <NIcon v-if="action.icon">
+              <component :is="action.icon" />
+            </NIcon>
+            {{ $t(action.label) }}
+          </UIButton>
         </div>
         <div v-else class="head-left">
           {{ $t({ zh: '正在进一步生成素材...', en: 'Further generating assets...' }) }}
@@ -76,15 +87,21 @@
           <template v-else>
             <AISpriteEditor
               v-if="asset.assetType === AssetType.Sprite"
+              ref="spriteEditor"
               :asset="asset as TaggedAIAssetData<AssetType.Sprite>"
               class="asset-editor sprite-editor"
             />
             <AIBackdropEditor
               v-else-if="asset.assetType === AssetType.Backdrop"
+              ref="backdropEditor"
               :asset="asset as TaggedAIAssetData<AssetType.Backdrop>"
               class="asset-editor backdrop-editor"
             />
-            <AISoundEditor v-else-if="asset.assetType === AssetType.Sound" :asset="asset" />
+            <AISoundEditor
+              v-else-if="asset.assetType === AssetType.Sound"
+              ref="soundEditor"
+              :asset="asset"
+            />
           </template>
         </Transition>
       </main>
@@ -115,12 +132,20 @@
     </div>
   </div>
 </template>
-
+<script lang="ts">
+export interface EditorAction {
+  name: string
+  label: LocaleMessage
+  type: ButtonType
+  icon?: any
+  action: () => void
+}
+</script>
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue'
 import { NIcon, NSpin } from 'naive-ui'
 import { AssetType, getAsset, type AssetData } from '@/apis/asset'
-import UIButton from '@/components/ui/UIButton.vue'
+import UIButton, { type ButtonType } from '@/components/ui/UIButton.vue'
 import AIAssetItem from '../AIAssetItem.vue'
 import { NScrollbar } from 'naive-ui'
 import {
@@ -147,6 +172,7 @@ import AISoundEditor from './AISoundEditor.vue'
 import { convertAIAssetToBackdrop } from '@/models/common/asset'
 import { hashFileCollection } from '@/models/common/hash'
 import { addAssetToFavorites, removeAssetFromFavorites } from '@/apis/user'
+import type { LocaleMessage } from '@/utils/i18n'
 
 // Define component props
 const props = defineProps<{
@@ -159,6 +185,23 @@ const emit = defineEmits<{
   addToProject: [asset: AssetData]
   selectAi: [asset: TaggedAIAssetData]
 }>()
+
+const spriteEditor = ref<InstanceType<typeof AISpriteEditor> | null>(null)
+const backdropEditor = ref<InstanceType<typeof AIBackdropEditor> | null>(null)
+const soundEditor = ref<InstanceType<typeof AISoundEditor> | null>(null)
+
+const currentActions = computed<EditorAction[]>(() => {
+  if (props.asset.assetType === AssetType.Sprite && spriteEditor.value && 'actions' in spriteEditor.value) {
+    return spriteEditor?.value?.actions as EditorAction[]
+  }
+  if (props.asset.assetType === AssetType.Backdrop && backdropEditor.value && 'actions' in backdropEditor.value) {
+    return backdropEditor?.value?.actions as EditorAction[]
+  }
+  if (props.asset.assetType === AssetType.Sound && soundEditor.value && 'actions' in soundEditor.value) {
+    return soundEditor?.value?.actions as EditorAction[]
+  }
+  return []
+})
 
 const contentReady = ref(props.asset[isContentReady])
 const contentJobId = ref<string | null>(null)
@@ -296,6 +339,9 @@ const displayTime = computed(() => {
 
 .head-left {
   flex: 1;
+  display: flex;
+  gap: 10px;
+  flex-direction: row;
 }
 
 .head-right {

--- a/spx-gui/src/components/asset/library/ai/ImageEditor/ImageCrop.vue
+++ b/spx-gui/src/components/asset/library/ai/ImageEditor/ImageCrop.vue
@@ -1,0 +1,275 @@
+<template>
+  <div ref="editorContainer" class="container">
+    <v-stage v-if="stageConfig != null" ref="stage" :config="stageConfig">
+      <v-layer ref="layer">
+        <v-image ref="nodeRef" :config="imageConfig" />
+        <v-rect
+          ref="rectRef"
+          :config="rectConfig"
+          @transformend="handleTransformEnd"
+          @transform="handleTransformEnd"
+          @dragend="handleDragEnd"
+          @dragmove="handleDragEnd"
+        />
+        <v-transformer ref="cropHandlerRef" :config="cropHandlerConfig" />
+        <v-shape ref="croppedMaskRef" :config="croppedMaskConfig" />
+      </v-layer>
+    </v-stage>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { computed, onMounted, ref, watch } from 'vue'
+import type Konva from 'konva'
+import type { ImageConfig } from 'konva/lib/shapes/Image'
+import type { KonvaNode } from '../AIBackdropEditor.vue'
+import type { TransformerConfig } from 'konva/lib/shapes/Transformer'
+import { useRenderScale } from './useRenderScale'
+import { useCenterPosition } from './useCenterPosition'
+import { c } from 'naive-ui'
+
+const nodeRef = ref<KonvaNode<Konva.Image>>()
+const rectRef = ref<KonvaNode<Konva.Rect>>()
+const cropHandlerRef = ref<KonvaNode<Konva.Transformer>>()
+const croppedMaskRef = ref<KonvaNode<Konva.Shape>>()
+const node = computed(() => nodeRef.value?.getNode())
+const rect = computed(() => rectRef.value?.getNode())
+const cropHandler = computed(() => cropHandlerRef.value?.getNode())
+const croppedMask = computed(() => croppedMaskRef.value?.getNode())
+
+const props = defineProps<{
+  stageConfig: Konva.StageConfig
+  image: HTMLImageElement
+  width: number
+  height: number
+  fillPercent: number
+}>()
+
+const { renderScale, updateRenderScale } = useRenderScale(props, false)
+
+const imageSize = computed(() => {
+  if (!props.image) {
+    return null
+  }
+  return { width: props.image.width, height: props.image.height }
+})
+
+const { position: centerPos, updatePosition: updateCenterPosition } = useCenterPosition(props)
+
+const crop = ref({
+  x: 0,
+  y: 0,
+  width: 0,
+  height: 0
+})
+
+watch(
+  imageSize,
+  (newSize) => {
+    const { width, height } = newSize ?? { width: 0, height: 0 }
+    updateRenderScale(width, height)
+    updateCenterPosition(width * renderScale.value, height * renderScale.value)
+    crop.value.width = width
+    crop.value.height = height
+    crop.value.x = centerPos.value.x
+    crop.value.y = centerPos.value.y
+  },
+  { immediate: true }
+)
+
+onMounted(() => {
+  // show the crop handler
+  if (!cropHandler.value || !rect.value) {
+    return
+  }
+  cropHandler.value.visible(true)
+  cropHandler.value.nodes([rect.value])
+})
+
+const handleTransformEnd = () => {
+  if (!rect.value) {
+    return
+  }
+  const x = rect.value.x()
+  const y = rect.value.y()
+  const width = rect.value.width() * rect.value.scaleX()
+  const height = rect.value.height() * rect.value.scaleY()
+  rect.value.width(width)
+  rect.value.height(height)
+  rect.value.scaleX(1)
+  rect.value.scaleY(1)
+  crop.value = { x, y, width: width / renderScale.value, height: height / renderScale.value }
+}
+
+const handleDragEnd = () => {
+  if (!rect.value) {
+    return
+  }
+  crop.value.x = rect.value.x()
+  crop.value.y = rect.value.y()
+}
+
+const cropHandlerConfig = computed<TransformerConfig | null>(() => {
+  if (!rectConfig.value) {
+    return null
+  }
+  return {
+    anchorStyleFunc: ((anchor: Konva.Rect) => {
+      anchor.cornerRadius(1)
+      anchor.stroke('rgba(11, 192, 207, 1)')
+      anchor.strokeWidth(1)
+      const width = 20
+      const height = 20
+      anchor.width(width)
+      anchor.height(height)
+      const left = ['top-left', 'middle-left', 'bottom-left']
+      const right = ['top-right', 'middle-right', 'bottom-right']
+      const top = ['top-left', 'top-center', 'top-right']
+      const bottom = ['bottom-left', 'bottom-center', 'bottom-right']
+      const has = (arr: string[], anchor: Konva.Rect) => arr.some((name) => anchor.hasName(name))
+      const offsetX = has(left, anchor) ? -1 : has(right, anchor) ? width + 1 : width / 2
+      const offsetY = has(top, anchor) ? -1 : has(bottom, anchor) ? height + 1 : height / 2
+      anchor.offsetX(offsetX)
+      anchor.offsetY(offsetY)
+    }) as TransformerConfig['anchorStyleFunc'],
+    borderStroke: 'rgba(11, 192, 207, 1)',
+    rotateEnabled: false,
+    boundBoxFunc: function (oldBoundBox, newBoundBox) {
+      const MIN_WIDTH = 10
+      const MIN_HEIGHT = 10
+      if (newBoundBox.width < MIN_WIDTH || newBoundBox.height < MIN_HEIGHT) {
+        return oldBoundBox
+      }
+      const left = centerPos.value.x
+      const top = centerPos.value.y
+      const right = centerPos.value.x + (imageSize.value?.width ?? 0) * renderScale.value
+      const bottom = centerPos.value.y + (imageSize.value?.height ?? 0) * renderScale.value
+      const x = Math.max(left, Math.min(right, newBoundBox.x))
+      const y = Math.max(top, Math.min(bottom, newBoundBox.y))
+      const width = Math.max(MIN_WIDTH, Math.min(right - x, newBoundBox.width))
+      const height = Math.max(MIN_HEIGHT, Math.min(bottom - y, newBoundBox.height))
+      newBoundBox.x = x
+      newBoundBox.y = y
+      newBoundBox.width = width
+      newBoundBox.height = height
+      return newBoundBox
+    }
+  }
+})
+
+const imageConfig = computed<ImageConfig | null>(() => {
+  return {
+    spriteName: 'main-backdrop',
+    image: props.image ?? undefined,
+    draggable: false,
+    offsetX: 0,
+    offsetY: 0,
+    visible: true,
+    x: centerPos.value.x,
+    y: centerPos.value.y,
+    rotation: 0,
+    width: imageSize.value?.width ?? 0,
+    height: imageSize.value?.height ?? 0,
+    scaleX: renderScale.value ?? 1,
+    scaleY: renderScale.value ?? 1
+  } satisfies ImageConfig
+})
+
+const rectConfig = computed<Konva.RectConfig | null>(() => {
+  return {
+    x: crop.value.x,
+    y: crop.value.y,
+    width: crop.value.width * renderScale.value,
+    height: crop.value.height * renderScale.value,
+    fill: 'rgba(0, 0, 0, 0)',
+    stroke: 'rgba(11, 192, 207, 1)',
+    draggable: true,
+    listening: true,
+    dragBoundFunc: function (pos) {
+      const left = centerPos.value.x
+      const top = centerPos.value.y
+      const right =
+        centerPos.value.x + ((imageSize.value?.width ?? 0) - crop.value.width) * renderScale.value
+      const bottom =
+        centerPos.value.y + ((imageSize.value?.height ?? 0) - crop.value.height) * renderScale.value
+      const x = Math.max(left, Math.min(right, pos.x))
+      const y = Math.max(top, Math.min(bottom, pos.y))
+      return { x, y }
+    }
+  } satisfies Konva.RectConfig
+})
+
+const croppedMaskConfig = computed<Konva.ShapeConfig | null>(() => {
+  return {
+    x: 0,
+    y: 0,
+    width: props.width,
+    height: props.height,
+    listening: false,
+    sceneFunc: function (ctx) {
+      ctx.fillStyle = 'rgba(0, 0, 0, 0.3)'
+      ctx.beginPath()
+      const { x: cx, y: cy, width, height } = crop.value
+      ctx.moveTo(0, 0)
+      ctx.lineTo(props.width, 0)
+      ctx.lineTo(props.width, props.height)
+      ctx.lineTo(0, props.height)
+      ctx.closePath()
+      ctx.moveTo(cx - 1, cy - 1)
+      ctx.lineTo(cx - 1, cy + height * renderScale.value + 1)
+      ctx.lineTo(cx + width * renderScale.value + 1, cy + height * renderScale.value + 1)
+      ctx.lineTo(cx + width * renderScale.value + 1, cy - 1)
+      ctx.closePath()
+
+      ctx.fill()
+    }
+  } satisfies Konva.ShapeConfig
+})
+/**
+ * Get the edited image
+ */
+const getImage = () => {
+  return new Promise<HTMLImageElement>((resolve) => {
+    const canvas = document.createElement('canvas')
+    canvas.width = crop.value.width
+    canvas.height = crop.value.height
+    const ctx = canvas.getContext('2d')
+    if (!ctx) {
+      return
+    }
+    const img = new Image()
+    img.src = props.image.src
+    img.onload = () => {
+      ctx.drawImage(
+        img,
+        (crop.value.x - centerPos.value.x) / renderScale.value,
+        (crop.value.y - centerPos.value.y) / renderScale.value,
+        crop.value.width,
+        crop.value.height,
+        0,
+        0,
+        crop.value.width,
+        crop.value.height
+      )
+      const newImg = new Image()
+      newImg.src = canvas.toDataURL()
+      newImg.onload = () => {
+        resolve(newImg)
+      }
+    }
+  })
+}
+
+defineExpose({
+  getImage
+})
+</script>
+
+<style scoped>
+.container {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  z-index: 0;
+}
+</style>

--- a/spx-gui/src/components/asset/library/ai/ImageEditor/ImageResize.vue
+++ b/spx-gui/src/components/asset/library/ai/ImageEditor/ImageResize.vue
@@ -1,0 +1,200 @@
+<template>
+  <div ref="editorContainer" class="container">
+    <v-stage v-if="stageConfig != null" ref="stage" :config="stageConfig">
+      <v-layer ref="layer">
+        <v-image
+          ref="nodeRef"
+          :config="config"
+          @transformend="handleTransformEnd"
+          @dragend="handleDragEnd"
+        />
+        <v-transformer ref="resizeTransformerRef" :config="resizeTransformerConfig" />
+      </v-layer>
+    </v-stage>
+    <div class="resize-info info-tip">
+      <span>{{ resizedImageSize?.width }} x {{ resizedImageSize?.height }}</span>
+    </div>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { computed, onMounted, ref, watch } from 'vue'
+import type Konva from 'konva'
+import type { ImageConfig } from 'konva/lib/shapes/Image'
+import type { KonvaNode } from '../AIBackdropEditor.vue'
+import type { TransformerConfig } from 'konva/lib/shapes/Transformer'
+import { useRenderScale } from './useRenderScale'
+import { useAnimatedCenterPosition } from './useCenterPosition'
+
+const nodeRef = ref<KonvaNode<Konva.Image>>()
+const resizeTransformerRef = ref<KonvaNode<Konva.Transformer>>()
+const node = computed(() => nodeRef.value?.getNode())
+const resizeTransformer = computed(() => resizeTransformerRef.value?.getNode())
+
+const props = defineProps<{
+  stageConfig: Konva.StageConfig
+  image: HTMLImageElement
+  width: number
+  height: number
+  fillPercent: number
+}>()
+
+const { renderScale, updateRenderScale } = useRenderScale(props)
+
+const initialImageSize = computed(() => {
+  if (!props.image) {
+    return null
+  }
+  return { width: props.image.width, height: props.image.height }
+})
+
+const resizedImageSize = ref(initialImageSize.value)
+
+const {
+  currentPos: centerPos,
+  updateCenterPosition,
+  immediateUpdatePosition
+} = useAnimatedCenterPosition(props)
+
+const handleTransformEnd = () => {
+  if (!node.value) {
+    return
+  }
+  // since we are resizing the image, we need to apply the scale to the size
+  // and reset the scale to 1;
+  // the scaleX() and scaleY() contains the renderScale factor,
+  // so we need to remove it
+  const scaleX = node.value.scaleX() / renderScale.value
+  const scaleY = node.value.scaleY() / renderScale.value
+  const width = Math.max(10, Math.round(node.value.width() * scaleX))
+  const height = Math.max(10, Math.round(node.value.height() * scaleY))
+  renderScale.value = 1
+  node.value.scaleX(1)
+  node.value.scaleY(1)
+  resizedImageSize.value = {
+    width: width,
+    height: height
+  }
+  immediateUpdatePosition(node.value.x(), node.value.y())
+}
+
+const handleDragEnd = () => {
+  if (!node.value || !resizedImageSize.value) {
+    return
+  }
+  immediateUpdatePosition(node.value.x(), node.value.y())
+  // trigger the update of the center position
+  resizedImageSize.value = {
+    ...resizedImageSize.value
+  }
+}
+
+onMounted(() => {
+  // show the resize transformer
+  if (!resizeTransformer.value || !node.value) {
+    return
+  }
+  resizeTransformer.value.visible(true)
+  resizeTransformer.value.nodes([node.value])
+})
+
+watch(
+  initialImageSize,
+  (newSize) => {
+    const { width, height } = newSize ?? { width: 0, height: 0 }
+    resizedImageSize.value = newSize
+    updateRenderScale(width, height)
+    updateCenterPosition(width * renderScale.value, height * renderScale.value)
+  },
+  { immediate: true }
+)
+
+watch(resizedImageSize, () => {
+  const { width, height } = resizedImageSize.value ?? { width: 0, height: 0 }
+  updateRenderScale(width, height)
+  updateCenterPosition(width * renderScale.value, height * renderScale.value)
+})
+
+const resizeTransformerConfig = computed<TransformerConfig | null>(() => {
+  if (!config.value) {
+    return null
+  }
+  return {
+    anchorStyleFunc: ((anchor: Konva.Rect) => {
+      anchor.cornerRadius(10)
+      anchor.stroke('rgba(11, 192, 207, 1)')
+      if (anchor.hasName('top-center') || anchor.hasName('bottom-center')) {
+        anchor.height(6)
+        anchor.offsetY(3)
+        anchor.width(30)
+        anchor.offsetX(15)
+      }
+      if (anchor.hasName('middle-left') || anchor.hasName('middle-right')) {
+        anchor.height(30)
+        anchor.offsetY(15)
+        anchor.width(6)
+        anchor.offsetX(3)
+      }
+    }) as TransformerConfig['anchorStyleFunc'],
+    borderStroke: 'rgba(11, 192, 207, 1)',
+    rotateEnabled: false,
+    boundBoxFunc: function (oldBoundBox, newBoundBox) {
+      const MIN_WIDTH = 10
+      const MIN_HEIGHT = 10
+      if (newBoundBox.width < MIN_WIDTH || newBoundBox.height < MIN_HEIGHT) {
+        return oldBoundBox
+      }
+
+      return newBoundBox
+    }
+  }
+})
+
+const config = computed<ImageConfig | null>(() => {
+  return {
+    spriteName: 'main-backdrop',
+    image: props.image ?? undefined,
+    draggable: true,
+    offsetX: 0,
+    offsetY: 0,
+    visible: true,
+    x: centerPos.value.x,
+    y: centerPos.value.y,
+    rotation: 0,
+    width: resizedImageSize.value?.width ?? 0,
+    height: resizedImageSize.value?.height ?? 0,
+    scaleX: renderScale.value ?? 1,
+    scaleY: renderScale.value ?? 1
+  } satisfies ImageConfig
+})
+
+/**
+ * Get the edited image
+ */
+const getImage = () => {
+  return new Promise<HTMLImageElement>((resolve) => {
+    node.value?.width(resizedImageSize.value?.width ?? node.value.width())
+    node.value?.height(resizedImageSize.value?.height ?? node.value.height())
+    node.value?.toImage({
+      callback: (img) => {
+        img.width = resizedImageSize.value?.width ?? img.width
+        img.height = resizedImageSize.value?.height ?? img.height
+        resolve(img)
+      }
+    })
+  })
+}
+
+defineExpose({
+  getImage
+})
+</script>
+
+<style scoped>
+.container {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  z-index: 0;
+}
+</style>

--- a/spx-gui/src/components/asset/library/ai/ImageEditor/useCenterPosition.ts
+++ b/spx-gui/src/components/asset/library/ai/ImageEditor/useCenterPosition.ts
@@ -1,0 +1,112 @@
+import { ref, type Ref } from 'vue'
+
+/**
+ * Calculate the position to center an object in a container.
+ *
+ * @param props The width and height of the container. Pass a ref if the size is reactive.
+ * @returns `position`: The reactive position object.
+ * @returns `updatePosition`: Update the position with the width and height of the object.
+ */
+export function useCenterPosition(props: {
+  width: number | Ref<number>
+  height: number | Ref<number>
+}) {
+  const position = ref({ x: 0, y: 0 })
+
+  const updatePosition = (width: number, height: number) => {
+    const containerWidth = typeof props.width === 'number' ? props.width : props.width.value
+    const containerHeight = typeof props.height === 'number' ? props.height : props.height.value
+    position.value = {
+      x: (containerWidth - width) / 2,
+      y: (containerHeight - height) / 2
+    }
+  }
+
+  return {
+    position,
+    updatePosition
+  }
+}
+
+/**
+ * Get a transition effect for the position.
+ *
+ * When the target position is updated, the current position will move towards the target position
+ * with given step.
+ *
+ * @param initital The initial position.
+ * @param step The step to move towards the target position.
+ * @returns `currentPos`: The reactive current position.
+ * @returns `updatePosition`: Update the target position.
+ * @returns `immediateUpdatePosition`: Update the target position immediately without animation.
+ */
+export function useAnimatedPosition(initital: { x: number; y: number }, step = 0.1) {
+  const currentPos = ref(initital)
+  const targetPos = ref(initital)
+
+  const updatePosition = (x: number, y: number) => {
+    targetPos.value = { x, y }
+    animateToTarget()
+  }
+
+  const immediateUpdatePosition = (x: number, y: number) => {
+    targetPos.value = { x, y }
+    currentPos.value = { x, y }
+  }
+
+  const animateToTarget = () => {
+    currentPos.value.x += (targetPos.value.x - currentPos.value.x) * step
+    currentPos.value.y += (targetPos.value.y - currentPos.value.y) * step
+
+    if (
+      Math.abs(targetPos.value.x - currentPos.value.x) >= step ||
+      Math.abs(targetPos.value.y - currentPos.value.y) >= step
+    ) {
+      requestAnimationFrame(animateToTarget)
+    }
+  }
+
+  return {
+    currentPos,
+    updatePosition,
+    immediateUpdatePosition
+  }
+}
+
+/**
+ * Calculate the position to center an object in a container with animation.
+ *
+ * @param props The width and height of the container. Pass a ref if the size is reactive.
+ * @returns `currentPos`: The reactive current position.
+ * @returns `updateCenterPosition`: Update the position with the width and height of the object with animation.
+ * @returns `immediateUpdatePosition`: Update the position with the width and height of the object immediately without animation.
+ */
+export function useAnimatedCenterPosition(props: {
+  width: number | Ref<number>
+  height: number | Ref<number>
+}) {
+  const { currentPos, updatePosition, immediateUpdatePosition } = useAnimatedPosition({
+    x: 0,
+    y: 0
+  })
+  let init = true
+  const updateCenterPosition = (width: number, height: number) => {
+    const containerWidth = typeof props.width === 'number' ? props.width : props.width.value
+    const containerHeight = typeof props.height === 'number' ? props.height : props.height.value
+    const targetX = (containerWidth - width) / 2
+    const targetY = (containerHeight - height) / 2
+    if (init) {
+      // avoid animation on first render. And thus the object will be centered immediately on show up.
+      init = false
+      immediateUpdatePosition(targetX, targetY)
+      return
+    }
+    updatePosition(targetX, targetY)
+  }
+
+  return {
+    currentPos,
+    updateCenterPosition,
+    immediateUpdatePosition
+  }
+}

--- a/spx-gui/src/components/asset/library/ai/ImageEditor/useRenderScale.ts
+++ b/spx-gui/src/components/asset/library/ai/ImageEditor/useRenderScale.ts
@@ -4,15 +4,19 @@ import { ref, type Ref } from 'vue'
  * renderScale is used to scale the image to fit the map
  * so that the whole image could always be visible when the image is larger than the map.
  *
- * The renderScale will not be updated if the image is smaller than the map.
- * @param props
+ * @param props The width and height of the container. Pass a ref if the size is reactive.
+ * @param shrinkingOnly If true, the image will only be scaled down. 
+ * 	Set it to false to scale up the image when the image is small.
  * @returns
  */
-export function useRenderScale(props: {
-  width: number | Ref<number>
-  height: number | Ref<number>
-  fillPercent: number | Ref<number>
-}) {
+export function useRenderScale(
+  props: {
+    width: number | Ref<number>
+    height: number | Ref<number>
+    fillPercent: number | Ref<number>
+  },
+  shrinkingOnly = true
+) {
   const renderScale = ref(1)
 
   const updateRenderScale = (width: number, height: number) => {
@@ -21,7 +25,7 @@ export function useRenderScale(props: {
     const fillPercent =
       typeof props.fillPercent === 'number' ? props.fillPercent : props.fillPercent.value
     const scale = Math.min(containerWidth / width, containerHeight / height) * fillPercent
-    if (scale < 1) {
+    if (scale < 1 || !shrinkingOnly) {
       renderScale.value = scale
     }
   }

--- a/spx-gui/src/components/asset/library/ai/ImageEditor/useRenderScale.ts
+++ b/spx-gui/src/components/asset/library/ai/ImageEditor/useRenderScale.ts
@@ -1,0 +1,33 @@
+import { ref, type Ref } from 'vue'
+
+/**
+ * renderScale is used to scale the image to fit the map
+ * so that the whole image could always be visible when the image is larger than the map.
+ *
+ * The renderScale will not be updated if the image is smaller than the map.
+ * @param props
+ * @returns
+ */
+export function useRenderScale(props: {
+  width: number | Ref<number>
+  height: number | Ref<number>
+  fillPercent: number | Ref<number>
+}) {
+  const renderScale = ref(1)
+
+  const updateRenderScale = (width: number, height: number) => {
+    const containerWidth = typeof props.width === 'number' ? props.width : props.width.value
+    const containerHeight = typeof props.height === 'number' ? props.height : props.height.value
+    const fillPercent =
+      typeof props.fillPercent === 'number' ? props.fillPercent : props.fillPercent.value
+    const scale = Math.min(containerWidth / width, containerHeight / height) * fillPercent
+    if (scale < 1) {
+      renderScale.value = scale
+    }
+  }
+
+  return {
+    renderScale,
+    updateRenderScale
+  }
+}


### PR DESCRIPTION
This pull requests implements a backdrop editor for AI generated backdrop, including `resize` and `crop`.

## TODO:
- [x] resize backdrop
  - [x] basic resize functionality.
  - [x] scale the backdrop (just visually) for large image to fit in container. So that user can still resize the image.
  - [x] limit minimal size. 
- [x] save backdrop to asset.
- [x] crop

![Peek 2024-08-27 17-42](https://github.com/user-attachments/assets/30980a1a-8716-4100-a6b8-887a30d4b48b)

