### PR TITLE
feat(spx-gui): add  `EditorMenu.vue`  props comments

### DIFF
--- a/spx-gui/src/components/editor/code-editor/ui/EditorMenu.vue
+++ b/spx-gui/src/components/editor/code-editor/ui/EditorMenu.vue
@@ -14,6 +14,9 @@ export interface EditorMenuItem {
 defineProps<{
   listStyles?: CSSProperties
   items: Array<T>
+  // If true, it means that the highlight style will only be displayed
+  //                  when hovering over or when `EditorMenuItem.active = true`.
+  // If false, it means that the highlight style will always be displayed.
   onlyFocusActive?: boolean
 }>()
 


### PR DESCRIPTION
## Overview
this pr is about add `EditorMenu.vue` props `onlyFocusActive` comment for better understanding.