### PR TITLE
feat(spx-gui): implement playlist icon trigger completion menu

### DIFF
--- a/spx-gui/src/components/editor/code-editor/CodeEditor.vue
+++ b/spx-gui/src/components/editor/code-editor/CodeEditor.vue
@@ -34,6 +34,7 @@ const wasmContainer = ref<HTMLIFrameElement>()
 onUnmounted(() => {
   // for vite HMR, we have to dispose editorUI when HMR triggered
   editorUI.dispose()
+  compiler.dispose()
 })
 
 watchEffect(() => {

--- a/spx-gui/src/components/editor/code-editor/EditorUI.ts
+++ b/spx-gui/src/components/editor/code-editor/EditorUI.ts
@@ -382,7 +382,7 @@ export class EditorUI extends Disposable {
           const word = model.getWordUntilPosition(position)
           const project = getProject()
           const fileHash = project.currentFilesHash || ''
-          const completionItemCacheID = {
+          const completionItemStagingID = {
             id: fileHash,
             lineNumber: position.lineNumber,
             column: word.startColumn
@@ -395,10 +395,11 @@ export class EditorUI extends Disposable {
             this.completionMenu.hideCompletionMenu()
             return { suggestions: [] }
           }
-          const stagingItems = this.completionMenu.completionStagingItem.get(completionItemCacheID)
+          const stagingItems =
+            this.completionMenu.completionStagingItem.get(completionItemStagingID)
           if (stagingItems == null) {
             const completionItems: CompletionItem[] = []
-            this.completionMenu.completionStagingItem.set(completionItemCacheID, completionItems)
+            this.completionMenu.completionStagingItem.set(completionItemStagingID, completionItems)
             const abortController = this.completionMenu.refreshAbortController()
             this.requestCompletionProviderResolve(
               model,
@@ -411,9 +412,12 @@ export class EditorUI extends Disposable {
                 if (!this.completionMenu) return console.warn('completionMenu is null')
 
                 if (this.completionMenu.completionMenuState.triggerMode.type !== 'playlist') {
-                  const isSamePosition =
-                    this.completionMenu.completionStagingItem.isSameStagingID(completionItemCacheID)
-                  if (!isSamePosition) return abortController.abort()
+                  if (
+                    !this.completionMenu.completionStagingItem.isSameStagingID(
+                      completionItemStagingID
+                    )
+                  )
+                    return abortController.abort()
                   if (this.completionMenu.abortController !== abortController) return
 
                   completionItems.push(...items)

--- a/spx-gui/src/components/editor/code-editor/EditorUI.ts
+++ b/spx-gui/src/components/editor/code-editor/EditorUI.ts
@@ -374,6 +374,7 @@ export class EditorUI extends Disposable {
 
     this.monacoProviderDisposes.completionProvider =
       monaco.languages.registerCompletionItemProvider(LANGUAGE_NAME, {
+        triggerCharacters: ['"'],
         provideCompletionItems: (model, position) => {
           if (!this.completionMenu) throw new Error('completionMenu is null')
 
@@ -386,14 +387,18 @@ export class EditorUI extends Disposable {
             lineNumber: position.lineNumber,
             column: word.startColumn
           }
-          if (!word.word) {
+          if (
+            !word.word &&
+            // sometimes token like `""` `getWordUntilPosition` is empty, but still necessary for 'playlist' to show completion menu
+            this.completionMenu.completionMenuState.triggerMode.type !== 'playlist'
+          ) {
             this.completionMenu.hideCompletionMenu()
             return { suggestions: [] }
           }
-          const cachedItems = this.completionMenu.completionItemCache.get(completionItemCacheID)
+          const cachedItems = this.completionMenu.completionStagingItem.get(completionItemCacheID)
           if (cachedItems == null) {
             const completionItems: CompletionItem[] = []
-            this.completionMenu.completionItemCache.set(completionItemCacheID, completionItems)
+            this.completionMenu.completionStagingItem.set(completionItemCacheID, completionItems)
             const abortController = this.completionMenu.refreshAbortController()
             this.requestCompletionProviderResolve(
               model,
@@ -404,14 +409,41 @@ export class EditorUI extends Disposable {
               },
               (items: CompletionItem[]) => {
                 if (!this.completionMenu) return console.warn('completionMenu is null')
-                const isSamePosition =
-                  this.completionMenu.completionItemCache.isSamePosition(completionItemCacheID)
-                if (!isSamePosition) return abortController.abort()
-                if (this.completionMenu.abortController !== abortController) return
-                completionItems.push(...items)
-                // if you need user immediately show updated completion items, we need close it and reopen it.
-                this.completionMenu.hideCompletionMenu()
-                this.completionMenu.showCompletionMenu()
+
+                if (this.completionMenu.completionMenuState.triggerMode.type !== 'playlist') {
+                  const isSamePosition =
+                    this.completionMenu.completionStagingItem.isSamePosition(completionItemCacheID)
+                  if (!isSamePosition) return abortController.abort()
+                  if (this.completionMenu.abortController !== abortController) return
+
+                  completionItems.push(...items)
+                  // if you need user immediately show updated completion items, we need close it and reopen it.
+                  this.completionMenu.hideCompletionMenu()
+                  this.completionMenu.showCompletionMenu('default')
+                } else {
+                  // using position to get word is not correct word, like: `"soundName"` => `sound`, quote will not be included
+                  // here range is from wasm `Hint` item and `type = 'mediaName'` to get correct range
+                  const range = this.completionMenu.completionMenuState.triggerMode.range
+                  if (!range) return
+
+                  // must use next render time to avoid monaco inner conflict
+                  // when selection has changed, completion menu will be self closed
+                  // here we move `hideCompletion` and `showCompletion` in same code block to avoid after showCompletion and update selection result completion menu closed
+                  setTimeout(() => {
+                    this.completionMenu?.editor.setSelection(range)
+                    this.completionMenu?.completionStagingItem.updateCacheID({
+                      id: fileHash,
+                      lineNumber: range.endLineNumber,
+                      column: range.endColumn
+                    })
+
+                    completionItems.push(...items)
+                    // if you need user immediately show updated completion items, we need close it and reopen it.
+                    this.completionMenu?.hideCompletionMenu()
+                    // for can not know when `addItems` will be called, this range will always be saved until code has been changed
+                    this.completionMenu?.showCompletionMenu('playlist', range)
+                  })
+                }
               }
             )
             return { suggestions: [] }

--- a/spx-gui/src/components/editor/code-editor/EditorUI.ts
+++ b/spx-gui/src/components/editor/code-editor/EditorUI.ts
@@ -395,8 +395,8 @@ export class EditorUI extends Disposable {
             this.completionMenu.hideCompletionMenu()
             return { suggestions: [] }
           }
-          const cachedItems = this.completionMenu.completionStagingItem.get(completionItemCacheID)
-          if (cachedItems == null) {
+          const stagingItems = this.completionMenu.completionStagingItem.get(completionItemCacheID)
+          if (stagingItems == null) {
             const completionItems: CompletionItem[] = []
             this.completionMenu.completionStagingItem.set(completionItemCacheID, completionItems)
             const abortController = this.completionMenu.refreshAbortController()
@@ -412,7 +412,7 @@ export class EditorUI extends Disposable {
 
                 if (this.completionMenu.completionMenuState.triggerMode.type !== 'playlist') {
                   const isSamePosition =
-                    this.completionMenu.completionStagingItem.isSamePosition(completionItemCacheID)
+                    this.completionMenu.completionStagingItem.isSameStagingID(completionItemCacheID)
                   if (!isSamePosition) return abortController.abort()
                   if (this.completionMenu.abortController !== abortController) return
 
@@ -449,7 +449,7 @@ export class EditorUI extends Disposable {
             return { suggestions: [] }
           } else {
             const suggestions =
-              cachedItems.map(
+              stagingItems.map(
                 (item, i): languages.CompletionItem => ({
                   label: item.label,
                   kind: icon2CompletionItemKind(item.icon),

--- a/spx-gui/src/components/editor/code-editor/compiler.ts
+++ b/spx-gui/src/components/editor/code-editor/compiler.ts
@@ -123,8 +123,9 @@ export class Compiler extends Disposable {
 
   private reloadIframe() {
     // each load will emit 'load' event, after 'load', will trigger `initIframe` function
-    this.containerElement?.contentWindow?.location.reload()
+    // fixme: fix when wasm crashed and reload not working
     this.wasmHandlerRef.value = null
+    this.containerElement?.contentWindow?.location.reload()
   }
 
   private codes2CompileCode(codes: Code[]): CompilerCodes {

--- a/spx-gui/src/components/editor/code-editor/coordinators/completion-provider.ts
+++ b/spx-gui/src/components/editor/code-editor/coordinators/completion-provider.ts
@@ -1,0 +1,322 @@
+import {
+  type CompletionItem,
+  DocPreviewLevel,
+  type EditorUI,
+  Icon,
+  type LayerContent,
+  type TextModel
+} from '@/components/editor/code-editor/EditorUI'
+import { DocAbility } from '@/components/editor/code-editor/document'
+import {
+  type CoordinatorState,
+  transformInput2MarkdownCode,
+  usageEffect2Icon,
+  usageType2Icon
+} from '@/components/editor/code-editor/coordinators/index'
+import type { Project } from '@/models/project'
+import { type ChatBot, Suggest } from '@/components/editor/code-editor/chat-bot'
+import { type IPosition, type Position } from 'monaco-editor'
+import type { TokenId, UsageWithDoc } from '@/components/editor/code-editor/tokens/types'
+import type { Compiler } from '@/components/editor/code-editor/compiler'
+
+export class CompletionProvider {
+  constructor(
+    private ui: EditorUI,
+    private docAbility: DocAbility,
+    private coordinatorState: CoordinatorState,
+    private project: Project,
+    private chatBot: ChatBot,
+    private compiler: Compiler,
+    private suggest: Suggest
+  ) {}
+
+  private get currentFilename() {
+    return (this.project.selectedSprite?.name ?? 'main') + '.spx'
+  }
+
+  private getProjectAllCodes() {
+    const spritesCodes = this.project.sprites.map((sprite) => ({
+      filename: sprite.name + '.spx',
+      content: sprite.code
+    }))
+
+    const stageCodes = [{ filename: 'main.spx', content: this.project.stage.code }]
+
+    return [...spritesCodes, ...stageCodes]
+  }
+
+  private createCompletionItem(name: string, preview?: LayerContent) {
+    return {
+      icon: Icon.Property,
+      insertText: `"${name}"`,
+      label: `"${name}"`,
+      preview
+    }
+  }
+
+  private getContextualCode(
+    code: string,
+    position: { line: number; column: number },
+    numLines: number
+  ) {
+    const lines = code.split('\n')
+
+    const startLine = Math.max(0, position.line - numLines)
+    const endLine = Math.min(lines.length - 1, position.line + numLines)
+
+    const contextualLines = lines.slice(startLine, endLine + 1)
+
+    return contextualLines.join('\n')
+  }
+
+  provideCompletion(
+    model: TextModel,
+    ctx: {
+      position: Position
+      unitWord: string
+      signal: AbortSignal
+    },
+    addItems: (items: CompletionItem[]) => void
+  ) {
+    let isSyncCodeDone = false
+    const syncCacheItems: CompletionItem[] = []
+
+    // for each `addItems` will close completion menu and reopen it, to reduce this case, we collect sync items and batch add them
+    const batchAddItems = (items: CompletionItem[]) => {
+      if (isSyncCodeDone) return addItems([...items, ...syncCacheItems])
+      syncCacheItems.push(...items)
+    }
+
+    const finishSyncCodeCall = () => {
+      isSyncCodeDone = true
+      batchAddItems([])
+      syncCacheItems.length = 0
+    }
+
+    this.resolveProjectSuggest(model, ctx, batchAddItems)
+    // this.resolveAISuggest(model, ctx, batchAddItems)
+    this.resolveSoundListSuggest(model, ctx, batchAddItems)
+    this.resolveCompilerSuggest(model, ctx, batchAddItems)
+
+    finishSyncCodeCall()
+  }
+
+  resolveCompilerSuggest(
+    model: TextModel,
+    ctx: {
+      position: IPosition
+      signal: AbortSignal
+      unitWord: string
+    },
+    addItems: (items: CompletionItem[]) => void
+  ) {
+    const transferUsageDeclaration = (declaration: string) =>
+      declaration
+        // if param type is func() (func(mi *github.com/goplus/spx.MovingInfo))
+        // this line remove: "github.com/goplus/spx."
+        .replace(/(?:[\w/]+\.)+/g, '')
+    this.compiler
+      .getCompletionItems(
+        this.currentFilename,
+        this.getProjectAllCodes(),
+        ctx.position.lineNumber,
+        ctx.position.column
+      )
+      .then(async (completionItems) => {
+        // todo: this function code is running very slowly! need refactor
+        const completionItemDocMap = new Map<string, UsageWithDoc>()
+        for (let i = 0; i < completionItems.length; i++) {
+          const completionItem = completionItems[i]
+          const tokenId: TokenId = {
+            pkgPath: completionItem.tokenPkg,
+            name: completionItem.tokenName
+          }
+          const { usages } = await this.docAbility.getNormalDoc(tokenId)
+          usages.forEach((usage: UsageWithDoc) => completionItemDocMap.set(usage.insertText, usage))
+        }
+        addItems(
+          completionItems.map((completionItem) => {
+            const completionItemDoc = completionItemDocMap.get(completionItem.insertText)
+            if (!completionItemDoc)
+              return {
+                icon: usageType2Icon(completionItem.type),
+                insertText: completionItem.insertText,
+                label: completionItem.label
+              }
+            return {
+              icon: usageType2Icon(completionItem.type),
+              insertText: completionItem.insertText,
+              label: completionItem.label,
+              preview: {
+                type: 'doc',
+                layer: {
+                  level: DocPreviewLevel.Normal,
+                  content: completionItemDoc.doc,
+                  header: {
+                    icon: usageEffect2Icon(completionItemDoc.effect),
+                    declaration: transferUsageDeclaration(completionItemDoc.declaration)
+                  },
+                  recommendAction: {
+                    label: this.ui.i18n.t({
+                      zh: '还有疑惑？场外求助',
+                      en: 'Still in confusion? Ask for help'
+                    }),
+                    activeLabel: this.ui.i18n.t({ zh: '在线答疑', en: 'Online Q&A' }),
+                    onActiveLabelClick: () => {
+                      if (completionItemDoc.doc) {
+                        const chat = this.chatBot.startExplainChat('\n\n' + completionItemDoc.doc)
+                        this.ui.invokeAIChatModal(chat)
+                      } else {
+                        const chat = this.chatBot.startExplainChat(
+                          transformInput2MarkdownCode(completionItemDoc.declaration)
+                        )
+                        this.ui.invokeAIChatModal(chat)
+                      }
+                    }
+                  },
+                  moreActions: [
+                    {
+                      icon: Icon.Document,
+                      label: this.ui.i18n.t({ zh: '查看文档', en: 'Document' }),
+                      onClick: () => {
+                        const usageId = completionItemDoc.id
+                        this.docAbility
+                          .getDetailDoc({
+                            name: completionItem.tokenName,
+                            pkgPath: completionItem.tokenPkg
+                          })
+                          .then((detailDoc) => {
+                            const usageDetailDoc = detailDoc.usages.find(
+                              (usage: UsageWithDoc) => usage.id === usageId
+                            )?.doc
+                            if (usageDetailDoc) return this.ui.invokeDocumentDetail(usageDetailDoc)
+                            console.warn(
+                              'usageDetailDoc not found. tokenId: ' +
+                                JSON.stringify({
+                                  name: completionItem.tokenName,
+                                  pkgPath: completionItem.tokenPkg
+                                }) +
+                                ' usageId: ' +
+                                usageId
+                            )
+                          })
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          })
+        )
+      })
+  }
+
+  resolveSoundListSuggest(
+    model: TextModel,
+    ctx: {
+      position: IPosition
+      signal: AbortSignal
+      unitWord: string
+    },
+    addItems: (items: CompletionItem[]) => void
+  ) {
+    // resolve completion menu sound items
+    const matchedHint = this.coordinatorState.inlayHints.find((hint) => {
+      return (
+        hint.startPosition.filename === this.currentFilename &&
+        hint.startPosition.line === ctx.position.lineNumber &&
+        // sometimes position has one offset to real token position
+        (hint.startPosition.column === ctx.position.column + 1 ||
+          hint.startPosition.column === ctx.position.column)
+      )
+    })
+    if (matchedHint?.name !== 'mediaName') return
+    const { sounds } = this.project
+    // attention! here modified EditorUI member `completionMenu` inner state! is it right?
+    if (this.ui.completionMenu?.completionMenuState.triggerMode.type === 'playlist') {
+      this.ui.completionMenu.completionMenuState.triggerMode.range = {
+        startLineNumber: matchedHint.startPosition.line,
+        endLineNumber: matchedHint.endPosition.line,
+        startColumn: matchedHint.startPosition.column,
+        endColumn: matchedHint.endPosition.column
+      }
+    }
+    addItems(
+      sounds.map((sound) =>
+        this.createCompletionItem(sound.name, {
+          type: 'audio',
+          layer: {
+            file: sound.file
+          }
+        })
+      )
+    )
+  }
+
+  resolveProjectSuggest(
+    _model: TextModel,
+    _ctx: {
+      position: IPosition
+      signal: AbortSignal
+      unitWord: string
+    },
+    addItems: (items: CompletionItem[]) => void
+  ) {
+    // add project variables
+    const { sprites, stage, selectedSprite } = this.project
+
+    const items = [
+      ...sprites.map((sprite) => this.createCompletionItem(sprite.name)),
+      ...stage.backdrops.map((backdrop) => this.createCompletionItem(backdrop.name))
+    ]
+
+    if (selectedSprite) {
+      const { animations, costumes } = selectedSprite
+      items.push(
+        ...animations.map((animation) => this.createCompletionItem(animation.name)),
+        ...costumes.map((costume) => this.createCompletionItem(costume.name))
+      )
+    }
+
+    addItems(items)
+  }
+
+  resolveAISuggest(
+    model: TextModel,
+    ctx: {
+      position: IPosition
+      signal: AbortSignal
+      unitWord: string
+    },
+    addItems: (items: CompletionItem[]) => void
+  ) {
+    const code = model.getValue()
+    const position = {
+      line: ctx.position.lineNumber,
+      column: ctx.position.column
+    }
+
+    const contextualCode = this.getContextualCode(code, position, 3)
+
+    this.suggest
+      .startSuggestTask({
+        code: contextualCode,
+        position: {
+          line: position.line,
+          column: position.column
+        }
+      })
+      .then((items) => {
+        if (ctx.signal.aborted) return
+        addItems(
+          items.map((item) => {
+            return {
+              icon: Icon.AIAbility,
+              insertText: item.insertText,
+              label: ctx.unitWord + item.label
+            }
+          })
+        )
+      })
+  }
+}

--- a/spx-gui/src/components/editor/code-editor/coordinators/hover-provider.ts
+++ b/spx-gui/src/components/editor/code-editor/coordinators/hover-provider.ts
@@ -22,25 +22,13 @@ import { File } from '@/models/common/file'
 import type { ChatBot } from '@/components/editor/code-editor/chat-bot'
 
 export class HoverProvider {
-  private ui: EditorUI
-  private docAbility: DocAbility
-  private coordinatorState: CoordinatorState
-  private project: Project
-  private chatBot: ChatBot
-
   constructor(
-    ui: EditorUI,
-    docAbility: DocAbility,
-    coordinatorState: CoordinatorState,
-    project: Project,
-    chatBot: ChatBot
-  ) {
-    this.ui = ui
-    this.docAbility = docAbility
-    this.coordinatorState = coordinatorState
-    this.project = project
-    this.chatBot = chatBot
-  }
+    private ui: EditorUI,
+    private docAbility: DocAbility,
+    private coordinatorState: CoordinatorState,
+    private project: Project,
+    private chatBot: ChatBot
+  ) {}
 
   private get currentFilename() {
     return (this.project.selectedSprite?.name ?? 'main') + '.spx'

--- a/spx-gui/src/components/editor/code-editor/tokens/spx.ts
+++ b/spx-gui/src/components/editor/code-editor/tokens/spx.ts
@@ -467,7 +467,7 @@ export const xpos: Token = {
       effect: 'read',
       target: 'Sprite',
       declaration: 'func() float64',
-      sample: '5',
+      sample: '',
       insertText: 'xpos'
     }
   ]
@@ -518,7 +518,7 @@ export const ypos: Token = {
       effect: 'read',
       target: 'Sprite',
       declaration: 'func() float64',
-      sample: '10',
+      sample: '',
       insertText: 'ypos'
     }
   ]

--- a/spx-gui/src/components/editor/code-editor/ui/features/chat-bot/ChatAvator.vue
+++ b/spx-gui/src/components/editor/code-editor/ui/features/chat-bot/ChatAvator.vue
@@ -1,31 +1,40 @@
 <script setup lang="ts">
 import { useUserStore } from '@/stores'
 import ChatBot from '../../icons/chat-bot.svg?raw'
-import { normalizeIconSize } from '../../common';
-
+import { normalizeIconSize } from '../../common'
 
 defineProps<{
-    role: 'assistant' | 'user'
+  role: 'assistant' | 'user'
 }>()
 const userStore = useUserStore()
 </script>
 
 <template>
-    <div v-if="role === 'assistant'">
-        <!-- eslint-disable-next-line vue/no-v-html -->
-        <span :ref="(el) => normalizeIconSize(el as Element, 24)" class="chat-avatar" v-html="ChatBot"></span>
-    </div>
-    <div v-else>
-        <img v-if="userStore.userInfo" class="chat-avatar" draggable="false" :src="userStore.userInfo.avatar">
-    </div>
+  <div v-if="role === 'assistant'">
+    <!-- eslint-disable vue/no-v-html -->
+    <span
+      :ref="(el) => normalizeIconSize(el as Element, 24)"
+      class="chat-avatar"
+      v-html="ChatBot"
+    ></span>
+  </div>
+  <div v-else>
+    <img
+      v-if="userStore.userInfo"
+      class="chat-avatar"
+      draggable="false"
+      :src="userStore.userInfo.avatar"
+      :alt="userStore.userInfo.displayName"
+    />
+  </div>
 </template>
 
 <style scoped>
 .chat-avatar {
-    width: 26px;
-    height: 26px;
-    border-radius: 10px;
-    margin: 0 4px;
-    user-select: none;
+  width: 26px;
+  height: 26px;
+  border-radius: 10px;
+  margin: 0 4px;
+  user-select: none;
 }
 </style>

--- a/spx-gui/src/components/editor/code-editor/ui/features/chat-bot/ChatBotModalComponent.vue
+++ b/spx-gui/src/components/editor/code-editor/ui/features/chat-bot/ChatBotModalComponent.vue
@@ -15,7 +15,7 @@ const props = defineProps<{
 }>()
 
 const resend = async () => {
-  props.chat.resendMessage()
+  await props.chat.resendMessage()
 }
 </script>
 
@@ -36,7 +36,7 @@ const resend = async () => {
       ></ChatBubble>
       <ChatLoading v-if="chat.chatState.loading"></ChatLoading>
     </div>
-    <div v-if="chat.chatState.responseError" class="reload-btn-container" >
+    <div v-if="chat.chatState.responseError" class="reload-btn-container">
       <UIButton @click="resend">{{ $t({ zh: '重新发送', en: 'Resend' }) }}</UIButton>
     </div>
   </UIFormModal>
@@ -58,9 +58,8 @@ const resend = async () => {
   border-radius: 4px;
 }
 
-.reload-btn-container{
+.reload-btn-container {
   display: flex;
   justify-content: center;
 }
-
 </style>

--- a/spx-gui/src/components/editor/code-editor/ui/features/chat-bot/ChatBubble.vue
+++ b/spx-gui/src/components/editor/code-editor/ui/features/chat-bot/ChatBubble.vue
@@ -1,54 +1,59 @@
 <script setup lang="ts">
-import MarkdownPreview from '../../MarkdownPreview.vue';
-import ChatAvator from './ChatAvator.vue';
-import ChatSuggestItem from './ChatSuggestItem.vue';
-import type { ChatMessage, ContinueAction } from '../../../chat-bot';
+import MarkdownPreview from '../../MarkdownPreview.vue'
+import ChatAvator from './ChatAvator.vue'
+import ChatSuggestItem from './ChatSuggestItem.vue'
+import type { ChatMessage, ContinueAction } from '../../../chat-bot'
 
-defineProps<{ message: ChatMessage, loading: boolean }>()
+defineProps<{ message: ChatMessage; loading: boolean }>()
 
 const nextMessage = (q: ContinueAction) => {
-    q.click()
+  q.click()
 }
-
 </script>
 
 <template>
-    <div class="container" :style="{ alignItems: message.role === 'assistant' ? 'flex-start' : 'flex-end' }">
-        <ChatAvator :role="message.role"></ChatAvator>
-        <MarkdownPreview class="bubble" :content="message.content"></MarkdownPreview>
-        <div v-if="message.role === 'assistant' && message.actions && loading === false" class="suggestions">
-            <ChatSuggestItem
-                v-for="a, index in message.actions" :key="index" :content="a.action"
-                @click="nextMessage(a)">
-            </ChatSuggestItem>
-        </div>
+  <div
+    class="container"
+    :style="{ alignItems: message.role === 'assistant' ? 'flex-start' : 'flex-end' }"
+  >
+    <ChatAvator :role="message.role"></ChatAvator>
+    <MarkdownPreview class="bubble" :content="message.content"></MarkdownPreview>
+    <div v-if="message.role === 'assistant' && message.actions && !loading" class="suggestions">
+      <ChatSuggestItem
+        v-for="(a, index) in message.actions"
+        :key="index"
+        :content="a.action"
+        @click="nextMessage(a)"
+      >
+      </ChatSuggestItem>
     </div>
+  </div>
 </template>
 
 <style scoped lang="scss">
 .container {
-    display: flex;
-    flex-direction: column;
-    height: auto !important;
-    margin-bottom: 10px;
+  display: flex;
+  flex-direction: column;
+  height: auto !important;
+  margin-bottom: 10px;
 }
 
 .container:last-of-type > .suggestions {
-    display: flex;
+  display: flex;
 }
 
 .bubble {
-    max-width: 80%;
-    overflow: auto;
-    padding: 10px;
-    border-radius: var(--ui-border-radius-2);
-    background-color: var(--ui-color-grey-100);
+  max-width: 80%;
+  overflow: auto;
+  padding: 10px;
+  border-radius: var(--ui-border-radius-2);
+  background-color: var(--ui-color-grey-100);
 }
 
 .container .suggestions {
-    display: none;
-    flex-direction: row;
-    gap: 5px;
-    margin: 6px 0 0 2px;
+  display: none;
+  flex-direction: row;
+  gap: 5px;
+  margin: 6px 0 0 2px;
 }
 </style>

--- a/spx-gui/src/components/editor/code-editor/ui/features/completion-menu/completion-staging-item.ts
+++ b/spx-gui/src/components/editor/code-editor/ui/features/completion-menu/completion-staging-item.ts
@@ -7,7 +7,7 @@ export interface CompletionItemCachePosition {
   column: number
 }
 
-export class CompletionItemCache extends Disposable {
+export class CompletionStagingItem extends Disposable {
   private cache: CompletionItem[] | null = null
   private position: CompletionItemCachePosition = {
     id: '',
@@ -32,6 +32,10 @@ export class CompletionItemCache extends Disposable {
   public set(position: CompletionItemCachePosition, items: CompletionItem[]) {
     this.position = { ...position }
     this.cache = items
+  }
+
+  public updateCacheID(position: CompletionItemCachePosition) {
+    this.position = { ...position }
   }
 
   public clear() {

--- a/spx-gui/src/components/editor/code-editor/ui/features/completion-menu/completion-staging-item.ts
+++ b/spx-gui/src/components/editor/code-editor/ui/features/completion-menu/completion-staging-item.ts
@@ -1,15 +1,15 @@
 import { Disposable } from '@/utils/disposable'
 import type { CompletionItem } from '@/components/editor/code-editor/EditorUI'
 
-export interface CompletionItemCachePosition {
+export interface CompletionStagingItemID {
   id: string
   lineNumber: number
   column: number
 }
 
 export class CompletionStagingItem extends Disposable {
-  private cache: CompletionItem[] | null = null
-  private position: CompletionItemCachePosition = {
+  private stagingItems: CompletionItem[] | null = null
+  private stagingItemID: CompletionStagingItemID = {
     id: '',
     lineNumber: -1,
     column: -1
@@ -21,7 +21,7 @@ export class CompletionStagingItem extends Disposable {
     // will throw undefined error.
     this.addDisposer(() => {
       this.clear()
-      this.position = {
+      this.stagingItemID = {
         id: '',
         lineNumber: -1,
         column: -1
@@ -29,37 +29,37 @@ export class CompletionStagingItem extends Disposable {
     })
   }
 
-  public set(position: CompletionItemCachePosition, items: CompletionItem[]) {
-    this.position = { ...position }
-    this.cache = items
+  public set(stagingItemID: CompletionStagingItemID, items: CompletionItem[]) {
+    this.stagingItemID = { ...stagingItemID }
+    this.stagingItems = items
   }
 
-  public updateCacheID(position: CompletionItemCachePosition) {
-    this.position = { ...position }
+  public updateCacheID(stagingItemID: CompletionStagingItemID) {
+    this.stagingItemID = { ...stagingItemID }
   }
 
   public clear() {
-    this.cache = []
+    this.stagingItems = []
   }
 
-  public get(completionItemCacheID: CompletionItemCachePosition) {
-    if (this.isSamePosition(completionItemCacheID)) {
-      return this.cache
+  public get(stagingItemID: CompletionStagingItemID) {
+    if (this.isSameStagingID(stagingItemID)) {
+      return this.stagingItems
     } else {
       return null
     }
   }
 
   public getCompletionCacheItemByIdx(idx: number): CompletionItem | undefined {
-    if (this.cache == null) return
-    return this.cache[idx]
+    if (this.stagingItems == null) return
+    return this.stagingItems[idx]
   }
 
-  public isSamePosition(position: CompletionItemCachePosition) {
+  public isSameStagingID(stagingItemID: CompletionStagingItemID) {
     return (
-      this.position.id === position.id &&
-      this.position.lineNumber === position.lineNumber &&
-      this.position.column === position.column
+      this.stagingItemID.id === stagingItemID.id &&
+      this.stagingItemID.lineNumber === stagingItemID.lineNumber &&
+      this.stagingItemID.column === stagingItemID.column
     )
   }
 }

--- a/spx-gui/src/components/editor/code-editor/ui/features/inlay-hint/InlayHintComponent.vue
+++ b/spx-gui/src/components/editor/code-editor/ui/features/inlay-hint/InlayHintComponent.vue
@@ -52,9 +52,10 @@ const { dispose: didChangeModelContentDispose } =
 
 const { dispose: onMouseDownDispose } = props.inlayHint.editor.onMouseDown((e) => {
   const element = e.target.element
-  if (element?.classList.contains('inlay-hint__icon-playlist')) {
-    props.ui.completionMenu?.showCompletionMenu()
-  }
+  const model = props.inlayHint.editor.getModel()
+  if (!model) return
+  if (!element?.classList.contains('inlay-hint__icon-playlist')) return
+  props.ui.completionMenu?.showCompletionMenu('playlist')
 })
 
 props.inlayHint.eventDisposeHandler.push(didChangeModelContentDispose)
@@ -72,7 +73,7 @@ onMounted(() => {
 <style lang="scss">
 // this is global css and active in monaco editor code line, add `.view-line` to avoid style override by monaco editor
 .view-line {
-  .inlay-hint__param::after {
+  .inlay-hint__param {
     font-size: 0.8em;
     margin-right: 0.5em;
     color: rgba(0, 0, 0, 0.3);
@@ -81,11 +82,12 @@ onMounted(() => {
 
   .inlay-hint__icon-playlist {
     cursor: pointer;
-    &::after {
+    &::before {
       content: '';
       display: inline-block;
       width: 0.75em;
       height: 0.75em;
+      margin-left: -0.25em;
       margin-right: 0.25em;
       background-image: var(--monaco-editor-icon-playlist);
       background-size: contain;
@@ -95,14 +97,14 @@ onMounted(() => {
     }
   }
 
-  .inlay-hint__tag::after {
+  .inlay-hint__tag {
     color: rgba(0, 0, 0, 0.3);
-    padding: 2px 4px;
-    margin: 0 2px;
+    padding: 0 4px;
+    margin-left: 0.25em;
     background: rgba(0, 0, 0, 0.05);
     border-radius: 2px;
     font-size: 0.85em;
-    vertical-align: top;
+    vertical-align: middle;
   }
 }
 </style>

--- a/spx-gui/src/components/editor/code-editor/ui/features/inlay-hint/inlay-hint.ts
+++ b/spx-gui/src/components/editor/code-editor/ui/features/inlay-hint/inlay-hint.ts
@@ -1,7 +1,6 @@
 import { type editor as IEditor, type IDisposable, Range } from 'monaco-editor'
-import { StyleSheetContent } from '@/components/editor/code-editor/ui/common/style-sheet-content'
 
-export class InlayHint extends StyleSheetContent implements IDisposable {
+export class InlayHint implements IDisposable {
   editor: IEditor.IStandaloneCodeEditor
   abortController = new AbortController()
   eventDisposeHandler: Array<() => void> = []
@@ -9,14 +8,11 @@ export class InlayHint extends StyleSheetContent implements IDisposable {
   public mouseColumn = 0
 
   constructor(editor: IEditor.IStandaloneCodeEditor) {
-    super()
     this.editor = editor
     this.textDecorationsCollection = editor.createDecorationsCollection([])
     this.editor.onMouseMove((e) => {
       this.mouseColumn = e.target.range?.startColumn || e.target.mouseColumn
     })
-
-    // todo: trigger completion menu
   }
 
   public createParamDecoration(
@@ -25,10 +21,13 @@ export class InlayHint extends StyleSheetContent implements IDisposable {
     content: string
   ): IEditor.IModelDeltaDecoration {
     return {
-      range: new Range(line, column - 1, line, column),
+      range: new Range(line, column, line, column + 1),
       options: {
-        inlineClassName: `inlay-hint__param ${this.addPseudoElementClassNameWithHashContent(content)}`,
-        inlineClassNameAffectsLetterSpacing: true
+        before: {
+          content: content,
+          inlineClassName: 'inlay-hint__param',
+          inlineClassNameAffectsLetterSpacing: true
+        }
       }
     }
   }
@@ -39,34 +38,23 @@ export class InlayHint extends StyleSheetContent implements IDisposable {
     content: string
   ): IEditor.IModelDeltaDecoration {
     return {
-      range: {
-        startLineNumber: line,
-        endLineNumber: line,
-        startColumn: column - 1,
-        endColumn: column
-      },
+      range: new Range(line, column - 1, line, column),
       options: {
-        inlineClassName: `inlay-hint__tag ${this.addPseudoElementClassNameWithHashContent(content)}`,
-        inlineClassNameAffectsLetterSpacing: true
+        after: {
+          content: content,
+          inlineClassName: 'inlay-hint__tag',
+          inlineClassNameAffectsLetterSpacing: true
+        }
       }
     }
   }
 
   public createIconDecoration(line: number, column: number): IEditor.IModelDeltaDecoration {
     return {
-      range: {
-        startLineNumber: 1,
-        endLineNumber: line,
-        startColumn: column,
-        endColumn: column
-      },
+      range: new Range(line, column, line, column + 1),
       options: {
-        after: {
-          inlineClassName: 'inlay-hint__icon-playlist',
-          // must add a word in content property, here use space, otherwise the icon will not be displayed
-          content: ' ',
-          inlineClassNameAffectsLetterSpacing: true
-        }
+        inlineClassName: 'inlay-hint__icon-playlist',
+        inlineClassNameAffectsLetterSpacing: true
       }
     }
   }
@@ -76,6 +64,5 @@ export class InlayHint extends StyleSheetContent implements IDisposable {
 
     this.textDecorationsCollection.clear()
     this.abortController.abort()
-    super.dispose()
   }
 }


### PR DESCRIPTION
## Overview
this pr is about following updates:
 - implement playlist icon trigger completion item, after trigger will auto select `play` param named `mediaName`
 - refactor `completion-item-cache` into `completion-staging-item` and related codes
 - remove `inlay-hint` unnecessary codes
 - abstract `completionProvider` into a single file
 - some small bugs fix and code styles refactor