### PR TITLE
Provide `I18nT` to simplify element translation

### DIFF
--- a/spx-gui/.eslintrc.cjs
+++ b/spx-gui/.eslintrc.cjs
@@ -28,7 +28,8 @@ module.exports = {
           // These rules will match components in both kebab-case and CamelCase
           'router-view',
           'router-link',
-          'v-.*' // for Vue Konva components
+          'v-.*', // for Vue Konva components
+          'I18nT'
         ]
       }
     ],

--- a/spx-gui/src/components/project/ProjectPublishedModal.vue
+++ b/spx-gui/src/components/project/ProjectPublishedModal.vue
@@ -18,20 +18,6 @@ const emit = defineEmits<{
 const projectPageRoute = computed(() => getProjectPageRoute(props.project.owner!, props.project.name!))
 const projectPageLink = computed(() => `${location.origin}${projectPageRoute.value}`)
 
-// TODO: support vnode as i18n message to simplify such case
-const preLinkText = {
-  en: 'Visit ',
-  zh: '访问'
-}
-const linkText = {
-  en: 'project page',
-  zh: '项目主页'
-}
-const postLinkText = {
-  en: ', or copy the link below to share the project with others.',
-  zh: '，或者复制下方链接将项目分享给其他人。'
-}
-
 const handleCopy = useMessageHandle(
   () => navigator.clipboard.writeText(projectPageLink.value),
   { en: 'Failed to copy link to clipboard', zh: '分享链接复制到剪贴板失败' },
@@ -47,8 +33,15 @@ const handleCopy = useMessageHandle(
     @update:visible="emit('cancelled')"
   >
     <div class="desc">
-      {{ $t(preLinkText) }}<UILink target="_blank" :href="projectPageRoute">{{ $t(linkText) }}</UILink
-      >{{ $t(postLinkText) }}
+      <I18nT>
+        <template #en>
+          Visit <UILink target="_blank" :href="projectPageRoute">project page</UILink>, or copy the link below to share
+          the project with others.
+        </template>
+        <template #zh>
+          访问<UILink target="_blank" :href="projectPageRoute">项目主页</UILink>，或者复制下方链接将项目分享给其他人。
+        </template>
+      </I18nT>
     </div>
     <div class="link-wrapper">
       <UITextInput :value="projectPageLink" :readonly="true" @focus="$event.target.select()" />

--- a/spx-gui/src/pages/community/search.vue
+++ b/spx-gui/src/pages/community/search.vue
@@ -1,12 +1,17 @@
 <template>
   <CommunityHeader>
-    <template v-if="titleForResult != null">
-      <!-- TODO: support vnode as i18n message to simplify such case -->
-      {{ $t(titleForResult.prefix) }}<span class="keyword">{{ keyword }}</span
-      >{{ $t(titleForResult.suffix) }}
-    </template>
+    <I18nT v-if="queryRet.data.value != null">
+      <template #en>
+        Found {{ queryRet.data.value?.total }} projects for "<span class="keyword">{{ keyword }}</span
+        >"
+      </template>
+      <template #zh>
+        找到 {{ queryRet.data.value?.total }} 个关于“<span class="keyword">{{ keyword }}</span
+        >”的项目
+      </template>
+    </I18nT>
     <template v-else>
-      {{ $t(titleForNoResult) }}
+      {{ $t({ en: 'Search projects', zh: '搜索项目' }) }}
     </template>
     <template #options>
       <label>
@@ -121,24 +126,6 @@ const queryRet = useQuery(() => listProject(listParams.value), {
   en: 'Failed to search projects',
   zh: '搜索项目失败'
 })
-
-const titleForResult = computed(() => {
-  if (queryRet.data.value == null) return null
-  return {
-    prefix: {
-      en: `Found ${queryRet.data.value?.total} projects for "`,
-      zh: `找到 ${queryRet.data.value?.total} 个关于“`
-    },
-    suffix: {
-      en: '"',
-      zh: '”的项目'
-    }
-  }
-})
-const titleForNoResult = computed(() => ({
-  en: 'Search projects',
-  zh: '搜索项目'
-}))
 </script>
 
 <style lang="scss" scoped>

--- a/spx-gui/src/utils/i18n/README.md
+++ b/spx-gui/src/utils/i18n/README.md
@@ -24,9 +24,11 @@ i18n.setLang('zh')
 ### Do translation in template of SFC
 
 ```vue
-<button>
-  {{$t({ en: 'Sign in', zh: '登录' })}}
-</button>
+<template>
+  <button>
+    {{ $t({ en: 'Sign in', zh: '登录' }) }}
+  </button>
+</template>
 ```
 
 ### Do translation in setup script
@@ -37,6 +39,17 @@ import { useI18n } from '@/utils/i18n'
 const { t } = useI18n()
 
 const signoutText = t({ en: 'Sign out', zh: '登出' })
+```
+
+### Translate complex elements in template of SFC
+
+```vue
+<template>
+  <I18nT>
+    <template #en>Please <a :href="link">sign in</a>.</template>
+    <template #zh>请<a :href="link">登录</a>。</template>
+  </I18nT>
+</template>
 ```
 
 ### Locale Message Functions

--- a/spx-gui/src/utils/utils.ts
+++ b/spx-gui/src/utils/utils.ts
@@ -155,6 +155,8 @@ export function memoizeAsync<T extends (...args: any) => Promise<unknown>>(
   }) as T
 }
 
+// TODO: we may move these `humanizeX` functions to i18n module as exposed helpers
+
 /** Convert time string to human-friendly format, e.g., "3 days ago" */
 export function humanizeTime(time: string): LocaleMessage {
   const t = dayjs(time)


### PR DESCRIPTION
Provide `I18nT` to simplify element translation:

```vue
<template>
  <I18nT>
    <template #en>Please <a :href="link">sign in</a>.</template>
    <template #zh>请<a :href="link">登录</a>。</template>
  </I18nT>
</template>
```