### PR TITLE
fix`WASM Compiler`: fix from #913 comment.

### DIFF
--- a/tools/compiler/internal/base.go
+++ b/tools/compiler/internal/base.go
@@ -146,7 +146,7 @@ func GetInlayHint(currentFileName string, fileMap map[string]string) (interface{
 }
 
 func GetCompletions(fileName string, fileMap map[string]string, line, column int) (interface{}, error) {
-	list, err := getScopesItems(fileName, fileMap, line, column)
+	list, err := getCompletionItems(fileName, fileMap, line, column)
 	if err != nil {
 		fmt.Println("Internal error: ", err)
 	}

--- a/tools/compiler/internal/completion.go
+++ b/tools/compiler/internal/completion.go
@@ -161,7 +161,7 @@ func (list *completionList) Contains(text string) bool {
 	return false
 }
 
-func getScopesItems(fileName string, fileMap map[string]string, line, column int) (completionList, error) {
+func getCompletionItems(fileName string, fileMap map[string]string, line, column int) (completionList, error) {
 	fset := token.NewFileSet()
 	pkg, err := initProjectParser(fset, fileMap)
 	if err != nil {
@@ -195,7 +195,7 @@ func getScopesItems(fileName string, fileMap map[string]string, line, column int
 	selector, find := getSelector(file, cursorPos)
 	if find {
 		selectorInfoGetter(info, selector, items)
-		if items != nil {
+		if len(*items) != 0 {
 			return *items, nil
 		}
 	}


### PR DESCRIPTION
fix: rename `getScopesItems` -> `getCompletionItems`.

fix: fix wrong if statement.