### PR TITLE
Add `Cross-Origin-*` headers for worker script

### DIFF
--- a/scripts/nginx.conf
+++ b/scripts/nginx.conf
@@ -23,6 +23,8 @@ server {
         add_header 'Access-Control-Allow-Methods' 'GET' always;
         add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range' always;
         add_header 'Access-Control-Expose-Headers' 'Content-Length,Content-Range' always;
+        add_header 'Cross-Origin-Embedder-Policy' 'credentialless' always;
+        add_header 'Cross-Origin-Opener-Policy' 'same-origin' always;
 
         root /usr/share/nginx/html;
         try_files $uri =404; # Serve the file if it exists, otherwise return a 404
@@ -34,6 +36,8 @@ server {
         add_header 'Access-Control-Allow-Methods' 'GET' always;
         add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range' always;
         add_header 'Access-Control-Expose-Headers' 'Content-Length,Content-Range' always;
+        add_header 'Cross-Origin-Embedder-Policy' 'credentialless' always;
+        add_header 'Cross-Origin-Opener-Policy' 'same-origin' always;
 
         root /usr/share/nginx/html;
         gzip_static on;


### PR DESCRIPTION
Supplement to #1110.

> * Configure response headers (see details in [SPX 2.0 Integration #1083](https://github.com/goplus/builder/pull/1083)) for document requests of staging env

The `Cross-Origin-*` headers are also required for worker scripts (which are treated as "frame"s as well):

![image](https://github.com/user-attachments/assets/1f48205d-5a5e-4108-8de6-4f6f8309ef04)

