### PR TITLE
Fix adding-asset from asset-library

### DIFF
--- a/spx-gui/src/models/animation.test.ts
+++ b/spx-gui/src/models/animation.test.ts
@@ -118,8 +118,7 @@ describe('Animation', () => {
     // id should be not null and not empty
     expect(id).not.toBeNull()
 
-    const exportedId = animation.export({
-      basePath: '',
+    const exportedId = animation.export('', {
       includeId: false,
       sounds: project.sounds
     })[0].builder_id

--- a/spx-gui/src/models/animation.ts
+++ b/spx-gui/src/models/animation.ts
@@ -43,6 +43,11 @@ export type RawAnimationConfig = {
   onPlay?: ActionConfig
 }
 
+export type AnimationExportLoadOptions = {
+  sounds: Sound[]
+  includeId?: boolean
+}
+
 export class Animation extends Disposable {
   id: string
 
@@ -127,7 +132,7 @@ export class Animation extends Disposable {
       anitype
     }: RawAnimationConfig,
     costumes: Costume[],
-    sounds: Sound[]
+    { sounds, includeId = true }: AnimationExportLoadOptions
   ): [animation: Animation, animationCostumeNames: string[]] {
     frameFrom = frameFrom ?? from
     frameTo = frameTo ?? to
@@ -149,7 +154,7 @@ export class Animation extends Disposable {
       else soundId = sound.id
     }
     const animation = new Animation(name, {
-      id,
+      id: includeId ? id : undefined,
       duration,
       sound: soundId
     })
@@ -165,7 +170,8 @@ export class Animation extends Disposable {
 
   export(
     /** Path of directory which contains the sprite's config file */
-    { basePath, sounds, includeId = true }: { basePath: string; includeId?: boolean; sounds: Sound[] }
+    basePath: string,
+    { sounds, includeId = true }: AnimationExportLoadOptions
   ): [RawAnimationConfig, RawCostumeConfig[], Files] {
     const costumeConfigs: RawCostumeConfig[] = []
     const files: Files = {}

--- a/spx-gui/src/models/backdrop.ts
+++ b/spx-gui/src/models/backdrop.ts
@@ -11,6 +11,10 @@ export type RawBackdropConfig = RawCostumeConfig
 
 const backdropAssetPath = 'assets'
 
+export type BackdropExportLoadOptions = {
+  includeId?: boolean
+}
+
 // Backdrop is almost the same as Costume
 export class Backdrop extends Costume {
   private stage: Stage | null = null
@@ -41,15 +45,22 @@ export class Backdrop extends Costume {
     })
   }
 
-  static load({ name, path, builder_id: id, ...inits }: RawBackdropConfig, files: Files) {
+  static load(
+    { name, path, builder_id: id, ...inits }: RawBackdropConfig,
+    files: Files,
+    { includeId = true }: BackdropExportLoadOptions = {}
+  ) {
     if (name == null) throw new Error(`name expected for backdrop`)
     if (path == null) throw new Error(`path expected for backdrop ${name}`)
     const file = files[resolve(backdropAssetPath, path)]
     if (file == null) throw new Error(`file ${path} for backdrop ${name} not found`)
-    return new Backdrop(name, file, { ...inits, id })
+    return new Backdrop(name, file, {
+      ...inits,
+      id: includeId ? id : undefined
+    })
   }
 
-  export({ includeId = true }: { includeId?: boolean } = {}): [RawBackdropConfig, Files] {
+  export({ includeId = true }: BackdropExportLoadOptions = {}): [RawBackdropConfig, Files] {
     return super.export({ basePath: backdropAssetPath, includeId })
   }
 }

--- a/spx-gui/src/models/common/asset.ts
+++ b/spx-gui/src/models/common/asset.ts
@@ -17,7 +17,7 @@ export type AssetModel<T extends AssetType = AssetType> = T extends AssetType.So
 
 export async function sprite2Asset(sprite: Sprite): Promise<PartialAssetData> {
   const { fileCollection, fileCollectionHash } = await saveFiles(
-    sprite.export({ includeId: false, sounds: [], includeCode: false }) // animation sound is not preserved when saving as assets
+    sprite.export({ sounds: [], includeId: false, includeCode: false }) // animation sound is not preserved when saving as assets
   )
   return {
     displayName: sprite.name,
@@ -28,8 +28,12 @@ export async function sprite2Asset(sprite: Sprite): Promise<PartialAssetData> {
 }
 
 export async function asset2Sprite(assetData: PartialAssetData) {
-  const files = await getFiles(assetData.files)
-  const sprites = await Sprite.loadAll(files, [])
+  const files = getFiles(assetData.files)
+  const sprites = await Sprite.loadAll(files, {
+    sounds: [],
+    includeId: false,
+    includeCode: false
+  })
   if (sprites.length === 0) throw new Error('no sprite loaded')
   return sprites[0]
 }
@@ -50,11 +54,11 @@ export async function backdrop2Asset(backdrop: Backdrop): Promise<PartialAssetDa
 }
 
 export async function asset2Backdrop(assetData: PartialAssetData) {
-  const files = await getFiles(assetData.files)
+  const files = getFiles(assetData.files)
   const configFile = files[virtualBackdropConfigFileName]
   if (configFile == null) throw new Error('no config file found')
   const config = (await toConfig(configFile)) as BackdropInits
-  return Backdrop.load(config, files)
+  return Backdrop.load(config, files, { includeId: false })
 }
 
 export async function sound2Asset(sound: Sound): Promise<PartialAssetData> {
@@ -68,8 +72,8 @@ export async function sound2Asset(sound: Sound): Promise<PartialAssetData> {
 }
 
 export async function asset2Sound(assetData: PartialAssetData) {
-  const files = await getFiles(assetData.files)
-  const sounds = await Sound.loadAll(files)
+  const files = getFiles(assetData.files)
+  const sounds = await Sound.loadAll(files, { includeId: false })
   if (sounds.length === 0) throw new Error('no sound loaded')
   return sounds[0]
 }

--- a/spx-gui/src/models/costume.ts
+++ b/spx-gui/src/models/costume.ts
@@ -24,6 +24,13 @@ export type RawCostumeConfig = Omit<CostumeInits, 'id'> & {
   path?: string
 }
 
+export type CostumeExportLoadOptions = {
+  /** Path of directory which contains the sprite's config file */
+  basePath: string
+  includeId?: boolean
+  namePrefix?: string
+}
+
 export class Costume {
   id: string
 
@@ -141,26 +148,19 @@ export class Costume {
   static load(
     { builder_id: id, name, path, ...inits }: RawCostumeConfig,
     files: Files,
-    /** Path of directory which contains the sprite's config file */
-    basePath: string
+    { basePath, includeId }: CostumeExportLoadOptions
   ) {
     if (name == null) throw new Error(`name expected for costume`)
     if (path == null) throw new Error(`path expected for costume ${name}`)
     const file = files[resolve(basePath, path)]
     if (file == null) throw new Error(`file ${path} for costume ${name} not found`)
-    return new Costume(name, file, { ...inits, id })
+    return new Costume(name, file, {
+      ...inits,
+      id: includeId ? id : undefined
+    })
   }
 
-  export({
-    basePath,
-    includeId = true,
-    namePrefix = ''
-  }: {
-    /** Path of directory which contains the sprite's config file */
-    basePath: string
-    includeId?: boolean
-    namePrefix?: string
-  }): [RawCostumeConfig, Files] {
+  export({ basePath, includeId = true, namePrefix = '' }: CostumeExportLoadOptions): [RawCostumeConfig, Files] {
     const name = namePrefix + this.name
     const filename = name + extname(this.img.name)
     const config: RawCostumeConfig = {

--- a/spx-gui/src/models/project/index.ts
+++ b/spx-gui/src/models/project/index.ts
@@ -323,7 +323,7 @@ export class Project extends Disposable {
     } = config
 
     const sounds = await Sound.loadAll(files)
-    const sprites = await Sprite.loadAll(files, sounds)
+    const sprites = await Sprite.loadAll(files, { sounds })
 
     const widgets: RawWidgetConfig[] = []
     const zorder: string[] = []

--- a/spx-gui/src/models/sprite.test.ts
+++ b/spx-gui/src/models/sprite.test.ts
@@ -20,7 +20,7 @@ describe('Sprite', () => {
     sprite.addAnimation(animation1)
     sprite.addAnimation(animation2)
     const exported = sprite.export({ sounds: [] })
-    const [loadedSprite] = await Sprite.loadAll(exported, [])
+    const [loadedSprite] = await Sprite.loadAll(exported, { sounds: [] })
     expect(loadedSprite.costumes.map((c) => c.name)).toEqual(['costume1', 'costume2'])
     expect(loadedSprite.animations.map((c) => c.name)).toEqual(['animation1', 'animation2'])
     expect(loadedSprite.animations[0].costumes.map((c) => c.name)).toEqual(['costume3', 'costume4'])
@@ -35,7 +35,7 @@ describe('Sprite', () => {
     expect(sprite.getAnimationBoundStates(animation.id)).toEqual([State.die, State.turn])
 
     const exported = sprite.export({ sounds: [] })
-    const imported = await Sprite.loadAll(exported, [])
+    const imported = await Sprite.loadAll(exported, { sounds: [] })
 
     expect(imported[0].getAnimationBoundStates(animation.id)).toEqual([State.die, State.turn])
   })


### PR DESCRIPTION
There may be assets with field `builder_id` in asset-library, which are added by Spritehub rather than Builder.

Now we do control `includeID: bool` during both export and load processes, allowing us to exclude `builder_id` when adding asset from asset-library, to avoid issues caused by duplicate ID.
