### PR TITLE
fix: load scale property from avatar to auto scale the animation

### DIFF
--- a/spx-gui/src/components/asset/animation/skeleton/SkeletonAnimationPlayer.vue
+++ b/spx-gui/src/components/asset/animation/skeleton/SkeletonAnimationPlayer.vue
@@ -36,13 +36,13 @@ const props = withDefaults(
     fps?: number
     autoplay?: boolean
     color?: Color
-    scale?: number
+    scale?: [number, number]
   }>(),
   {
     fps: 30,
     autoplay: true,
     color: 'sprite',
-    scale: 40
+    scale: () => [40, 40]
   }
 )
 

--- a/spx-gui/src/components/asset/animation/skeleton/SkeletonAnimationRenderer.vue
+++ b/spx-gui/src/components/asset/animation/skeleton/SkeletonAnimationRenderer.vue
@@ -19,12 +19,12 @@ const props = withDefaults(
     texture: string
     fps?: number
     autoplay?: boolean
-    scale?: number
+    scale?: [number, number]
   }>(),
   {
     fps: 30,
     autoplay: true,
-    scale: 40
+    scale: () => [40, 40] as [number, number]
   }
 )
 
@@ -67,7 +67,6 @@ watch(() => props.scale, () => {
 })
 
 onUnmounted(() => {
-  console.log('unmounted')
   window.removeEventListener('resize', resize)
   clearInterval(resizeTimer)
 })
@@ -88,6 +87,7 @@ type CanvasWebGLRenderingContext = WebGLRenderingContext & {
 interface Uniforms {
   uTexture: WebGLTexture
   uResolution: [number, number]
+  uScale: [number, number]
   uFlipY: 1 | -1
   uTranslate: [number, number]
 }
@@ -129,7 +129,7 @@ export class Renderer {
     fs: string,
     texSrc: string,
     fps: number = 30,
-    scale: number = 40
+    scale: [number, number] = [40, 40]
   ) {
     this.gl = gl
     this.programInfo = setupProgram(gl, vs, fs)
@@ -252,11 +252,11 @@ export class Renderer {
     return img
   }
 
-  private _scale: number = 40
+  private _scale: [number, number] = [40, 40]
   get scale() {
     return this._scale
   }
-  set scale(scale: number) {
+  set scale(scale: [number, number]) {
     this._scale = scale
     this.resize()
   }
@@ -376,8 +376,9 @@ export function initScene(gl: CanvasWebGLRenderingContext, cull: false | 'front'
  * @param uniforms The uniforms to set the projection and view matrix
  * @param scale
  */
-export function setupResolutionMap(gl: CanvasWebGLRenderingContext, uniforms: Partial<Uniforms>, scale: number = 40) {
-  uniforms.uResolution = [gl.canvas.width / scale, gl.canvas.height / scale]
+export function setupResolutionMap(gl: CanvasWebGLRenderingContext, uniforms: Partial<Uniforms>, scale: [number, number] = [40, 40]) {
+  uniforms.uResolution = [gl.canvas.width, gl.canvas.height]
+  uniforms.uScale = scale
   uniforms.uTranslate = [1, 1]
   uniforms.uFlipY = 1
 }
@@ -411,7 +412,7 @@ export function setupUniforms(
   gl: CanvasWebGLRenderingContext,
   programInfo: twgl.ProgramInfo,
   texSrc: string,
-  scale: number = 40
+  scale: [number, number] = [40, 40]
 ) {
   const uniforms = {} as Partial<Uniforms>
   setupTexture(gl, uniforms, texSrc)

--- a/spx-gui/src/components/asset/animation/skeleton/shader.vert
+++ b/spx-gui/src/components/asset/animation/skeleton/shader.vert
@@ -1,4 +1,5 @@
 uniform vec2 uResolution;
+uniform vec2 uScale;
 uniform float uFlipY;
 uniform vec2 uTranslate;
 
@@ -8,7 +9,7 @@ attribute vec2 aUV;
 varying vec2 vUV;
 
 void main() {
-    vec2 zeroToOne = position.xy / uResolution;
+    vec2 zeroToOne = position.xy * uScale / uResolution;
     vec2 zeroToTwo = zeroToOne * 2.0;
     vec2 clipSpace = zeroToTwo - 1.0;
     clipSpace += uTranslate;

--- a/spx-gui/src/components/asset/library/details/SpriteCarousel.vue
+++ b/spx-gui/src/components/asset/library/details/SpriteCarousel.vue
@@ -26,7 +26,7 @@
             :fps="30"
             :autoplay="true"
             :style="{ width: '100%', height: '100%', position: 'relative' }"
-            :scale="30"
+            :scale="[anim.animation.scale.x, anim.animation.scale.y]"
             @ready="(renderer) => loadPreviewForSkeleton(anim, renderer)"
             @pause-autoplay="autoplay = false"
             @resume-autoplay="autoplay = true"

--- a/spx-gui/src/models/skeletonAnimation.ts
+++ b/spx-gui/src/models/skeletonAnimation.ts
@@ -104,6 +104,7 @@ export class SkeletonAnimation extends Disposable {
       const animator = (await toConfig(animatorFile)) as SkeletonAnimator
 
       skeletonAnim.type = avatar.type as 'skeleton' | 'vertex'
+      skeletonAnim.scale = avatar.scale
       
       if (avatar.type === 'skeleton') {       
         // load skeleton hierarchy from mesh file


### PR DESCRIPTION
- update scale prop over related components to [number, number] type to match the scale property from animation avatar
- update the shader to scale the animation based on the scale property from animation avatar
- load and apply the scale property from animation avatar to the animation renderer

![Peek 2024-09-09 16-41](https://github.com/user-attachments/assets/b14b3216-a4cb-4bcc-acc4-4b4219e227e7)
