### PR TITLE
feat(spx-gui): refactor hoverPreivew codes

### DIFF
--- a/spx-gui/src/components/editor/code-editor/EditorUI.ts
+++ b/spx-gui/src/components/editor/code-editor/EditorUI.ts
@@ -34,7 +34,15 @@ export enum Icon {
 
 export type Markdown = string
 
+export enum DocPreviewLevel {
+  Nothing,
+  Normal,
+  Warning,
+  Error
+}
+
 export type DocPreview = {
+  level: DocPreviewLevel
   content: Markdown
   recommendAction?: RecommendAction | undefined
   moreActions?: Action[] | undefined
@@ -121,7 +129,7 @@ export interface HoverProvider {
       hoverUnitWord: string
       signal: AbortSignal
     }
-  ): Promise<LayerContent[] | null>
+  ): Promise<LayerContent[]>
 }
 
 export type InputItemUsage = {
@@ -359,7 +367,8 @@ export class EditorUI extends Disposable {
         }
       })
 
-    const isDocPreview = (layer: LayerContent): layer is DocPreview => 'content' in layer
+    const isDocPreview = (layer: LayerContent): layer is DocPreview =>
+      'content' in layer && 'level' in layer
 
     const isAudioPlayer = (layer: LayerContent): layer is AudioPlayer =>
       'src' in layer && 'duration' in layer
@@ -383,18 +392,13 @@ export class EditorUI extends Disposable {
             })
           ).flat()
 
-          for (let i = 0; i < result.length; i++) {
-            const layerContent = result[i]
-            if (layerContent == null) continue
-            if (isDocPreview(layerContent)) {
-              this.hoverPreview?.showDocument(layerContent, {
-                startLineNumber: position.lineNumber,
-                startColumn: word.startColumn,
-                endLineNumber: position.lineNumber,
-                endColumn: word.endColumn
-              })
-            }
-          }
+          // filter docPreview
+          this.hoverPreview?.showDocuments(result.filter(isDocPreview), {
+            startLineNumber: position.lineNumber,
+            startColumn: word.startColumn,
+            endLineNumber: position.lineNumber,
+            endColumn: word.endColumn
+          })
 
           return {
             // we only need to know when to trigger hover preview, no need to show raw content

--- a/spx-gui/src/components/editor/code-editor/EditorUI.ts
+++ b/spx-gui/src/components/editor/code-editor/EditorUI.ts
@@ -375,11 +375,13 @@ export class EditorUI extends Disposable {
           if (word == null) return
           const abortController = new AbortController()
           token.onCancellationRequested(() => abortController.abort())
-          const result = (await this.requestHoverProviderResolve(model, {
-            signal: abortController.signal,
-            hoverUnitWord: word.word,
-            position
-          })).flat()
+          const result = (
+            await this.requestHoverProviderResolve(model, {
+              signal: abortController.signal,
+              hoverUnitWord: word.word,
+              position
+            })
+          ).flat()
 
           for (let i = 0; i < result.length; i++) {
             const layerContent = result[i]
@@ -395,7 +397,7 @@ export class EditorUI extends Disposable {
           }
 
           return {
-            // we only need use to know when to trigger hover preview, no need to show raw content
+            // we only need to know when to trigger hover preview, no need to show raw content
             // so here we return empty result
             contents: []
           }
@@ -444,7 +446,7 @@ export class EditorUI extends Disposable {
     }
   ) {
     const promiseResults = await Promise.all(
-      this.editorUIRequestCallback.hover.map(item => item.provideHover(model, ctx))
+      this.editorUIRequestCallback.hover.map((item) => item.provideHover(model, ctx))
     )
     return promiseResults.flat().filter(Boolean)
   }

--- a/spx-gui/src/components/editor/code-editor/EditorUI.ts
+++ b/spx-gui/src/components/editor/code-editor/EditorUI.ts
@@ -8,7 +8,7 @@ import {
 import { Disposable } from '@/utils/disposable'
 import {
   type CompletionMenu,
-  Icon2CompletionItemKind
+  icon2CompletionItemKind
 } from '@/components/editor/code-editor/ui/features/completion-menu/completion-menu'
 import loader from '@monaco-editor/loader'
 import EditorWorker from 'monaco-editor/esm/vs/editor/editor.worker?worker'
@@ -35,7 +35,6 @@ export enum Icon {
 export type Markdown = string
 
 export enum DocPreviewLevel {
-  Nothing,
   Normal,
   Warning,
   Error
@@ -352,7 +351,7 @@ export class EditorUI extends Disposable {
               this.completionMenu?.completionItemCache.getAll(completionItemCacheID).map(
                 (item): languages.CompletionItem => ({
                   label: item.label,
-                  kind: Icon2CompletionItemKind(item.icon),
+                  kind: icon2CompletionItemKind(item.icon),
                   insertText: item.insertText,
                   range: {
                     startLineNumber: position.lineNumber,

--- a/spx-gui/src/components/editor/code-editor/compiler.ts
+++ b/spx-gui/src/components/editor/code-editor/compiler.ts
@@ -6,7 +6,7 @@ enum CodeEnum {
 }
 
 type TokenUsage = {
-  // when don't hava markdown, here show declaration signature
+  // when don't have markdown, here show declaration signature
   desc: LocaleMessage
   insertText: string
 }

--- a/spx-gui/src/components/editor/code-editor/compiler.ts
+++ b/spx-gui/src/components/editor/code-editor/compiler.ts
@@ -1,9 +1,15 @@
+import type { LocaleMessage } from '@/utils/i18n'
+
 enum CodeEnum {
   Sprite,
   Backdrop
 }
 
-enum TokenUsage {}
+type TokenUsage = {
+  // when don't hava markdown, here show declaration signature
+  desc: LocaleMessage
+  insertText: string
+}
 
 enum CompletionItemEnum {}
 
@@ -30,12 +36,16 @@ type CompletionItem = {
   insertText: string
 }
 
-export type Token = {
+export type TokenId = {
   // "github.com/goplus/spx"
   module: string
   // "Sprite.touching"
   name: string
-  usages?: TokenUsage[]
+}
+
+export type Token = {
+  id: TokenId
+  usages: TokenUsage[]
 }
 
 type Code = {

--- a/spx-gui/src/components/editor/code-editor/compiler.ts
+++ b/spx-gui/src/components/editor/code-editor/compiler.ts
@@ -3,11 +3,6 @@ enum CodeEnum {
   Backdrop
 }
 
-export enum TokenEnum {
-  // todo: remove me after compiler has done! this is temp using to make ts compile pass.
-  ANY
-}
-
 enum TokenUsage {}
 
 enum CompletionItemEnum {}
@@ -40,8 +35,7 @@ export type Token = {
   module: string
   // "Sprite.touching"
   name: string
-  type: TokenEnum
-  usages: TokenUsage[]
+  usages?: TokenUsage[]
 }
 
 type Code = {

--- a/spx-gui/src/components/editor/code-editor/compiler.ts
+++ b/spx-gui/src/components/editor/code-editor/compiler.ts
@@ -7,7 +7,7 @@ enum CodeEnum {
 
 type TokenUsage = {
   // declaration signature
-  desc: LocaleMessage
+  desc: string
   insertText: string
 }
 

--- a/spx-gui/src/components/editor/code-editor/compiler.ts
+++ b/spx-gui/src/components/editor/code-editor/compiler.ts
@@ -6,7 +6,7 @@ enum CodeEnum {
 }
 
 type TokenUsage = {
-  // when don't have markdown, here show declaration signature
+  // declaration signature
   desc: LocaleMessage
   insertText: string
 }
@@ -45,7 +45,7 @@ export type TokenId = {
 
 export type Token = {
   id: TokenId
-  usages: TokenUsage[]
+  usages: TokenUsage
 }
 
 type Code = {

--- a/spx-gui/src/components/editor/code-editor/coordinators/index.ts
+++ b/spx-gui/src/components/editor/code-editor/coordinators/index.ts
@@ -6,7 +6,7 @@ import {
   type TextModel
 } from '@/components/editor/code-editor/EditorUI'
 import { Runtime } from '../runtime'
-import { Compiler, TokenEnum } from '../compiler'
+import { Compiler } from '../compiler'
 import { ChatBot } from '../chat-bot'
 import { DocAbility } from '../document'
 import { Project } from '@/models/project'
@@ -68,21 +68,23 @@ export class Coordinator {
       hoverUnitWord: string
       signal: AbortSignal
     }
-  ): Promise<LayerContent> {
-    const content =
-      this.docAbility.getNormalDoc({
-        module: '',
-        name: ctx.hoverUnitWord,
-        type: TokenEnum.ANY,
-        usages: []
-      })?.content || ''
-    return {
-      content: content,
+  ): Promise<LayerContent[] | null> {
+    const contents = this.docAbility.getNormalDoc({
+      module: '',
+      name: ctx.hoverUnitWord
+    })
+
+    if (!contents || contents.length === 0) {
+      return null
+    }
+
+    return contents.map((doc) => ({
+      content: doc.content,
       recommendAction: {
-        label: this.ui.i18n.t({ zh: '还有疑惑？场外求助', en: 'still in confusion? Ask for help' }),
+        label: this.ui.i18n.t({ zh: '还有疑惑？场外求助', en: 'Still in confusion? Ask for help' }),
         activeLabel: this.ui.i18n.t({ zh: '在线答疑', en: 'Online Q&A' }),
         onActiveLabelClick() {
-          console.log('=>(index.ts:75) Ask for help')
+          // TODO: add some logic code here
         }
       },
       moreActions: [
@@ -90,11 +92,11 @@ export class Coordinator {
           icon: Icon.Document,
           label: this.ui.i18n.t({ zh: '查看文档', en: 'Document' }),
           onClick() {
-            console.log('=>(index.ts:82) Document')
+            // TODO: add some logic code here
           }
         }
       ]
-    }
+    }))
   }
 
   public jump(position: JumpPosition): void {}

--- a/spx-gui/src/components/editor/code-editor/coordinators/index.ts
+++ b/spx-gui/src/components/editor/code-editor/coordinators/index.ts
@@ -1,5 +1,6 @@
 import {
   type CompletionItem,
+  DocPreviewLevel,
   type EditorUI,
   Icon,
   type LayerContent,
@@ -68,22 +69,23 @@ export class Coordinator {
       hoverUnitWord: string
       signal: AbortSignal
     }
-  ): Promise<LayerContent[] | null> {
+  ): Promise<LayerContent[]> {
     const contents = this.docAbility.getNormalDoc({
       module: '',
       name: ctx.hoverUnitWord
     })
 
     if (!contents || contents.length === 0) {
-      return null
+      return []
     }
 
     return contents.map((doc) => ({
+      level: DocPreviewLevel.Normal,
       content: doc.content,
       recommendAction: {
         label: this.ui.i18n.t({ zh: '还有疑惑？场外求助', en: 'Still in confusion? Ask for help' }),
         activeLabel: this.ui.i18n.t({ zh: '在线答疑', en: 'Online Q&A' }),
-        onActiveLabelClick() {
+        onActiveLabelClick: () => {
           // TODO: add some logic code here
         }
       },
@@ -91,8 +93,10 @@ export class Coordinator {
         {
           icon: Icon.Document,
           label: this.ui.i18n.t({ zh: '查看文档', en: 'Document' }),
-          onClick() {
-            // TODO: add some logic code here
+          onClick: () => {
+            const detailDoc = this.docAbility.getDetailDoc(doc.token)
+            if (!detailDoc) return
+            this.ui.invokeDocumentDetail(detailDoc.content)
           }
         }
       ]
@@ -110,6 +114,7 @@ function getCompletionItems(i18n: I18n, project: Project): CompletionItem[] {
       icon: Icon.Keywords,
       desc: '',
       preview: {
+        level: DocPreviewLevel.Normal,
         content: ''
       }
     })),
@@ -119,6 +124,7 @@ function getCompletionItems(i18n: I18n, project: Project): CompletionItem[] {
       icon: Icon.Keywords,
       desc: '',
       preview: {
+        level: DocPreviewLevel.Normal,
         content: ''
       }
     }))
@@ -128,6 +134,7 @@ function getCompletionItems(i18n: I18n, project: Project): CompletionItem[] {
       label: tool.keyword,
       icon: getCompletionItemKind(tool.type),
       preview: {
+        level: 1,
         content: ''
       }
     }

--- a/spx-gui/src/components/editor/code-editor/document.ts
+++ b/spx-gui/src/components/editor/code-editor/document.ts
@@ -1,4 +1,4 @@
-import type { Token } from '@/components/editor/code-editor/compiler'
+import type { Token, TokenId } from '@/components/editor/code-editor/compiler'
 import type { I18n } from '@/utils/i18n'
 import { Project } from '@/models/project'
 import { getAllTools } from '@/components/editor/code-editor/tools'
@@ -19,15 +19,20 @@ export class DocAbility {
     this.project = getProject()
   }
 
-  public getNormalDoc(token: Token): Doc[] | null {
-    const document = getDocumentByKeywords(token.name, this.i18n, this.project)
+  public getNormalDoc(tokenId: TokenId): Doc[] | null {
+    const document = getDocumentByKeywords(tokenId.name, this.i18n, this.project)
     if (document == null) {
       return []
     } else {
-      return [{
-        content: document,
-        token
-      }]
+      return [
+        {
+          content: document,
+          token: {
+            id: tokenId,
+            usages: []
+          }
+        }
+      ]
     }
   }
   public getDetailDoc(token: Token): Doc | null {

--- a/spx-gui/src/components/editor/code-editor/document.ts
+++ b/spx-gui/src/components/editor/code-editor/document.ts
@@ -32,7 +32,7 @@ export class DocAbility {
             id: tokenId,
             usages: {
               insertText: '',
-              desc: { zh: '', en: '' }
+              desc: ''
             }
           }
         })

--- a/spx-gui/src/components/editor/code-editor/document.ts
+++ b/spx-gui/src/components/editor/code-editor/document.ts
@@ -19,10 +19,15 @@ export class DocAbility {
     this.project = getProject()
   }
 
-  public getNormalDoc(token: Token): Doc | null {
-    return {
-      content: getDocumentByKeywords(token.name, this.i18n, this.project) || '',
-      token
+  public getNormalDoc(token: Token): Doc[] | null {
+    const document = getDocumentByKeywords(token.name, this.i18n, this.project)
+    if (document == null) {
+      return []
+    } else {
+      return [{
+        content: document,
+        token
+      }]
     }
   }
   public getDetailDoc(token: Token): Doc | null {

--- a/spx-gui/src/components/editor/code-editor/ui/MarkdownPreview.vue
+++ b/spx-gui/src/components/editor/code-editor/ui/MarkdownPreview.vue
@@ -69,7 +69,6 @@ window.addEventListener('click', (e) => {
     timeoutIdMap.set(el, timeoutId as unknown as number)
   })
 })
-
 </script>
 <script setup lang="ts">
 import { renderMarkdown } from './common/languages'

--- a/spx-gui/src/components/editor/code-editor/ui/MarkdownPreview.vue
+++ b/spx-gui/src/components/editor/code-editor/ui/MarkdownPreview.vue
@@ -1,3 +1,76 @@
+<script lang="ts">
+import type MarkdownIt from 'markdown-it'
+export function preWrapperPlugin(md: MarkdownIt) {
+  const fence = md.renderer.rules.fence!
+  md.renderer.rules.fence = (...args) => {
+    return `<div class="markdown-preview__wrapper"><button class="markdown-preview__copy-button"></button>${fence(...args)}</div>`
+  }
+}
+
+async function copyToClipboard(text: string) {
+  try {
+    return navigator.clipboard.writeText(text)
+  } catch {
+    const element = document.createElement('textarea')
+    const previouslyFocusedElement = document.activeElement
+
+    element.value = text
+
+    // Prevent keyboard from showing on mobile
+    element.setAttribute('readonly', '')
+
+    element.style.contain = 'strict'
+    element.style.position = 'absolute'
+    element.style.left = '-9999px'
+    element.style.fontSize = '12pt' // Prevent zooming on iOS
+
+    const selection = document.getSelection()
+    const originalRange = selection ? selection.rangeCount > 0 && selection.getRangeAt(0) : null
+
+    document.body.appendChild(element)
+    element.select()
+
+    // Explicit selection workaround for iOS
+    element.selectionStart = 0
+    element.selectionEnd = text.length
+
+    document.execCommand('copy')
+    document.body.removeChild(element)
+
+    if (originalRange) {
+      selection!.removeAllRanges() // originalRange can't be truthy when selection is falsy
+      selection!.addRange(originalRange)
+    }
+
+    // Get the focus back on the previously focused element, if any
+    if (previouslyFocusedElement) {
+      ;(previouslyFocusedElement as HTMLElement).focus()
+    }
+  }
+}
+
+const timeoutIdMap: WeakMap<HTMLElement, number> = new WeakMap()
+window.addEventListener('click', (e) => {
+  const el = e.target as HTMLElement
+  if (!el.matches('.markdown-preview__wrapper > .markdown-preview__copy-button')) return
+  const parent = el.parentElement
+  const sibling = el.nextElementSibling
+  if (!parent || !sibling) return
+  const clone = sibling.cloneNode(true) as HTMLElement
+  const text = clone.textContent || ''
+  copyToClipboard(text).then(() => {
+    el.classList.add('copied')
+    clearTimeout(timeoutIdMap.get(el))
+    const timeoutId = setTimeout(() => {
+      el.classList.remove('copied')
+      el.blur()
+      timeoutIdMap.delete(el)
+    }, 2000)
+    timeoutIdMap.set(el, timeoutId as unknown as number)
+  })
+})
+
+</script>
 <script setup lang="ts">
 import { renderMarkdown } from './common/languages'
 import CopyIcon from './icons/copy.svg'

--- a/spx-gui/src/components/editor/code-editor/ui/code-text-editor/CodeTextEditor.vue
+++ b/spx-gui/src/components/editor/code-editor/ui/code-text-editor/CodeTextEditor.vue
@@ -16,7 +16,7 @@ let monaco: typeof import('monaco-editor')
 let editorCtx: EditorCtx // define `editorCtx` here so `getProject` in `initMonaco` can get the right `editorCtx.project`
 </script>
 <script setup lang="ts">
-import { getCurrentInstance, ref, shallowRef, watch, watchEffect } from 'vue'
+import { ref, shallowRef, watch, watchEffect } from 'vue'
 import { formatSpxCode as onlineFormatSpxCode } from '@/apis/util'
 import loader from '@monaco-editor/loader'
 import { KeyCode, type editor, Position, MarkerSeverity, KeyMod } from 'monaco-editor'
@@ -45,7 +45,6 @@ const completionMenu = shallowRef<CompletionMenu>()
 const hoverPreview = shallowRef<HoverPreview>()
 const i18n = useI18n()
 const uiVariables = useUIVariables()
-const appInstance = getCurrentInstance()
 
 const loaderConfig = {
   paths: {
@@ -142,9 +141,7 @@ watchEffect(async (onCleanup) => {
     // Note that it is not appropriate to call global undo here, because global undo/redo merges code changes, it is not expected for Cmd+Z.
   })
 
-  if (!appInstance?.appContext) throw new Error("Can't get appContext")
-
-  const _hoverPreview = new HoverPreview(editor, appInstance?.appContext)
+  const _hoverPreview = new HoverPreview(editor)
   hoverPreview.value = _hoverPreview
   props.ui.setHoverPreview(_hoverPreview)
 

--- a/spx-gui/src/components/editor/code-editor/ui/common/languages/index.ts
+++ b/spx-gui/src/components/editor/code-editor/ui/common/languages/index.ts
@@ -12,7 +12,7 @@ import GOTextmate from './go.tmLanguage.json' // this is sample using, need keep
 import GOPTextmate from './gop.tmLanguage.json'
 import SpxLightTheme from './spx-light.json'
 import markdownIt from 'markdown-it'
-import type MarkdownIt from 'markdown-it'
+import { preWrapperPlugin } from '../../MarkdownPreview.vue'
 
 let highlighter: HighlighterGeneric<BundledLanguage, BundledTheme> | null = null
 const highlighterPromise = createHighlighter({
@@ -58,73 +58,3 @@ export async function injectMonacoHighlightTheme(monaco: typeof IMonaco) {
 export function renderMarkdown(content: string) {
   return md.render(content)
 }
-
-function preWrapperPlugin(md: MarkdownIt) {
-  const fence = md.renderer.rules.fence!
-  md.renderer.rules.fence = (...args) => {
-    return `<div class="markdown-preview__wrapper"><button class="markdown-preview__copy-button"></button>${fence(...args)}</div>`
-  }
-}
-
-async function copyToClipboard(text: string) {
-  try {
-    return navigator.clipboard.writeText(text)
-  } catch {
-    const element = document.createElement('textarea')
-    const previouslyFocusedElement = document.activeElement
-
-    element.value = text
-
-    // Prevent keyboard from showing on mobile
-    element.setAttribute('readonly', '')
-
-    element.style.contain = 'strict'
-    element.style.position = 'absolute'
-    element.style.left = '-9999px'
-    element.style.fontSize = '12pt' // Prevent zooming on iOS
-
-    const selection = document.getSelection()
-    const originalRange = selection ? selection.rangeCount > 0 && selection.getRangeAt(0) : null
-
-    document.body.appendChild(element)
-    element.select()
-
-    // Explicit selection workaround for iOS
-    element.selectionStart = 0
-    element.selectionEnd = text.length
-
-    document.execCommand('copy')
-    document.body.removeChild(element)
-
-    if (originalRange) {
-      selection!.removeAllRanges() // originalRange can't be truthy when selection is falsy
-      selection!.addRange(originalRange)
-    }
-
-    // Get the focus back on the previously focused element, if any
-    if (previouslyFocusedElement) {
-      ;(previouslyFocusedElement as HTMLElement).focus()
-    }
-  }
-}
-
-const timeoutIdMap: WeakMap<HTMLElement, number> = new WeakMap()
-window.addEventListener('click', (e) => {
-  const el = e.target as HTMLElement
-  if (!el.matches('.markdown-preview__wrapper > .markdown-preview__copy-button')) return
-  const parent = el.parentElement
-  const sibling = el.nextElementSibling
-  if (!parent || !sibling) return
-  const clone = sibling.cloneNode(true) as HTMLElement
-  const text = clone.textContent || ''
-  copyToClipboard(text).then(() => {
-    el.classList.add('copied')
-    clearTimeout(timeoutIdMap.get(el))
-    const timeoutId = setTimeout(() => {
-      el.classList.remove('copied')
-      el.blur()
-      timeoutIdMap.delete(el)
-    }, 2000)
-    timeoutIdMap.set(el, timeoutId as unknown as number)
-  })
-})

--- a/spx-gui/src/components/editor/code-editor/ui/features/completion-menu/completion-menu.ts
+++ b/spx-gui/src/components/editor/code-editor/ui/features/completion-menu/completion-menu.ts
@@ -272,7 +272,7 @@ function completionItemKind2Icon(completionIcon: languages.CompletionItemKind): 
   }
 }
 
-export function Icon2CompletionItemKind(icon: Icon): languages.CompletionItemKind {
+export function icon2CompletionItemKind(icon: Icon): languages.CompletionItemKind {
   switch (icon) {
     case Icon.Function:
       return languages.CompletionItemKind.Function

--- a/spx-gui/src/components/editor/code-editor/ui/features/completion-menu/completion-menu.ts
+++ b/spx-gui/src/components/editor/code-editor/ui/features/completion-menu/completion-menu.ts
@@ -13,9 +13,9 @@ import {
 import { reactive, type UnwrapNestedRefs } from 'vue'
 import type { CompletionMenuFeatureItem, MonacoCompletionModelItem } from './completion'
 import { createMatches, type IMatch } from '../../common'
-import EditorOption = editor.EditorOption
 import { CompletionItemCache } from '@/components/editor/code-editor/ui/features/completion-menu/completion-item-cache'
-import { Icon } from '@/components/editor/code-editor/EditorUI'
+import { DocPreviewLevel, Icon } from '@/components/editor/code-editor/EditorUI'
+import EditorOption = editor.EditorOption
 
 export interface CompletionMenuState {
   visible: boolean
@@ -245,6 +245,7 @@ export class CompletionMenu implements IDisposable {
         icon: completionItemKind2Icon(completion.completion.kind),
         label: completion.completion.label as string,
         preview: {
+          level: DocPreviewLevel.Normal,
           content: ''
         },
         insertText: completion.completion.insertText,

--- a/spx-gui/src/components/editor/code-editor/ui/features/hover-preview/DocumentPreview.vue
+++ b/spx-gui/src/components/editor/code-editor/ui/features/hover-preview/DocumentPreview.vue
@@ -7,14 +7,10 @@ defineProps<{
   recommendAction?: RecommendAction
   moreActions?: Action[]
 }>()
-
-defineEmits<{
-  close: []
-}>()
 </script>
 
 <template>
-  <section class="document-preview" @mouseleave="$emit('close')">
+  <section class="document-preview">
     <MarkdownPreview class="markdown" :content></MarkdownPreview>
     <footer class="actions-footer">
       <nav class="recommend">
@@ -53,19 +49,7 @@ div[widgetid='editor.contrib.resizableContentHoverWidget'] {
   border: 1px solid #a6a6a6;
   color: black;
   box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
-  transform-origin: left top;
   transition: 0.15s;
-
-  &.v-enter-active,
-  &.v-leave-active {
-    transition: 0.15s cubic-bezier(0, 1.25, 1, 1);
-  }
-
-  &.v-enter-from,
-  &.v-leave-to {
-    opacity: 0;
-    transform: scale(0.8) translateY(20px);
-  }
 }
 
 .actions-footer {

--- a/spx-gui/src/components/editor/code-editor/ui/features/hover-preview/DocumentPreview.vue
+++ b/spx-gui/src/components/editor/code-editor/ui/features/hover-preview/DocumentPreview.vue
@@ -11,7 +11,10 @@ defineProps<{
 
 <template>
   <section class="document-preview">
-    <MarkdownPreview class="markdown" :content></MarkdownPreview>
+    <header>
+      <!--  Todo: add header interface in props  -->
+    </header>
+    <MarkdownPreview class="markdown" :content="content"></MarkdownPreview>
     <footer class="actions-footer">
       <nav class="recommend">
         {{ recommendAction?.label }}

--- a/spx-gui/src/components/editor/code-editor/ui/features/hover-preview/HoverPreviewComponent.vue
+++ b/spx-gui/src/components/editor/code-editor/ui/features/hover-preview/HoverPreviewComponent.vue
@@ -1,10 +1,91 @@
 <script setup lang="ts">
 import type { HoverPreview } from './hover-preview'
-
-defineProps<{
+import DocumentPreview from './DocumentPreview.vue'
+import { editor as IEditor } from 'monaco-editor'
+const props = defineProps<{
   hoverPreview: HoverPreview
 }>()
+const hoverPreviewState = props.hoverPreview.hoverPreviewState
+
+props.hoverPreview.onMousemove((e) => {
+  if (e.type !== IEditor.MouseTargetType.CONTENT_TEXT) return props.hoverPreview.hideDocument(true)
+
+  const position = props.hoverPreview.editor.getModel()?.getWordAtPosition({
+    column: e.range.startColumn,
+    lineNumber: e.range.startLineNumber
+  })
+  if (!position || !position.word) return props.hoverPreview.hideDocument(true)
+  const { startColumn, endColumn } = position
+  const lineNumber = e.position.lineNumber
+  if (
+    (lineNumber === hoverPreviewState.range.startLineNumber &&
+      endColumn <= hoverPreviewState.range.startColumn) ||
+    (lineNumber === hoverPreviewState.range.endLineNumber &&
+      startColumn >= hoverPreviewState.range.endColumn) ||
+    lineNumber < hoverPreviewState.range.startLineNumber ||
+    lineNumber > hoverPreviewState.range.endLineNumber
+  ) {
+    return props.hoverPreview.hideDocument(true)
+  }
+})
+
+props.hoverPreview.onShowDocument((range) => {
+  const containerRect = props.hoverPreview.editor.getContainerDomNode().getBoundingClientRect()
+  const scrolledVisiblePosition = props.hoverPreview.editor.getScrolledVisiblePosition({
+    lineNumber: range.endLineNumber,
+    column: range.startColumn
+  })
+  if (!scrolledVisiblePosition) return
+  props.hoverPreview.tryToPreventHideDocument()
+  hoverPreviewState.visible = true
+  hoverPreviewState.range = { ...range }
+  const top = containerRect.top + scrolledVisiblePosition.top + scrolledVisiblePosition.height
+  const left = containerRect.left + scrolledVisiblePosition.left
+  hoverPreviewState.style.top = `${top}px`
+  hoverPreviewState.style.left = `${left}px`
+})
 </script>
 <template>
   <slot></slot>
+  <teleport to="body">
+    <div class="hover-preview-wrapper">
+      <transition>
+        <DocumentPreview
+          v-show="hoverPreviewState.visible"
+          :style="hoverPreviewState.style"
+          :content="hoverPreviewState.content"
+          :more-actions="hoverPreviewState.moreActions"
+          :recommend-action="hoverPreviewState.recommendAction"
+          class="hover-document"
+          @mouseleave="hoverPreview.hideDocument()"
+          @mouseenter="hoverPreview.tryToPreventHideDocument()"
+        ></DocumentPreview>
+      </transition>
+    </div>
+  </teleport>
 </template>
+
+<style lang="scss" scoped>
+.hover-preview-wrapper {
+  position: fixed;
+  inset: 0;
+  width: 0;
+  height: 0;
+}
+
+.hover-document {
+  position: absolute;
+  transform-origin: left top;
+
+  &.v-enter-active,
+  &.v-leave-active {
+    transition: 0.15s cubic-bezier(0, 1.25, 1, 1);
+  }
+
+  &.v-enter-from,
+  &.v-leave-to {
+    opacity: 0;
+    transform: scale(0.8) translateY(20px);
+  }
+}
+</style>

--- a/spx-gui/src/components/editor/code-editor/ui/features/hover-preview/hover-preview.ts
+++ b/spx-gui/src/components/editor/code-editor/ui/features/hover-preview/hover-preview.ts
@@ -1,112 +1,89 @@
-import { editor as IEditor, type IRange, type IDisposable } from 'monaco-editor'
-import { type AppContext, h, render, Transition, type VNode } from 'vue'
+import { editor as IEditor, type IRange, type IDisposable, Emitter } from 'monaco-editor'
+import { reactive } from 'vue'
 import type { DocPreview } from '@/components/editor/code-editor/EditorUI'
-import DocumentPreviewComponent from '@/components/editor/code-editor/ui/features/hover-preview/DocumentPreview.vue'
+import type { Action, RecommendAction } from '@/components/editor/code-editor/EditorUI'
 
 export class HoverPreview implements IDisposable {
-  private editor: IEditor.IStandaloneCodeEditor
+  public editor: IEditor.IStandaloneCodeEditor
   // classic ts type matches error between Browser timer and Node.js timer, god knows why 2024 still has this problem.
   // overview: https://stackoverflow.com/questions/45802988/typescript-use-correct-version-of-settimeout-node-vs-window
   // here can use force transformed type.
   // or use `ReturnType<typeof setTimeout>`
-  private editorDocumentTimer: ReturnType<typeof setTimeout> | null = null
-  private readonly appContext: AppContext
-  private readonly cardContainer: HTMLDivElement
-  private documentRange: {
-    startLineNumber: number
-    startColumn: number
-    endLineNumber: number
-    endColumn: number
-  } = {
-    startLineNumber: 0,
-    startColumn: 0,
-    endLineNumber: 0,
-    endColumn: 0
-  }
+  public editorDocumentTimer: ReturnType<typeof setTimeout> | null = null
+  private _onMousemove = new Emitter<IEditor.IMouseTarget>()
+  private _onShowDocument = new Emitter<IRange>()
+  public onMousemove = this._onMousemove.event
+  public onShowDocument = this._onShowDocument.event
+  public hoverPreviewState = reactive<{
+    visible: boolean
+    content: string
+    moreActions?: Action[]
+    recommendAction?: RecommendAction
+    style: {
+      position: 'absolute'
+      top: string
+      left: string
+    }
+    range: {
+      startLineNumber: number
+      startColumn: number
+      endLineNumber: number
+      endColumn: number
+    }
+  }>({
+    visible: false,
+    content: '',
+    moreActions: undefined,
+    recommendAction: undefined,
+    style: {
+      position: 'absolute',
+      top: '0',
+      left: '0'
+    },
+    range: {
+      startLineNumber: 0,
+      startColumn: 0,
+      endLineNumber: 0,
+      endColumn: 0
+    }
+  })
 
-  constructor(editor: IEditor.IStandaloneCodeEditor, appContext: AppContext) {
+  constructor(editor: IEditor.IStandaloneCodeEditor) {
     this.editor = editor
-    this.appContext = appContext
-
-    this.cardContainer = document.createElement('div')
-    this.cardContainer.style.cssText = `
-      position: fixed;
-      inset: 0;
-      width: 0;
-      height: 0;
-      z-index: 999;
-    `
-    document.body.appendChild(this.cardContainer)
-
-    this.editor.onMouseMove((e) => this.onMousemove(e.target))
-  }
-
-  showDocument(docPreview: DocPreview, range: IRange) {
-    if (!docPreview.content) return
-    const containerRect = this.editor.getContainerDomNode().getBoundingClientRect()
-    const scrolledVisiblePosition = this.editor.getScrolledVisiblePosition({
-      lineNumber: range.endLineNumber,
-      column: range.startColumn
+    this.editor.onMouseMove((e) => {
+      this._onMousemove.fire(e.target)
     })
-    if (!scrolledVisiblePosition) return
-    if (this.editorDocumentTimer) clearTimeout(this.editorDocumentTimer)
-
-    this.documentRange = { ...range }
-    const top = containerRect.top + scrolledVisiblePosition.top + scrolledVisiblePosition.height
-    const left = containerRect.left + scrolledVisiblePosition.left
-    this.renderDocument(
-      h(DocumentPreviewComponent, {
-        content: docPreview.content,
-        moreActions: docPreview.moreActions,
-        recommendAction: docPreview.recommendAction,
-        style: {
-          position: 'absolute',
-          top: `${top}px`,
-          left: `${left}px`
-        },
-        onClose: () => this.hideDocument(),
-        onMouseenter: () => {
-          if (this.editorDocumentTimer) clearTimeout(this.editorDocumentTimer)
-        }
-      })
-    )
   }
 
-  renderDocument(documentNode: VNode | null) {
-    const vNode = h(
-      Transition,
-      {
-        appear: true
-      },
-      () => documentNode
-    )
-    vNode.appContext = this.appContext
-    render(vNode, this.cardContainer)
+  public showDocument(docPreview: DocPreview, range: IRange) {
+    if (!docPreview.content) return
+    this.hoverPreviewState.content = docPreview.content
+    this.hoverPreviewState.moreActions = docPreview.moreActions
+    this.hoverPreviewState.recommendAction = docPreview.recommendAction
+    this._onShowDocument.fire(range)
   }
 
-  hideDocument(immediately: boolean = false) {
+  public hideDocument(immediately: boolean = false) {
     if (immediately) {
-      return this.renderDocument(null)
+      this.hoverPreviewState.visible = false
     } else {
-      if (this.editorDocumentTimer) clearTimeout(this.editorDocumentTimer)
-      this.editorDocumentTimer = setTimeout(() => this.renderDocument(null), 300)
+      this.tryToPreventHideDocument()
+      this.editorDocumentTimer = setTimeout(() => {
+        this.hoverPreviewState.visible = false
+      }, 300)
     }
   }
 
-  onMousemove(target: IEditor.IMouseTarget) {
-    if (target.type !== IEditor.MouseTargetType.CONTENT_TEXT) return this.hideDocument(true)
-    const position = this.editor.getModel()?.getWordAtPosition({
-      column: target.range.startColumn,
-      lineNumber: target.range.startLineNumber
-    })
-    if (!position || !position.word) return this.hideDocument(true)
-    const { startColumn, endColumn } = position
-    if (this.documentRange.startColumn < startColumn && this.documentRange.endColumn > endColumn) {
-      return this.hideDocument()
+  public tryToPreventHideDocument() {
+    if (this.editorDocumentTimer) {
+      console.log('tryToPreventHideDocument')
+      clearTimeout(this.editorDocumentTimer)
+      this.editorDocumentTimer = null
     }
   }
 
   dispose() {
-    this.cardContainer.remove()
+    this._onMousemove.dispose()
+    this._onShowDocument.dispose()
   }
 }

--- a/spx-gui/src/components/editor/code-editor/ui/features/hover-preview/hover-preview.ts
+++ b/spx-gui/src/components/editor/code-editor/ui/features/hover-preview/hover-preview.ts
@@ -16,36 +16,29 @@ export class HoverPreview implements IDisposable {
   public onShowDocument = this._onShowDocument.event
   public hoverPreviewState = reactive<{
     visible: boolean
-    content: string
-    moreActions?: Action[]
-    recommendAction?: RecommendAction
-    style: {
-      position: 'absolute'
-      top: string
-      left: string
+    range: IRange
+    position: {
+      top: number
+      left: number
     }
-    range: {
-      startLineNumber: number
-      startColumn: number
-      endLineNumber: number
-      endColumn: number
-    }
+    docs: Array<{
+      content: string
+      moreActions?: Action[]
+      recommendAction?: RecommendAction
+    }>
   }>({
     visible: false,
-    content: '',
-    moreActions: undefined,
-    recommendAction: undefined,
-    style: {
-      position: 'absolute',
-      top: '0',
-      left: '0'
-    },
     range: {
       startLineNumber: 0,
       startColumn: 0,
       endLineNumber: 0,
       endColumn: 0
-    }
+    },
+    position: {
+      top: 0,
+      left: 0
+    },
+    docs: []
   })
 
   constructor(editor: IEditor.IStandaloneCodeEditor) {
@@ -55,11 +48,14 @@ export class HoverPreview implements IDisposable {
     })
   }
 
-  public showDocument(docPreview: DocPreview, range: IRange) {
-    if (!docPreview.content) return
-    this.hoverPreviewState.content = docPreview.content
-    this.hoverPreviewState.moreActions = docPreview.moreActions
-    this.hoverPreviewState.recommendAction = docPreview.recommendAction
+  public showDocuments(_docPreviews: DocPreview[], range: IRange) {
+    if (!_docPreviews.length) return
+    const docPreviews = _docPreviews.filter((docPreview) => Boolean(docPreview.content))
+    this.hoverPreviewState.docs = docPreviews.map((docPreview) => ({
+      content: docPreview.content,
+      moreActions: docPreview.moreActions,
+      recommendAction: docPreview.recommendAction
+    }))
     this._onShowDocument.fire(range)
   }
 
@@ -76,7 +72,6 @@ export class HoverPreview implements IDisposable {
 
   public tryToPreventHideDocument() {
     if (this.editorDocumentTimer) {
-      console.log('tryToPreventHideDocument')
       clearTimeout(this.editorDocumentTimer)
       this.editorDocumentTimer = null
     }


### PR DESCRIPTION
## Overview
this pr is about refacor some codes for `HoverPreview`
 - refactor code from `languages/index.ts` to `MarkdownPreview.vue`
 - remove `TokenEnum` protoype， and modify some defination in `compiler.ts`
 - make some funcions return type from `LayerContent` to `LayerContent[]` 
 - refactor code from `hover-preview.ts` to `HoverPreviewComponent.vue`