### PR TITLE
fix`WASM Compiler`: fix some details.

### DIFF
--- a/tools/compiler/internal/base.go
+++ b/tools/compiler/internal/base.go
@@ -159,7 +159,7 @@ func GetTokensDetail(tokenMap []TokenID) (interface{}, error) {
 		} else {
 			pkg, ok := gopbuild.LookupPackageFromLib(tok.TokenPkg)
 			if !ok {
-				return nil, fmt.Errorf("can't find lib %s", tok.TokenPkg)
+				continue
 			}
 			pkgMap[tok.TokenPkg] = pkg
 			detailList = append(detailList, tokenDetail(pkg, tok.TokenName))

--- a/tools/compiler/internal/base.go
+++ b/tools/compiler/internal/base.go
@@ -152,7 +152,7 @@ func GetTokensDetail(tokenMap []TokenID) (interface{}, error) {
 		return nil, fmt.Errorf("can't find spx lib")
 	}
 	pkgMap["github.com/goplus/spx"] = spxPrepare
-	var detailList []definitionItem
+	var detailList []baseToken
 	for _, tok := range tokenMap {
 		if pkg, ok := pkgMap[tok.TokenPkg]; ok {
 			detailList = append(detailList, tokenDetail(pkg, tok.TokenName))

--- a/tools/compiler/internal/completion.go
+++ b/tools/compiler/internal/completion.go
@@ -169,23 +169,40 @@ func getScopesItems(fileName string, fileMap map[string]string, line, column int
 	}
 	file := pkg[PKG].Files[fileName]
 
-	cursorOffset := int(fset.File(file.Pos()).LineStart(line)) + column - 1
+	fileObj := fset.File(file.Pos())
+	cursorOffset := int(fileObj.LineStart(line)) + column - 1
+	totalLine := fileObj.LineCount()
+
+	if line+1 <= totalLine {
+		nextLineOffset := int(fileObj.LineStart(line + 1))
+		if cursorOffset > nextLineOffset {
+			cursorOffset = int(fileObj.LineStart(line))
+		}
+	}
+
 	cursorPos := token.Pos(cursorOffset)
 
 	ctx := igop.NewContext(0)
 	gopCtx := gopbuild.NewContext(ctx)
-	conf := &types.Config{Importer: gopCtx}
+	conf := &types.Config{}
+	conf.Importer = gopCtx
 	chkOpts := initTypeConfig(file, fset)
 
 	info := initTypeInfo()
 	checker := typesutil.NewChecker(conf, chkOpts, nil, info)
-	if err = checker.Files(nil, []*ast.File{file}); err != nil {
+
+	var files []*ast.File
+	for _, f := range pkg[PKG].Files {
+		files = append(files, f)
+	}
+
+	if err = checker.Files(nil, files); err != nil {
 		fmt.Println("Compiler error: ", err)
 	}
 
 	items := &completionList{}
 
-	smallScopes := findSmallestScopesAtPosition(info, cursorPos)
+	smallScopes := findSmallestScopesAtPosition(info, cursorPos, fset)
 	for _, scope := range smallScopes {
 		traverseToRoot(scope, items, info)
 	}
@@ -193,7 +210,7 @@ func getScopesItems(fileName string, fileMap map[string]string, line, column int
 	return *items, nil
 }
 
-func findSmallestScopesAtPosition(info *typesutil.Info, pos token.Pos) []*types.Scope {
+func findSmallestScopesAtPosition(info *typesutil.Info, pos token.Pos, fset *token.FileSet) []*types.Scope {
 	var scopeList []*types.Scope
 	var smallList []*types.Scope
 
@@ -204,6 +221,11 @@ func findSmallestScopesAtPosition(info *typesutil.Info, pos token.Pos) []*types.
 	}
 
 	if len(scopeList) == 0 {
+		for _, scope := range info.Scopes {
+			if strings.Contains(scope.String(), fset.Position(pos).Filename) {
+				return []*types.Scope{scope}
+			}
+		}
 		return nil
 	}
 
@@ -297,15 +319,14 @@ func handleFunc(obj types.Object, name string, items *completionList) {
 func handleType(obj types.Object, name string, items *completionList) {
 	if structType, ok := obj.Type().Underlying().(*types.Struct); ok {
 		for i := 0; i < structType.NumFields(); i++ {
-			if structType.Field(i).Type().String() != "*github.com/goplus/spx.Game" {
+			if structType.Field(i).Type().String() != "github.com/goplus/spx.Game" {
 				continue
 			}
-			pointer, ok := structType.Field(i).Type().(*types.Pointer)
-			if ok {
-				stru, ok := pointer.Elem().Underlying().(*types.Struct)
-				if ok {
-					structMethodsToCompletion(stru, items)
-				}
+			if gameStruct, ok := structType.Field(i).Type().Underlying().(*types.Struct); ok {
+				structMethodsToCompletion(gameStruct, items)
+			}
+			if gameNamed, ok := structType.Field(i).Type().(*types.Named); ok {
+				extractMethodsFromNamed(gameNamed, items, false)
 			}
 		}
 		if checkFieldExist(structType, "github.com/goplus/spx.Sprite") {
@@ -313,32 +334,7 @@ func handleType(obj types.Object, name string, items *completionList) {
 		}
 	}
 	if named, ok := obj.Type().(*types.Named); ok {
-		for i := 0; i < named.NumMethods(); i++ {
-			method := named.Method(i)
-			if method.Name() == "Main" || method.Name() == "Classfname" {
-				continue
-			}
-			item := &completionItem{
-				Label: method.Name(),
-				Type:  "func",
-				TokenID: TokenID{
-					TokenName: method.Name(),
-					TokenPkg:  method.Pkg().Path(),
-				},
-			}
-			signature := method.Type().(*types.Signature)
-			signList, sampleList, _ := extractParams(signature)
-			if listContains(sampleList, "__gop_overload_args__") {
-				continue
-			}
-			item.InsertText = name
-			if len(signList) != 0 {
-				item.InsertText += " " + strings.Join(signList, ", ")
-			}
-			if !items.Contains(item.InsertText) {
-				*items = append(*items, item)
-			}
-		}
+		extractMethodsFromNamed(named, items, true)
 	}
 }
 
@@ -366,33 +362,36 @@ func structMethodsToCompletion(structType *types.Struct, items *completionList) 
 		if !ok {
 			continue
 		}
+		extractMethodsFromNamed(named, items, false)
+	}
+}
 
-		for i := 0; i < named.NumMethods(); i++ {
-			method := named.Method(i)
-			if !method.Exported() {
-				continue
-			}
-			methodName, _ := convertOverloadToSimple(method.Name())
-			item := &completionItem{
-				Label: methodName,
-				Type:  "func",
-				TokenID: TokenID{
-					TokenName: methodName,
-					TokenPkg:  method.Pkg().Path(),
-				},
-			}
-			signature := method.Type().(*types.Signature)
-			signList, sampleList, _ := extractParams(signature)
-			if listContains(sampleList, "__gop_overload_args__") {
-				continue
-			}
-			item.InsertText = methodName
-			if len(signList) != 0 {
-				item.InsertText += " " + strings.Join(signList, ", ")
-			}
-			if !items.Contains(item.InsertText) {
-				*items = append(*items, item)
-			}
+func extractMethodsFromNamed(named *types.Named, items *completionList, export bool) {
+	for i := 0; i < named.NumMethods(); i++ {
+		method := named.Method(i)
+		if method.Exported() == export || method.Name() == "Main" || method.Name() == "Classfname" {
+			continue
+		}
+		methodName, _ := convertOverloadToSimple(method.Name())
+		item := &completionItem{
+			Label: methodName,
+			Type:  "func",
+			TokenID: TokenID{
+				TokenName: methodName,
+				TokenPkg:  method.Pkg().Path(),
+			},
+		}
+		signature := method.Type().(*types.Signature)
+		signList, sampleList, _ := extractParams(signature)
+		if listContains(sampleList, "__gop_overload_args__") {
+			continue
+		}
+		item.InsertText = methodName
+		if len(signList) != 0 {
+			item.InsertText += " " + strings.Join(signList, ", ")
+		}
+		if !items.Contains(item.InsertText) {
+			*items = append(*items, item)
 		}
 	}
 }

--- a/tools/compiler/internal/definition.go
+++ b/tools/compiler/internal/definition.go
@@ -13,12 +13,16 @@ import (
 
 type definitionItem struct {
 	BasePos
+	baseToken
+	From BasePos `json:"from"`
+}
+
+type baseToken struct {
 	PkgName    string  `json:"pkgName"`
 	PkgPath    string  `json:"pkgPath"`
 	Name       string  `json:"name"`   // This is the token name
 	Usages     []usage `json:"usages"` // contains 1 or n usage for matches.
 	StructName string  `json:"structName"`
-	From       BasePos
 }
 
 type usage struct {
@@ -151,9 +155,11 @@ func createDefinitionItem(ident *ast.Ident, obj types.Object) *definitionItem {
 			StartPos: int(ident.Pos()),
 			EndPos:   int(ident.End()),
 		},
-		PkgName: obj.Pkg().Name(),
-		PkgPath: obj.Pkg().Path(),
-		Name:    ident.Name,
+		baseToken: baseToken{
+			PkgName: obj.Pkg().Name(),
+			PkgPath: obj.Pkg().Path(),
+			Name:    ident.Name,
+		},
 	}
 	if fn, ok := obj.(*types.Func); ok {
 		sign := fn.Type().(*types.Signature)
@@ -241,10 +247,10 @@ func findDef(defs map[*ast.Ident]types.Object, obj types.Object) (int, int) {
 	return 0, 0
 }
 
-func tokenDetail(pkg *types.Package, token string) definitionItem {
+func tokenDetail(pkg *types.Package, token string) baseToken {
 	names := pkg.Scope().Names()
 
-	definitionItem := definitionItem{
+	definitionItem := baseToken{
 		PkgName: pkg.Name(),
 		PkgPath: pkg.Path(),
 		Name:    token,

--- a/tools/compiler/internal/diagnostics.go
+++ b/tools/compiler/internal/diagnostics.go
@@ -8,7 +8,7 @@ import (
 
 // diagnostics contains error after analyse the code.
 type diagnostics struct {
-	FileName string `json:"fileName"`
+	FileName string `json:"filename"`
 	Column   int    `json:"column"`
 	Line     int    `json:"line"`
 	Message  string `json:"message"`

--- a/tools/compiler/js.go
+++ b/tools/compiler/js.go
@@ -54,8 +54,8 @@ func jsValue2List(value js.Value) (result []internal.TokenID) {
 	for i := range value.Length() {
 		elem := value.Index(i)
 		token := internal.TokenID{
-			TokenName: elem.Get("TokenName").String(),
-			TokenPkg:  elem.Get("TokenPkg").String(),
+			TokenName: elem.Get("name").String(),
+			TokenPkg:  elem.Get("module").String(),
 		}
 		result = append(result, token)
 	}
@@ -97,9 +97,9 @@ func getCompletionItems(this js.Value, p []js.Value) interface{} {
 }
 
 func getTokenDetail(this js.Value, p []js.Value) interface{} {
-	tokenName := p[0].String()
-	pkgPath := p[1].String()
-	return internal.NewReply(internal.GetTokenDetail(tokenName, pkgPath))
+	name := p[0].String()
+	module := p[1].String()
+	return internal.NewReply(internal.GetTokenDetail(name, module))
 }
 
 func getTokensDetail(this js.Value, p []js.Value) interface{} {

--- a/tools/compiler/js.go
+++ b/tools/compiler/js.go
@@ -55,7 +55,7 @@ func jsValue2List(value js.Value) (result []internal.TokenID) {
 		elem := value.Index(i)
 		token := internal.TokenID{
 			TokenName: elem.Get("name").String(),
-			TokenPkg:  elem.Get("module").String(),
+			TokenPkg:  elem.Get("pkgPath").String(),
 		}
 		result = append(result, token)
 	}
@@ -65,30 +65,35 @@ func jsValue2List(value js.Value) (result []internal.TokenID) {
 // Functions following below is the entry functions for js.
 
 func getInlayHints(this js.Value, p []js.Value) interface{} {
+	defer handlePanic()
 	fileName := p[0].String()
 	fileMap := p[1]
 	return internal.NewReply(internal.GetInlayHint(fileName, jsValue2Map(fileMap)))
 }
 
 func getDiagnostics(this js.Value, p []js.Value) interface{} {
+	defer handlePanic()
 	fileName := p[0].String()
 	fileMap := p[1]
 	return internal.NewReply(internal.GetDiagnostics(fileName, jsValue2Map(fileMap)))
 }
 
 func getDefinition(this js.Value, p []js.Value) interface{} {
+	defer handlePanic()
 	fileName := p[0].String()
 	fileMap := p[1]
 	return internal.NewReply(internal.GetDefinition(fileName, jsValue2Map(fileMap)))
 }
 
 func getTypes(this js.Value, p []js.Value) interface{} {
+	defer handlePanic()
 	fileName := p[0].String()
 	fileMap := p[1]
 	return internal.NewReply(internal.GetSPXFileType(fileName, jsValue2Map(fileMap)))
 }
 
 func getCompletionItems(this js.Value, p []js.Value) interface{} {
+	defer handlePanic()
 	fileName := p[0].String()
 	fileMap := p[1]
 	cursorLine := p[2].Int()
@@ -97,12 +102,14 @@ func getCompletionItems(this js.Value, p []js.Value) interface{} {
 }
 
 func getTokenDetail(this js.Value, p []js.Value) interface{} {
+	defer handlePanic()
 	name := p[0].String()
-	module := p[1].String()
-	return internal.NewReply(internal.GetTokenDetail(name, module))
+	pkgPath := p[1].String()
+	return internal.NewReply(internal.GetTokenDetail(name, pkgPath))
 }
 
 func getTokensDetail(this js.Value, p []js.Value) interface{} {
+	defer handlePanic()
 	tokens := p[0]
 	return internal.NewReply(internal.GetTokensDetail(jsValue2List(tokens)))
 }

--- a/tools/compiler/main.go
+++ b/tools/compiler/main.go
@@ -8,12 +8,17 @@ import (
 
 // wasm entry
 func main() {
-	// make channel
-	c := make(chan struct{})
+	defer handlePanic()
 
 	fmt.Println("WASM Init")
 	// js functions
 	jsFuncRegister()
 
-	<-c
+	select {}
+}
+
+func handlePanic() {
+	if r := recover(); r != nil {
+		fmt.Println("Recovered from panic: ", r)
+	}
 }

--- a/tools/compiler/static/parent.html
+++ b/tools/compiler/static/parent.html
@@ -227,9 +227,15 @@ onStart => {
                 in: {
                     tokens: [
                         {
-                            TokenName:"step",
-                            TokenPkg:"github.com/goplus/spx"
-                        }
+                            name:"step",
+                            pkgPath:"github.com/goplus/spx"
+                        },{
+                            name:"play",
+                            pkgPath:"github.com/goplus/spx"
+                        },{
+                            name:"onStart",
+                            pkgPath:"github.com/goplus/spx"
+                        },
                     ]
                 }
             })


### PR DESCRIPTION
fix: fix the bug of can't use the completion items in the end empty lines of file.

fix: fix get token details parameter names.

fix: split the baseToken struct from definition item struct.

fix: extract function `extractMethodsFromNamed`.