### PR TITLE
refactor(tools/spxls): improve compile error handling and add spx type getters

### DIFF
--- a/tools/spxls/internal/server/command.go
+++ b/tools/spxls/internal/server/command.go
@@ -43,12 +43,8 @@ func (s *Server) workspaceExecuteCommand(params *ExecuteCommandParams) (any, err
 func (s *Server) spxRenameResources(params []SpxRenameResourceParams) (*WorkspaceEdit, error) {
 	result, err := s.compile()
 	if err != nil {
-		if errors.Is(err, errNoValidSpxFiles) || errors.Is(err, errNoMainSpxFile) {
-			return nil, nil
-		}
-		return nil, fmt.Errorf("failed to compile: %w", err)
+		return nil, err
 	}
-
 	return s.spxRenameResourcesWithCompileResult(result, params)
 }
 
@@ -111,9 +107,6 @@ func (s *Server) spxGetDefinitions(params []SpxGetDefinitionsParams) ([]SpxDefin
 
 	result, spxFile, astFile, err := s.compileAndGetASTFileForDocumentURI(param.TextDocument.URI)
 	if err != nil {
-		if errors.Is(err, errNoValidSpxFiles) || errors.Is(err, errNoMainSpxFile) {
-			return nil, nil
-		}
 		return nil, err
 	}
 	if astFile == nil {

--- a/tools/spxls/internal/server/command_test.go
+++ b/tools/spxls/internal/server/command_test.go
@@ -48,21 +48,21 @@ onStart => {
 			Name:    util.ToPtr("MySprite"),
 		}))
 		assert.True(t, spxDefinitionIdentifierSliceContains(mainSpxFileScopeDefs, SpxDefinitionIdentifier{
-			Package:    util.ToPtr(spxPkgPath),
+			Package:    util.ToPtr(GetSpxPkg().Path()),
 			Name:       util.ToPtr("Game.play"),
 			OverloadID: util.ToPtr("1"),
 		}))
 		assert.True(t, spxDefinitionIdentifierSliceContains(mainSpxFileScopeDefs, SpxDefinitionIdentifier{
-			Package: util.ToPtr(spxPkgPath),
+			Package: util.ToPtr(GetSpxPkg().Path()),
 			Name:    util.ToPtr("Game.onStart"),
 		}))
 		assert.False(t, spxDefinitionIdentifierSliceContains(mainSpxFileScopeDefs, SpxDefinitionIdentifier{
-			Package:    util.ToPtr(spxPkgPath),
+			Package:    util.ToPtr(GetSpxPkg().Path()),
 			Name:       util.ToPtr("Sprite.turn"),
 			OverloadID: util.ToPtr("1"),
 		}))
 		assert.False(t, spxDefinitionIdentifierSliceContains(mainSpxFileScopeDefs, SpxDefinitionIdentifier{
-			Package: util.ToPtr(spxPkgPath),
+			Package: util.ToPtr(GetSpxPkg().Path()),
 			Name:    util.ToPtr("Sprite.onStart"),
 		}))
 
@@ -82,21 +82,21 @@ onStart => {
 			Name:    util.ToPtr("println"),
 		}))
 		assert.True(t, spxDefinitionIdentifierSliceContains(mySpriteSpxFileScopeDefs, SpxDefinitionIdentifier{
-			Package:    util.ToPtr(spxPkgPath),
+			Package:    util.ToPtr(GetSpxPkg().Path()),
 			Name:       util.ToPtr("Game.play"),
 			OverloadID: util.ToPtr("1"),
 		}))
 		assert.False(t, spxDefinitionIdentifierSliceContains(mySpriteSpxFileScopeDefs, SpxDefinitionIdentifier{
-			Package: util.ToPtr(spxPkgPath),
+			Package: util.ToPtr(GetSpxPkg().Path()),
 			Name:    util.ToPtr("Game.onStart"),
 		}))
 		assert.True(t, spxDefinitionIdentifierSliceContains(mySpriteSpxFileScopeDefs, SpxDefinitionIdentifier{
-			Package:    util.ToPtr(spxPkgPath),
+			Package:    util.ToPtr(GetSpxPkg().Path()),
 			Name:       util.ToPtr("Sprite.turn"),
 			OverloadID: util.ToPtr("1"),
 		}))
 		assert.True(t, spxDefinitionIdentifierSliceContains(mySpriteSpxFileScopeDefs, SpxDefinitionIdentifier{
-			Package: util.ToPtr(spxPkgPath),
+			Package: util.ToPtr(GetSpxPkg().Path()),
 			Name:    util.ToPtr("Sprite.onStart"),
 		}))
 
@@ -116,25 +116,25 @@ onStart => {
 			Name:    util.ToPtr("println"),
 		}))
 		assert.True(t, spxDefinitionIdentifierSliceContains(mySpriteSpxOnStartScopeDefs, SpxDefinitionIdentifier{
-			Package:    util.ToPtr(spxPkgPath),
+			Package:    util.ToPtr(GetSpxPkg().Path()),
 			Name:       util.ToPtr("Game.play"),
 			OverloadID: util.ToPtr("1"),
 		}))
 		assert.False(t, spxDefinitionIdentifierSliceContains(mySpriteSpxOnStartScopeDefs, SpxDefinitionIdentifier{
-			Package: util.ToPtr(spxPkgPath),
+			Package: util.ToPtr(GetSpxPkg().Path()),
 			Name:    util.ToPtr("Game.onStart"),
 		}))
 		assert.True(t, spxDefinitionIdentifierSliceContains(mySpriteSpxOnStartScopeDefs, SpxDefinitionIdentifier{
-			Package:    util.ToPtr(spxPkgPath),
+			Package:    util.ToPtr(GetSpxPkg().Path()),
 			Name:       util.ToPtr("Sprite.turn"),
 			OverloadID: util.ToPtr("1"),
 		}))
 		assert.False(t, spxDefinitionIdentifierSliceContains(mySpriteSpxOnStartScopeDefs, SpxDefinitionIdentifier{
-			Package: util.ToPtr(spxPkgPath),
+			Package: util.ToPtr(GetSpxPkg().Path()),
 			Name:    util.ToPtr("Sprite.onStart"),
 		}))
 		assert.True(t, spxDefinitionIdentifierSliceContains(mySpriteSpxOnStartScopeDefs, SpxDefinitionIdentifier{
-			Package:    util.ToPtr(spxPkgPath),
+			Package:    util.ToPtr(GetSpxPkg().Path()),
 			Name:       util.ToPtr("Sprite.clone"),
 			OverloadID: util.ToPtr("1"),
 		}))
@@ -169,11 +169,11 @@ var (
 			Name:    util.ToPtr("Game.MySprite"),
 		}))
 		assert.True(t, spxDefinitionIdentifierSliceContains(mainSpxFileScopeDefs, SpxDefinitionIdentifier{
-			Package: util.ToPtr(spxPkgPath),
+			Package: util.ToPtr(GetSpxPkg().Path()),
 			Name:    util.ToPtr("Game.onStart"),
 		}))
 		assert.False(t, spxDefinitionIdentifierSliceContains(mainSpxFileScopeDefs, SpxDefinitionIdentifier{
-			Package: util.ToPtr(spxPkgPath),
+			Package: util.ToPtr(GetSpxPkg().Path()),
 			Name:    util.ToPtr("Sprite.onStart"),
 		}))
 	})
@@ -210,20 +210,20 @@ onStart => {
 		require.NoError(t, err)
 		require.NotNil(t, mySpriteSpxFileScopeDefs)
 		assert.True(t, spxDefinitionIdentifierSliceContains(mySpriteSpxFileScopeDefs, SpxDefinitionIdentifier{
-			Package:    util.ToPtr(spxPkgPath),
+			Package:    util.ToPtr(GetSpxPkg().Path()),
 			Name:       util.ToPtr("Game.play"),
 			OverloadID: util.ToPtr("1"),
 		}))
 		assert.False(t, spxDefinitionIdentifierSliceContains(mySpriteSpxFileScopeDefs, SpxDefinitionIdentifier{
-			Package: util.ToPtr(spxPkgPath),
+			Package: util.ToPtr(GetSpxPkg().Path()),
 			Name:    util.ToPtr("Game.onStart"),
 		}))
 		assert.True(t, spxDefinitionIdentifierSliceContains(mySpriteSpxFileScopeDefs, SpxDefinitionIdentifier{
-			Package: util.ToPtr(spxPkgPath),
+			Package: util.ToPtr(GetSpxPkg().Path()),
 			Name:    util.ToPtr("Sprite.onStart"),
 		}))
 		assert.True(t, spxDefinitionIdentifierSliceContains(mySpriteSpxFileScopeDefs, SpxDefinitionIdentifier{
-			Package: util.ToPtr(spxPkgPath),
+			Package: util.ToPtr(GetSpxPkg().Path()),
 			Name:    util.ToPtr("Sprite.onClick"),
 		}))
 	})
@@ -247,7 +247,7 @@ onStart => {}
 		require.NoError(t, err)
 		require.NotNil(t, mainSpxOnStartScopeDefs)
 		assert.False(t, spxDefinitionIdentifierSliceContains(mainSpxOnStartScopeDefs, SpxDefinitionIdentifier{
-			Package: util.ToPtr(spxPkgPath),
+			Package: util.ToPtr(GetSpxPkg().Path()),
 			Name:    util.ToPtr("Game.onStart"),
 		}))
 
@@ -263,7 +263,7 @@ onStart => {}
 		require.NoError(t, err)
 		require.NotNil(t, mainSpxFileScopeDefs)
 		assert.True(t, spxDefinitionIdentifierSliceContains(mainSpxFileScopeDefs, SpxDefinitionIdentifier{
-			Package: util.ToPtr(spxPkgPath),
+			Package: util.ToPtr(GetSpxPkg().Path()),
 			Name:    util.ToPtr("Game.onStart"),
 		}))
 	})

--- a/tools/spxls/internal/server/completion.go
+++ b/tools/spxls/internal/server/completion.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"errors"
 	"fmt"
 	"go/types"
 	"path"
@@ -22,9 +21,6 @@ import (
 func (s *Server) textDocumentCompletion(params *CompletionParams) ([]CompletionItem, error) {
 	result, spxFile, astFile, err := s.compileAndGetASTFileForDocumentURI(params.TextDocument.URI)
 	if err != nil {
-		if errors.Is(err, errNoValidSpxFiles) || errors.Is(err, errNoMainSpxFile) {
-			return nil, nil
-		}
 		return nil, err
 	}
 	if astFile == nil {
@@ -637,24 +633,24 @@ func (ctx *completionContext) collectTypeSpecific(typ types.Type) error {
 	}
 
 	var spxResourceNames []string
-	switch typ.String() {
-	case spxBackdropNameTypeFullName:
+	switch typ {
+	case GetSpxBackdropNameType():
 		spxResourceNames = slices.Grow(spxResourceNames, len(ctx.result.spxResourceSet.backdrops))
 		for spxBackdropName := range ctx.result.spxResourceSet.backdrops {
 			spxResourceNames = append(spxResourceNames, spxBackdropName)
 		}
-	case spxSpriteTypeFullName, spxSpriteImplTypeFullName:
+	case GetSpxSpriteType(), GetSpxSpriteImplType():
 		for spxSprite := range ctx.result.spxSpriteResourceAutoBindings {
-			if spxSprite.Type().String() == typ.String() {
+			if spxSprite.Type() == typ {
 				ctx.itemSet.addSpxDefs(ctx.result.spxDefinitionsFor(spxSprite, "Game")...)
 			}
 		}
-	case spxSpriteNameTypeFullName:
+	case GetSpxSpriteNameType():
 		spxResourceNames = slices.Grow(spxResourceNames, len(ctx.result.spxResourceSet.sprites))
 		for spxSpriteName := range ctx.result.spxResourceSet.sprites {
 			spxResourceNames = append(spxResourceNames, spxSpriteName)
 		}
-	case spxSpriteCostumeNameTypeFullName:
+	case GetSpxSpriteCostumeNameType():
 		expectedSpxSprite := ctx.getSpxSpriteResource()
 		for _, spxSprite := range ctx.result.spxResourceSet.sprites {
 			if expectedSpxSprite == nil || spxSprite == expectedSpxSprite {
@@ -664,7 +660,7 @@ func (ctx *completionContext) collectTypeSpecific(typ types.Type) error {
 				}
 			}
 		}
-	case spxSpriteAnimationNameTypeFullName:
+	case GetSpxSpriteAnimationNameType():
 		expectedSpxSprite := ctx.getSpxSpriteResource()
 		for _, spxSprite := range ctx.result.spxResourceSet.sprites {
 			if expectedSpxSprite == nil || spxSprite == expectedSpxSprite {
@@ -674,18 +670,18 @@ func (ctx *completionContext) collectTypeSpecific(typ types.Type) error {
 				}
 			}
 		}
-	case spxSoundTypeFullName:
+	case GetSpxSoundType():
 		for spxSound := range ctx.result.spxSoundResourceAutoBindings {
-			if spxSound.Type().String() == typ.String() {
+			if spxSound.Type() == typ {
 				ctx.itemSet.addSpxDefs(ctx.result.spxDefinitionsFor(spxSound, "Game")...)
 			}
 		}
-	case spxSoundNameTypeFullName:
+	case GetSpxSoundNameType():
 		spxResourceNames = slices.Grow(spxResourceNames, len(ctx.result.spxResourceSet.sounds))
 		for spxSoundName := range ctx.result.spxResourceSet.sounds {
 			spxResourceNames = append(spxResourceNames, spxSoundName)
 		}
-	case spxWidgetNameTypeFullName:
+	case GetSpxWidgetNameType():
 		spxResourceNames = slices.Grow(spxResourceNames, len(ctx.result.spxResourceSet.widgets))
 		for spxWidgetName := range ctx.result.spxResourceSet.widgets {
 			spxResourceNames = append(spxResourceNames, spxWidgetName)

--- a/tools/spxls/internal/server/definition.go
+++ b/tools/spxls/internal/server/definition.go
@@ -1,9 +1,6 @@
 package server
 
-import (
-	"errors"
-	"go/types"
-)
+import "go/types"
 
 // See https://microsoft.github.io/language-server-protocol/specifications/lsp/3.18/specification/#textDocument_declaration
 func (s *Server) textDocumentDeclaration(params *DeclarationParams) (any, error) {
@@ -18,9 +15,6 @@ func (s *Server) textDocumentDeclaration(params *DeclarationParams) (any, error)
 func (s *Server) textDocumentDefinition(params *DefinitionParams) (any, error) {
 	result, _, astFile, err := s.compileAndGetASTFileForDocumentURI(params.TextDocument.URI)
 	if err != nil {
-		if errors.Is(err, errNoValidSpxFiles) || errors.Is(err, errNoMainSpxFile) {
-			return nil, nil
-		}
 		return nil, err
 	}
 	if astFile == nil {
@@ -49,9 +43,6 @@ func (s *Server) textDocumentDefinition(params *DefinitionParams) (any, error) {
 func (s *Server) textDocumentTypeDefinition(params *TypeDefinitionParams) (any, error) {
 	result, _, astFile, err := s.compileAndGetASTFileForDocumentURI(params.TextDocument.URI)
 	if err != nil {
-		if errors.Is(err, errNoValidSpxFiles) || errors.Is(err, errNoMainSpxFile) {
-			return nil, nil
-		}
 		return nil, err
 	}
 	if astFile == nil {

--- a/tools/spxls/internal/server/diagnostic_test.go
+++ b/tools/spxls/internal/server/diagnostic_test.go
@@ -207,7 +207,7 @@ var (
 		s := New(newMapFSWithoutModTime(map[string][]byte{}), nil)
 
 		report, err := s.workspaceDiagnostic(&WorkspaceDiagnosticParams{})
-		require.EqualError(t, err, "no valid spx files found in main package")
+		require.EqualError(t, err, "no valid main.spx file found in main package")
 		require.Nil(t, report)
 	})
 

--- a/tools/spxls/internal/server/document.go
+++ b/tools/spxls/internal/server/document.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"errors"
 	"slices"
 
 	gopast "github.com/goplus/gop/ast"
@@ -11,9 +10,6 @@ import (
 func (s *Server) textDocumentDocumentLink(params *DocumentLinkParams) (links []DocumentLink, err error) {
 	result, spxFile, astFile, err := s.compileAndGetASTFileForDocumentURI(params.TextDocument.URI)
 	if err != nil {
-		if errors.Is(err, errNoValidSpxFiles) || errors.Is(err, errNoMainSpxFile) {
-			return nil, nil
-		}
 		return nil, err
 	}
 	if astFile == nil {

--- a/tools/spxls/internal/server/document_test.go
+++ b/tools/spxls/internal/server/document_test.go
@@ -272,7 +272,7 @@ onStart => {
 		}
 
 		links, err := s.textDocumentDocumentLink(params)
-		assert.NoError(t, err)
+		assert.EqualError(t, err, `file "main.gop" does not have .spx extension`)
 		assert.Nil(t, links)
 	})
 
@@ -283,7 +283,7 @@ onStart => {
 		}
 
 		links, err := s.textDocumentDocumentLink(params)
-		assert.NoError(t, err)
+		assert.ErrorIs(t, err, errNoMainSpxFile)
 		assert.Nil(t, links)
 	})
 

--- a/tools/spxls/internal/server/format_test.go
+++ b/tools/spxls/internal/server/format_test.go
@@ -67,7 +67,7 @@ run "assets", {Title: "Bullet (by Go+)"}
 		}
 
 		edits, err := s.textDocumentFormatting(params)
-		require.Error(t, err)
+		require.ErrorIs(t, err, errNoMainSpxFile)
 		require.Nil(t, edits)
 	})
 

--- a/tools/spxls/internal/server/highlight.go
+++ b/tools/spxls/internal/server/highlight.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"errors"
 	"slices"
 
 	"github.com/goplus/builder/tools/spxls/internal/util"
@@ -13,9 +12,6 @@ import (
 func (s *Server) textDocumentDocumentHighlight(params *DocumentHighlightParams) (*[]DocumentHighlight, error) {
 	result, _, astFile, err := s.compileAndGetASTFileForDocumentURI(params.TextDocument.URI)
 	if err != nil {
-		if errors.Is(err, errNoValidSpxFiles) || errors.Is(err, errNoMainSpxFile) {
-			return nil, nil
-		}
 		return nil, err
 	}
 	if astFile == nil {

--- a/tools/spxls/internal/server/hover.go
+++ b/tools/spxls/internal/server/hover.go
@@ -1,17 +1,11 @@
 package server
 
-import (
-	"errors"
-	"strings"
-)
+import "strings"
 
 // See https://microsoft.github.io/language-server-protocol/specifications/lsp/3.18/specification#textDocument_hover
 func (s *Server) textDocumentHover(params *HoverParams) (*Hover, error) {
 	result, _, astFile, err := s.compileAndGetASTFileForDocumentURI(params.TextDocument.URI)
 	if err != nil {
-		if errors.Is(err, errNoValidSpxFiles) || errors.Is(err, errNoMainSpxFile) {
-			return nil, nil
-		}
 		return nil, err
 	}
 	if astFile == nil {

--- a/tools/spxls/internal/server/implementation.go
+++ b/tools/spxls/internal/server/implementation.go
@@ -1,17 +1,11 @@
 package server
 
-import (
-	"errors"
-	"go/types"
-)
+import "go/types"
 
 // See https://microsoft.github.io/language-server-protocol/specifications/lsp/3.18/specification/#textDocument_implementation
 func (s *Server) textDocumentImplementation(params *ImplementationParams) (any, error) {
 	result, _, astFile, err := s.compileAndGetASTFileForDocumentURI(params.TextDocument.URI)
 	if err != nil {
-		if errors.Is(err, errNoValidSpxFiles) || errors.Is(err, errNoMainSpxFile) {
-			return nil, nil
-		}
 		return nil, err
 	}
 	if astFile == nil {

--- a/tools/spxls/internal/server/reference.go
+++ b/tools/spxls/internal/server/reference.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"errors"
 	"go/types"
 
 	gopast "github.com/goplus/gop/ast"
@@ -11,9 +10,6 @@ import (
 func (s *Server) textDocumentReferences(params *ReferenceParams) ([]Location, error) {
 	result, _, astFile, err := s.compileAndGetASTFileForDocumentURI(params.TextDocument.URI)
 	if err != nil {
-		if errors.Is(err, errNoValidSpxFiles) || errors.Is(err, errNoMainSpxFile) {
-			return nil, nil
-		}
 		return nil, err
 	}
 	if astFile == nil {

--- a/tools/spxls/internal/server/rename.go
+++ b/tools/spxls/internal/server/rename.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"errors"
 	"fmt"
 	"go/types"
 	"slices"
@@ -13,9 +12,6 @@ import (
 func (s *Server) textDocumentPrepareRename(params *PrepareRenameParams) (*Range, error) {
 	result, _, astFile, err := s.compileAndGetASTFileForDocumentURI(params.TextDocument.URI)
 	if err != nil {
-		if errors.Is(err, errNoValidSpxFiles) || errors.Is(err, errNoMainSpxFile) {
-			return nil, nil
-		}
 		return nil, err
 	}
 	if astFile == nil {
@@ -45,9 +41,6 @@ func (s *Server) textDocumentPrepareRename(params *PrepareRenameParams) (*Range,
 func (s *Server) textDocumentRename(params *RenameParams) (*WorkspaceEdit, error) {
 	result, _, astFile, err := s.compileAndGetASTFileForDocumentURI(params.TextDocument.URI)
 	if err != nil {
-		if errors.Is(err, errNoValidSpxFiles) || errors.Is(err, errNoMainSpxFile) {
-			return nil, nil
-		}
 		return nil, err
 	}
 	if astFile == nil {

--- a/tools/spxls/internal/server/semantic_token.go
+++ b/tools/spxls/internal/server/semantic_token.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"errors"
 	"go/types"
 	"slices"
 	"sort"
@@ -74,9 +73,6 @@ type semanticTokenInfo struct {
 func (s *Server) textDocumentSemanticTokensFull(params *SemanticTokensParams) (tokens *SemanticTokens, err error) {
 	result, _, astFile, err := s.compileAndGetASTFileForDocumentURI(params.TextDocument.URI)
 	if err != nil {
-		if errors.Is(err, errNoValidSpxFiles) || errors.Is(err, errNoMainSpxFile) {
-			return nil, nil
-		}
 		return nil, err
 	}
 	if astFile == nil {

--- a/tools/spxls/internal/server/signature.go
+++ b/tools/spxls/internal/server/signature.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"errors"
 	"go/types"
 	"strings"
 )
@@ -10,9 +9,6 @@ import (
 func (s *Server) textDocumentSignatureHelp(params *SignatureHelpParams) (*SignatureHelp, error) {
 	result, _, astFile, err := s.compileAndGetASTFileForDocumentURI(params.TextDocument.URI)
 	if err != nil {
-		if errors.Is(err, errNoValidSpxFiles) || errors.Is(err, errNoMainSpxFile) {
-			return nil, nil
-		}
 		return nil, err
 	}
 	if astFile == nil {

--- a/tools/spxls/internal/server/spx_definition.go
+++ b/tools/spxls/internal/server/spx_definition.go
@@ -271,42 +271,86 @@ var GetSpxBuiltinDefinitions = sync.OnceValue(func() []SpxDefinition {
 	return slices.Clip(defs)
 })
 
-// GetSpxPkg returns the spx package.
-var GetSpxPkg = sync.OnceValue(func() *types.Package {
-	spxPkg, err := internal.Importer.Import(spxPkgPath)
-	if err != nil {
-		panic(fmt.Errorf("failed to import spx package: %w", err))
-	}
-	return spxPkg
-})
+var (
+	// GetSpxPkg returns the spx package.
+	GetSpxPkg = sync.OnceValue(func() *types.Package {
+		spxPkg, err := internal.Importer.Import("github.com/goplus/spx")
+		if err != nil {
+			panic(fmt.Errorf("failed to import spx package: %w", err))
+		}
+		return spxPkg
+	})
 
-// GetSpxGameType returns the [spx.Game] type.
-var GetSpxGameType = sync.OnceValue(func() *types.Named {
-	spxPkg := GetSpxPkg()
-	return spxPkg.Scope().Lookup("Game").Type().(*types.Named)
-})
+	// GetSpxGameType returns the [spx.Game] type.
+	GetSpxGameType = sync.OnceValue(func() *types.Named {
+		spxPkg := GetSpxPkg()
+		return spxPkg.Scope().Lookup("Game").Type().(*types.Named)
+	})
 
-// GetSpxSpriteType returns the [spx.Sprite] type.
-var GetSpxSpriteType = sync.OnceValue(func() *types.Named {
-	spxPkg := GetSpxPkg()
-	return spxPkg.Scope().Lookup("Sprite").Type().(*types.Named)
-})
+	// GetSpxBackdropNameType returns the [spx.BackdropName] type.
+	GetSpxBackdropNameType = sync.OnceValue(func() *types.Alias {
+		spxPkg := GetSpxPkg()
+		return spxPkg.Scope().Lookup("BackdropName").Type().(*types.Alias)
+	})
 
-// GetSpxSpriteImplType returns the [spx.SpriteImpl] type.
-var GetSpxSpriteImplType = sync.OnceValue(func() *types.Named {
-	spxPkg := GetSpxPkg()
-	return spxPkg.Scope().Lookup("SpriteImpl").Type().(*types.Named)
-})
+	// GetSpxSpriteType returns the [spx.Sprite] type.
+	GetSpxSpriteType = sync.OnceValue(func() *types.Named {
+		spxPkg := GetSpxPkg()
+		return spxPkg.Scope().Lookup("Sprite").Type().(*types.Named)
+	})
 
-// GetSpxPkgDefinitions returns the spx definitions for the spx package.
-var GetSpxPkgDefinitions = sync.OnceValue(func() []SpxDefinition {
-	spxPkg := GetSpxPkg()
-	spxPkgDoc, err := pkgdata.GetPkgDoc(spxPkg.Path())
-	if err != nil {
-		panic(fmt.Errorf("failed to get spx package doc: %w", err))
-	}
-	return GetPkgSpxDefinitions(spxPkg, spxPkgDoc)
-})
+	// GetSpxSpriteImplType returns the [spx.SpriteImpl] type.
+	GetSpxSpriteImplType = sync.OnceValue(func() *types.Named {
+		spxPkg := GetSpxPkg()
+		return spxPkg.Scope().Lookup("SpriteImpl").Type().(*types.Named)
+	})
+
+	// GetSpxSpriteNameType returns the [spx.SpriteName] type.
+	GetSpxSpriteNameType = sync.OnceValue(func() *types.Alias {
+		spxPkg := GetSpxPkg()
+		return spxPkg.Scope().Lookup("SpriteName").Type().(*types.Alias)
+	})
+
+	// GetSpxSpriteCostumeNameType returns the [spx.SpriteCostumeName] type.
+	GetSpxSpriteCostumeNameType = sync.OnceValue(func() *types.Alias {
+		spxPkg := GetSpxPkg()
+		return spxPkg.Scope().Lookup("SpriteCostumeName").Type().(*types.Alias)
+	})
+
+	// GetSpxSpriteAnimationNameType returns the [spx.SpriteAnimationName] type.
+	GetSpxSpriteAnimationNameType = sync.OnceValue(func() *types.Alias {
+		spxPkg := GetSpxPkg()
+		return spxPkg.Scope().Lookup("SpriteAnimationName").Type().(*types.Alias)
+	})
+
+	// GetSpxSoundType returns the [spx.Sound] type.
+	GetSpxSoundType = sync.OnceValue(func() *types.Named {
+		spxPkg := GetSpxPkg()
+		return spxPkg.Scope().Lookup("Sound").Type().(*types.Named)
+	})
+
+	// GetSpxSoundNameType returns the [spx.SoundName] type.
+	GetSpxSoundNameType = sync.OnceValue(func() *types.Alias {
+		spxPkg := GetSpxPkg()
+		return spxPkg.Scope().Lookup("SoundName").Type().(*types.Alias)
+	})
+
+	// GetSpxWidgetNameType returns the [spx.WidgetName] type.
+	GetSpxWidgetNameType = sync.OnceValue(func() *types.Alias {
+		spxPkg := GetSpxPkg()
+		return spxPkg.Scope().Lookup("WidgetName").Type().(*types.Alias)
+	})
+
+	// GetSpxPkgDefinitions returns the spx definitions for the spx package.
+	GetSpxPkgDefinitions = sync.OnceValue(func() []SpxDefinition {
+		spxPkg := GetSpxPkg()
+		spxPkgDoc, err := pkgdata.GetPkgDoc(spxPkg.Path())
+		if err != nil {
+			panic(fmt.Errorf("failed to get spx package doc: %w", err))
+		}
+		return GetPkgSpxDefinitions(spxPkg, spxPkgDoc)
+	})
+)
 
 // nonMainPkgSpxDefsCache is a cache of non-main package spx definitions.
 var nonMainPkgSpxDefsCache sync.Map // map[*types.Package][]SpxDefinition

--- a/tools/spxls/internal/server/util.go
+++ b/tools/spxls/internal/server/util.go
@@ -249,7 +249,7 @@ func isSpxEventHandlerFuncName(name string) bool {
 
 // isSpxPkgObject reports whether the given object is defined in the spx package.
 func isSpxPkgObject(obj types.Object) bool {
-	return obj != nil && obj.Pkg() != nil && obj.Pkg().Path() == spxPkgPath
+	return obj != nil && obj.Pkg() == GetSpxPkg()
 }
 
 // isMainPkgObject reports whether the given object is defined in the main package.
@@ -281,7 +281,7 @@ func isRenameableObject(obj types.Object) bool {
 // with the spx package name omitted while other packages use their short names.
 func getSimplifiedTypeString(typ types.Type) string {
 	return types.TypeString(typ, func(p *types.Package) string {
-		if p.Path() == spxPkgPath {
+		if p == GetSpxPkg() {
 			return ""
 		}
 		return p.Name()


### PR DESCRIPTION
Currently, errors returned by `Server.compile` are only fatal errors that make the compilation result completely unusable. Therefore, we no longer ignore these errors in most cases.