### PR TITLE
fix(spx-gui): fix when wasm crashed compiler can not auto recover

### DIFF
--- a/spx-gui/src/components/editor/code-editor/compiler.ts
+++ b/spx-gui/src/components/editor/code-editor/compiler.ts
@@ -129,7 +129,13 @@ export class Compiler extends Disposable {
 
   public setContainerElement(containerElement: HTMLIFrameElement) {
     this.containerElement = containerElement
-    containerElement.addEventListener('load', this.initIframe.bind(this))
+    if (containerElement.contentDocument?.readyState === 'complete') {
+      // If the iframe is already loaded, call initIframe directly
+      this.initIframe()
+    } else {
+      // If not, add the load event listener
+      containerElement.addEventListener('load', this.initIframe.bind(this))
+    }
   }
 
   public handleConsoleLog(message: any) {

--- a/spx-gui/src/components/editor/code-editor/compiler.ts
+++ b/spx-gui/src/components/editor/code-editor/compiler.ts
@@ -87,8 +87,13 @@ type Code = {
 }
 
 export class Compiler extends Disposable {
-  containerElement: HTMLIFrameElement | null = null
+  containerElement?: HTMLIFrameElement
   private wasmHandlerRef = shallowRef<WasmHandler | null>()
+
+  constructor() {
+    super()
+    this.addDisposer(() => this.containerElement?.removeEventListener('load', this.initIframe))
+  }
 
   private initIframe() {
     if (!this.containerElement?.contentWindow) return
@@ -108,7 +113,9 @@ export class Compiler extends Disposable {
   }
 
   private reloadIframe() {
+    // each load will emit 'load' event, after 'load', will trigger `initIframe` function
     this.containerElement?.contentWindow?.location.reload()
+    this.wasmHandlerRef.value = null
   }
 
   private codes2CompileCode(codes: Code[]): CompilerCodes {
@@ -122,20 +129,17 @@ export class Compiler extends Disposable {
 
   public setContainerElement(containerElement: HTMLIFrameElement) {
     this.containerElement = containerElement
-    this.initIframe()
+    containerElement.addEventListener('load', this.initIframe.bind(this))
   }
 
   public handleConsoleLog(message: any) {
     if (!message) return
     if (message.includes('goroutine ')) this.reloadIframe()
-    if (message === 'WASM Init') this.handleWasmReady()
-  }
-
-  private handleWasmReady() {
-    this.wasmHandlerRef.value = this.containerElement?.contentWindow as
-      | WasmHandler
-      | null
-      | undefined
+    if (message === 'WASM Init')
+      this.wasmHandlerRef.value = this.containerElement?.contentWindow as
+        | WasmHandler
+        | null
+        | undefined
   }
 
   private async waitForWasmInit(): Promise<WasmHandler> {


### PR DESCRIPTION
## Overview
this pr is about fix when wasm crashed compiler can not auto reload to recover wasm ability