### PR TITLE
Optimize speed for running project

### DIFF
--- a/spx-gui/src/components/editor/preview/EditorPreview.vue
+++ b/spx-gui/src/components/editor/preview/EditorPreview.vue
@@ -64,7 +64,7 @@
       >
         {{ $t({ en: 'Rerun', zh: '重新运行' }) }}
       </UIButton>
-      <UIButton class="button" type="boring" :disabled="running.initializing" @click="handleStop">
+      <UIButton class="button" type="boring" @click="handleStop">
         {{ $t({ en: 'Stop', zh: '停止' }) }}
       </UIButton>
     </UICardHeader>

--- a/spx-gui/src/components/project/runner/ProjectRunner.vue
+++ b/spx-gui/src/components/project/runner/ProjectRunner.vue
@@ -20,8 +20,8 @@ function handleConsole(type: 'log' | 'warn', args: unknown[]) {
 const version = useSpxVersion()
 
 defineExpose({
-  async run() {
-    return projectRunnerRef.value?.run()
+  async run(signal?: AbortSignal) {
+    return projectRunnerRef.value?.run(signal)
   },
   async stop() {
     return projectRunnerRef.value?.stop()

--- a/spx-gui/src/components/project/runner/v2/ProjectRunnerV2.vue
+++ b/spx-gui/src/components/project/runner/v2/ProjectRunnerV2.vue
@@ -106,12 +106,15 @@ onMounted(() => {
 })
 
 defineExpose({
-  async run() {
+  async run(signal?: AbortSignal) {
     loading.value = true
     registered.onStart()
     const iframeWindow = await untilNotNull(iframeWindowRef)
+    signal?.throwIfAborted()
     const projectData = await getProjectData()
+    signal?.throwIfAborted()
     await withLog('startGame', iframeWindow.startGame(projectData, assetURLs))
+    signal?.throwIfAborted()
     loading.value = false
   },
   async stop() {


### PR DESCRIPTION
In #1229, we convert SVG images to PNG before project execution, resulting in slower "running". In this PR, we:

* Use `OffscreenCanvas` instead of `Canvas`
* Implement caching for converted results

to mitigate this issue.