### PR TITLE
Adjust preference for published content of project

### DIFF
--- a/spx-gui/src/components/project/ProjectItem.vue
+++ b/spx-gui/src/components/project/ProjectItem.vue
@@ -99,7 +99,7 @@ import { useMessageHandle } from '@/utils/exception'
 import { humanizeCount, humanizeExactCount, humanizeTime, humanizeExactTime, useAsyncComputed } from '@/utils/utils'
 import { getProjectEditorRoute, getProjectPageRoute } from '@/router'
 import { Visibility, type ProjectData } from '@/apis/project'
-import { universalUrlToWebUrl } from '@/models/common/cloud'
+import { getPublishedContent, universalUrlToWebUrl } from '@/models/common/cloud'
 import { useUserStore } from '@/stores/user'
 import { useIsLikingProject } from '@/stores/liking'
 import { UIImg, UIDropdown, UIIcon, UIMenu, UIMenuItem } from '@/components/ui'
@@ -141,8 +141,9 @@ const to = computed(() => {
 })
 
 const thumbnailUrl = useAsyncComputed(async () => {
-  if (props.project.thumbnail === '') return null
-  return universalUrlToWebUrl(props.project.thumbnail)
+  const thumbnail = getPublishedContent(props.project)?.thumbnail ?? props.project.thumbnail
+  if (thumbnail === '') return null
+  return universalUrlToWebUrl(thumbnail)
 })
 
 const { data: liking } = useIsLikingProject(() => ({

--- a/spx-gui/src/models/common/cloud.ts
+++ b/spx-gui/src/models/common/cloud.ts
@@ -19,13 +19,22 @@ const fileUniversalUrlSchemes = {
   kodo: 'kodo:' // for objects stored in Qiniu Kodo, e.g. kodo://bucket/key
 } as const
 
-export async function load(owner: string, name: string, preferReleasedContent: boolean = false, signal?: AbortSignal) {
+export async function load(owner: string, name: string, preferPublishedContent: boolean = false, signal?: AbortSignal) {
   const projectData = await getProject(owner, name, signal)
-  if (preferReleasedContent && projectData.latestRelease != null) {
-    projectData.thumbnail = projectData.latestRelease.thumbnail
-    projectData.files = projectData.latestRelease.files
+  if (preferPublishedContent) {
+    const published = getPublishedContent(projectData)
+    if (published != null) {
+      projectData.thumbnail = published.thumbnail
+      projectData.files = published.files
+    }
   }
   return parseProjectData(projectData)
+}
+
+export function getPublishedContent(project: ProjectData) {
+  // "published content" is the latest release of a public project
+  if (project.visibility === Visibility.Public && project.latestRelease != null) return project.latestRelease
+  return null
 }
 
 export async function save(metadata: Metadata, files: Files, signal?: AbortSignal) {

--- a/spx-gui/src/models/project/index.ts
+++ b/spx-gui/src/models/project/index.ts
@@ -404,8 +404,8 @@ export class Project extends Disposable {
   }
 
   /** Load from cloud */
-  async loadFromCloud(owner: string, name: string, preferReleasedContent: boolean = false, signal?: AbortSignal) {
-    const { metadata, files } = await cloudHelper.load(owner, name, preferReleasedContent, signal)
+  async loadFromCloud(owner: string, name: string, preferPublishedContent: boolean = false, signal?: AbortSignal) {
+    const { metadata, files } = await cloudHelper.load(owner, name, preferPublishedContent, signal)
     signal?.throwIfAborted()
     await this.load(metadata, files)
     return this as CloudProject

--- a/spx-gui/src/widgets/spx-runner/SpxRunner.ce.vue
+++ b/spx-gui/src/widgets/spx-runner/SpxRunner.ce.vue
@@ -47,7 +47,7 @@ watch(
       errorMsg.value = ''
       try {
         const newProject = new Project()
-        await newProject.loadFromCloud(owner, name)
+        await newProject.loadFromCloud(owner, name, true)
         project.value.dispose()
         project.value = newProject
         ready.value = true


### PR DESCRIPTION
When showcasing a project, such as in the `ProjectItem` component or project page, prefer published content rather than draft content. 

"Prefer published content" means to use the published content if it exists. 

"Published content exists" means the project is public and has a latest release, which is the "published content".