### PR TITLE
Fix image size for svg

### DIFF
--- a/spx-gui/src/components/editor/preview/stage-viewer/SpriteNode.vue
+++ b/spx-gui/src/components/editor/preview/stage-viewer/SpriteNode.vue
@@ -14,7 +14,7 @@ import type { Image, ImageConfig } from 'konva/lib/shapes/Image'
 import type { Action } from '@/models/project'
 import { LeftRight, RotationStyle, headingToLeftRight, leftRightToHeading, type Sprite } from '@/models/sprite'
 import type { Size } from '@/models/common'
-import { nomalizeDegree, round } from '@/utils/utils'
+import { nomalizeDegree, round, useAsyncComputed } from '@/utils/utils'
 import { useFileImg } from '@/utils/file'
 import { useEditorCtx } from '../../EditorContextProvider.vue'
 import { getNodeId } from './node'
@@ -30,6 +30,7 @@ const editorCtx = useEditorCtx()
 const costume = computed(() => props.sprite.defaultCostume)
 const bitmapResolution = computed(() => costume.value?.bitmapResolution ?? 1)
 const [image] = useFileImg(() => costume.value?.img)
+const rawSize = useAsyncComputed(async () => costume.value?.getRawSize() ?? null)
 
 const nodeId = computed(() => getNodeId(props.sprite))
 
@@ -71,6 +72,8 @@ const config = computed<ImageConfig>(() => {
   const config = {
     nodeId: nodeId.value,
     image: image.value ?? undefined,
+    width: rawSize.value?.width ?? 0,
+    height: rawSize.value?.height ?? 0,
     draggable: true,
     offsetX: 0,
     offsetY: 0,

--- a/spx-gui/src/models/costume.ts
+++ b/spx-gui/src/models/costume.ts
@@ -3,9 +3,7 @@ import { nanoid } from 'nanoid'
 
 import { extname, resolve } from '@/utils/path'
 import { adaptImg } from '@/utils/spx'
-import { Disposable } from '@/utils/disposable'
-import { File, type Files } from './common/file'
-import type { Size } from './common'
+import { File, type Files, getImageSize } from './common/file'
 import { getCostumeName, validateCostumeName } from './common/asset-name'
 import type { Sprite } from './sprite'
 import type { Animation } from './animation'
@@ -71,24 +69,8 @@ export class Costume {
     this.bitmapResolution = bitmapResolution
   }
 
-  private async getRawSize() {
-    const d = new Disposable()
-    const imgUrl = await this.img.url((fn) => d.addDisposer(fn))
-    return new Promise<Size>((resolve, reject) => {
-      const img = new window.Image()
-      img.src = imgUrl
-      img.onload = () => {
-        resolve({
-          width: img.width,
-          height: img.height
-        })
-      }
-      img.onerror = (e) => {
-        reject(new Error(`load image failed: ${e.toString()}`))
-      }
-    }).finally(() => {
-      d.dispose()
-    })
+  async getRawSize() {
+    return getImageSize(this.img)
   }
 
   async getSize() {


### PR DESCRIPTION
Updated behavior: Use the `viewBox` size for SVG images in Builder to ensure consistency with SPX.

Previous behavior: We retrieved the size of the `<img>` element containing SVG to determine the image size. While it was rendered within a `300x150` box by default, resulting in dimensions like `300x150`, `140x150`, `300x100`, etc.

> Why is the rendered SVG sometimes very small?
> 
> In some user-agents, when they fail to calculate a size for the element they fall back to a default size for replaced elements of 300px width × 150px height. That size is from deep within [a dark corner of the CSS 2.1 spec](http://www.w3.org/TR/CSS2/visudet.html#inline-replaced-width), so I guess that’s somewhat reasonable. Mostly it seems to happen when the viewBox attribute values are set in pixels instead of unitless.

Related:

* https://github.com/goplus/spx/blob/15b2e572746f3aaea519c2d9c0027188b50b62c8/internal/svgr/svg.go#L39
* https://thatemil.com/blog/2014/04/06/intrinsic-sizing-of-svg-in-responsive-web-design/