### PR TITLE
LS intergration for semantic tokens highlighting

### DIFF
--- a/spx-gui/src/components/editor/code-editor/common.ts
+++ b/spx-gui/src/components/editor/code-editor/common.ts
@@ -11,6 +11,7 @@ import { Costume } from '@/models/costume'
 import { Animation } from '@/models/animation'
 import { isWidget } from '@/models/widget'
 import { stageCodeFilePaths } from '@/models/stage'
+import type { Monaco, monaco } from './monaco'
 
 export type Position = {
   line: number
@@ -561,4 +562,12 @@ export function textDocumentId2CodeFileName(id: TextDocumentIdentifier) {
     const spriteName = codeFilePath.replace(/\.spx$/, '')
     return { en: spriteName, zh: spriteName }
   }
+}
+
+export function fromMonacoUri(uri: monaco.Uri): TextDocumentIdentifier {
+  return { uri: uri.toString() }
+}
+
+export function toMonacoUri(id: TextDocumentIdentifier, monaco: Monaco): monaco.Uri {
+  return monaco.Uri.parse(id.uri)
 }

--- a/spx-gui/src/components/editor/code-editor/lsp/index.ts
+++ b/spx-gui/src/components/editor/code-editor/lsp/index.ts
@@ -163,6 +163,11 @@ export class SpxLSPClient extends Disposable {
     return spxlc.request<lsp.TextEdit[] | null>(lsp.DocumentFormattingRequest.method, params)
   }
 
+  async textDocumentSemanticTokens(params: lsp.SemanticTokensParams): Promise<lsp.SemanticTokens | null> {
+    const spxlc = await this.prepareRequest()
+    return spxlc.request<lsp.SemanticTokens | null>(lsp.SemanticTokensRequest.method, params)
+  }
+
   // Higher-level APIs
 
   async getResourceReferences(textDocument: TextDocumentIdentifier): Promise<ResourceReference[]> {
@@ -199,4 +204,31 @@ export class SpxLSPClient extends Disposable {
     if (!Array.isArray(completionResult)) return [] // For now, we support CompletionItem[] only
     return completionResult as CompletionItem[]
   }
+}
+
+// Keep in sync with `tools/spxls/internal/server/semantic_token.go`
+export const semanticTokenLegend = {
+  tokenTypes: [
+    lsp.SemanticTokenTypes.namespace,
+    lsp.SemanticTokenTypes.type,
+    lsp.SemanticTokenTypes.interface,
+    lsp.SemanticTokenTypes.struct,
+    lsp.SemanticTokenTypes.parameter,
+    lsp.SemanticTokenTypes.variable,
+    lsp.SemanticTokenTypes.property,
+    lsp.SemanticTokenTypes.function,
+    lsp.SemanticTokenTypes.method,
+    lsp.SemanticTokenTypes.keyword,
+    lsp.SemanticTokenTypes.comment,
+    lsp.SemanticTokenTypes.string,
+    lsp.SemanticTokenTypes.number,
+    lsp.SemanticTokenTypes.operator,
+    'label' // since LSP 3.18.0, Not supported by `vscode-languageserver-protocol` yet
+  ],
+  tokenModifiers: [
+    lsp.SemanticTokenModifiers.declaration,
+    lsp.SemanticTokenModifiers.readonly,
+    lsp.SemanticTokenModifiers.static,
+    lsp.SemanticTokenModifiers.defaultLibrary
+  ]
 }

--- a/spx-gui/src/components/editor/code-editor/text-document.ts
+++ b/spx-gui/src/components/editor/code-editor/text-document.ts
@@ -11,7 +11,8 @@ import {
   type TextDocumentIdentifier,
   type WordAtPosition,
   type TextEdit,
-  getTextDocumentId
+  getTextDocumentId,
+  toMonacoUri
 } from './common'
 import { toMonacoPosition, toMonacoRange, fromMonacoPosition } from './ui/common'
 import type { Monaco, monaco } from './monaco'
@@ -114,7 +115,11 @@ export class TextDocument
   ) {
     super()
 
-    this.monacoTextModel = monaco.editor.createModel(codeOwner.getCode() ?? '', 'spx')
+    this.monacoTextModel = monaco.editor.createModel(
+      codeOwner.getCode() ?? '',
+      'spx',
+      toMonacoUri(this.codeOwner.getTextDocumentId(), monaco)
+    )
 
     this.addDisposer(
       watch(

--- a/spx-gui/src/components/editor/code-editor/ui/CodeEditorUI.vue
+++ b/spx-gui/src/components/editor/code-editor/ui/CodeEditorUI.vue
@@ -128,7 +128,9 @@ const monacoEditorOptions = computed<monaco.editor.IStandaloneEditorConstruction
   tabSize,
   insertSpaces,
   fontSize: fontSize.value,
-  contextmenu: false
+  contextmenu: false,
+  // TODO: preserve `semanticHighlighting` of theme (in `@shikijs/monaco`), then remove this line
+  'semanticHighlighting.enabled': true
 }))
 
 const monacEditorInitDataRef = shallowRef<MonacoEditorInitData | null>(null)

--- a/spx-gui/src/components/editor/code-editor/ui/common.ts
+++ b/spx-gui/src/components/editor/code-editor/ui/common.ts
@@ -4,8 +4,7 @@ import type { ResourceModel } from '@/models/common/resource-model'
 import { Sprite } from '@/models/sprite'
 import { Sound } from '@/models/sound'
 import { isWidget } from '@/models/widget'
-import { type Range, type Position, type TextDocumentIdentifier, type Selection } from '../common'
-import type { Monaco } from '../monaco'
+import { type Range, type Position, type Selection } from '../common'
 
 export function token2Signal(token: monaco.CancellationToken): AbortSignal {
   const ctrl = new AbortController()
@@ -58,15 +57,6 @@ export function toMonacoSelection(selection: Selection): monaco.ISelection {
     positionLineNumber: selection.position.line,
     positionColumn: selection.position.column
   }
-}
-
-export function fromMonacoUri(uri: monaco.Uri): TextDocumentIdentifier {
-  // TODO: check if this is correct
-  return { uri: uri.toString() }
-}
-
-export function toMonacoUri(id: TextDocumentIdentifier, monaco: Monaco): monaco.Uri {
-  return monaco.Uri.parse(id.uri)
 }
 
 export function supportGoTo(resourceModel: ResourceModel): boolean {

--- a/spx-gui/src/utils/spx/gop-tm-language.json
+++ b/spx-gui/src/utils/spx/gop-tm-language.json
@@ -5,9 +5,6 @@
 	"name": "GoPlus",
 	"scopeName": "source.gop",
 	"patterns": [
-		{
-			"include": "#statements"
-		}
 	],
 	"repository": {
 		"statements": {


### PR DESCRIPTION
close #1172.

- [ ] Relationship between `tokenTypes`/`tokenModifiers` and TextMate patterns
- [ ] Optimize highlighting: comment, function-call, command-call, etc.

Related:

* https://code.visualstudio.com/api/language-extensions/semantic-highlight-guide
* https://github.com/microsoft/vscode/wiki/Semantic-Highlighting-Overview
