### PR TITLE
Fix SVG size retrieval logic

### DIFF
--- a/spx-gui/src/models/common/file.ts
+++ b/spx-gui/src/models/common/file.ts
@@ -127,8 +127,12 @@ async function getSVGImageSize(svgFile: File) {
   const parser = new DOMParser()
   const svg = parser.parseFromString(svgText, 'image/svg+xml').documentElement
   if (!(svg instanceof SVGSVGElement)) throw new Error(`invalid svg: ${svgFile.name}`)
-  // Keep consistent with spx, for details see https://github.com/goplus/spx/blob/15b2e572746f3aaea519c2d9c0027188b50b62c8/internal/svgr/svg.go#L39
-  const { width, height } = svg.viewBox.baseVal
+  // Keep consistent with spx, for details see:
+  // * https://github.com/goplus/spx/blob/15b2e572746f3aaea519c2d9c0027188b50b62c8/internal/svgr/svg.go#L39
+  // * https://github.com/qiniu/oksvg/blob/917f53935572252ba3da8909ca4fbedec418bde1/svgd.go#L1015-L1049
+  let { width, height } = svg.viewBox.baseVal
+  if (width === 0) width = svg.width.baseVal.value
+  if (height === 0) height = svg.height.baseVal.value
   return { width, height }
 }
 


### PR DESCRIPTION
In follow-up to #1186.

spx uses value of attribute `width` & `height` when attribute `viewBox` lacks a valid value. Details can be found at https://github.com/qiniu/oksvg/blob/917f53935572252ba3da8909ca4fbedec418bde1/svgd.go#L1015-L1049

We are replicating this logic for consistency.