### PR TITLE
chore(spx-backend): fix `GOP_SPX_DSN` in `.env.dev`

### DIFF
--- a/spx-backend/.env.dev
+++ b/spx-backend/.env.dev
@@ -1,7 +1,7 @@
 PORT=:8080
 ALLOWED_ORIGIN=*
 # Use local DB by default for dev
-GOP_SPX_DSN=root:123456@tcp(127.0.0.1:3306)/builder?charset=utf8&parseTime=True&loc=Local
+GOP_SPX_DSN=root:123456@tcp(127.0.0.1:3306)/builder?charset=utf8mb4&parseTime=True&loc=UTC
 # AIGC Service
 AIGC_ENDPOINT=http://36.213.14.15:8888
 


### PR DESCRIPTION
- Use `utf8mb4` instead of `utf8` for full Unicode support. (Fixes #987)
- Set `loc` to `UTC` for consistent time zone handling.

---

TODO (after merge):

- [ ] Sync the config change to the staging environment.
- [ ] Sync the config change to the production environment.