### PR TITLE
Optimize style detail for `UserItem` with empty `description`

### DIFF
--- a/spx-gui/src/components/community/user/UserItem.vue
+++ b/spx-gui/src/components/community/user/UserItem.vue
@@ -20,7 +20,7 @@ const userRoute = computed(() => getUserPageRoute(props.user.username))
     <UserAvatar class="avatar" :user="user.username" />
     <RouterUILink class="name" type="boring" :to="userRoute">{{ user.displayName }}</RouterUILink>
     <UserJoinedAt class="joined-at" :time="user.createdAt" />
-    <TextView class="description" :text="user.description" />
+    <TextView v-if="!!user.description" class="description" :text="user.description" />
     <FollowButton class="follow" :name="user.username" />
   </li>
 </template>


### PR DESCRIPTION
Avoid empty description block in `UserItem`.