### PR TITLE
Add doc for Tagging

### DIFF
--- a/docs/develop/guidance/feature_Mask.md
+++ b/docs/develop/guidance/feature_Mask.md
@@ -1,0 +1,14 @@
+# Mask 伪代码
+
+## 组件调用
+
+```vue
+<script lang="ts" setup>
+const visible = ref(false); // Mask是否显示
+const currentTags = ref(["RectComponent", "ButtonComponent"]); // 当前步骤需要高亮显示的组件的查找路径
+</script>
+
+<template>
+  <Mask :visible="visible" :tags="currentTags" />
+</template>
+```

--- a/docs/develop/guidance/feature_Tagging.md
+++ b/docs/develop/guidance/feature_Tagging.md
@@ -1,0 +1,112 @@
+# TagManager
+
+```typescript
+import { ref, type Ref } from "vue";
+
+export type TagInfo = {
+  key: string;
+  element: HTMLElement;
+};
+
+export class TagManager {
+  private tagsMap: Ref<Map<string, HTMLElement>> = ref(new Map());
+
+  /**
+   * 添加标注
+   */
+  addTag(key: string, element: HTMLElement) {
+    if (this.tagsMap.value.has(key)) {
+      console.warn(`Tag ${key} already exists`);
+      return;
+    }
+    this.tagsMap.value.set(key, element);
+  }
+
+  /**
+   * 移除标注
+   */
+  removeTag(key: string) {
+    this.tagsMap.value.delete(key);
+  }
+
+  /**
+   * 获取所有标注
+   */
+  getAllTags(): TagInfo[] {
+    const tags: TagInfo[] = [];
+    this.tagsMap.value.forEach((element, key) => {
+      tags.push({ key, element });
+    });
+    return tags;
+  }
+
+  /**
+   * 根据 key 筛选标注
+   */
+  getTagByKey(key: string): TagInfo | undefined {
+    const element = this.tagsMap.value.get(key);
+    if (element) {
+      return { key, element };
+    }
+    return undefined;
+  }
+
+  /**
+   * 清空所有标注
+   */
+  clearAllTags() {
+    this.tagsMap.value.clear();
+  }
+}
+```
+
+## v-tag Directive
+
+```typescript
+import { DirectiveBinding, App } from "vue";
+import { TagManager } from "./TagManager";
+
+const TAG_MANAGER_KEY = "tag-manager";
+
+/**
+ * 注册全局指令 v-tag
+ */
+export function registerTagDirective(app: App, tagManager: TagManager) {
+  app.provide(TAG_MANAGER_KEY, tagManager);
+
+  app.directive("tag", {
+    mounted(el: HTMLElement, binding) {
+      const key = binding.arg;
+      if (!key) throw new Error("v-tag requires a key");
+
+      const observer = new MutationObserver(() => {
+        if (!document.contains(el)) {
+          tagManager.removeTag(key);
+          observer.disconnect();
+        }
+      });
+
+      tagManager.addTag(key, el);
+      el.dataset.tagKey = key;
+    },
+  });
+}
+```
+
+## ToolFunction
+
+```typescript
+import { inject } from 'vue'
+import { TagManager } from './TagManager'
+
+const TAG_MANAGER_KEY = 'tag-manager'
+
+/**
+ * 获取全局 TagManager 实例
+ */
+export function useTagManager() {
+  const tagManager = inject(TAG_MANAGER_KEY)
+  if (!tagManager) throw new Error('TagManager not installed')
+  return tagManager as TagManager
+}
+```

--- a/docs/develop/guidance/module_Mask.md
+++ b/docs/develop/guidance/module_Mask.md
@@ -1,0 +1,6 @@
+```ts
+type Props = {
+  visible: boolean; // 是否显示蒙层
+  tags: string[]; // 需要高亮组件的查找路径
+};
+```

--- a/docs/develop/guidance/module_Tagging.md
+++ b/docs/develop/guidance/module_Tagging.md
@@ -1,22 +1,22 @@
 ```typescript
 /** Tag 类 */
-export class TagManage {
+export class Tagging {
+  /** key 和 element 的映射 */
+  private tags: Map<string, HTMLElement>;
+
   /** 添加一个标注  */
-  function addTag(key: string, element: HTMLElement): void
+  addTag(key: string, element: HTMLElement): void;
 
   /** 移除标注 */
-  function removeTag(key: string): void
+  removeTag(key: string): void;
 
   /** 获取所有标注 */
-  function getAllTags(): TagInfo[]
+  getAllTags(): TagInfo[];
 
-  /** 按 key 获取标注 */
-  function getTagByKey(key: string): TagInfo | undefined
+  /** 通过查找路径keys获取目标组件 */
+  getElementByKeys(keys: string[]): HTMLElement | null;
 
   /** 清空所有标注 */
-  function clearAllTags(): void
+  clearAllTags(): void;
 }
-
-/** 消费工具 */
-export function useTagManager(): TagManager
 ```

--- a/docs/develop/guidance/module_Tagging.md
+++ b/docs/develop/guidance/module_Tagging.md
@@ -1,0 +1,22 @@
+```typescript
+/** Tag 类 */
+export class TagManage {
+  /** 添加一个标注  */
+  function addTag(key: string, element: HTMLElement): void
+
+  /** 移除标注 */
+  function removeTag(key: string): void
+
+  /** 获取所有标注 */
+  function getAllTags(): TagInfo[]
+
+  /** 按 key 获取标注 */
+  function getTagByKey(key: string): TagInfo | undefined
+
+  /** 清空所有标注 */
+  function clearAllTags(): void
+}
+
+/** 消费工具 */
+export function useTagManager(): TagManager
+```


### PR DESCRIPTION
> Tagging 作为一个插件模块需要给其他模块提供接口，比如对于Mask蒙层（Component）模块，需要使用 Tagging 获取需要在蒙层中高亮的元素，并由 Mask 对元素进行高亮显示。Tagging 不需要消费方的具体业务的。

- 标注方 ：
    - 使用 v-tag 指令进行标注。
    - 标注信息仅包含一个唯一的 key。
- 消费方 ：
    - 提供全局 API 或工具函数，方便消费方获取所有标注信息。
    - 支持按 key 筛选标注。