### PR TITLE
 fix: patch to fix duplicate display and overwriting issues in completion menu items

### DIFF
--- a/spx-gui/src/components/editor/code-editor/CodeEditor.vue
+++ b/spx-gui/src/components/editor/code-editor/CodeEditor.vue
@@ -7,7 +7,7 @@ import { Runtime } from '@/components/editor/code-editor/runtime'
 import { DocAbility } from '@/components/editor/code-editor/document'
 import { ChatBot } from '@/components/editor/code-editor/chat-bot'
 import { Coordinator } from '@/components/editor/code-editor/coordinators'
-import { ref } from 'vue'
+import { onUnmounted, ref } from 'vue'
 import { useI18n } from '@/utils/i18n'
 import { useEditorCtx } from '@/components/editor/EditorContextProvider.vue'
 
@@ -29,6 +29,11 @@ const i18n = useI18n()
 const editorCtx = useEditorCtx()
 const codeEditorUI = ref<InstanceType<typeof CodeEditorUI>>()
 const { editorUI } = initCoordinator()
+
+onUnmounted(() => {
+  // for vite HMR, we have to dispose editorUI when HMR triggered
+  editorUI.dispose()
+})
 
 function initCoordinator() {
   const editorUI = new EditorUI(i18n, () => editorCtx.project)

--- a/spx-gui/src/components/editor/code-editor/coordinators/index.ts
+++ b/spx-gui/src/components/editor/code-editor/coordinators/index.ts
@@ -4,8 +4,6 @@ import {
   type EditorUI,
   Icon,
   type LayerContent,
-  type Markdown,
-  type Reply,
   type SelectionMenuItem,
   type TextModel
 } from '@/components/editor/code-editor/EditorUI'

--- a/spx-gui/src/components/editor/code-editor/ui/code-text-editor/CodeTextEditor.vue
+++ b/spx-gui/src/components/editor/code-editor/ui/code-text-editor/CodeTextEditor.vue
@@ -99,6 +99,7 @@ watchEffect(async (onCleanup) => {
     useTabStops: false, // use tab key
     renderControlCharacters: false,
     fontSize: fontSize.value,
+    wordBasedSuggestions: 'off', // set off means only show completion items form completion providers instead of matching words in current code.
     quickSuggestionsDelay: 100,
     wordWrapColumn: 40,
     tabSize: 4,

--- a/spx-gui/src/components/editor/code-editor/ui/features/completion-menu/CompletionMenuComponent.vue
+++ b/spx-gui/src/components/editor/code-editor/ui/features/completion-menu/CompletionMenuComponent.vue
@@ -107,10 +107,7 @@ function handleMenuItemSelect(item: CompletionMenuItem) {
 <style lang="scss">
 // hidden monaco suggest widget
 div[widgetid='editor.widget.suggestWidget'].suggest-widget {
-  z-index: -999;
-  visibility: hidden;
-  opacity: 0;
-  pointer-events: none;
+  display: none !important;
 }
 
 .view-line .completion-menu__item-preview {

--- a/spx-gui/src/components/editor/code-editor/ui/features/completion-menu/completion-menu.ts
+++ b/spx-gui/src/components/editor/code-editor/ui/features/completion-menu/completion-menu.ts
@@ -141,6 +141,7 @@ export class CompletionMenu implements IDisposable {
     this.completionMenuState.suggestions = this.completionModelItems2CompletionItems(
       this.monacoCompletionModelItems
     )
+    if (this.completionMenuState.suggestions.length === 0) this.hideCompletionMenu()
   }
 
   private showCodePreview(position: IPosition, insertText: string, word: string) {
@@ -159,8 +160,8 @@ export class CompletionMenu implements IDisposable {
 
     // single line code preview
     const remainWords = firstLine.substring(word.length)
-    // Occasionally, a column may be slightly larger than the actual column by just one unit. This can prevent the inline code preview from displaying correctly.
-    // To avoid this, we need to subtract 1 from the column value.
+    // occasionally, a column may be slightly larger than the actual column by just one unit. This can prevent the inline code preview from displaying correctly.
+    // to avoid this, we need to subtract 1 from the column value.
     const startColumn = position.column - 1
     const endColum = startColumn + word.length
 
@@ -187,6 +188,16 @@ export class CompletionMenu implements IDisposable {
         domNode: this.viewZoneChangeAccessorState.codePreviewElement
       })
     })
+  }
+
+  public showCompletionMenu() {
+    this.completionMenuState.visible = true
+    this.editor.trigger('keyboard', 'editor.action.triggerSuggest', {})
+  }
+
+  public hideCompletionMenu() {
+    this.completionMenuState.visible = false
+    this.editor.trigger('editor', 'hideSuggestWidget', {})
   }
 
   select(idx: number) {


### PR DESCRIPTION
## Overview
This PR addresses the issue where the completion menu items are duplicated when repeatedly entering content at the same location. It also fixes the problem where multiple calls to the `addItem` function result in the previous completion menu items being overwritten.