### PR TITLE
fix`WASM Compiler`: fix some bugs.

### DIFF
--- a/tools/compiler/internal/base.go
+++ b/tools/compiler/internal/base.go
@@ -21,7 +21,13 @@ func GetDiagnostics(fileName string, fileMap map[string]string) (interface{}, er
 	}
 	_, err = codeInfo(pkg[PKG].Files[fileName], fset, pkg)
 	list := parseErrorLines(error2List(err))
-	return list, nil
+	filter := []diagnostics{}
+	for _, item := range list {
+		if item.FileName == fileName {
+			filter = append(filter, item)
+		}
+	}
+	return filter, nil
 }
 
 // GetDefinition return user's code definition.
@@ -38,8 +44,13 @@ func GetDefinition(fileName string, fileMap map[string]string) (interface{}, err
 	}
 	definitionList := getDefinitionList(info)
 	definitionList.Position(fset)
-
-	return definitionList, nil
+	filter := definitions{}
+	for _, item := range definitionList {
+		if item.StartPosition.Filename == fileName {
+			filter = append(filter, item)
+		}
+	}
+	return filter, nil
 }
 
 // GetSPXFileType return a json object with spx type info.
@@ -124,7 +135,14 @@ func GetInlayHint(currentFileName string, fileMap map[string]string) (interface{
 		}
 	}
 
-	return inlayHintList, nil
+	filter := []*inlayHint{}
+	for _, item := range inlayHintList {
+		if item.StartPosition.Filename == currentFileName {
+			filter = append(filter, item)
+		}
+	}
+
+	return filter, nil
 }
 
 func GetCompletions(fileName string, fileMap map[string]string, line, column int) (interface{}, error) {

--- a/tools/compiler/internal/completion.go
+++ b/tools/compiler/internal/completion.go
@@ -276,7 +276,12 @@ func handleThis(obj types.Object, name string, items *completionList) {
 	}
 
 	structMethodsToCompletion(structType, items)
-	// TODO: fields of struct
+
+	named, ok := variable.Type().Underlying().(*types.Pointer).Elem().(*types.Named)
+	if !ok {
+		return
+	}
+	extractMethodsFromNamed(named, items, false)
 }
 
 func handleFunc(obj types.Object, name string, items *completionList) {
@@ -311,6 +316,7 @@ func handleFunc(obj types.Object, name string, items *completionList) {
 func handleType(obj types.Object, name string, items *completionList) {
 	if structType, ok := obj.Type().Underlying().(*types.Struct); ok {
 		for i := 0; i < structType.NumFields(); i++ {
+			handleFunc(structType.Field(i), structType.Field(i).Name(), items)
 			if structType.Field(i).Type().String() != "github.com/goplus/spx.Game" {
 				continue
 			}

--- a/tools/compiler/internal/completion.go
+++ b/tools/compiler/internal/completion.go
@@ -244,7 +244,6 @@ func checkScopeChildrenContainsPos(scope *types.Scope, pos token.Pos) bool {
 }
 
 func traverseToRoot(scope *types.Scope, items *completionList, info *typesutil.Info) {
-	fmt.Println(scope)
 	for _, name := range scope.Names() {
 		obj := scope.Lookup(name)
 		handleScopeItem(obj, name, items)
@@ -259,7 +258,6 @@ func handleScopeItem(obj types.Object, name string, items *completionList) {
 	if name == "this" {
 		handleThis(obj, name, items)
 	}
-	handleStruct(obj.Type(), name, items)
 	addCompletionItem(obj, name, items)
 }
 
@@ -278,6 +276,9 @@ func handleStruct(T types.Type, name string, items *completionList) {
 		}
 		if stru.Field(i).Exported() {
 			addCompletionItem(stru.Field(i), name, items)
+		}
+		if stru.Field(i).Pkg().Path() == PKG {
+			addCompletionItem(stru.Field(i), stru.Field(i).Name(), items)
 		}
 	}
 	extractMethodsFromNamed(named, items, false)

--- a/tools/compiler/internal/completion.go
+++ b/tools/compiler/internal/completion.go
@@ -256,7 +256,7 @@ func traverseToRoot(scope *types.Scope, items *completionList, info *typesutil.I
 
 func handleObject(obj types.Object, name string, items *completionList) {
 	handleThis(obj, name, items)
-	handleFunc(obj, name, items)
+	handleStruct(obj, name, items)
 	handleType(obj, name, items)
 }
 
@@ -276,15 +276,9 @@ func handleThis(obj types.Object, name string, items *completionList) {
 	}
 
 	structMethodsToCompletion(structType, items)
-
-	named, ok := variable.Type().Underlying().(*types.Pointer).Elem().(*types.Named)
-	if !ok {
-		return
-	}
-	extractMethodsFromNamed(named, items, false)
 }
 
-func handleFunc(obj types.Object, name string, items *completionList) {
+func handleStruct(obj types.Object, name string, items *completionList) {
 	scopeItem := &completionItem{
 		Label: name,
 		Type:  obj.Type().String(),
@@ -316,7 +310,7 @@ func handleFunc(obj types.Object, name string, items *completionList) {
 func handleType(obj types.Object, name string, items *completionList) {
 	if structType, ok := obj.Type().Underlying().(*types.Struct); ok {
 		for i := 0; i < structType.NumFields(); i++ {
-			handleFunc(structType.Field(i), structType.Field(i).Name(), items)
+			handleStruct(structType.Field(i), structType.Field(i).Name(), items)
 			if structType.Field(i).Type().String() != "github.com/goplus/spx.Game" {
 				continue
 			}

--- a/tools/compiler/internal/completion.go
+++ b/tools/compiler/internal/completion.go
@@ -244,9 +244,10 @@ func checkScopeChildrenContainsPos(scope *types.Scope, pos token.Pos) bool {
 }
 
 func traverseToRoot(scope *types.Scope, items *completionList, info *typesutil.Info) {
+	fmt.Println(scope)
 	for _, name := range scope.Names() {
 		obj := scope.Lookup(name)
-		handleObject(obj, name, items)
+		handleScopeItem(obj, name, items)
 	}
 
 	if scope.Parent() != nil {
@@ -254,31 +255,47 @@ func traverseToRoot(scope *types.Scope, items *completionList, info *typesutil.I
 	}
 }
 
-func handleObject(obj types.Object, name string, items *completionList) {
-	handleThis(obj, name, items)
-	handleStruct(obj, name, items)
-	handleType(obj, name, items)
+func handleScopeItem(obj types.Object, name string, items *completionList) {
+	if name == "this" {
+		handleThis(obj, name, items)
+	}
+	handleStruct(obj.Type(), name, items)
+	addCompletionItem(obj, name, items)
+}
+
+func handleStruct(T types.Type, name string, items *completionList) {
+	if pointer, ok := T.Underlying().(*types.Pointer); ok {
+		handleStruct(pointer.Elem(), name, items)
+	}
+	stru, ok := T.Underlying().(*types.Struct)
+	if !ok {
+		return
+	}
+	named := T.(*types.Named)
+	for i := range stru.NumFields() {
+		if stru.Field(i).Embedded() {
+			handleStruct(stru.Field(i).Type(), name, items)
+		}
+		if stru.Field(i).Exported() {
+			addCompletionItem(stru.Field(i), name, items)
+		}
+	}
+	extractMethodsFromNamed(named, items, false)
 }
 
 func handleThis(obj types.Object, name string, items *completionList) {
-	if name != "this" {
-		return
-	}
-
 	variable, ok := obj.(*types.Var)
 	if !ok {
 		return
 	}
-
-	structType, ok := variable.Type().Underlying().(*types.Pointer).Elem().Underlying().(*types.Struct)
+	pointer, ok := variable.Type().Underlying().(*types.Pointer)
 	if !ok {
 		return
 	}
-
-	structMethodsToCompletion(structType, items)
+	handleStruct(pointer.Elem(), name, items)
 }
 
-func handleStruct(obj types.Object, name string, items *completionList) {
+func addCompletionItem(obj types.Object, name string, items *completionList) {
 	scopeItem := &completionItem{
 		Label: name,
 		Type:  obj.Type().String(),
@@ -307,29 +324,6 @@ func handleStruct(obj types.Object, name string, items *completionList) {
 	}
 }
 
-func handleType(obj types.Object, name string, items *completionList) {
-	if structType, ok := obj.Type().Underlying().(*types.Struct); ok {
-		for i := 0; i < structType.NumFields(); i++ {
-			handleStruct(structType.Field(i), structType.Field(i).Name(), items)
-			if structType.Field(i).Type().String() != "github.com/goplus/spx.Game" {
-				continue
-			}
-			if gameStruct, ok := structType.Field(i).Type().Underlying().(*types.Struct); ok {
-				structMethodsToCompletion(gameStruct, items)
-			}
-			if gameNamed, ok := structType.Field(i).Type().(*types.Named); ok {
-				extractMethodsFromNamed(gameNamed, items, false)
-			}
-		}
-		if checkFieldExist(structType, "github.com/goplus/spx.Sprite") {
-			structMethodsToCompletion(structType, items)
-		}
-	}
-	if named, ok := obj.Type().(*types.Named); ok {
-		extractMethodsFromNamed(named, items, true)
-	}
-}
-
 func listContains(signList []string, target string) bool {
 	for _, s := range signList {
 		if s == target {
@@ -339,35 +333,19 @@ func listContains(signList []string, target string) bool {
 	return false
 }
 
-func checkFieldExist(structType *types.Struct, field string) bool {
-	for i := range structType.NumFields() {
-		if structType.Field(i).Type().String() == field {
-			return true
-		}
-	}
-	return false
-}
-
-func structMethodsToCompletion(structType *types.Struct, items *completionList) {
-	for i := 0; i < structType.NumFields(); i++ {
-		named, ok := structType.Field(i).Type().(*types.Named)
-		if !ok {
-			continue
-		}
-		extractMethodsFromNamed(named, items, false)
-	}
-}
-
-func extractMethodsFromNamed(named *types.Named, items *completionList, export bool) {
+func extractMethodsFromNamed(named *types.Named, items *completionList, ignoreExport bool) {
 	for i := 0; i < named.NumMethods(); i++ {
 		method := named.Method(i)
 		if method.Name() == "Main" || method.Name() == "Classfname" {
 			continue
 		}
-		if export || !method.Exported() {
+		if !ignoreExport && !method.Exported() {
 			continue
 		}
 		methodName, _ := convertOverloadToSimple(method.Name())
+		if method.Pkg().Path() != "github.com/goplus/spx" {
+			methodName = method.Name()
+		}
 		item := &completionItem{
 			Label: methodName,
 			Type:  "func",

--- a/tools/compiler/internal/definition.go
+++ b/tools/compiler/internal/definition.go
@@ -201,7 +201,9 @@ func createDefinitionItem(ident *ast.Ident, obj types.Object) *definitionItem {
 // createUsages creates a slice of usage based on the type of obj.
 func createUsages(obj types.Object, name string) []usage {
 	switch t := obj.Type().(type) {
-	case *types.Basic:
+	case *types.Signature:
+		return []usage{createSignatureUsage(obj, t)}
+	default:
 		return []usage{{
 			UsageID:     "0",
 			Declaration: obj.String(),
@@ -210,11 +212,6 @@ func createUsages(obj types.Object, name string) []usage {
 			Params:      []param{},
 			Type:        t.String(),
 		}}
-	case *types.Signature:
-		return []usage{createSignatureUsage(obj, t)}
-	default:
-		// TODO: Handle other types.
-		return []usage{}
 	}
 }
 

--- a/tools/compiler/static/parent.html
+++ b/tools/compiler/static/parent.html
@@ -23,6 +23,27 @@ func add(a,b int) int {
     return a + b + c
 }
 
+type sA struct{
+    sC sC
+    sD
+    sP *sP
+}
+
+type sC struct{
+    ca int
+    cb int
+}
+
+type sD struct{
+    da int
+    db int
+}
+
+type sP struct{
+    pa int
+    pb int
+}
+
 onStart => {
     varBlockA01 = 1
     varBlockB01 = 1

--- a/tools/compiler/static/parent.html
+++ b/tools/compiler/static/parent.html
@@ -24,7 +24,12 @@ func add(a,b int) int {
 }
 
 onStart => {
+    varBlockA01 = 1
+    varBlockB01 = 1
+    varBlockC01 = 1
+    normalVar01 = 1
     Hi()
+    t.x = 1
     play "sound1"
     flag := true
     sum := add(1,2)
@@ -48,9 +53,28 @@ onStart => {
     </textarea>
 
     <textarea id="mainCode" style="width: 400px;height: 100px">
-        func Hi() string {
-            return "Hi"
-        }
+var (
+    varBlockA01 int
+    varBlockA02 int
+)
+
+var (
+    varBlockB01 int
+    varBlockB02 int
+)
+
+var (
+    varBlockC01 int
+    varBlockC02 int
+)
+
+var normalVar01 int
+
+var t *test
+
+func Hi() string {
+    return "Hi"
+}
     </textarea>
 
     <br>


### PR DESCRIPTION
- fix: fix can't get the definition of var block.

- fix: fix the bug of hover out nothing.

- fix: change the way of get completion items.

- feat: add a filter to make sure only return current file's info(diagnostics, inlay hint, definitions).