### PR TITLE
Fix code-change in markdown with blank-line content

### DIFF
--- a/spx-backend/internal/copilot/custom_element_code_change.md
+++ b/spx-backend/internal/copilot/custom_element_code_change.md
@@ -2,6 +2,8 @@
 
 Display a change in the code. The change shows the difference between the original code and the new code. The user can apply the change by clicking "Apply" button in the element.
 
+NOTE: Instead of `<code-change>`, you should use `<pre is="code-change">` to properly wrap the code change.
+
 ## Attributes
 
 ### `file`
@@ -25,10 +27,10 @@ The new code.
 ### Basic example
 
 ```xml
-<code-change file="file:///NiuXiaoQi.spx" line-range="10-12">
+<pre is="code-change" file="file:///NiuXiaoQi.spx" line-range="10-12">
 show
 say "Hello, world!"
-</code-change>
+</pre>
 ```
 
 This is a change in the code of sprite `NiuXiaoQi`. The original code is line 10 & line 11. The new code is `show\nsay "Hello, world!"\n`.

--- a/spx-gui/src/components/editor/code-editor/ui/markdown/CodeChange.vue
+++ b/spx-gui/src/components/editor/code-editor/ui/markdown/CodeChange.vue
@@ -81,9 +81,9 @@ const handleApply = useMessageHandle(
         </BlockActionBtn>
       </BlockFooter>
     </template>
-    <template v-else>
-      <p>{{ $t({ en: 'Invalid code position', zh: '无效的代码位置' }) }}</p>
-    </template>
+    <div v-else class="invalid">
+      <p>{{ $t({ en: 'Invalid code change', zh: '无效的代码变更' }) }}</p>
+    </div>
   </BlockWrapper>
 </template>
 
@@ -101,5 +101,10 @@ const handleApply = useMessageHandle(
 }
 .code {
   padding-right: 8px;
+}
+.invalid {
+  padding: 8px;
+  text-align: center;
+  color: var(--ui-color-hint-2);
 }
 </style>

--- a/spx-gui/src/components/editor/code-editor/ui/markdown/CodeView.vue
+++ b/spx-gui/src/components/editor/code-editor/ui/markdown/CodeView.vue
@@ -25,16 +25,16 @@ const props = withDefaults(
 )
 
 const childrenText = useSlotText()
+const codeToDisplay = computed(() => childrenText.value.replace(/\n$/, '')) // omit last line break when displaying
 const highlighter = useAsyncComputed(getHighlighter)
 
 const hasLineNumbers = computed(() => {
-  return props.lineNumbers && props.mode === 'block' && childrenText.value.split('\n').length > 1
+  return props.lineNumbers && props.mode === 'block' && codeToDisplay.value.split('\n').length > 1
 })
 
 const codeHtml = computed(() => {
   if (highlighter.value == null) return ''
-  const codeToDisplay = childrenText.value.replace(/\n$/, '') // omit last line break when displaying
-  return highlighter.value.codeToHtml(codeToDisplay, {
+  return highlighter.value.codeToHtml(codeToDisplay.value, {
     lang: props.language,
     structure: props.mode === 'block' ? 'classic' : 'inline',
     theme

--- a/spx-gui/src/components/editor/code-editor/ui/markdown/MarkdownView.vue
+++ b/spx-gui/src/components/editor/code-editor/ui/markdown/MarkdownView.vue
@@ -25,18 +25,16 @@ const basicComponents = {
   /**
    * Usage:
    * ```html
-   * <code-link file="file:///NiuXiaoQi.spx" position="10,20">
-   *   Default link text here
-   * </code-link>
+   * <code-link file="file:///NiuXiaoQi.spx" position="10,20">Default link text</code-link>
    * ```
    */
   'code-link': CodeLink,
   /**
    * Usage:
    * ```html
-   * <code-change file="file:///NiuXiaoQi.spx" line-range="1-10">
+   * <pre is="code-change" file="file:///NiuXiaoQi.spx" line-range="1-10">
    *   New code content here
-   * </code-change>
+   * </pre>
    * ```
    */
   'code-change': CodeChange,


### PR DESCRIPTION
* Fix `code-change` in markdown to allow blank lines, closes #1184
* Additional updates:
    - Optimize style for the "invalid" placeholder in `CodeChange`
    - Fix visibility of line numbers in `CodeView`

### Explanation

Blank lines may appear in the content of the `code-change` component, such as:

```html
<code-change file="...">
var a int

onStart => {
  // ...
}
</code-change>
```

While according to Markdown specifications (e.g., [CommonMark](https://spec.commonmark.org/0.31.2/#html-blocks)), blank lines are not permitted within HTML blocks, except for tags like `pre`, `script`, `style`, and `textarea`. As a result, `MarkdownView` does not parse the above example corretly.

To allow blank lines in content of custom elements, we introduced the `is` attribute, allowing them to be declared as a `pre` element. The example above can now be written as:

```html
<pre is="code-change" file="...">
var a int

onStart => {
  // ...
}
</pre>
```