### PR TITLE
fix: update correct category select presets for backdrop and sound asset

### DIFF
--- a/spx-gui/src/components/asset/library/AssetLibrary.vue
+++ b/spx-gui/src/components/asset/library/AssetLibrary.vue
@@ -64,7 +64,7 @@
         <LibraryMenu @update:value="handleUserSelectCategory" />
         <UIDivider />
         <LibraryTree
-          :type="type"
+          :type="assetType"
           style="flex: 1 1 0%; overflow: auto; scrollbar-width: thin"
         />
       </div>
@@ -92,7 +92,7 @@
   </div>
 </template>
 <script setup lang="ts">
-import { computed, ref, shallowRef, watch } from 'vue'
+import { computed, ref, shallowRef, watch, watchEffect } from 'vue'
 import { UITextInput, UIIcon, UIModalClose, UIDivider } from '@/components/ui'
 import { AssetType, getAssetSearchSuggestion, type AssetData } from '@/apis/asset'
 import { debounce, useAsyncComputed } from '@/utils/utils'
@@ -154,12 +154,18 @@ const searchInput = ref('')
 const searchCtx = useSearchCtx()
 const searchResultCtx = useSearchResultCtx()
 const entityMessage = computed(() => entityMessages[searchCtx.type])
-const type = ref(searchCtx.type) //just for display
+
+const assetType = ref(searchCtx.type ?? AssetType.Sprite)
+watchEffect(() => {
+    assetType.value = searchCtx.type
+})
 
 const suggestions = useAsyncComputed(async () => {
   return (await getAssetSearchSuggestion(searchCtx.keyword)).suggestions
 })
-const suggestionsOptions = computed(() => suggestions.value?.map((s) => ({ label: s, value: s })) ?? [])
+const suggestionsOptions = computed(
+  () => suggestions.value?.map((s) => ({ label: s, value: s })) ?? []
+)
 
 // do search (with a delay) when search-input changed
 watch(

--- a/spx-gui/src/components/asset/library/LibraryTree.vue
+++ b/spx-gui/src/components/asset/library/LibraryTree.vue
@@ -12,7 +12,7 @@
 </template>
 
 <script setup lang="ts">
-import { h, ref, watch } from 'vue'
+import { computed, h, ref, watch } from 'vue'
 import type { TreeOption } from 'naive-ui'
 import { categories, type Category } from './category'
 import { type LocaleMessage, useI18n } from '@/utils/i18n'
@@ -41,7 +41,7 @@ function createData(categories: Category[], t: (key: LocaleMessage) => string): 
             {
               color: 'var(--text-color)',
               style: {
-                paddingRight: '10px',
+                paddingRight: '10px'
               }
             },
             {
@@ -62,12 +62,8 @@ function createData(categories: Category[], t: (key: LocaleMessage) => string): 
 }
 
 const { t } = useI18n()
-const data = ref<TreeOption[]>(
-  createData(
-    categories.find((category) => category.value === AssetType[props.type].toLowerCase())
-      ?.children!,
-    t
-  )
+const data = computed<TreeOption[]>(() =>
+  createData(categories.find((category) => category.type === props.type)?.children!, t)
 )
 
 watch(

--- a/spx-gui/src/components/asset/library/category.ts
+++ b/spx-gui/src/components/asset/library/category.ts
@@ -1,6 +1,8 @@
+import { AssetType } from '@/apis/asset'
 import type { LocaleMessage } from '@/utils/i18n'
 
 export type Category = {
+  type?: AssetType
   value: string
   message: LocaleMessage
   children?: Category[]
@@ -8,6 +10,7 @@ export type Category = {
 
 export const categories: Category[] = [
   {
+    type: AssetType.Sprite,
     value: 'sprite',
     message: { en: 'Sprite', zh: '精灵' },
     children: [
@@ -58,6 +61,7 @@ export const categories: Category[] = [
     ]
   },
   {
+    type: AssetType.Backdrop,
     value: 'backdrop',
     message: { en: 'Backdrop', zh: '背景' },
     children: [
@@ -108,6 +112,7 @@ export const categories: Category[] = [
     ]
   },
   {
+    type: AssetType.Sound,
     value: 'sound',
     message: { en: 'Sound', zh: '音频' },
     children: [


### PR DESCRIPTION
- Update the way to match the correct category presets.
- Let the tree select component to be reactive to current asset type.
- Now the backdrop and sound asset library could show the correct category select presets.