### PR TITLE
refactor(spx-gui): refactor completion menu cache

### DIFF
--- a/spx-gui/src/components/editor/code-editor/EditorUI.ts
+++ b/spx-gui/src/components/editor/code-editor/EditorUI.ts
@@ -29,7 +29,7 @@ export interface TextModel extends IEditor.ITextModel {}
 export enum Icon {
   Function,
   Event,
-  Prototype,
+  Property,
   Keywords,
   AIAbility,
   Document,

--- a/spx-gui/src/components/editor/code-editor/EditorUI.ts
+++ b/spx-gui/src/components/editor/code-editor/EditorUI.ts
@@ -351,11 +351,6 @@ export class EditorUI extends Disposable {
       ]
     })
 
-    // TODO: monaco editor completion is not fully match our features, we need implement it by self, we may need do following,
-    //  trigger completion menu by handle listen keyboard down, up, shortcut, mouse down up, focus, blur, and custom fuzzy search to match completion item.
-    // current bug is when you type same code remove it then type it, it will show duplicate completion items depends on how many times you repeat it.
-    // because our completionMenuCache use { lineNumber: number, column: number, fileId: string  } to make completionMenuCacheID，thus, we can not recognize the difference between old typing and new typing and typing code is same.
-    // in `completionItemCache` i try to add function `has` to force avoid duplicate item in `completionItemCache`
     this.monacoProviderDisposes.completionProvider =
       monaco.languages.registerCompletionItemProvider(LANGUAGE_NAME, {
         provideCompletionItems: (model, position) => {
@@ -374,12 +369,11 @@ export class EditorUI extends Disposable {
             this.completionMenu.hideCompletionMenu()
             return { suggestions: [] }
           }
-          // if completionItemCacheID changed, inner cache will clean `cached data`
-          // in a word, if CompletionItemCacheID changed will call `requestCompletionProviderResolve`
-          const isNeedRequestCompletionProviderResolve =
-            !this.completionMenu.completionItemCache.isCacheAvailable(completionItemCacheID)
-          if (isNeedRequestCompletionProviderResolve) {
-            const abortController = new AbortController()
+          const cachedItems = this.completionMenu.completionItemCache.get(completionItemCacheID)
+          if (cachedItems == null) {
+            const completionItems: CompletionItem[] = []
+            this.completionMenu.completionItemCache.set(completionItemCacheID, completionItems)
+            const abortController = this.completionMenu.refreshAbortController()
             this.requestCompletionProviderResolve(
               model,
               {
@@ -392,8 +386,8 @@ export class EditorUI extends Disposable {
                 const isSamePosition =
                   this.completionMenu.completionItemCache.isSamePosition(completionItemCacheID)
                 if (!isSamePosition) return abortController.abort()
-
-                this.completionMenu.completionItemCache.add(completionItemCacheID, items)
+                if (this.completionMenu.abortController !== abortController) return
+                completionItems.push(...items)
                 // if you need user immediately show updated completion items, we need close it and reopen it.
                 this.completionMenu.hideCompletionMenu()
                 this.completionMenu.showCompletionMenu()
@@ -402,7 +396,7 @@ export class EditorUI extends Disposable {
             return { suggestions: [] }
           } else {
             const suggestions =
-              this.completionMenu.completionItemCache.getAll(completionItemCacheID).map(
+              this.completionMenu.completionItemCache.get(completionItemCacheID)?.map(
                 (item): languages.CompletionItem => ({
                   label: item.label,
                   kind: icon2CompletionItemKind(item.icon),

--- a/spx-gui/src/components/editor/code-editor/coordinators/index.ts
+++ b/spx-gui/src/components/editor/code-editor/coordinators/index.ts
@@ -5,12 +5,12 @@ import {
   DocPreviewLevel,
   type EditorUI,
   Icon,
+  type InlayHintDecoration,
   type InputItem,
   type InputItemCategory,
   type LayerContent,
   type SelectionMenuItem,
-  type TextModel,
-  type InlayHintDecoration
+  type TextModel
 } from '@/components/editor/code-editor/EditorUI'
 import { Runtime } from '../runtime'
 import { Compiler } from '../compiler'
@@ -25,13 +25,13 @@ import {
   eventCategory,
   gameCategory,
   getAllTools,
+  getVariableCategory,
   lookCategory,
   motionCategory,
   sensingCategory,
   soundCategory,
-  getVariableCategory,
-  TokenType,
-  type TokenCategory
+  type TokenCategory,
+  TokenType
 } from '@/components/editor/code-editor/tools'
 
 type JumpPosition = {
@@ -98,6 +98,49 @@ export class Coordinator {
     addItems: (items: CompletionItem[]) => void
   ) {
     addItems(getCompletionItems(this.ui.i18n, this.project))
+
+    setTimeout(() => {
+      addItems([
+        {
+          icon: Icon.Keywords,
+          label: 'a',
+          desc: 'a',
+          insertText: 'a',
+          preview: {
+            content: '',
+            level: DocPreviewLevel.Normal
+          }
+        }
+      ])
+    }, 1000)
+    setTimeout(() => {
+      addItems([
+        {
+          icon: Icon.Keywords,
+          label: 'ab',
+          desc: 'ab',
+          insertText: 'ab',
+          preview: {
+            content: '',
+            level: DocPreviewLevel.Normal
+          }
+        }
+      ])
+    }, 2000)
+    setTimeout(() => {
+      addItems([
+        {
+          icon: Icon.Keywords,
+          label: 'abc',
+          desc: 'abc',
+          insertText: 'abc',
+          preview: {
+            content: '',
+            level: DocPreviewLevel.Normal
+          }
+        }
+      ])
+    }, 3000)
   }
 
   async implementsPreDefinedHoverProvider(

--- a/spx-gui/src/components/editor/code-editor/coordinators/index.ts
+++ b/spx-gui/src/components/editor/code-editor/coordinators/index.ts
@@ -104,6 +104,36 @@ export class Coordinator {
 
     const stageCodes = [{ filename: 'main.spx', content: this.project.stage.code }]
 
+    // add project variables
+    const { sprites, sounds, stage, selectedSprite } = this.project
+
+    const createCompletionItem = (name: string) => ({
+      icon: Icon.Variable,
+      insertText: `"${name}"`,
+      label: `"${name}"`,
+      desc: '',
+      preview: {
+        level: DocPreviewLevel.Normal,
+        content: ''
+      }
+    })
+
+    const items = [
+      ...sprites.map(sprite => createCompletionItem(sprite.name)),
+      ...sounds.map(sound => createCompletionItem(sound.name)),
+      ...stage.backdrops.map(backdrop => createCompletionItem(backdrop.name))
+    ]
+
+    if (selectedSprite) {
+      const { animations, costumes } = selectedSprite
+      items.push(
+        ...animations.map(animation => createCompletionItem(animation.name)),
+        ...costumes.map(costume => createCompletionItem(costume.name))
+      )
+    }
+
+    addItems(items)
+
     this.compiler
       .getCompletionItems(
         (this.project.selectedSprite?.name ?? 'main') + '.spx',
@@ -118,7 +148,7 @@ export class Coordinator {
               icon: completionItemType2Icon(completionItem.type),
               insertText: completionItem.insert_text,
               label: completionItem.label,
-              desc: completionItem.token_pkg,
+              desc: '',
               preview: {
                 level: DocPreviewLevel.Normal,
                 content: '' /* todo: get content with docAbility */
@@ -316,7 +346,7 @@ export class Coordinator {
     return getInputItemCategories(this.project)
   }
 
-  public jump(position: JumpPosition): void {}
+  public jump(position: JumpPosition): void { }
 }
 
 function getCompletionItems(i18n: I18n, project: Project): CompletionItem[] {

--- a/spx-gui/src/components/editor/code-editor/ui/common/index.ts
+++ b/spx-gui/src/components/editor/code-editor/ui/common/index.ts
@@ -28,7 +28,7 @@ export function icon2SVG(icon: Icon): string {
       return iconEvent
     case Icon.Listen:
       return IconListen
-    case Icon.Prototype:
+    case Icon.Property:
       return IconRead
     case Icon.Keywords:
       return IconCode
@@ -81,7 +81,11 @@ export function isElementInViewport(containerElement: Element, checkElement: Ele
 }
 
 /** normalize icon size to static size, like npm package XIcon component */
-export function normalizeIconSize(targetElement: Element | null, size: number, height = size): undefined {
+export function normalizeIconSize(
+  targetElement: Element | null,
+  size: number,
+  height = size
+): undefined {
   const innerSvgElement = targetElement?.firstElementChild
   if (!innerSvgElement) return
   innerSvgElement.setAttribute('height', String(height))

--- a/spx-gui/src/components/editor/code-editor/ui/features/completion-menu/completion-menu.ts
+++ b/spx-gui/src/components/editor/code-editor/ui/features/completion-menu/completion-menu.ts
@@ -295,13 +295,13 @@ function completionItemKind2Icon(completionIcon: languages.CompletionItemKind): 
     case languages.CompletionItemKind.Function:
       return Icon.Function
     case languages.CompletionItemKind.Variable:
-      return Icon.Prototype
+      return Icon.Property
     case languages.CompletionItemKind.Constant:
-      return Icon.Prototype
+      return Icon.Property
     case languages.CompletionItemKind.Snippet:
       return Icon.Function
     default:
-      return Icon.Prototype
+      return Icon.Property
   }
 }
 
@@ -309,7 +309,7 @@ export function icon2CompletionItemKind(icon: Icon): languages.CompletionItemKin
   switch (icon) {
     case Icon.Function:
       return languages.CompletionItemKind.Function
-    case Icon.Prototype:
+    case Icon.Property:
       return languages.CompletionItemKind.Variable
     case Icon.Keywords:
       return languages.CompletionItemKind.Snippet

--- a/spx-gui/src/components/editor/code-editor/ui/features/completion-menu/completion-menu.ts
+++ b/spx-gui/src/components/editor/code-editor/ui/features/completion-menu/completion-menu.ts
@@ -107,7 +107,6 @@ export class CompletionMenu implements IDisposable {
 
     const { dispose: keyDownDispose } = this.editor.onKeyDown((e) => {
       if (e.keyCode === KeyCode.Escape) {
-        console.log('中断')
         this.abortController.abort()
       }
     })

--- a/spx-gui/src/components/editor/code-editor/ui/features/completion-menu/completion-menu.ts
+++ b/spx-gui/src/components/editor/code-editor/ui/features/completion-menu/completion-menu.ts
@@ -4,18 +4,17 @@
 
 import {
   editor as IEditor,
-  editor,
   type IDisposable,
   type IPosition,
+  KeyCode,
   languages,
   Range
 } from 'monaco-editor'
-import { reactive, type UnwrapNestedRefs } from 'vue'
+import { reactive } from 'vue'
 import type { CompletionMenuFeatureItem, MonacoCompletionModelItem } from './completion'
 import { createMatches, type IMatch } from '../../common'
 import { CompletionItemCache } from '@/components/editor/code-editor/ui/features/completion-menu/completion-item-cache'
 import { DocPreviewLevel, Icon } from '@/components/editor/code-editor/EditorUI'
-import EditorOption = editor.EditorOption
 
 export interface CompletionMenuState {
   visible: boolean
@@ -33,8 +32,20 @@ export interface CompletionMenuState {
 
 export class CompletionMenu implements IDisposable {
   public editor: IEditor.IStandaloneCodeEditor
-  public completionMenuState: UnwrapNestedRefs<CompletionMenuState>
+  public completionMenuState = reactive<CompletionMenuState>({
+    visible: false,
+    suggestions: [],
+    activeIdx: 0,
+    position: {
+      top: 0,
+      left: 0
+    },
+    fontSize: 14,
+    lineHeight: 19,
+    word: ''
+  })
   public completionItemCache = new CompletionItemCache()
+  public abortController = new AbortController()
   private suggestController: any
   private suggestControllerWidget: any
   private readonly TabSize: number
@@ -42,9 +53,15 @@ export class CompletionMenu implements IDisposable {
   private viewZoneChangeAccessorState: {
     viewZoneId: string | null
     codePreviewElement: HTMLElement | null
+  } = {
+    viewZoneId: null,
+    // no need to remove this element by self, because it will be removed by monaco editor.
+    codePreviewElement: null
   }
   private monacoCompletionModelItems: MonacoCompletionModelItem[] = []
   private completionMenuItemPreviewDecorationsCollection: IEditor.IEditorDecorationsCollection
+
+  private eventsDisposers: Record<string, null | (() => void)> = {}
 
   constructor(editor: IEditor.IStandaloneCodeEditor) {
     this.editor = editor
@@ -52,45 +69,27 @@ export class CompletionMenu implements IDisposable {
     if (!this.suggestController) throw new Error("can't find suggestController")
     this.suggestControllerWidget = this.suggestController.widget.value
 
-    this.completionMenuState = reactive({
-      visible: false,
-      suggestions: [],
-      activeIdx: 0,
-      position: {
-        top: 0,
-        left: 0
-      },
-      fontSize: 14,
-      lineHeight: 19,
-      word: ''
-    })
-
     this.TabSize = editor.getModel()?.getOptions().tabSize || 4
     this.indentSymbolBySpace = ' '.repeat(this.TabSize)
 
-    this.viewZoneChangeAccessorState = {
-      viewZoneId: null,
-      // no need to remove this element by self, because it will be removed by monaco editor.
-      codePreviewElement: null
-    }
     this.completionMenuItemPreviewDecorationsCollection = editor.createDecorationsCollection([])
 
     this.initEventListeners()
   }
 
   private initEventListeners() {
-    this.suggestControllerWidget.onDidHide(() => {
+    const { dispose: didHideDispose } = this.suggestControllerWidget.onDidHide(() => {
       this.completionMenuState.visible = false
       this.completionMenuState.suggestions.length = 0
       this.disposeCodePreview()
     })
-    this.suggestControllerWidget.onDidShow(() => {
+    const { dispose: didShowDispose } = this.suggestControllerWidget.onDidShow(() => {
       this.completionMenuState.visible = true
       this.syncCompletionMenuStateFromSuggestControllerWidget(0)
       // must be use next render time to update correct position
       setTimeout(() => this.updateCompletionMenuPosition(), 0)
     })
-    this.suggestControllerWidget.onDidFocus(() => {
+    const { dispose: didFocusDispose } = this.suggestControllerWidget.onDidFocus(() => {
       this.completionMenuState.visible = true
       const focusedItem = this.suggestControllerWidget.getFocusedItem()
       if (!focusedItem) return
@@ -105,6 +104,18 @@ export class CompletionMenu implements IDisposable {
       )
       this.updateCompletionMenuPosition()
     })
+
+    const { dispose: keyDownDispose } = this.editor.onKeyDown((e) => {
+      if (e.keyCode === KeyCode.Escape) {
+        console.log('中断')
+        this.abortController.abort()
+      }
+    })
+
+    this.eventsDisposers.didHideDispose = didHideDispose
+    this.eventsDisposers.didShowDispose = didShowDispose
+    this.eventsDisposers.didFocusDispose = didFocusDispose
+    this.eventsDisposers.keyDownDispose = keyDownDispose
   }
 
   private disposeCodePreview() {
@@ -190,27 +201,6 @@ export class CompletionMenu implements IDisposable {
     })
   }
 
-  public showCompletionMenu() {
-    this.completionMenuState.visible = true
-    this.editor.trigger('keyboard', 'editor.action.triggerSuggest', {})
-  }
-
-  public hideCompletionMenu() {
-    this.completionMenuState.visible = false
-    this.editor.trigger('editor', 'hideSuggestWidget', {})
-  }
-
-  select(idx: number) {
-    const completionItems: MonacoCompletionModelItem[] = this.monacoCompletionModelItems
-    if (!completionItems.length || idx < 0 || idx >= completionItems.length) return
-    this.suggestControllerWidget._select(completionItems[idx], idx)
-  }
-
-  dispose() {
-    this.completionItemCache.dispose()
-    this.disposeCodePreview()
-  }
-
   private updateCompletionMenuPosition() {
     const position = this.editor.getPosition()
     if (!position) return
@@ -218,7 +208,7 @@ export class CompletionMenu implements IDisposable {
     if (!completionMenuElement) return
     const pixelPosition = this.editor.getScrolledVisiblePosition(position)
     if (!pixelPosition) return
-    const fontSize = this.editor.getOption(EditorOption.fontSize)
+    const fontSize = this.editor.getOption(IEditor.EditorOption.fontSize)
     const isMultiline = () => {
       const { suggestions, activeIdx } = this.completionMenuState
       if (activeIdx < 0 || activeIdx >= suggestions.length) return false
@@ -264,6 +254,38 @@ export class CompletionMenu implements IDisposable {
         matches: createMatches(completion.score)
       }
     })
+  }
+
+  public refreshAbortController() {
+    this.abortController.abort()
+    this.abortController = new AbortController()
+    return this.abortController
+  }
+
+  public showCompletionMenu() {
+    this.completionMenuState.visible = true
+    this.editor.trigger('keyboard', 'editor.action.triggerSuggest', {})
+  }
+
+  public hideCompletionMenu() {
+    this.completionMenuState.visible = false
+    this.editor.trigger('editor', 'hideSuggestWidget', {})
+  }
+
+  public select(idx: number) {
+    const completionItems: MonacoCompletionModelItem[] = this.monacoCompletionModelItems
+    if (!completionItems.length || idx < 0 || idx >= completionItems.length) return
+    this.suggestControllerWidget._select(completionItems[idx], idx)
+  }
+
+  public dispose() {
+    for (const key in this.eventsDisposers) {
+      this.eventsDisposers[key]?.()
+    }
+
+    this.completionItemCache.dispose()
+    this.disposeCodePreview()
+    this.abortController.abort()
   }
 }
 


### PR DESCRIPTION
## Overview
this pr is about refactor completion menu cache

## Todo
- [x] fix `esc` can not abort delay `addItems` function
- [x] implement wasm function `getCompletinItems`