### PR TITLE
chore: remove `wasm_exec.js` copy step from Wasm build scripts

### DIFF
--- a/spx-gui/build-wasm.bat
+++ b/spx-gui/build-wasm.bat
@@ -24,8 +24,5 @@ copy ispx\main.wasm ..\spx-gui\src\assets\ispx\main.wasm
 REM Get GOROOT environment variable
 for /f "tokens=*" %%i in ('go env GOROOT') do set GOROOT=%%i
 
-REM Copy the wasm_exec.js file
-copy "%GOROOT%\misc\wasm\wasm_exec.js" ..\spx-gui\src\assets\wasm_exec.js
-
 echo Build WASM complete
 endlocal

--- a/spx-gui/build-wasm.sh
+++ b/spx-gui/build-wasm.sh
@@ -16,4 +16,3 @@ cd ..
 
 cp fmt/static/main.wasm ../spx-gui/src/assets/format.wasm
 cp ispx/main.wasm ../spx-gui/src/assets/ispx/main.wasm
-cp "$(go env GOROOT)/misc/wasm/wasm_exec.js" ../spx-gui/src/assets/wasm_exec.js


### PR DESCRIPTION
The `wasm_exec.js` file is already tracked at `spx-gui/src/assets/wasm_exec.js`, making the copy step redundant.

Additionally, copying from `$GOROOT/misc/wasm/wasm_exec.js` is unreliable because:

1. In Go 1.24, the file will be moved to `$GOROOT/lib/wasm`[^1].
2. `$GOROOT/misc` is not included in Go toolchain archives, which breaks Wasm builds when using `GOTOOLCHAIN`[^2].

[^1]: https://tip.golang.org/doc/go1.24#wasm
[^2]: https://go.dev/issue/68024