### PR TITLE
fix(spx-gui): fix new exits bugs

### DIFF
--- a/spx-gui/src/components/editor/code-editor/chat-bot.ts
+++ b/spx-gui/src/components/editor/code-editor/chat-bot.ts
@@ -76,14 +76,14 @@ export class ChatBot {
   private i18nInputWithAction(input: string, action: ChatAction): string {
     switch (action) {
       case ChatAction.explain:
-        return this.i18n.t({ en: 'Explain the code: ', zh: '解释一下这段代码: ' }) + '\n```gop  \n' + input + '\n```'
+        return this.i18n.t({ en: 'Explain the code: ', zh: '解释一下这段代码: ' }) + input
       case ChatAction.comment:
         return (
-          this.i18n.t({ en: 'I want to comment the code: ', zh: '我想给这段代码写注释: ' }) + '\n```gop  \n' + input + '\n```'
+          this.i18n.t({ en: 'I want to comment the code: ', zh: '我想给这段代码写注释: ' }) + input
         )
       case ChatAction.fixCode:
         return (
-          this.i18n.t({ en: 'I want to fix the code: ', zh: '帮我修复这段代码的问题: ' }) + '\n```gop  \n' + input + '\n```'
+          this.i18n.t({ en: 'I want to fix the code: ', zh: '帮我修复这段代码的问题: ' }) + input
         )
     }
     return ''
@@ -112,7 +112,7 @@ export class Chat {
     messages: [],
     length: 0,
     loading: true,
-    currentQuestion: "",
+    currentQuestion: '',
     responseError: false
   })
 
@@ -163,12 +163,12 @@ export class Chat {
     this.chatState.length++
     this.chatState.loading = false
     this.chatState.currentQuestion = msg
-    if(res.respMessage == "") {
+    if (res.respMessage == '') {
       this.chatState.responseError = true
       return false
     }
     const content = res.respMessage
-    
+
     const questions = res.respQuestions
     const assistantMessage: ChatMessage = {
       content: content,

--- a/spx-gui/src/components/editor/code-editor/compiler.ts
+++ b/spx-gui/src/components/editor/code-editor/compiler.ts
@@ -1,3 +1,5 @@
+// todo: refactor this into webWorker
+
 import compilerWasmHtml from '@/assets/compiler/index.html?raw'
 import compilerWasm from '@/assets/compiler/main.wasm?url'
 import compilerWasmExec from '@/assets/wasm_exec.js?url'

--- a/spx-gui/src/components/editor/code-editor/tokens/spx.ts
+++ b/spx-gui/src/components/editor/code-editor/tokens/spx.ts
@@ -467,7 +467,7 @@ export const xpos: Token = {
       effect: 'read',
       target: 'Sprite',
       declaration: 'func() float64',
-      sample: '',
+      sample: '5',
       insertText: 'xpos'
     }
   ]

--- a/spx-gui/src/components/editor/code-editor/ui/EditorSidebar.vue
+++ b/spx-gui/src/components/editor/code-editor/ui/EditorSidebar.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { onMounted, onUnmounted, ref, shallowRef, watch } from 'vue'
+import { nextTick, onMounted, onUnmounted, ref, shallowRef, watch } from 'vue'
 import ToolItem from './ToolItem.vue'
 import IconCollapse from './icons/collapse.svg?raw'
 import IconOverview from './icons/overview.svg?raw'
@@ -63,15 +63,17 @@ function handleCategoryClick(index: number) {
   props.ui.documentDetailState.visible = false
   activeCategoryIndex.value = index
 
-  if (categoryTitleElements.value[index] && sidebarContainerElement.value) {
-    const el = categoryTitleElements.value[index]
-    const top = el.offsetTop
-    sidebarContainerElement.value.scrollTo({
-      top: top,
-      behavior: 'smooth'
-    })
-    isInCategoryClickScrollingState.value = true
-  }
+  nextTick(() => {
+    if (categoryTitleElements.value[index] && sidebarContainerElement.value) {
+      const el = categoryTitleElements.value[index]
+      const top = el.offsetTop
+      sidebarContainerElement.value.scrollTo({
+        top: top,
+        behavior: 'smooth'
+      })
+      isInCategoryClickScrollingState.value = true
+    }
+  })
 }
 
 const categoryTitleElements = ref<HTMLElement[]>([])
@@ -86,6 +88,7 @@ onBeforeUpdate(() => {
 })
 
 function handleScroll() {
+  if (props.ui.documentDetailState.visible) return
   if (!(sidebarContainerElement.value && categoryTitleElements.value.length)) return
   cancelCategoryClickScrollingState()
   const scrollTop = sidebarContainerElement.value.scrollTop
@@ -166,7 +169,7 @@ onUnmounted(() => {
     }"
     class="sidebar-container"
   >
-    <section v-if="!ui.documentDetailState.visible" class="tools-wrapper">
+    <section v-show="!ui.documentDetailState.visible" class="tools-wrapper">
       <template v-if="categories.length">
         <template v-for="(category, i) in categories" :key="i">
           <h4 :ref="(el) => setCategoryTitleRef(el as HTMLElement | null, i)" class="title">
@@ -201,7 +204,7 @@ onUnmounted(() => {
         </div>
       </template>
     </section>
-    <section v-else class="document-wrapper">
+    <section v-show="ui.documentDetailState.visible" class="document-wrapper">
       <header class="header">
         <span
           :ref="(el) => normalizeIconSize(el as Element, 28)"

--- a/spx-gui/src/components/editor/code-editor/ui/MarkdownPreview.vue
+++ b/spx-gui/src/components/editor/code-editor/ui/MarkdownPreview.vue
@@ -134,8 +134,7 @@ $markdown-code-font-family: 'JetBrains Mono NL', Consolas, 'Courier New', 'Aliba
   h4,
   h5,
   h6 {
-    margin-top: 24px;
-    margin-bottom: 16px;
+    padding-bottom: 0.3em;
     font-weight: 600;
     line-height: 1.25;
   }
@@ -237,8 +236,12 @@ $markdown-code-font-family: 'JetBrains Mono NL', Consolas, 'Courier New', 'Aliba
     background-color: #f6f8fa;
   }
 
+  & > *:first-child {
+    margin-top: 0;
+  }
+
   & > *:last-child {
-    margin-bottom: 0 !important;
+    margin-bottom: 0;
   }
 }
 

--- a/spx-gui/src/components/editor/code-editor/ui/features/completion-menu/CompletionMenuComponent.vue
+++ b/spx-gui/src/components/editor/code-editor/ui/features/completion-menu/CompletionMenuComponent.vue
@@ -3,7 +3,7 @@ import { computed, ref, watchEffect } from 'vue'
 import { type CompletionMenu, resolveSuggestMatches2Highlight } from './completion-menu'
 import EditorMenu from '../../EditorMenu.vue'
 import { determineClosestEdge, isElementInViewport } from '../../common'
-import type { Icon, LayerContent } from '@/components/editor/code-editor/EditorUI'
+import type { Action, Icon, LayerContent } from '@/components/editor/code-editor/EditorUI'
 import DocumentPreview from '@/components/editor/code-editor/ui/features/hover-preview/DocumentPreview.vue'
 import type { CompletionMenuFeatureItem } from '@/components/editor/code-editor/ui/features/completion-menu/completion'
 import AudioPreview from '@/components/editor/code-editor/ui/features/hover-preview/AudioPreview.vue'
@@ -83,6 +83,10 @@ const activeCompletionMenuItem = computed<CompletionMenuFeatureItem | null>(() =
 function handleMenuItemSelect(item: CompletionMenuItem) {
   props.completionMenu.select(item.key)
 }
+
+function handleActionClick(action: Action) {
+  action.onClick()
+}
 </script>
 
 <template>
@@ -127,6 +131,7 @@ function handleMenuItemSelect(item: CompletionMenuItem) {
         :more-actions="activeCompletionMenuItem.preview.layer.moreActions"
         :header="activeCompletionMenuItem.preview.layer.header"
         :content="activeCompletionMenuItem.preview.layer.content"
+        @action-click="handleActionClick"
       ></DocumentPreview>
       <AudioPreview
         v-else-if="activeCompletionMenuItem?.preview?.type === 'audio'"

--- a/spx-gui/src/components/editor/code-editor/ui/features/completion-menu/completion-menu.ts
+++ b/spx-gui/src/components/editor/code-editor/ui/features/completion-menu/completion-menu.ts
@@ -119,9 +119,17 @@ export class CompletionMenu implements IDisposable {
     // attention! here we intercept `fire` function to prevent global `onDidChangeBlurWidget` active
     // this is monaco inner function no need dispose manually
     const rawFireFn = this.editorWidgetFocus._onDidChangeToFalse.fire
+    // This function runs when the Monaco Editor loses focus.
+    // It starts when Monaco's own completion menu is open,
+    // and the user clicks outside any Monaco HTML element.
+    // Our custom completion menu is separate from Monaco's, so clicking it moves focus from Monaco to our menu.
+    // This function makes sure clicking our menu doesn't change the focus,
+    // so users can use the menu (like selecting items with keys or pressing 'Enter'/'Tab' to insert words) without losing focus on the editor.
+    // If our custom menu is active, we stop the normal focus loss but keep original events working.
     this.editorWidgetFocus._onDidChangeToFalse.fire = () => {
       if (this.completionMenuState.focus) {
         this.suggestControllerWidget._listElement?.firstElementChild.focus()
+        this.editor.focus()
       } else {
         rawFireFn.call(this.editorWidgetFocus._onDidChangeToFalse)
       }

--- a/spx-gui/src/components/editor/code-editor/ui/features/hover-preview/DocumentPreview.vue
+++ b/spx-gui/src/components/editor/code-editor/ui/features/hover-preview/DocumentPreview.vue
@@ -68,6 +68,7 @@ div[widgetid='editor.contrib.resizableContentHoverWidget'] {
 // for here is under body, not in #app, so can't use var(--ui-font-family-main)
 .document-preview {
   min-width: 370px;
+  max-width: 420px;
   background: white;
   border-radius: 5px;
   border: 1px solid #a6a6a6;


### PR DESCRIPTION
## Overview
this pr is about fix some new bugs
- Fix the issue with Markdown text being incorrectly displayed or garbled in the chat-bot dialog activated from inputAssistant.
- Resolve the problem where the completion menu does not correctly display documentation and fails to respond to click events in the actions area.
- Fix the issue where clicking the nav icon after displaying detailed documentation does not respond quickly and does not scroll to the correct position.
- Address the problem where focus does not fully return to the Monaco editor after clicking on linked elements in the completion menu.
- Adjust the margin issue between the first element of the Markdown Preview component and the Markdown display container.