### PR TITLE
fix(utils/file): resolve race condition in `useFileUrl`

### DIFF
--- a/spx-gui/src/models/common/file.ts
+++ b/spx-gui/src/models/common/file.ts
@@ -59,9 +59,7 @@ export class File {
 
   async url(onCleanup: (disposer: Disposer) => void) {
     let cancelled = false
-    onCleanup(() => {
-      cancelled = true
-    })
+    onCleanup(() => (cancelled = true))
     const ab = await this.arrayBuffer()
     if (cancelled) throw new Cancelled()
     const url = URL.createObjectURL(new Blob([ab], { type: this.type }))

--- a/spx-gui/src/utils/file.ts
+++ b/spx-gui/src/utils/file.ts
@@ -135,9 +135,23 @@ export function useFileUrl(fileSource: WatchSource<File | undefined>) {
         return
       }
       loadingRef.value = true
+      let cancelled = false
+      let fileUrlCleanup: (() => void) | null = null
+      onCleanup(() => {
+        cancelled = true
+        urlRef.value = null
+        fileUrlCleanup?.()
+      })
       file
-        .url(onCleanup)
+        .url((cleanup) => {
+          if (cancelled) {
+            cleanup()
+            return
+          }
+          fileUrlCleanup = cleanup
+        })
         .then((url) => {
+          if (cancelled) return
           urlRef.value = url
         })
         .catch((e) => {


### PR DESCRIPTION
- Prevent setting of stale URLs in fast-switching scenarios.
- Fix security error in Firefox where old blob URLs were being accessed after navigation (e.g., when opening a new project while another is being edited).

---

For example, when switching from `http://localhost:5173/editor/test1` to `http://localhost:5173/editor/test2`:

<img width="1097" alt="Screenshot 2024-09-29 at 09 04 47" src="https://github.com/user-attachments/assets/313f219b-cdfd-489e-884b-a2388516b3d3">

P.S.: These errors are triggered by the use of `useFileUrl` in `StageViewer`.