### PR TITLE
Inpainting AI-generated previews

### DIFF
--- a/spx-backend/cmd/spx-backend/gop_autogen.go
+++ b/spx-backend/cmd/spx-backend/gop_autogen.go
@@ -88,6 +88,10 @@ type post_aigc_image_sync struct {
 	yap.Handler
 	*AppV2
 }
+type post_aigc_inpainting struct {
+	yap.Handler
+	*AppV2
+}
 type post_aigc_matting struct {
 	yap.Handler
 	*AppV2
@@ -197,7 +201,7 @@ func (this *AppV2) MainEntry() {
 	}
 }
 func (this *AppV2) Main() {
-	yap.Gopt_AppV2_Main(this, new(delete_asset_id), new(delete_project_owner_name), new(delete_user_liked), new(get_aigc_status), new(get_asset_id), new(get_assets_list), new(get_assets_list_suggestions), new(get_project_owner_name), new(get_projects_list), new(get_user_history_list), new(get_user_liked_list), new(get_user_rate_id), new(get_util_upinfo), new(post_aigc_image), new(post_aigc_image_sync), new(post_aigc_matting), new(post_aigc_sprite), new(post_aigc_text), new(post_asset), new(post_asset_id_click), new(post_project), new(post_user_history), new(post_user_liked), new(post_user_rate_id), new(post_util_fileurls), new(post_util_fmtcode), new(put_asset_id), new(put_project_owner_name))
+	yap.Gopt_AppV2_Main(this, new(delete_asset_id), new(delete_project_owner_name), new(delete_user_liked), new(get_aigc_status), new(get_asset_id), new(get_assets_list), new(get_assets_list_suggestions), new(get_project_owner_name), new(get_projects_list), new(get_user_history_list), new(get_user_liked_list), new(get_user_rate_id), new(get_util_upinfo), new(post_aigc_image), new(post_aigc_image_sync), new(post_aigc_inpainting), new(post_aigc_matting), new(post_aigc_sprite), new(post_aigc_text), new(post_asset), new(post_asset_id_click), new(post_project), new(post_user_history), new(post_user_liked), new(post_user_rate_id), new(post_util_fileurls), new(post_util_fmtcode), new(put_asset_id), new(put_project_owner_name))
 }
 //line cmd/spx-backend/delete_asset_#id.yap:6
 func (this *delete_asset_id) Main(_gop_arg0 *yap.Context) {
@@ -805,6 +809,40 @@ func (this *post_aigc_image_sync) Main(_gop_arg0 *yap.Context) {
 }
 func (this *post_aigc_image_sync) Classfname() string {
 	return "post_aigc_image_sync"
+}
+//line cmd/spx-backend/post_aigc_inpainting.yap:10
+func (this *post_aigc_inpainting) Main(_gop_arg0 *yap.Context) {
+	this.Handler.Main(_gop_arg0)
+//line cmd/spx-backend/post_aigc_inpainting.yap:10:1
+	ctx := &this.Context
+//line cmd/spx-backend/post_aigc_inpainting.yap:12:1
+	_, ok := ensureUser(ctx)
+//line cmd/spx-backend/post_aigc_inpainting.yap:13:1
+	if !ok {
+//line cmd/spx-backend/post_aigc_inpainting.yap:14:1
+		return
+	}
+//line cmd/spx-backend/post_aigc_inpainting.yap:17:1
+	params := &controller.GenerateInpaintingParams{}
+//line cmd/spx-backend/post_aigc_inpainting.yap:18:1
+	if !parseJSON(ctx, params) {
+//line cmd/spx-backend/post_aigc_inpainting.yap:19:1
+		return
+	}
+//line cmd/spx-backend/post_aigc_inpainting.yap:21:1
+	result, err := this.ctrl.GenerateInpainting(ctx.Context(), params)
+//line cmd/spx-backend/post_aigc_inpainting.yap:23:1
+	if err != nil {
+//line cmd/spx-backend/post_aigc_inpainting.yap:24:1
+		replyWithInnerError(ctx, err)
+//line cmd/spx-backend/post_aigc_inpainting.yap:25:1
+		return
+	}
+//line cmd/spx-backend/post_aigc_inpainting.yap:27:1
+	this.Json__1(result)
+}
+func (this *post_aigc_inpainting) Classfname() string {
+	return "post_aigc_inpainting"
 }
 //line cmd/spx-backend/post_aigc_matting.yap:10
 func (this *post_aigc_matting) Main(_gop_arg0 *yap.Context) {

--- a/spx-backend/cmd/spx-backend/post_aigc_inpainting.yap
+++ b/spx-backend/cmd/spx-backend/post_aigc_inpainting.yap
@@ -1,0 +1,27 @@
+//Inpainting image with control image.
+//
+// Request:
+//   POST /aigc/inpainting
+
+import (
+	"github.com/goplus/builder/spx-backend/internal/controller"
+)
+
+ctx := &Context
+
+_, ok := ensureUser(ctx)
+if !ok {
+	return
+}
+
+params := &controller.GenerateInpaintingParams{}
+if !parseJSON(ctx, params) {
+	return
+}
+result, err := ctrl.GenerateInpainting(ctx.Context(),params)
+
+if err != nil {
+	replyWithInnerError(ctx, err)
+	return
+}
+json result

--- a/spx-backend/internal/controller/aigc.go
+++ b/spx-backend/internal/controller/aigc.go
@@ -60,6 +60,21 @@ type GetEmbeddingResult struct {
 	Desc      string    `json:"desc"`
 }
 
+type GenerateInpaintingParams struct {
+	Prompt          string `json:"prompt"`
+	Category        string `json:"category"`
+	Type            int    `json:"type"`
+	ModelName       string `json:"model_name"`
+	ImageUrl        string `json:"image_url"`
+	ControlImageUrl string `json:"control_image_url"`
+	CallbackUrl     string `json:"callback_url"`
+}
+
+type GenerateInpaintingResult struct {
+	ImageUrl string `json:"image_url"`
+	Desc     string `json:"desc"`
+}
+
 type GetAIAssetStatusResult struct {
 	// Status is the status of the AI asset.
 	Status AssetStatus    `json:"status"`
@@ -226,6 +241,20 @@ func (ctrl *Controller) GetEmbedding(ctx context.Context, param *GetEmbeddingPar
 		return nil, err
 	}
 	return &embeddingResult, nil
+}
+
+// GenerateInpainting call AIGC service to inpainting image with control image.
+func (ctrl *Controller) GenerateInpainting(ctx context.Context, param *GenerateInpaintingParams) (*GenerateInpaintingResult, error) {
+	logger := log.GetReqLogger(ctx)
+	var generateInpaintingResult GenerateInpaintingResult
+	// print param.ControlImageUrl
+	logger.Printf("ControlImageUrl: %s", param.ControlImageUrl)
+	err := ctrl.aigcClient.Call(ctx, http.MethodPost, "/generate", &param, &generateInpaintingResult)
+	if err != nil {
+		logger.Printf("failed to call: %v", err)
+		return nil, err
+	}
+	return &generateInpaintingResult, nil
 }
 
 // GetAIAssetStatus get AI asset status.

--- a/spx-gui/src/apis/aigc.ts
+++ b/spx-gui/src/apis/aigc.ts
@@ -87,7 +87,6 @@ export interface CreateAIImageParams {
 /**
  * Generate AI image with given keyword and category
  *
- * WARNING: This API has not been implemented yet. It will return a mock result.
  */
 export async function generateAIImage({
   keyword,
@@ -136,6 +135,26 @@ export async function generateAISprite(imageJobId: string) {
   return result
 }
 
+export interface GenerateInpaintingParams {
+  prompt: string
+  category: string
+  type: number
+  model_name: string
+  image_url: string
+  control_image_url: string
+  callback_url: string
+}
+
+export interface GenerateInpaintingResult {
+  image_url: string
+  desc: string
+}
+
+export async function generateInpainting(params: GenerateInpaintingParams) {
+  const result = (await client.post('/aigc/inpainting', params, { timeout: 60 * 1000 })) as GenerateInpaintingResult
+  return result
+}
+
 export enum AIGCType {
   Image,
   Sprite,
@@ -175,7 +194,6 @@ export interface AIGCStatusResponse {
  * @param jobId The job ID returned by `generateAIXxx`
  * @returns
  *
- * WARNING: This API has not been implemented yet. It will return a mock result.
  */
 export async function getAIGCStatus(jobId: string) {
   const result = (await client.get(
@@ -187,7 +205,6 @@ export async function getAIGCStatus(jobId: string) {
 }
 
 /**
- * WARNING: This API is not implemented in the backend yet.
  * The parameter has not been determined yet.
  * As some ai-generated asset may be edited by user or js code, 
  * the backend may need to get the partial asset instead of the jobId.

--- a/spx-gui/src/apis/aigc.ts
+++ b/spx-gui/src/apis/aigc.ts
@@ -128,9 +128,9 @@ export async function syncGenerateAIImage({
  *
  * WARNING: This API has not been implemented yet. It will return a mock result.
  */
-export async function generateAISprite(imageJobId: string) {
-  const result = (await client.post('/aigc/sprite', { imageJobId }, { timeout: 20 * 1000 })) as {
-    spriteJobId: string
+export async function generateAISprite(imageUrl: string) {
+  const result = (await client.post('/aigc/sprite', { image_url: imageUrl }, { timeout: 20 * 1000 })) as {
+    material_url: string
   }
   return result
 }

--- a/spx-gui/src/apis/asset.ts
+++ b/spx-gui/src/apis/asset.ts
@@ -89,8 +89,6 @@ export function increaseAssetClickCount(id: string) {
 }
 
 /**
- * WARNING: This API is not implemented in the backend yet.
- * Currently, it searches for assets with the given keyword and returns the first `count` unique display names.
  * @param keyword 
  * @param count 
  * @returns 
@@ -112,9 +110,6 @@ export interface AssetRate {
 /**
  * Get the rate of an asset
  * 
- * WARNING: This API is not implemented in the backend yet. 
- * Currently, it returns a random rate that follows a normal distribution.
- * 
  * @param id 
  * @returns 
  */
@@ -125,7 +120,6 @@ export function getAssetRate(id: string): Promise<AssetRate> {
 /**
  * Rate an asset
  * 
- * WARNING: This API is not implemented in the backend yet.
  * @param id asset id
  * @param rate rate value, 1-5
  * @returns

--- a/spx-gui/src/apis/util.ts
+++ b/spx-gui/src/apis/util.ts
@@ -64,3 +64,16 @@ export const makeObjectUrls = (() => {
     return Object.fromEntries(objects.map((url) => [url, objectUrls[url]]))
   }
 })()
+
+/**
+ * Get the web URL(https://) of the given universal URL(kodo://)
+ * 
+ * @param universalUrl 
+ * @returns 
+ */
+export async function getWebUrl (universalUrl: UniversalUrl) {
+  const webUrls = await client.post('/util/fileurls', { objects: [universalUrl] }) as {
+    objectUrls: UniversalToWebUrlMap
+  }
+  return webUrls.objectUrls[universalUrl]
+}

--- a/spx-gui/src/components/asset/library/ai/AIBackdropEditor.vue
+++ b/spx-gui/src/components/asset/library/ai/AIBackdropEditor.vue
@@ -382,7 +382,6 @@ const actions = computed(() =>
         type: 'secondary' satisfies ButtonType,
         disabled: redoStackLength.value === 0,
         action: () => {
-          // redo()
           const current = redo()
           if (current) {
             backdrop.value!.img = current

--- a/spx-gui/src/components/asset/library/ai/AIBackdropEditor.vue
+++ b/spx-gui/src/components/asset/library/ai/AIBackdropEditor.vue
@@ -57,7 +57,7 @@ export interface KonvaNode<T extends Konva.Node = Konva.Node> {
 import { computed, onMounted, onUnmounted, ref, shallowRef, watch } from 'vue'
 import { isContentReady, type TaggedAIAssetData } from '@/apis/aigc'
 import type { ImageConfig } from 'konva/lib/shapes/Image'
-import { backdrop2Asset, cachedConvertAssetData } from '@/models/common/asset'
+import { backdrop2Asset, cachedConvertAssetData, convertAIAssetToBackdrop } from '@/models/common/asset'
 import { useAsyncComputed } from '@/utils/utils'
 import type { AssetType } from '@/apis/asset'
 import type { Backdrop } from '@/models/backdrop'
@@ -89,6 +89,18 @@ import ImageCrop from './ImageEditor/ImageCrop.vue'
 const props = defineProps<{
   asset: TaggedAIAssetData<AssetType.Backdrop>
 }>()
+
+const emit = defineEmits<{
+  contentReady: []
+}>()
+
+const contentReady = ref(props.asset[isContentReady])
+const generateContent = async () => {
+  await convertAIAssetToBackdrop(props.asset)
+  contentReady.value = true
+  emit('contentReady')
+}
+
 
 const backdrop = useAsyncComputed<Backdrop | undefined>(() => {
   if (!props.asset[isContentReady]) {
@@ -132,6 +144,9 @@ const updateMapSize = () => {
 }
 
 onMounted(() => {
+  if (!contentReady.value) {
+    generateContent()
+  }
   updateMapSize()
   window.addEventListener('resize', updateMapSize)
 })

--- a/spx-gui/src/components/asset/library/ai/AIPreviewModal.vue
+++ b/spx-gui/src/components/asset/library/ai/AIPreviewModal.vue
@@ -2,22 +2,29 @@
   <div class="container">
     <div class="head head-actions">
       <Transition name="slide-fade" mode="out-in" appear>
-        <div v-if="contentReady" class="head-left">
-          <UIButton v-for="action in currentActions" :key="action.name" size="large" :type="action.type"
-            :disabled="action.disabled" @click="action.action">
+        <div class="head-left">
+          <UIButton
+            v-for="action in currentActions"
+            :key="action.name"
+            size="large"
+            :type="action.type"
+            :disabled="action.disabled"
+            @click="action.action"
+          >
             <NIcon v-if="action.icon">
               <component :is="action.icon" />
             </NIcon>
             {{ $t(action.label) }}
           </UIButton>
         </div>
-        <div v-else class="head-left">
-          {{ $t({ zh: '正在进一步生成素材...', en: 'Further generating assets...' }) }}
-        </div>
       </Transition>
       <div class="head-right">
-        <UIButton size="large" class="insert-button" :disabled="!contentReady || addToProjectPending || exportPending"
-          @click="handleAddButton">
+        <UIButton
+          size="large"
+          class="insert-button"
+          :disabled="!contentReady || addToProjectPending || exportPending"
+          @click="handleAddButton"
+        >
           <span style="white-space: nowrap">
             {{
               addToProjectPending || exportPending
@@ -39,59 +46,48 @@
     </div>
     <div class="content">
       <main>
-        <Transition name="slide-fade" mode="out-in" appear>
-          <template v-if="!contentReady">
-            <div class="generating-info">
-              <NSpin :size="64">
-                <template #description>
-                  <Transition name="slide-fade" mode="out-in" appear>
-                    <span v-if="status === AIGCStatus.Waiting" class="generating-text">
-                      {{ $t({ en: `Pending...`, zh: `排队中...` }) }}
-                    </span>
-                    <span v-else-if="status === AIGCStatus.Generating" class="generating-text">
-                      {{ $t({ en: `Generating...`, zh: `生成中...` }) }}
-                    </span>
-                    <span v-else-if="status === AIGCStatus.Finished && !contentReady" class="generating-text">
-                      {{ $t({ en: `Loading...`, zh: `加载中...` }) }}
-                    </span>
-                  </Transition>
-                </template>
-              </NSpin>
-            </div>
-          </template>
-          <template v-else-if="status === AIGCStatus.Failed">
-            <div class="failing-info">
-              <NIcon color="var(--ui-color-danger-main, #ef4149)" :size="32">
-                <CancelOutlined />
-              </NIcon>
-              <span v-if="status === AIGCStatus.Failed" class="failing-text">
-                {{ $t({ en: `Generation failed`, zh: `生成失败` }) }}
-              </span>
-              <span v-else class="failing-text">
-                {{ $t({ en: `Loading failed`, zh: `加载失败` }) }}
-              </span>
-            </div>
-          </template>
-          <template v-else>
-            <AISpriteEditor v-if="asset.assetType === AssetType.Sprite" ref="spriteEditor"
-              :asset="asset as TaggedAIAssetData<AssetType.Sprite>" class="asset-editor sprite-editor" />
-            <AIBackdropEditor v-else-if="asset.assetType === AssetType.Backdrop" ref="backdropEditor"
-              :asset="asset as TaggedAIAssetData<AssetType.Backdrop>" class="asset-editor backdrop-editor" />
-            <AISoundEditor v-else-if="asset.assetType === AssetType.Sound" ref="soundEditor" :asset="asset" />
-          </template>
-        </Transition>
+        <AISpriteEditor
+          v-if="asset.assetType === AssetType.Sprite"
+          ref="spriteEditor"
+          :asset="asset as TaggedAIAssetData<AssetType.Sprite>"
+          class="asset-editor sprite-editor"
+          @content-ready="contentReady = true"
+        />
+        <AIBackdropEditor
+          v-else-if="asset.assetType === AssetType.Backdrop"
+          ref="backdropEditor"
+          :asset="asset as TaggedAIAssetData<AssetType.Backdrop>"
+          class="asset-editor backdrop-editor"
+          @content-ready="contentReady = true"
+        />
+        <AISoundEditor
+          v-else-if="asset.assetType === AssetType.Sound"
+          ref="soundEditor"
+          :asset="asset"
+          @content-ready="contentReady = true"
+        />
       </main>
       <aside>
-        <NScrollbar :content-style="{
-          paddingRight: '15px',
-          display: 'flex',
-          flexDirection: 'column',
-          gap: '10px'
-        }">
-          <div v-for="aiAsset in aiAssets" :key="aiAsset.taskId" class="ai-asset-wrapper"
-            :class="{ selected: aiAsset.result?.id === asset.id }">
-            <AIAssetItem :task="aiAsset" :show-ai-asset-tip="false" @ready="(aiAsset as any)[isPreviewReady] = true"
-              @click="(aiAsset as any)[isPreviewReady] && emit('selectAi', aiAsset.result!)" />
+        <NScrollbar
+          :content-style="{
+            paddingRight: '15px',
+            display: 'flex',
+            flexDirection: 'column',
+            gap: '10px'
+          }"
+        >
+          <div
+            v-for="aiAsset in aiAssets"
+            :key="aiAsset.taskId"
+            class="ai-asset-wrapper"
+            :class="{ selected: aiAsset.result?.id === asset.id }"
+          >
+            <AIAssetItem
+              :task="aiAsset"
+              :show-ai-asset-tip="false"
+              @ready="(aiAsset as any)[isPreviewReady] = true"
+              @click="(aiAsset as any)[isPreviewReady] && emit('selectAi', aiAsset.result!)"
+            />
           </div>
         </NScrollbar>
       </aside>
@@ -109,32 +105,29 @@ export interface EditorAction {
 }
 </script>
 <script setup lang="ts">
-import { computed, ref, watch } from 'vue'
-import { NIcon, NSpin } from 'naive-ui'
-import { addAsset, AssetType, getAsset, IsPublic, type AddAssetParams, type AssetData } from '@/apis/asset'
+import { computed, ref } from 'vue'
+import { NIcon } from 'naive-ui'
+import {
+  addAsset,
+  AssetType,
+  getAsset,
+  IsPublic,
+  type AddAssetParams,
+  type AssetData
+} from '@/apis/asset'
 import UIButton, { type ButtonType } from '@/components/ui/UIButton.vue'
 import AIAssetItem from '../AIAssetItem.vue'
 import { NScrollbar } from 'naive-ui'
 import {
-  AIGCStatus,
-  type AIGCFiles,
   isContentReady,
   isPreviewReady,
   type TaggedAIAssetData,
-  exportedId,
-  type RequiredAIGCFiles,
-} from '@/apis/aigc'
-import { debounce } from '@/utils/utils'
-import { getFiles } from '@/models/common/cloud'
-import { type File } from '@/models/common/file'
-import { CancelOutlined } from '@vicons/material'
+  exportedId} from '@/apis/aigc'
 import AISpriteEditor from './AISpriteEditor.vue'
 import AIBackdropEditor from './AIBackdropEditor.vue'
 import AISoundEditor from './AISoundEditor.vue'
-import { convertAIAssetToBackdrop } from '@/models/common/asset'
-import { hashFileCollection } from '@/models/common/hash'
 import type { LocaleMessage } from '@/utils/i18n'
-import { AIGCTask, AISpriteTask } from '@/models/aigc'
+import { AIGCTask } from '@/models/aigc'
 import { useRenameAsset } from '../..'
 import { useMessageHandle } from '@/utils/exception'
 
@@ -155,86 +148,31 @@ const backdropEditor = ref<InstanceType<typeof AIBackdropEditor> | null>(null)
 const soundEditor = ref<InstanceType<typeof AISoundEditor> | null>(null)
 
 const currentActions = computed<EditorAction[]>(() => {
-  if (props.asset.assetType === AssetType.Sprite && spriteEditor.value && 'actions' in spriteEditor.value) {
+  if (
+    props.asset.assetType === AssetType.Sprite &&
+    spriteEditor.value &&
+    'actions' in spriteEditor.value
+  ) {
     return spriteEditor?.value?.actions as EditorAction[]
   }
-  if (props.asset.assetType === AssetType.Backdrop && backdropEditor.value && 'actions' in backdropEditor.value) {
+  if (
+    props.asset.assetType === AssetType.Backdrop &&
+    backdropEditor.value &&
+    'actions' in backdropEditor.value
+  ) {
     return backdropEditor?.value?.actions as EditorAction[]
   }
-  if (props.asset.assetType === AssetType.Sound && soundEditor.value && 'actions' in soundEditor.value) {
+  if (
+    props.asset.assetType === AssetType.Sound &&
+    soundEditor.value &&
+    'actions' in soundEditor.value
+  ) {
     return soundEditor?.value?.actions as EditorAction[]
   }
   return []
 })
 
 const contentReady = ref(props.asset[isContentReady])
-const contentJobId = ref<string | null>(null)
-const status = ref<AIGCStatus>(AIGCStatus.Finished)
-
-const generateContent = async () => {
-  if (props.asset.assetType === AssetType.Sprite) {
-    const generateTask = new AISpriteTask(props.asset.id)
-    generateTask.addEventListener('AIGCStatusChange', () => {
-      status.value = generateTask.status
-    })
-    generateTask.addEventListener('AIGCFinished', () => {
-      contentReady.value = true
-      if (generateTask.result?.files) {
-        loadCloudFiles(generateTask.result.files)
-      }
-    })
-    generateTask.start()
-  } else if (props.asset.assetType === AssetType.Backdrop) {
-    convertAIAssetToBackdrop(props.asset)
-    contentReady.value = true
-  } else if (props.asset.assetType === AssetType.Sound) {
-    contentReady.value = true
-  }
-}
-
-// avoid frequent requests when switching assets
-const debouncedGenerateContent = debounce(generateContent, 2000)
-
-watch(
-  () => props.asset.id,
-  () => {
-    contentReady.value = props.asset[isContentReady]
-    if (contentReady.value) {
-      return
-    }
-    if (props.asset.assetType === AssetType.Sprite) {
-      status.value = AIGCStatus.Waiting
-      contentJobId.value = null
-      debouncedGenerateContent()
-    } else if (props.asset.assetType === AssetType.Backdrop) {
-      generateContent()
-    } else if (props.asset.assetType === AssetType.Sound) {
-      contentReady.value = true
-    }
-  },
-  { immediate: true }
-)
-
-const loadCloudFiles = async (cloudFiles: RequiredAIGCFiles) => {
-  if (!cloudFiles) {
-    status.value = AIGCStatus.Failed
-    return
-  }
-  const files = (await getFiles(cloudFiles)) as {
-    [key in keyof AIGCFiles]: File
-  }
-
-  if (!files) {
-    status.value = AIGCStatus.Failed
-    return
-  }
-  props.asset.files = cloudFiles
-  props.asset.filesHash = await hashFileCollection(cloudFiles)
-  props.asset.displayName = props.asset.displayName ?? props.asset.id
-  props.asset[isContentReady] = true
-  contentReady.value = true
-  return
-}
 
 const isFavorite = ref(false)
 const exportPending = ref(false)
@@ -245,7 +183,7 @@ const publicAsset = ref<AssetData | null>(null)
  * Get the public asset data from the asset data
  * If the asset data is not exported, export it first
  */
- const exportAssetDataToPublic = async () => {
+const exportAssetDataToPublic = async () => {
   if (!props.asset[isContentReady]) {
     throw new Error('Could not export an incomplete asset')
   }
@@ -256,8 +194,8 @@ const publicAsset = ref<AssetData | null>(null)
     files: props.asset.files!,
     displayName: props.asset.displayName ?? props.asset.id,
     filesHash: props.asset.filesHash!,
-    preview: "TODO",
-    category: '*',
+    preview: 'TODO',
+    category: '*'
   }
   exportPending.value = true
   const assetId = props.asset[exportedId] ?? (await addAsset(addAssetParam)).id
@@ -266,20 +204,17 @@ const publicAsset = ref<AssetData | null>(null)
   return publicAsset
 }
 
-
 const handleAddButton = async () => {
   if (props.addToProjectPending) {
     return
   }
-  
+
   if (!publicAsset.value) {
     const exportedAsset = await exportAssetDataToPublic()
     publicAsset.value = exportedAsset
   }
   emit('addToProject', publicAsset.value)
 }
-
-
 
 const renameAsset = useRenameAsset()
 const handleRename = useMessageHandle(
@@ -364,51 +299,5 @@ aside {
 .ai-asset-wrapper.selected {
   border: 3px solid var(--ui-color-primary-main, #3f9ae5);
   border-radius: calc(3px + var(--ui-border-radius-1));
-}
-
-.generating-info {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  width: 100%;
-  height: 100%;
-}
-
-.generating-text {
-  display: inline-block;
-  font-size: 1rem;
-  color: var(--ui-color-turquoise-400, #3fcdd9);
-}
-
-.failing-info {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-}
-
-.failing-text {
-  display: inline-block;
-  font-size: 1rem;
-  color: var(--ui-color-danger-main, #ef4149);
-}
-
-.slide-fade-enter-active,
-.slide-fade-leave-active {
-  transition: all 0.3s;
-}
-
-.slide-fade-enter-from,
-.slide-fade-leave-to {
-  opacity: 0;
-}
-
-.slide-fade-enter-from {
-  transform: translateY(10px);
-}
-
-.slide-fade-leave-to {
-  transform: translateY(-10px);
 }
 </style>

--- a/spx-gui/src/components/asset/library/ai/AIPreviewModal.vue
+++ b/spx-gui/src/components/asset/library/ai/AIPreviewModal.vue
@@ -265,6 +265,7 @@ const displayTime = computed(() => {
   display: flex;
   gap: 10px;
   flex-direction: row;
+  align-items: center;
 }
 
 .head-right {

--- a/spx-gui/src/components/asset/library/ai/AIPreviewModal.vue
+++ b/spx-gui/src/components/asset/library/ai/AIPreviewModal.vue
@@ -3,19 +3,21 @@
     <div class="head head-actions">
       <Transition name="slide-fade" mode="out-in" appear>
         <div class="head-left">
-          <UIButton
-            v-for="action in currentActions"
-            :key="action.name"
-            size="large"
-            :type="action.type"
-            :disabled="action.disabled"
-            @click="action.action"
-          >
-            <NIcon v-if="action.icon">
-              <component :is="action.icon" />
-            </NIcon>
-            {{ $t(action.label) }}
-          </UIButton>
+          <template v-for="action in currentActions" :key="action.name">
+            <component :is="action.component" v-if="'component' in action" />
+            <UIButton
+              v-else
+              size="large"
+              :type="action.type"
+              :disabled="action.disabled"
+              @click="action.action"
+            >
+              <NIcon v-if="action.icon">
+                <component :is="action.icon" />
+              </NIcon>
+              {{ $t(action.label) }}
+            </UIButton>
+          </template>
         </div>
       </Transition>
       <div class="head-right">
@@ -95,17 +97,22 @@
   </div>
 </template>
 <script lang="ts">
-export interface EditorAction {
-  name: string
-  label: LocaleMessage
-  type: ButtonType
-  disabled?: boolean
-  icon?: any
-  action: () => void
-}
+export type EditorAction =
+  | {
+      name: string
+      label: LocaleMessage
+      type: ButtonType
+      disabled?: boolean
+      icon?: any
+      action: () => void
+    }
+  | {
+      name: string
+      component: Component
+    }
 </script>
 <script setup lang="ts">
-import { computed, ref } from 'vue'
+import { computed, ref, type Component } from 'vue'
 import { NIcon } from 'naive-ui'
 import {
   addAsset,
@@ -118,11 +125,7 @@ import {
 import UIButton, { type ButtonType } from '@/components/ui/UIButton.vue'
 import AIAssetItem from '../AIAssetItem.vue'
 import { NScrollbar } from 'naive-ui'
-import {
-  isContentReady,
-  isPreviewReady,
-  type TaggedAIAssetData,
-  exportedId} from '@/apis/aigc'
+import { isContentReady, isPreviewReady, type TaggedAIAssetData, exportedId } from '@/apis/aigc'
 import AISpriteEditor from './AISpriteEditor.vue'
 import AIBackdropEditor from './AIBackdropEditor.vue'
 import AISoundEditor from './AISoundEditor.vue'
@@ -253,6 +256,7 @@ const displayTime = computed(() => {
   align-items: center;
   padding: 10px;
   padding-top: 0;
+  gap: 4rem;
   border-bottom: 1px solid var(--ui-color-dividing-line-2, #cbd2d8);
 }
 

--- a/spx-gui/src/components/asset/library/ai/AISpriteEditor.vue
+++ b/spx-gui/src/components/asset/library/ai/AISpriteEditor.vue
@@ -37,6 +37,7 @@
         />
         <ImageRepaint
           v-else-if="editMode === 'repaint' && previewImageSrc"
+          ref="imageRepaint"
           :image-src="previewImageSrc"
           class="repaint"
         />
@@ -96,6 +97,17 @@ const props = defineProps<{
 const emit = defineEmits<{
   contentReady: []
 }>()
+
+const imageRepaint = ref<InstanceType<typeof ImageRepaint> | null>(null)
+const activeEditor = computed(
+  () =>
+    ({
+      preview: null,
+      repaint: imageRepaint.value,
+      anim: null,
+      skeleton: null,
+    })[editMode.value]
+)
 
 const status = ref<AIGCStatus | null>(null)
 const contentReady = ref(props.asset[isContentReady])
@@ -202,13 +214,22 @@ const hasSkeletonAnimation = computed(() => !!sprite.value?.skeletonAnimation)
 const actions = computed(() =>
   (
     [
-      {
+      editMode.value === 'preview' && {
         name: 'repaint',
         label: { zh: '重绘', en: 'Repaint' },
         icon: AutoFixHighOutlined,
-        type: (editMode.value === 'repaint' ? 'primary' : 'secondary') satisfies ButtonType,
+        type: 'secondary' satisfies ButtonType,
         action: () => {
           editMode.value = editMode.value === 'repaint' ? 'preview' : 'repaint'
+        }
+      },
+      editMode.value === 'repaint' && {
+        name: 'repaint',
+        label: { zh: '重绘', en: 'Repaint' },
+        icon: AutoFixHighOutlined,
+        type: 'primary' satisfies ButtonType,
+        action: () => {
+          activeEditor.value?.inpaint()
         }
       },
       {

--- a/spx-gui/src/components/asset/library/ai/AISpriteEditor.vue
+++ b/spx-gui/src/components/asset/library/ai/AISpriteEditor.vue
@@ -42,6 +42,7 @@
           class="repaint"
           @cancel="editMode = 'preview'"
           @resolve="handleRepaintResolve" 
+          @loading="loading => inpaintingLoading = loading"
         />
         <SpriteCarousel
           v-else-if="contentReady && editMode === 'anim' && sprite"
@@ -115,13 +116,16 @@ const activeEditor = computed(
 const status = ref<AIGCStatus | null>(null)
 const contentReady = ref(props.asset[isContentReady])
 
+const inpaintingLoading = ref(false)
+
 const loadingVisible = computed(() => {
   return (
     (status.value !== null &&
       (status.value === AIGCStatus.Waiting ||
         status.value === AIGCStatus.Generating ||
         (!contentReady.value && status.value === AIGCStatus.Finished))) ||
-    previewImageLoading.value
+    previewImageLoading.value ||
+    inpaintingLoading.value
   )
 })
 
@@ -134,6 +138,8 @@ const loadingInfoText = computed(() => {
     return t({ en: `Loading...`, zh: `加载中...` })
   } else if (previewImageLoading.value) {
     return t({ en: `Loading preview...`, zh: `加载预览...` })
+  } else if (inpaintingLoading.value) {
+    return t({ en: `Inpainting...`, zh: `重绘中...` })
   }
   return ''
 })

--- a/spx-gui/src/components/asset/library/ai/AISpriteEditor.vue
+++ b/spx-gui/src/components/asset/library/ai/AISpriteEditor.vue
@@ -28,21 +28,26 @@
     </Transition>
 
     <div class="container">
-      <NImage
-        v-if="editMode === 'preview' && previewImageSrc"
-        :src="previewImageSrc"
-        size="contain"
-        class="preview"
-      />
-      <SpriteCarousel
-        v-if="contentReady && editMode === 'anim' && sprite"
-        :sprite="sprite"
-        class="sprite-carousel"
-        width="75%"
-      />
       <Transition name="slide-fade" mode="out-in" appear>
+        <NImage
+          v-if="editMode === 'preview' && previewImageSrc"
+          :src="previewImageSrc"
+          size="contain"
+          class="preview"
+        />
+        <ImageRepaint
+          v-else-if="editMode === 'repaint' && previewImageSrc"
+          :image-src="previewImageSrc"
+          class="repaint"
+        />
+        <SpriteCarousel
+          v-else-if="contentReady && editMode === 'anim' && sprite"
+          :sprite="sprite"
+          class="sprite-carousel"
+          width="75%"
+        />
         <SkeletonEditor
-          v-if="contentReady && editMode === 'skeleton' && sprite && hasSkeletonAnimation"
+          v-else-if="contentReady && editMode === 'skeleton' && sprite && hasSkeletonAnimation"
           :sprite="sprite"
           class="skeleton-editor"
         />
@@ -81,6 +86,7 @@ import type { File } from '@/models/common/file'
 import { hashFileCollection } from '@/models/common/hash'
 import { CancelOutlined } from '@vicons/material'
 import { useI18n } from '@/utils/i18n'
+import ImageRepaint from './ImageEditor/ImageRepaint.vue'
 const { t } = useI18n()
 
 const props = defineProps<{
@@ -196,6 +202,15 @@ const hasSkeletonAnimation = computed(() => !!sprite.value?.skeletonAnimation)
 const actions = computed(() =>
   (
     [
+      {
+        name: 'repaint',
+        label: { zh: '重绘', en: 'Repaint' },
+        icon: AutoFixHighOutlined,
+        type: (editMode.value === 'repaint' ? 'primary' : 'secondary') satisfies ButtonType,
+        action: () => {
+          editMode.value = editMode.value === 'repaint' ? 'preview' : 'repaint'
+        }
+      },
       {
         name: 'generate-anim',
         label: { zh: '动画', en: 'Animation' },

--- a/spx-gui/src/components/asset/library/ai/AISpriteEditor.vue
+++ b/spx-gui/src/components/asset/library/ai/AISpriteEditor.vue
@@ -1,18 +1,63 @@
 <template>
-  <div class="container">
-    <SpriteCarousel v-if="sprite" :sprite="sprite" class="sprite-carousel" width="75%" />
-    <Transition name="slide-fade" mode="out-in" appear>
-      <SkeletonEditor
-        v-if="editing && sprite && hasSkeletonAnimation"
-        :sprite="sprite"
-        class="skeleton-editor"
-      />
-    </Transition>
-  </div>
+  <Transition name="slide-fade" mode="out-in" appear>
+    <template v-if="!contentReady">
+      <div class="generating-info">
+        <NSpin :size="64">
+          <template #description>
+            <Transition name="slide-fade" mode="out-in" appear>
+              <span v-if="status === AIGCStatus.Waiting" class="generating-text">
+                {{ $t({ en: `Pending...`, zh: `排队中...` }) }}
+              </span>
+              <span v-else-if="status === AIGCStatus.Generating" class="generating-text">
+                {{ $t({ en: `Generating...`, zh: `生成中...` }) }}
+              </span>
+              <span
+                v-else-if="status === AIGCStatus.Finished && !contentReady"
+                class="generating-text"
+              >
+                {{ $t({ en: `Loading...`, zh: `加载中...` }) }}
+              </span>
+            </Transition>
+          </template>
+        </NSpin>
+      </div>
+    </template>
+    <template v-else-if="status === AIGCStatus.Failed">
+      <div class="failing-info">
+        <NIcon color="var(--ui-color-danger-main, #ef4149)" :size="32">
+          <CancelOutlined />
+        </NIcon>
+        <span v-if="status === AIGCStatus.Failed" class="failing-text">
+          {{ $t({ en: `Generation failed`, zh: `生成失败` }) }}
+        </span>
+        <span v-else class="failing-text">
+          {{ $t({ en: `Loading failed`, zh: `加载失败` }) }}
+        </span>
+      </div>
+    </template>
+    <template v-else>
+      <div class="container">
+        <SpriteCarousel v-if="sprite" :sprite="sprite" class="sprite-carousel" width="75%" />
+        <Transition name="slide-fade" mode="out-in" appear>
+          <SkeletonEditor
+            v-if="editing && sprite && hasSkeletonAnimation"
+            :sprite="sprite"
+            class="skeleton-editor"
+          />
+        </Transition>
+      </div>
+    </template>
+  </Transition>
 </template>
 
 <script lang="ts" setup>
-import { isContentReady, type TaggedAIAssetData } from '@/apis/aigc'
+import {
+  AIGCStatus,
+  isContentReady,
+  type AIGCFiles,
+  type RequiredAIGCFiles,
+  type TaggedAIAssetData
+} from '@/apis/aigc'
 import type { AssetType } from '@/apis/asset'
 import AnimationPlayer from '@/components/editor/sprite/animation/AnimationPlayer.vue'
 import { cachedConvertAssetData } from '@/models/common/asset'
@@ -20,18 +65,77 @@ import type { SkeletonClip } from '@/models/skeletonAnimation'
 import type { Sprite } from '@/models/sprite'
 import type { AnimationExportData } from '@/utils/ispxLoader'
 import { useAsyncComputed } from '@/utils/utils'
-import { computed, ref, shallowRef, watch } from 'vue'
+import { computed, onMounted, ref, shallowRef, watch } from 'vue'
 import SkeletonEditor from '@/components/asset/animation/skeleton/SkeletonEditor.vue'
 import { useFileUrl } from '@/utils/file'
-import { NEmpty, NSpin } from 'naive-ui'
+import { NEmpty, NIcon, NSpin } from 'naive-ui'
 import SpriteCarousel from '../details/SpriteCarousel.vue'
 import { EditOutlined } from '@vicons/antd'
 import type { ButtonType } from '@/components/ui/UIButton.vue'
 import type { EditorAction } from './AIPreviewModal.vue'
+import { AISpriteTask } from '@/models/aigc'
+import { getFiles } from '@/models/common/cloud'
+import type { File } from '@/models/common/file'
+import { hashFileCollection } from '@/models/common/hash'
+import { CancelOutlined } from '@vicons/material'
 
 const props = defineProps<{
   asset: TaggedAIAssetData<AssetType.Sprite>
 }>()
+
+const emit = defineEmits<{
+  contentReady: []
+}>()
+
+const status = ref<AIGCStatus | null>(null)
+const contentReady = ref(props.asset[isContentReady])
+
+/**
+ * Generate content like animation from AI-generated sprite preview
+ */
+const generateContent = async () => {
+  status.value = AIGCStatus.Waiting
+  contentReady.value = props.asset[isContentReady]
+  const generateTask = new AISpriteTask(props.asset.id)
+  generateTask.addEventListener('AIGCStatusChange', () => {
+    status.value = generateTask.status
+  })
+  generateTask.addEventListener('AIGCFinished', () => {
+    contentReady.value = true
+    if (generateTask.result?.files) {
+      loadCloudFiles(generateTask.result.files)
+    }
+  })
+  generateTask.start()
+}
+
+const loadCloudFiles = async (cloudFiles: RequiredAIGCFiles) => {
+  if (!cloudFiles) {
+    status.value = AIGCStatus.Failed
+    return
+  }
+  const files = (await getFiles(cloudFiles)) as {
+    [key in keyof AIGCFiles]: File
+  }
+
+  if (!files) {
+    status.value = AIGCStatus.Failed
+    return
+  }
+  props.asset.files = cloudFiles
+  props.asset.filesHash = await hashFileCollection(cloudFiles)
+  props.asset.displayName = props.asset.displayName ?? props.asset.id
+  props.asset[isContentReady] = true
+  contentReady.value = true
+  emit('contentReady')
+  return
+}
+
+onMounted(() => {
+  if (!contentReady.value) {
+    generateContent()
+  }
+})
 
 const sprite = useAsyncComputed<Sprite | undefined>(() => {
   if (!props.asset[isContentReady]) {
@@ -78,21 +182,33 @@ defineExpose({
   height: 100%;
 }
 
-.slide-fade-enter-active,
-.slide-fade-leave-active {
-  transition: all 0.3s;
+
+
+.generating-info {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
 }
 
-.slide-fade-enter-from,
-.slide-fade-leave-to {
-  opacity: 0;
+.generating-text {
+  display: inline-block;
+  font-size: 1rem;
+  color: var(--ui-color-turquoise-400, #3fcdd9);
 }
 
-.slide-fade-enter-from {
-  transform: translateY(10px);
+.failing-info {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
 }
 
-.slide-fade-leave-to {
-  transform: translateY(-10px);
+.failing-text {
+  display: inline-block;
+  font-size: 1rem;
+  color: var(--ui-color-danger-main, #ef4149);
 }
 </style>

--- a/spx-gui/src/components/asset/library/ai/ImageEditor/BrushSize.vue
+++ b/spx-gui/src/components/asset/library/ai/ImageEditor/BrushSize.vue
@@ -1,0 +1,98 @@
+<template>
+  <div class="brush-size-selector">
+    <div
+      class="brush-size-circle active"
+      :style="{ '--brush-size': '24px' }"
+	  :title="$t({ en: 'Brush size', zh: '画笔大小' }) + `: ${brushSize}px`"
+      @click="brushPopoverVisible = !brushPopoverVisible"
+    ></div>
+    <Transition name="slide-fade" mode="out-in" appear>
+      <div
+        v-show="brushPopoverVisible"
+        class="brush-size-popover"
+      >
+        <div
+          v-for="preset in props.presets"
+          :key="preset"
+          class="brush-size-item"
+          :style="{ '--brush-size': preset + 'px' }"
+		  :title="$t({ en: 'Brush size', zh: '画笔大小' }) + ': ' + preset + 'px'"
+          @click="brushSize = preset"
+        >
+          <div class="brush-size-circle" :class="{ active: brushSize === preset }"></div>
+        </div>
+      </div>
+    </Transition>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { computed, ref } from 'vue'
+
+const props = withDefaults(
+  defineProps<{
+    presets?: number[]
+  }>(),
+  {
+    presets: () => [8, 18, 28, 42, 54]
+  }
+)
+
+const brushSize = defineModel('brushSize', {
+  type: Number,
+  default: 28,
+})
+
+const brushPopoverVisible = ref(false)
+</script>
+
+<style scoped>
+.brush-size-selector {
+  position: relative;
+}
+
+.brush-size-circle {
+  width: var(--brush-size);
+  height: var(--brush-size);
+  border-radius: 50%;
+  background-color: var(--ui-color-grey-700);
+  background-clip: padding-box;
+  border: 2px solid transparent;
+  transition: background-color 0.3s, border-color 0.3s, box-shadow 0.3s;
+  box-sizing: content-box;
+  cursor: pointer;
+}
+
+.brush-size-circle.active {
+  background-color: var(--ui-color-grey-1000);
+  border-color: var(--ui-color-grey-100);
+  box-shadow: 0px 3px 8px 0px rgba(51, 51, 51, 0.48);
+}
+
+.brush-size-popover {
+  position: absolute;
+  top: 100%;
+  margin-top: 8px;
+  left: 50%;
+  transform: translateX(-50%);
+  background-color: var(--ui-color-grey-100);
+  box-shadow: var(--ui-box-shadow-big);
+  border-radius: var(--ui-border-radius-1);
+  padding: 8px;
+  display: flex;
+  flex-direction: row;
+  flex-wrap: nowrap;
+  justify-content: center;
+  align-items: stretch;
+  z-index: 10000;
+}
+
+.brush-size-item {
+  margin: 0 4px;
+  min-width: 16px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  cursor: pointer;
+}
+</style>

--- a/spx-gui/src/components/asset/library/ai/ImageEditor/ImageRepaint.vue
+++ b/spx-gui/src/components/asset/library/ai/ImageEditor/ImageRepaint.vue
@@ -14,7 +14,7 @@
 import { saveFiles } from '@/models/common/cloud'
 import { Disposable } from '@/models/common/disposable'
 import { fromBlob } from '@/models/common/file'
-import { computed, h, onMounted, onUnmounted, ref } from 'vue'
+import { computed, h, onMounted, onUnmounted, ref, watch } from 'vue'
 import { useSearchCtx } from '../../SearchContextProvider.vue'
 import { InpaintingTask } from '@/models/aigc'
 import { client, type UniversalToWebUrlMap } from '@/apis/common'
@@ -52,6 +52,13 @@ let imageCtx: CanvasRenderingContext2D
 
 const currentImgData = ref<string>(props.imageSrc)
 
+watch(() => props.imageSrc, (newSrc) => {
+  currentImgData.value = newSrc
+  undoRedo.clear()
+  undoRedo.setInitial({ img: newSrc })
+  drawImage(newSrc)
+})
+
 const undoRedo = useUndoRedo<{ img?: string; draw?: string }>()
 
 const resizeCanvas = () => {
@@ -78,6 +85,7 @@ const resizeCanvas = () => {
 const applyUndoRedo = (data: { img?: string; draw?: string }) => {
   if (!drawCtx || !imageCtx) return
   if (data.img) {
+    currentImgData.value = data.img
     drawImage(data.img)
   }
   if (data.draw) {

--- a/spx-gui/src/components/asset/library/ai/ImageEditor/ImageRepaint.vue
+++ b/spx-gui/src/components/asset/library/ai/ImageEditor/ImageRepaint.vue
@@ -1,0 +1,162 @@
+<template>
+  <div ref="container" class="container repaint-container">
+    <canvas
+      ref="drawCanvas"
+      class="canvas draw-canvas"
+      @mousedown="startDraw"
+      @mousemove="drawing"
+    ></canvas>
+    <canvas ref="imageCanvas" class="canvas image-canvas"></canvas>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { onMounted, onUnmounted, ref } from 'vue'
+
+const props = defineProps<{
+  imageSrc: string
+}>()
+
+const container = ref<HTMLDivElement | null>(null)
+const drawCanvas = ref<HTMLCanvasElement | null>(null)
+const imageCanvas = ref<HTMLCanvasElement | null>(null)
+
+let drawCtx: CanvasRenderingContext2D
+let imageCtx: CanvasRenderingContext2D
+
+const resizeCanvas = () => {
+  if (!container.value || !drawCanvas.value || !imageCanvas.value) return
+  // save and restore the canvas content
+  const drawData = drawCtx.canvas.toDataURL()
+  const drawImg = new Image()
+  drawImg.src = drawData
+
+  const { width, height } = container.value.getBoundingClientRect()
+  drawCanvas.value.width = width
+  drawCanvas.value.height = height
+  imageCanvas.value.width = width
+  imageCanvas.value.height = height
+  drawImage(props.imageSrc)
+
+  drawImg.onload = () => {
+    setTimeout(() => {
+      drawCtx.drawImage(drawImg, 0, 0, drawCtx.canvas.width, drawCtx.canvas.height)
+    }, 0)
+  }
+}
+
+const drawImage = (src: string) => {
+  const image = new Image()
+  image.src = src
+  image.onload = () => {
+    const { width: imgWidth, height: imgHeight } = image
+    // scale to fit the canvas
+    const { width: canvasWidth, height: canvasHeight } = imageCtx.canvas
+    const scale = Math.min(canvasWidth / imgWidth, canvasHeight / imgHeight)
+    // resize both canvas to fit the image
+    imageCtx.canvas.width = imgWidth * scale
+    imageCtx.canvas.height = imgHeight * scale
+    drawCtx.canvas.width = imgWidth * scale
+    drawCtx.canvas.height = imgHeight * scale
+    imageCtx.drawImage(image, 0, 0, imgWidth, imgHeight, 0, 0, imgWidth * scale, imgHeight * scale)
+  }
+}
+
+const brushSize = 16
+const brushColor = '#EF4149'
+let isDrawing = false
+
+const startDraw = (e: MouseEvent) => {
+  if (!drawCtx) return
+  drawCtx.beginPath()
+  drawCtx.moveTo(e.offsetX, e.offsetY)
+  isDrawing = true
+}
+
+const drawing = (e: MouseEvent) => {
+  if (!drawCtx || !isDrawing) return
+  drawCtx.lineTo(e.offsetX, e.offsetY)
+  drawCtx.lineCap = 'round'
+  drawCtx.lineJoin = 'round'
+  drawCtx.lineWidth = brushSize
+  drawCtx.strokeStyle = brushColor
+  drawCtx.stroke()
+}
+
+const endDraw = () => {
+  if (!drawCtx || !isDrawing) return
+  isDrawing = false
+  drawCtx.closePath()
+}
+
+onMounted(() => {
+  if (!container.value || !drawCanvas.value || !imageCanvas.value) return
+  drawCtx = drawCanvas.value.getContext('2d') as CanvasRenderingContext2D
+  imageCtx = imageCanvas.value.getContext('2d') as CanvasRenderingContext2D
+  resizeCanvas()
+  drawImage(props.imageSrc)
+  window.addEventListener('resize', resizeCanvas)
+  document.addEventListener('mouseup', endDraw)
+})
+
+onUnmounted(() => {
+  window.removeEventListener('resize', resizeCanvas)
+  document.removeEventListener('mouseup', endDraw)
+})
+
+const exportMaskedImage = async () => {
+  if (!drawCanvas.value || !imageCanvas.value) return
+  console.log('exporting masked image')
+  const tempCanvas = document.createElement('canvas')
+  const baseImg = new Image()
+  baseImg.src = props.imageSrc
+  const drawImg = new Image()
+  drawImg.src = drawCanvas.value.toDataURL()
+  await asyncOnload(baseImg)
+  await asyncOnload(drawImg)
+  tempCanvas.width = baseImg.width
+  tempCanvas.height = baseImg.height
+  const tempCtx = tempCanvas.getContext('2d') as CanvasRenderingContext2D
+  tempCtx.drawImage(baseImg, 0, 0)
+  // clear the alpha channel
+  tempCtx.globalCompositeOperation = 'destination-out'
+  tempCtx.drawImage(drawImg, 0, 0, baseImg.width, baseImg.height)
+  tempCtx.globalCompositeOperation = 'source-over'
+  return tempCanvas.toDataURL()
+// download the image
+//   const a = document.createElement('a')
+//   a.href = tempCanvas.toDataURL()
+//   a.download = 'maskedImage.png'
+//   a.click()
+}
+
+const asyncOnload = (img: HTMLImageElement) => {
+  return new Promise<void>((resolve) => {
+	img.onload = () => resolve()
+  })
+}
+</script>
+
+<style scoped>
+.repaint-container {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.canvas {
+  position: absolute;
+}
+
+.draw-canvas {
+  z-index: 100;
+  opacity: 0.6;
+}
+
+.image-canvas {
+  z-index: 1;
+}
+</style>

--- a/spx-gui/src/components/asset/library/ai/ImageEditor/ImageRepaint.vue
+++ b/spx-gui/src/components/asset/library/ai/ImageEditor/ImageRepaint.vue
@@ -385,7 +385,7 @@ const actions = computed(
                     setCursors()
                   }
                 },
-                drawMode.value === 'draw' ? h(DrawOutlined) : h('svg', { innerHTML: Erase })
+                () => drawMode.value === 'draw' ? h(DrawOutlined) : h('svg', { innerHTML: Erase })
               )
             )
           ])

--- a/spx-gui/src/components/asset/library/ai/ImageEditor/ImageRepaint.vue
+++ b/spx-gui/src/components/asset/library/ai/ImageEditor/ImageRepaint.vue
@@ -21,6 +21,10 @@ import { client, type UniversalToWebUrlMap } from '@/apis/common'
 import { AutoFixHighOutlined, CancelOutlined, CheckFilled } from '@vicons/material'
 import type { ButtonType } from '@/components/ui/UIButton.vue'
 import type { EditorAction } from '../AIPreviewModal.vue'
+import { UITextInput } from '@/components/ui'
+import { useI18n } from '@/utils/i18n'
+
+const { t } = useI18n()
 
 const props = defineProps<{
   imageSrc: string
@@ -108,7 +112,7 @@ const endDraw = () => {
 const inpaint = async () => {
   const controlImg = await exportMaskedImage()
   if (!controlImg) return
-  const url = await requestInpainting(controlImg, 'a blue hair girl')
+  const url = await requestInpainting(controlImg, prompt.value)
   if (!url) return
   const img = new Image()
   img.src = url
@@ -172,6 +176,8 @@ const asyncOnload = (img: HTMLImageElement) => {
 }
 
 const searchCtx = useSearchCtx()
+
+const prompt = ref<string>(searchCtx.keyword)
 
 const requestInpainting = async (controlImg: HTMLCanvasElement, prompt?: string) => {
   const d = new Disposable()
@@ -237,7 +243,23 @@ defineExpose({
     {
       name: '__separator__',
       component: () => {
-        return h('div', { style: {flex: 1 } })
+        return h('div', { style: { flex: 1 } })
+      }
+    },
+    // prompt
+    {
+      name: 'prompt',
+      component: () => {
+        return h('div', { class: 'prompt-container' }, [
+          h('span', t({ zh: '提示: ', en: 'Prompt: ' })),
+          h(UITextInput, {
+            value: prompt.value,
+            style: { width: '200px' },
+            'onUpdate:value': (value: string) => {
+              prompt.value = value
+            }
+          })
+        ])
       }
     },
     {
@@ -274,5 +296,12 @@ defineExpose({
 
 .image-canvas {
   z-index: 1;
+}
+
+.prompt-container {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 14px;
 }
 </style>

--- a/spx-gui/src/components/asset/library/ai/ImageEditor/useUndoRedo.test.ts
+++ b/spx-gui/src/components/asset/library/ai/ImageEditor/useUndoRedo.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from 'vitest'
+import { useUndoRedo } from './useUndoRedo'
+
+describe('useUndoRedo', () => {
+  it('should initialize with the correct initial value', () => {
+    const { current } = useUndoRedo('initial')
+    expect(current()).toBe('initial')
+  })
+
+  it('should record new items and update undo stack', () => {
+    const { record, current, undoStackLength, redoStackLength } = useUndoRedo('initial')
+    record('item1')
+    expect(current()).toBe('item1')
+    expect(undoStackLength.value).toBe(1)
+    expect(redoStackLength.value).toBe(0)
+  })
+
+  it('should undo the last action', () => {
+    const { record, undo, current, undoStackLength, redoStackLength } = useUndoRedo('initial')
+    record('item1')
+    record('item2')
+    expect(undo()).toBe('item1')
+    expect(current()).toBe('item1')
+    expect(undoStackLength.value).toBe(1)
+    expect(redoStackLength.value).toBe(1)
+  })
+
+  it('should redo the last undone action', () => {
+    const { record, undo, redo, current, undoStackLength, redoStackLength } = useUndoRedo('initial')
+    record('item1')
+    record('item2')
+    undo()
+    expect(redo()).toBe('item2')
+    expect(current()).toBe('item2')
+    expect(undoStackLength.value).toBe(2)
+    expect(redoStackLength.value).toBe(0)
+  })
+
+  it('should clear all stacks', () => {
+    const { record, clear, undoStackLength, redoStackLength } = useUndoRedo('initial')
+    record('item1')
+    clear()
+    expect(undoStackLength.value).toBe(0)
+    expect(redoStackLength.value).toBe(0)
+  })
+
+  it('should return the correct current item', () => {
+    const { record, current } = useUndoRedo('initial')
+    record('item1')
+    expect(current()).toBe('item1')
+    record('item2')
+    expect(current()).toBe('item2')
+  })
+
+  it('should set a new initial value', () => {
+    const { setInitial, current } = useUndoRedo('initial')
+    setInitial('newInitial')
+    expect(current()).toBe('newInitial')
+  })
+
+  it('should handle recording items beyond the limit', () => {
+    const { record, current, undo, undoStackLength } = useUndoRedo('initial', 3)
+    record('item1')
+    record('item2')
+    record('item3')
+    record('item4')
+    expect(current()).toBe('item4')
+    expect(undoStackLength.value).toBe(3)
+	expect(undo()).toBe('item3')
+	expect(undo()).toBe('item2')
+	expect(undo()).toBe('initial')
+  })
+
+  it('should handle multiple undos and redos', () => {
+    const { record, undo, redo } = useUndoRedo('initial')
+    record('item1')
+    record('item2')
+    record('item3')
+    expect(undo()).toBe('item2')
+    expect(undo()).toBe('item1')
+    expect(undo()).toBe('initial')
+    expect(redo()).toBe('item1')
+    expect(redo()).toBe('item2')
+    expect(redo()).toBe('item3')
+  })
+
+  it('should handle undo with no items in the stack', () => {
+    const { undo, current } = useUndoRedo('initial')
+    expect(undo()).toBe('initial')
+    expect(current()).toBe('initial')
+  })
+
+  it('should handle redo with no items in the stack', () => {
+    const { redo, current } = useUndoRedo('initial')
+    expect(redo()).toBe('initial')
+    expect(current()).toBe('initial')
+  })
+
+  it('should clear redo stack when recording a new item', () => {
+	const { record, redo, redoStackLength } = useUndoRedo('initial')
+	record('item1')
+	record('item2')
+	redo()
+	record('item3')
+	expect(redoStackLength.value).toBe(0)
+  })
+})

--- a/spx-gui/src/components/asset/library/ai/ImageEditor/useUndoRedo.ts
+++ b/spx-gui/src/components/asset/library/ai/ImageEditor/useUndoRedo.ts
@@ -1,0 +1,80 @@
+import { ref } from 'vue'
+
+/**
+ * useUndoRedo is a hook to manage undo and redo stacks
+ *
+ * @template T the type of the items to be stored in the undo stack
+ * @param initial the initial item to start with
+ * @param limit the maximum number of items to keep in the undo stack
+ * @returns
+ */
+export function useUndoRedo<T>(initial: T | null = null, limit: number = Infinity) {
+  const undoStack: T[] = []
+  const redoStack: T[] = []
+  const undoStackLength = ref(0)
+  const redoStackLength = ref(0)
+  const updateLength = () => {
+    undoStackLength.value = undoStack.length
+    redoStackLength.value = redoStack.length
+  }
+
+  return {
+    undoStackLength,
+    redoStackLength,
+	setInitial: (_initial: T) => {
+		initial = _initial
+	},
+    /**
+     * undo the last action
+     * @returns the current item after undo
+     */
+    undo: () => {
+      if (undoStack.length <= 0) {
+        return initial
+      }
+      const item = undoStack.pop()!
+      redoStack.push(item!)
+      updateLength()
+      return undoStack[undoStack.length - 1] ?? initial
+    },
+    /**
+     * redo the last action
+     * @returns the current item after redo
+     */
+    redo: () => {
+      if (redoStack.length <= 0) {
+        return undoStack[undoStack.length - 1] ?? initial
+      }
+      const item = redoStack.pop()!
+      undoStack.push(item!)
+      updateLength()
+      return item
+    },
+    /**
+     * record a new item
+     * @param item the new item
+     */
+    record: (item: T) => {
+      undoStack.push(item)
+      redoStack.length = 0
+      if (undoStack.length > limit) {
+        undoStack.shift()
+      }
+      updateLength()
+    },
+    /**
+     * clear all undo and redo stacks
+     */
+    clear: () => {
+      undoStack.length = 0
+      redoStack.length = 0
+      updateLength()
+    },
+    /**
+     * get the current item
+     */
+    current() {
+      return undoStack[undoStack.length - 1] ?? initial
+    }
+  }
+}

--- a/spx-gui/src/components/asset/library/ai/ImageEditor/useUndoRedo.ts
+++ b/spx-gui/src/components/asset/library/ai/ImageEditor/useUndoRedo.ts
@@ -21,9 +21,9 @@ export function useUndoRedo<T>(initial: T | null = null, limit: number = Infinit
   return {
     undoStackLength,
     redoStackLength,
-	setInitial: (_initial: T) => {
-		initial = _initial
-	},
+    setInitial: (_initial: T) => {
+      initial = _initial
+    },
     /**
      * undo the last action
      * @returns the current item after undo

--- a/spx-gui/src/components/ui/global.scss
+++ b/spx-gui/src/components/ui/global.scss
@@ -18,7 +18,7 @@ button {
 // Transition effect for slide-fade
 .slide-fade-enter-active,
 .slide-fade-leave-active {
-  transition: all 0.3s;
+  transition: all 0.2s;
 }
 
 .slide-fade-enter-from,

--- a/spx-gui/src/components/ui/global.scss
+++ b/spx-gui/src/components/ui/global.scss
@@ -14,3 +14,22 @@ button {
   font-family: 'AlibabaHealthB';
   src: url('./fonts/AlibabaHealthFont2.0CN-85B.ttf') format('truetype');
 }
+
+// Transition effect for slide-fade
+.slide-fade-enter-active,
+.slide-fade-leave-active {
+  transition: all 0.3s;
+}
+
+.slide-fade-enter-from,
+.slide-fade-leave-to {
+  opacity: 0;
+}
+
+.slide-fade-enter-from {
+  transform: translateY(10px);
+}
+
+.slide-fade-leave-to {
+  transform: translateY(-10px);
+}

--- a/spx-gui/src/components/ui/icons/erase.svg
+++ b/spx-gui/src/components/ui/icons/erase.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 32 32"><path d="M7 27h23v2H7z" fill="currentColor"></path><path d="M27.38 10.51l-7.93-7.92a2 2 0 0 0-2.83 0l-14 14a2 2 0 0 0 0 2.83L7.13 24h9.59l10.66-10.66a2 2 0 0 0 0-2.83zM15.89 22H8l-4-4l6.31-6.31l7.93 7.92zm3.76-3.76l-7.92-7.93L18 4l8 7.93z" fill="currentColor"></path></svg>

--- a/spx-gui/src/models/aigc.ts
+++ b/spx-gui/src/models/aigc.ts
@@ -213,14 +213,17 @@ export class AIImageTask extends AIGCTask<TaggedAIAssetData>{
 
 
 export class AISpriteTask extends AIGCTask<WithStatus<{files: RequiredAIGCFiles}>> {
-  constructor(id: string) {
-    super(generateAISprite, [id], async ({spriteJobId: id}: {spriteJobId: string}) => {
-      const {status, result} = await getAIGCStatus(id)
-      return {
-        status,
-        files: result?.files as RequiredAIGCFiles,
-      }
-    })
+  constructor(imageUrl: string) {
+    super(AISpriteTask.request, [imageUrl])
+  }
+
+  private static async request(imageUrl: string) {
+    const res = await generateAISprite(imageUrl)
+    return {
+      spriteUrl: (res as any).material_url,
+      ...res,
+      status: AIGCStatus.Finished
+    }
   }
 }
 

--- a/spx-gui/src/models/aigc.ts
+++ b/spx-gui/src/models/aigc.ts
@@ -1,4 +1,4 @@
-import { AIGCStatus, generateAIImage, generateAISprite, getAIGCStatus, isAiAsset, isContentReady, isPreviewReady, syncGenerateAIImage, type AIGCFiles, type CreateAIImageParams, type RequiredAIGCFiles, type TaggedAIAssetData } from "@/apis/aigc"
+import { AIGCStatus, generateAIImage, generateAISprite, generateInpainting, getAIGCStatus, isAiAsset, isContentReady, isPreviewReady, syncGenerateAIImage, type AIGCFiles, type CreateAIImageParams, type GenerateInpaintingParams, type RequiredAIGCFiles, type TaggedAIAssetData } from "@/apis/aigc"
 import { saveFiles } from "./common/cloud"
 import { fromBlob } from "./common/file"
 import { useRetryHandle } from "@/utils/exception"
@@ -221,5 +221,18 @@ export class AISpriteTask extends AIGCTask<WithStatus<{files: RequiredAIGCFiles}
         files: result?.files as RequiredAIGCFiles,
       }
     })
+  }
+}
+
+export class InpaintingTask extends AIGCTask<WithStatus<{imageUrl: string}>> {
+  constructor(params: GenerateInpaintingParams) {
+    super(InpaintingTask.request, [params])
+  }
+  private static async request(params: GenerateInpaintingParams) {
+    const res = await generateInpainting(params)
+    return {
+      imageUrl: res.image_url,
+      status: AIGCStatus.Finished
+    }
   }
 }


### PR DESCRIPTION
This pull request implements the inpainting feature for AI-generated previews.

Changes:
 - [x] refactor content generation of AI asset into specific editor for scalability of future implementations
 - [x] update further generation of AI sprite asset to manual
 - [x] preview AI-generated sprite preview before generating
 - [x] paint inpainting area and export to masked image
 - [x] forwarding to inpainting services on the backend
 - [x] improve inpainting interaction like providing brush size configuration, undo & redo
   - [x] confirm, cancel, repaint
   - [x] inpainting status
   - [x] prompt
   - [x] undo & redo
   - [x] brush size


https://github.com/user-attachments/assets/72cd2bd8-08e4-4b74-b4e2-e16eb257012e
