### PR TITLE
refactor(auth): remove refresh token expiration handling

### DIFF
--- a/spx-backend/internal/controller/user.go
+++ b/spx-backend/internal/controller/user.go
@@ -69,7 +69,7 @@ func ensureUser(ctx context.Context, expectedUserID int64) (*model.User, error) 
 func (ctrl *Controller) UserFromToken(ctx context.Context, token string) (*model.User, error) {
 	claims, err := ctrl.casdoorClient.ParseJwtToken(token)
 	if err != nil {
-		return nil, fmt.Errorf("ctrl.casdoorClient.ParseJwtToken failed: %w", err)
+		return nil, fmt.Errorf("ctrl.casdoorClient.ParseJwtToken failed: %w: %w", ErrUnauthorized, err)
 	}
 	mUser, err := model.FirstOrCreateUser(ctx, ctrl.db, claims.Name)
 	if err != nil {

--- a/spx-backend/internal/controller/user_test.go
+++ b/spx-backend/internal/controller/user_test.go
@@ -133,7 +133,7 @@ func TestControllerUserFromToken(t *testing.T) {
 
 		_, err := ctrl.UserFromToken(context.Background(), "invalid-token")
 		require.Error(t, err)
-		assert.EqualError(t, err, "ctrl.casdoorClient.ParseJwtToken failed: token contains an invalid number of segments")
+		assert.EqualError(t, err, "ctrl.casdoorClient.ParseJwtToken failed: unauthorized: token contains an invalid number of segments")
 	})
 }
 

--- a/spx-gui/src/components/community/user/FollowButton.vue
+++ b/spx-gui/src/components/community/user/FollowButton.vue
@@ -10,7 +10,7 @@ const props = defineProps<{
   name: string
 }>()
 
-const followable = computed(() => props.name !== useUserStore().userInfo?.name)
+const followable = computed(() => props.name !== useUserStore().userInfo()?.name)
 const following = ref<boolean | null>(null)
 
 watch(

--- a/spx-gui/src/components/navbar/NavbarProfile.vue
+++ b/spx-gui/src/components/navbar/NavbarProfile.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="!userStore.userInfo" class="sign-in">
+  <div v-if="!userInfo" class="sign-in">
     <UIButton type="secondary" :disabled="!isOnline" @click="userStore.initiateSignIn()">{{
       $t({ en: 'Sign in', zh: '登录' })
     }}</UIButton>
@@ -7,13 +7,13 @@
   <UIDropdown v-else placement="bottom-end" :offset="{ x: -4, y: 8 }">
     <template #trigger>
       <div class="avatar">
-        <img class="avatar-img" :src="userStore.userInfo.avatar" />
+        <img class="avatar-img" :src="userInfo.avatar" />
       </div>
     </template>
     <UIMenu class="user-menu">
       <UIMenuGroup>
         <UIMenuItem :interactive="false">
-          {{ userStore.userInfo.displayName || userStore.userInfo.name }}
+          {{ userInfo.displayName || userInfo.name }}
         </UIMenuItem>
       </UIMenuGroup>
       <UIMenuGroup>
@@ -39,17 +39,20 @@ import { useNetwork } from '@/utils/network'
 import { getUserPageRoute } from '@/router'
 import { useUserStore } from '@/stores'
 import { UIButton, UIDropdown, UIMenu, UIMenuGroup, UIMenuItem } from '@/components/ui'
+import { computed } from 'vue'
 
 const userStore = useUserStore()
 const { isOnline } = useNetwork()
 const router = useRouter()
 
+const userInfo = computed(() => userStore.userInfo())
+
 function handleUserPage() {
-  router.push(getUserPageRoute(userStore.userInfo!.name))
+  router.push(getUserPageRoute(userInfo.value!.name))
 }
 
 function handleProjects() {
-  router.push(getUserPageRoute(userStore.userInfo!.name, 'projects'))
+  router.push(getUserPageRoute(userInfo.value!.name, 'projects'))
 }
 </script>
 

--- a/spx-gui/src/components/project/ProjectCreateModal.vue
+++ b/spx-gui/src/components/project/ProjectCreateModal.vue
@@ -58,6 +58,7 @@ import defaultSpritePng from '@/assets/default-sprite.png'
 import defaultBackdropImg from '@/assets/default-backdrop.png'
 import { Backdrop } from '@/models/backdrop'
 import { Project } from '@/models/project'
+import { computed } from 'vue'
 
 const props = defineProps<{
   visible: boolean
@@ -70,6 +71,8 @@ const emit = defineEmits<{
 
 const { t } = useI18n()
 const userStore = useUserStore()
+
+const userInfo = computed(() => userStore.userInfo())
 
 const form = useForm({
   name: ['', validateName]
@@ -134,8 +137,8 @@ async function validateName(name: string): Promise<FormValidationResult> {
     })
 
   // check naming conflict
-  if (userStore.userInfo == null) throw new Error('login required')
-  const username = userStore.userInfo.name
+  if (userInfo.value == null) throw new Error('login required')
+  const username = userInfo.value.name
   const existedProject = await getProject(username, name).catch((e) => {
     if (e instanceof ApiException && e.code === ApiExceptionCode.errorNotFound) return null
     throw e

--- a/spx-gui/src/pages/community/home.vue
+++ b/spx-gui/src/pages/community/home.vue
@@ -1,7 +1,7 @@
 <template>
   <CenteredWrapper class="main">
     <ProjectsSection
-      v-if="userStore.isSignedIn"
+      v-if="userStore.isSignedIn()"
       context="home"
       :link-to="myProjectsRoute"
       :query-ret="myProjects"
@@ -84,7 +84,7 @@
       />
     </ProjectsSection>
     <ProjectsSection
-      v-if="userStore.isSignedIn"
+      v-if="userStore.isSignedIn()"
       context="home"
       :link-to="followingCreatedRoute"
       :query-ret="followingCreatedProjects"
@@ -128,14 +128,16 @@ const numInRow = 5 // at most 5 projects in a row, depending on the screen width
 
 const userStore = useUserStore()
 
+const userInfo = computed(() => userStore.userInfo())
+
 const myProjectsRoute = computed(() => {
-  if (userStore.userInfo == null) return ''
-  return getUserPageRoute(userStore.userInfo.name, 'projects')
+  if (userInfo.value == null) return ''
+  return getUserPageRoute(userInfo.value.name, 'projects')
 })
 
 const myProjects = useQuery(
   async () => {
-    if (userStore.userInfo == null) return []
+    if (userInfo.value == null) return []
     const { data: projects } = await listProject({
       pageIndex: 1,
       pageSize: numInRow,
@@ -162,13 +164,13 @@ const communityRemixingProjects = useQuery(
 )
 
 const followingCreatedRoute = computed(() => {
-  if (userStore.userInfo == null) return ''
+  if (userInfo.value == null) return ''
   return getExploreRoute(ExploreOrder.FollowingCreated)
 })
 
 const followingCreatedProjects = useQuery(
   async () => {
-    if (userStore.userInfo == null) return []
+    if (userInfo.value == null) return []
     return exploreProjects({ order: ExploreOrder.FollowingCreated, count: numInRow })
   },
   { en: 'Failed to load projects', zh: '加载失败' }


### PR DESCRIPTION
- Remove handling of refresh token expiration as Casdoor never returns `refresh_expires_in`[^1].
- Treat refresh tokens as always valid as they are renewed with each access token refresh[^2].
- Return `401 Unauthorized` instead of `500 Internal Server Error` when JWT parsing fails.

[^1]: https://github.com/casdoor/casdoor/blob/6f1f93725e77c8288aa0ac1c0d996feff906ddcf/object/token_oauth.go#L383-L390
[^2]: https://github.com/casdoor/casdoor/blob/6f1f93725e77c8288aa0ac1c0d996feff906ddcf/object/token_oauth.go#L351-L376