### PR TITLE
Ignore decode error of animation frames

### DIFF
--- a/spx-gui/src/components/editor/sprite/animation/AnimationPlayer.vue
+++ b/spx-gui/src/components/editor/sprite/animation/AnimationPlayer.vue
@@ -59,7 +59,10 @@ const preloadFrames = async (costumeFiles: File[]) => {
       ...urls.map(async (url) => {
         const img = new Image()
         img.src = url
-        await img.decode()
+        await img.decode().catch((e) => {
+          // Sometimes `decode` fails, while the image is still able to be displayed
+          console.warn('Failed to decode image', url, e)
+        })
         return img
       })
     ])


### PR DESCRIPTION
`image.decode()` can sometimes fail even when the image can be  displayed correctly, resulting in the error:

```
EncodingError: The source image cannot be decoded.
```

Files that may trigger this issue can be found here: [decode_error_images.zip](https://github.com/user-attachments/files/17760016/decode_error_images.zip).

This problem may be linked to large image sizes. For further discussion, see: https://github.com/vuetifyjs/vuetify/issues/5418#issuecomment-489295740. However, this seems contradictory since `image.decode()` is intended to preload large images, as noted here: https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/decode#usage_notes.

We will need to investigate this further.