### PR TITLE
feat: crop ai backdrop image to project stage aspect ratio by default

### DIFF
--- a/spx-gui/src/components/asset/library/AssetLibrary.vue
+++ b/spx-gui/src/components/asset/library/AssetLibrary.vue
@@ -63,10 +63,7 @@
       <div class="sider">
         <LibraryMenu @update:value="handleUserSelectCategory" />
         <UIDivider />
-        <LibraryTree
-          :type="type"
-          style="flex: 1 1 0%; overflow: auto; scrollbar-width: thin"
-        />
+        <LibraryTree :type="type" style="flex: 1 1 0%; overflow: auto; scrollbar-width: thin;" />
       </div>
     </section>
     <Transition name="fade" mode="out-in" appear>
@@ -74,6 +71,7 @@
         <AIPreviewModal
           :asset="selectedAsset"
           :ai-assets="currentAIAssetList"
+          :project="props.project"
           class="asset-page"
           :add-to-project-pending="handleAddToProject.isLoading.value"
           @add-to-project="handleAddToProject.fn"

--- a/spx-gui/src/components/asset/library/ai/AIBackdropEditor.vue
+++ b/spx-gui/src/components/asset/library/ai/AIBackdropEditor.vue
@@ -21,6 +21,7 @@
     <ImageCrop
       v-if="editMode === 'crop' && image !== null && stageConfig != null && !loading"
       ref="imageCrop"
+      :initial-crop="props.defaultRatio"
       :image="image"
       :stage-config="stageConfig"
       :width="mapWidth"
@@ -88,6 +89,7 @@ import ImageCrop from './ImageEditor/ImageCrop.vue'
 
 const props = defineProps<{
   asset: TaggedAIAssetData<AssetType.Backdrop>
+  defaultRatio: number
 }>()
 
 const backdrop = useAsyncComputed<Backdrop | undefined>(() => {
@@ -107,7 +109,7 @@ const layer = ref<Konva.Layer>()
 const nodeRef = ref<KonvaNode<Konva.Image>>()
 const node = computed(() => nodeRef.value?.getNode())
 
-const editMode = ref<'resize' | 'crop' | 'preview'>('preview')
+const editMode = ref<'resize' | 'crop' | 'preview'>('crop')
 
 const imageResize = ref<InstanceType<typeof ImageResize> | null>(null)
 const imageCrop = ref<InstanceType<typeof ImageCrop> | null>(null)


### PR DESCRIPTION

## Changes
- get project stage aspect ratio from project
- set default edit mode to 'crop' when selecting backdrop image
- set crop handlers to project stage aspect ratio and center the crop box

![Peek 2024-09-09 17-37](https://github.com/user-attachments/assets/f2592f18-7f8a-46b4-8d7d-35ed0a0904d5)
