### PR TITLE
chore(ci): change Docker image tag from `latest` to `dev`

### DIFF
--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -25,4 +25,4 @@ jobs:
             NODE_ENV=staging
           push: true
           tags: |
-            ghcr.io/${{github.repository}}:latest
+            ghcr.io/${{github.repository}}:dev

--- a/scripts/k8s/redeploy/Dockerfile
+++ b/scripts/k8s/redeploy/Dockerfile
@@ -1,2 +1,0 @@
-FROM bitnami/kubectl:latest
-CMD ["rollout", "restart", "deployment/builder-spx-gui-v1", "-n", "builder"]


### PR DESCRIPTION
- Change Docker image tag to `dev` for clarity regarding its use in testing environments.
- Remove obsolete `scripts/k8s/redeploy/Dockerfile`.