### PR TITLE
Add doc for Mask and Tagging

### DIFF
--- a/docs/develop/guidance/achieve_Tagging.md
+++ b/docs/develop/guidance/achieve_Tagging.md
@@ -1,0 +1,188 @@
+# Taggin 内部实现说明
+
+## 实现原理说明
+
+1. 上下文管理：
+
+- 使用 `Vue` 的 `provide/inject` 实现跨多层级的组件通信
+- 每个 `Tag` 组件维护自己的子节点列表，间接实现 TagRoot 对子节点的收集
+- 通过 `onMounted/onBeforeUnmount` 生命周期管理节点注册，间接实现动态更新
+
+2. 树形结构构建：
+
+- 每个 `Tag` 节点包含 `name`、组件实例和子节点
+- 父节点自动收集子节点信息
+- 使用响应式对象`(reactive)`自动维护树结构
+
+3. 查询机制：
+
+- 使用深度优先搜索遍历 Tag 树
+- 支持路径匹配查询（如`"editorbox check"`）
+- 返回匹配的 HTMLElement
+
+4. 组件关系：
+
+- `<TagRoot />` 作为根容器和查询入口
+- `<Tag />` 组件支持无限嵌套，自动维护层级关系
+- 自动处理组件卸载时的节点清理
+
+## Tag 主要实现
+
+```vue
+<script setup lang="ts">
+const props = defineProps<{
+  name: string;
+}>();
+
+const parentContext = inject<TagContext>(TAG_CONTEXT_KEY);
+const instance = getCurrentInstance();
+
+// 当前节点的子节点管理
+const children = reactive<TagNode[]>([]);
+
+// 提供给子组件的上下文，用于子组件注册到当前节点和从当前节点移除
+const currentContext: TagContext = {
+  addChild(node: TagNode) {
+    children.push(node);
+  },
+  removeChild(node: TagNode) {
+    const index = children.indexOf(node);
+    if (index > -1) children.splice(index, 1);
+  },
+};
+
+provide(TAG_CONTEXT_KEY, currentContext);
+
+// 当前节点信息
+const selfNode = reactive<TagNode>({
+  name: props.name,
+  instance,
+  children,
+});
+
+// 挂载时注册到父节点
+onMounted(() => {
+  parentContext?.addChild(selfNode);
+});
+
+// 卸载时从父节点移除
+onBeforeUnmount(() => {
+  parentContext?.removeChild(selfNode);
+});
+</script>
+```
+
+## TagRoot
+
+```vue
+<script setup lang="ts">
+/* 维护一个root响应式对象，操作tagTree */
+const root = reactive<TagNode>({
+  name: "__root__",
+  instance: null,
+  children: [],
+});
+
+const getElement = (path: string) => {
+  /* 查找算法 */
+};
+
+onMounted(() => {
+  /*
+   * 因为provide/inject存在生命周期的前后问题，
+   * 这里使用了一个全局的响应式对象来存储TagRoot所需要暴露的api
+   */
+  tagApi.value = {
+    getElement,
+  };
+});
+
+onBeforeUnmount(() => {
+  tagApi.value = null;
+});
+
+/* 提供给子组件的上下文，用于子组件注册到根节点和从当根节点移除
+ */
+const context: TagContext = {
+  addChild(node: TagNode) {
+    root.children.push(node);
+  },
+  removeChild(node: TagNode) {
+    const index = root.children.indexOf(node);
+    if (index > -1) root.children.splice(index, 1);
+  },
+};
+
+provide(TAG_CONTEXT_KEY, context);
+</script>
+```
+
+## tagApi
+
+```ts
+/*
+ * 因为provide/inject存在生命周期的前后问题，
+ * 这里使用了一个全局的响应式对象来存储TagRoot所需要暴露的api
+ */
+const tagApi = ref<{
+  getElement: (path: string) => HTMLElement | null;
+} | null>(null);
+```
+
+## useTag
+
+```ts
+function useTag() {
+  const getElement = (path: string) => {
+    if (!tagApi.value) {
+      throw new Error("TagConsumer not mounted");
+    }
+    return tagApi.value.getElement(path);
+  };
+
+  return {
+    getElement,
+  };
+}
+```
+
+## 示例使用
+
+```vue
+<script setup lang="ts">
+const { getElement } = useTag();
+
+const handleCheck = () => {
+  console.log(getElement("editorbox check"));
+};
+
+const logCodeContext = () => {
+  console.log(getElement("editorbox pre"));
+};
+</script>
+
+<template>
+  <RootTag>
+    <Tag name="editorbox">
+      <div class="editor">
+        <h2>Coding Here</h2>
+        <div class="options">
+          <Tag name="check">
+            <button @click="handleCheck">Check</button>
+          </Tag>
+          <Tag name="logpre">
+            <button @click="logCodeContext">logpre</button>
+          </Tag>
+        </div>
+        <Tag name="pre">
+          <pre>
+            <Tag name="code">
+              <code>console.log("Hello, Tagging!");</code>
+            </Tag>
+          </pre>
+        </Tag>
+      </div>
+    </Tag>
+  </RootTag>
+</template>
+```

--- a/docs/develop/guidance/achieve_Tagging.md
+++ b/docs/develop/guidance/achieve_Tagging.md
@@ -1,4 +1,10 @@
-# Taggin 内部实现说明
+# Tagging 内部实现说明
+
+Tagging 主要有三部分组成：
+
+- `<Tag />`: 用于给组件添加标注的 vue component
+- `<TagRoot />`: 作为跟组件，收集`<Tag/>`上报的节点信息并构建`tagTree`，并向外提供方法。
+- `useTagRoot`: 用于返回给消费方`<TagRoot>`提供的方法。
 
 ## 实现原理说明
 
@@ -162,7 +168,7 @@ const logCodeContext = () => {
 </script>
 
 <template>
-  <RootTag>
+  <TagRoot>
     <Tag name="editorbox">
       <div class="editor">
         <h2>Coding Here</h2>
@@ -183,6 +189,6 @@ const logCodeContext = () => {
         </Tag>
       </div>
     </Tag>
-  </RootTag>
+  </TagRoot>
 </template>
 ```

--- a/docs/develop/guidance/feature_Mask.md
+++ b/docs/develop/guidance/feature_Mask.md
@@ -1,14 +1,20 @@
 # Mask 伪代码
 
-## 在编辑器页面的使用
+## 在 stepPlayer 的使用
 
 ```vue
 <script lang="ts" setup>
 const visible = ref(false); // Mask的显示隐藏
-const path = ref(["infoBox", "confirm"]); // 当前步骤需要高亮显示的组件的查找路径
+const path = ref("editorbox check"); // 当前步骤需要高亮显示的组件的查找路径
+const maskRef = ref(); // Mask组件的引用
+
+/* 计算卡通形象、箭头的显示层级 */
+const zIndex = computed(() => {
+  return maskRef.value.zIndex + 1;
+});
 </script>
 
 <template>
-  <Mask :visible="visible" :path="path" />
+  <Mask :visible="visible" :path="path" ref="maskRef" />
 </template>
 ```

--- a/docs/develop/guidance/feature_Mask.md
+++ b/docs/develop/guidance/feature_Mask.md
@@ -1,27 +1,43 @@
 # Mask 伪代码
 
+## Mask 对其 slot 传入 props
+
+```vue
+<script setup>
+const MaskProps = {
+  left: ...,
+  top: ...,
+  width: ...,
+  hight: ...
+};
+</script>
+
+<template>
+  <div class="mask">
+    <slot :slotProps="MaskProps"></slot>
+  </div>
+</template>
+```
+
 ## 在 stepPlayer 的使用
 
 ```vue
 <script lang="ts" setup>
 const visible = ref(false); // Mask的显示隐藏
-const path = ref("editorbox check"); // 当前步骤需要高亮显示的组件的查找路径
-const maskRef = ref(); // Mask组件的引用
+const highlightElementPath = ref("editorbox check"); // 当前步骤需要高亮显示的组件的查找路径
 
-/* 计算卡通形象、箭头的显示层级 */
-const zIndex = computed(() => {
-  return maskRef.value.zIndex + 1;
-});
-
-/* 计算卡通形象、箭头的位置 */
-const position = computed(() => {
-  const width = maskRef.value.lightElemntSize.width;
-  const hight = maskRef.value.lightElemntSize.height;
-  // ...内部处理逻辑
-});
+const handleSlotProps = (slotProps) => {
+  // 内部处理逻辑
+};
 </script>
 
 <template>
-  <Mask :visible="visible" :path="path" ref="maskRef" />
+  <Mask
+    :visible="visible"
+    :highlightElementPath="highlightElementPath"
+    v-slot="slotProps"
+  >
+    <div class="arrow" :style="handleSlotProps(slotProps)"></div>
+  </Mask>
 </template>
 ```

--- a/docs/develop/guidance/feature_Mask.md
+++ b/docs/develop/guidance/feature_Mask.md
@@ -5,7 +5,7 @@
 ```vue
 <script lang="ts" setup>
 const visible = ref(false); // Mask是否显示
-const currentTags = ref(["RectComponent", "ButtonComponent"]); // 当前步骤需要高亮显示的组件的查找路径
+const currentTags = ref(["mother", "son"]); // 当前步骤需要高亮显示的组件的查找路径
 </script>
 
 <template>

--- a/docs/develop/guidance/feature_Mask.md
+++ b/docs/develop/guidance/feature_Mask.md
@@ -1,0 +1,14 @@
+# Mask 伪代码
+
+## 组件调用
+
+```vue
+<script lang="ts" setup>
+const visible = ref(false); // Mask是否显示
+const currentTags = ref(["RectComponent", "ButtonComponent"]); // 当前步骤需要高亮显示的组件的查找路径
+</script>
+
+<template>
+  <Mask :visible="visible" :tags="currentTags" />
+</template>
+```

--- a/docs/develop/guidance/feature_Mask.md
+++ b/docs/develop/guidance/feature_Mask.md
@@ -12,6 +12,13 @@ const maskRef = ref(); // Mask组件的引用
 const zIndex = computed(() => {
   return maskRef.value.zIndex + 1;
 });
+
+/* 计算卡通形象、箭头的位置 */
+const position = computed(() => {
+  const width = maskRef.value.lightElemntSize.width;
+  const hight = maskRef.value.lightElemntSize.height;
+  // ...内部处理逻辑
+});
 </script>
 
 <template>

--- a/docs/develop/guidance/feature_Mask.md
+++ b/docs/develop/guidance/feature_Mask.md
@@ -1,14 +1,16 @@
 # Mask 伪代码
 
-## 组件调用
+## 在编辑器页面的使用
 
 ```vue
 <script lang="ts" setup>
-const visible = ref(false); // Mask是否显示
-const currentTags = ref(["mother", "son"]); // 当前步骤需要高亮显示的组件的查找路径
+const visible = ref(false); // Mask的显示隐藏
+const path = ref(["infoBox", "confirm"]); // 当前步骤需要高亮显示的组件的查找路径
+const editConsumerRef = ref(); // 要调用的tagConsumer组件的示例
 </script>
 
 <template>
-  <Mask :visible="visible" :tags="currentTags" />
+  <TagConsumer ref="editConsumerRef"> ... </TagConsumer>
+  <Mask :visible="visible" :path="path" tagConsumerRef="editConsumerRef" />
 </template>
 ```

--- a/docs/develop/guidance/feature_Mask.md
+++ b/docs/develop/guidance/feature_Mask.md
@@ -6,11 +6,9 @@
 <script lang="ts" setup>
 const visible = ref(false); // Mask的显示隐藏
 const path = ref(["infoBox", "confirm"]); // 当前步骤需要高亮显示的组件的查找路径
-const editConsumerRef = ref(); // 要调用的tagConsumer组件的示例
 </script>
 
 <template>
-  <TagConsumer ref="editConsumerRef"> ... </TagConsumer>
-  <Mask :visible="visible" :path="path" tagConsumerRef="editConsumerRef" />
+  <Mask :visible="visible" :path="path" />
 </template>
 ```

--- a/docs/develop/guidance/feature_Tagging.md
+++ b/docs/develop/guidance/feature_Tagging.md
@@ -7,10 +7,24 @@
 ```vue
 <template>
   <RootTag>
-    <Tag name="infoBox">
-      <div class="info-box">
-        <Tag name="content"> ... </Tag>
-        <Tag name="confirm"> ... </Tag>
+    <Tag name="editorbox">
+      <div class="editor">
+        <h2>Coding Here</h2>
+        <div class="options">
+          <Tag name="check">
+            <button @click="handleCheck">Check</button>
+          </Tag>
+          <Tag name="logpre">
+            <button @click="logCodeContext">logpre</button>
+          </Tag>
+        </div>
+        <Tag name="pre">
+          <pre>
+            <Tag name="code">
+              <code>console.log("Hello, World!");</code>
+            </Tag>
+          </pre>
+        </Tag>
       </div>
     </Tag>
   </RootTag>
@@ -21,14 +35,11 @@
 
 ```vue
 <script lang="ts" setup>
-defineProps({
-  path: string[],
-  visible: boolean,
-})
-/** 根据 path 路径查找 instance */
-const { find } = useTagFinder()
+const { getElement } = useTag()
+const path = ref("editorbox check")
 
-const instance = find(path)
+const element = getElement(path)
+
 /** 高亮逻辑 */
 const highlightComponentStyle = () => {
   ...

--- a/docs/develop/guidance/feature_Tagging.md
+++ b/docs/develop/guidance/feature_Tagging.md
@@ -6,7 +6,7 @@
 
 ```vue
 <template>
-  <RootTag>
+  <TagRoot>
     <Tag name="editorbox">
       <div class="editor">
         <h2>Coding Here</h2>
@@ -27,7 +27,7 @@
         </Tag>
       </div>
     </Tag>
-  </RootTag>
+  </TagRoot>
 </template>
 ```
 
@@ -35,13 +35,16 @@
 
 ```vue
 <script lang="ts" setup>
-const { getElement } = useTag()
-const path = ref("editorbox check")
+defineProps({
+  highlightElementPath: string,
+  ...
+})
+const { getElement } = useTagRoot()
 
-const element = getElement(path)
+const element = getElement(highlightElementPath)
 
 /** 高亮逻辑 */
-const highlightComponentStyle = () => {
+const highlightElementStyle = () => {
   ...
 }
 </script>

--- a/docs/develop/guidance/feature_Tagging.md
+++ b/docs/develop/guidance/feature_Tagging.md
@@ -11,14 +11,57 @@ app.provide("Tagging", new Tagging());
 
 ## 语义化标注（标注方）
 
+### 示例组件
+
 ```vue
+<!-- 示例组件1 -->
 <template>
-  <RectComponent data-tag="RectComponent">
-    <ButtonComponent data-tag="ButtonComponent" />
-    <InputComponent data-tag="InputComponent" />
-    ...
-  </RectComponent>
+  <Father data-tag="father">
+    <Son data-tag="son" />
+    <Daughter data-tag="daughter" />
+  </Father>
 </template>
+
+<!-- 示例组件2 -->
+<template>
+  <Mather data-tag="mather">
+    <Son data-tag="son" />
+    <Daughter data-tag="daughter" />
+  </Mather>
+</template>
+```
+
+### Tagging 中保存示例组件树结构信息
+
+```ts
+this.tagTree = {
+  father: {
+    e: FatherComponent,
+    children: {
+      son: {
+        e: SonComponent,
+        children: {},
+      },
+      daughter: {
+        e: DaughterComponent,
+        children: {},
+      },
+    },
+  },
+  mather: {
+    e: MatherComponent,
+    children: {
+      son: {
+        e: SonComponent,
+        children: {},
+      },
+      daughter: {
+        e: DaughterComponent,
+        children: {},
+      },
+    },
+  },
+};
 ```
 
 ## 在 Mask 组件中使用（消费方）
@@ -28,16 +71,16 @@ app.provide("Tagging", new Tagging());
 // 组件内注入
 const tagging = inject("Tagging");
 
-// 传入keys参数，查找为 key = ‘RectComponent’ 下的 key = ‘ButtonComponent’ 的组件，类似于CSS类选择器
-const element = tagging.getElementByKeys(["RectComponent", "ButtonComponent"]);
+// 传入keys参数，查找为 key = 'mother' 下的 key = 'son' 的组件，类似于CSS类选择器
+const component: Component = tagging.getElementByKeys(["mother", "son"]);
 
-const highlightElement = () => {
+const highlightComponentStyle = () => {
   const lightElementStyle = {
     ...
     ...
   }
 
-  element.style = highlightElement
+  component.style = highlightComponentStyle
 }
 </script>
 

--- a/docs/develop/guidance/feature_Tagging.md
+++ b/docs/develop/guidance/feature_Tagging.md
@@ -1,90 +1,77 @@
 # Tagging 伪代码
 
-## 全局注册（单例）
-
-```ts
-// 通过 provide 全局注册单例
-const app = createApp(App);
-//
-app.provide("Tagging", new Tagging());
-```
-
 ## 语义化标注（标注方）
 
 ### 示例组件
 
 ```vue
-<!-- 示例组件1 -->
 <template>
-  <Father data-tag="father">
-    <Son data-tag="son" />
-    <Daughter data-tag="daughter" />
-  </Father>
-</template>
-
-<!-- 示例组件2 -->
-<template>
-  <Mather data-tag="mather">
-    <Son data-tag="son" />
-    <Daughter data-tag="daughter" />
-  </Mather>
+  <TagConsumer ref="rootConsumerRef">
+    <Tag name="infoBox">
+      <div class="info-box">
+        <!-- contentConsumerRef 不会上报自己的tagTree -->
+        <TagConsumer ref="contentConsumerRef">
+          <Tag name="content"> ... </Tag>
+        </TagConsumer>
+        <Tag name="confirm"> ... </Tag>
+      </div>
+    </Tag>
+    <ClickToRender />
+  </TagConsumer>
 </template>
 ```
 
-### Tagging 中保存示例组件树结构信息
+### 示例组件的 TagTree
 
 ```ts
-this.tagTree = {
-  father: {
-    e: FatherComponent,
-    children: {
-      son: {
-        e: SonComponent,
-        children: {},
-      },
-      daughter: {
-        e: DaughterComponent,
-        children: {},
-      },
-    },
-  },
-  mather: {
-    e: MatherComponent,
-    children: {
-      son: {
-        e: SonComponent,
-        children: {},
-      },
-      daughter: {
-        e: DaughterComponent,
-        children: {},
-      },
-    },
-  },
-};
+// rootConsumerRef的tagTree
+{
+  name: "_root_",
+  instance: null,
+  children: [
+    {
+      name: "infoBox",
+      instance: ...,
+      children: [
+        {
+          name: "confirm",
+          instance: xxx,
+          children: []
+        }
+      ]
+    }
+  ]
+}
+
+// contentConsumerRef的tagTree
+{
+  name: "_root_",
+  instance: null,
+  children: [
+    {
+      name: "content",
+      instance: xxx,
+      children: []
+    }
+  ]
+}
 ```
 
 ## 在 Mask 组件中使用（消费方）
 
 ```vue
 <script lang="ts" setup>
-// 组件内注入
-const tagging = inject("Tagging");
+defineProps({
+  path: string[],
+  visible: boolean,
+  tagConsumerRef: componentInstance
+})
+/** 根据 path 路径查找 instance */
+const instance = tagConsumerRef.value?.find(["infoBox", "confirm"])
 
-// 传入keys参数，查找为 key = 'mother' 下的 key = 'son' 的组件，类似于CSS类选择器
-const component: Component = tagging.getElementByKeys(["mother", "son"]);
-
+/** 高亮逻辑 */
 const highlightComponentStyle = () => {
-  const lightElementStyle = {
-    ...
-    ...
-  }
-
-  component.style = highlightComponentStyle
+  ...
 }
 </script>
-
-<template>
-  <div class="mask" v-if="visible">...</div>
-</template>
 ```

--- a/docs/develop/guidance/feature_Tagging.md
+++ b/docs/develop/guidance/feature_Tagging.md
@@ -6,55 +6,15 @@
 
 ```vue
 <template>
-  <TagConsumer ref="rootConsumerRef">
+  <RootTag>
     <Tag name="infoBox">
       <div class="info-box">
-        <!-- contentConsumerRef 不会上报自己的tagTree -->
-        <TagConsumer ref="contentConsumerRef">
-          <Tag name="content"> ... </Tag>
-        </TagConsumer>
+        <Tag name="content"> ... </Tag>
         <Tag name="confirm"> ... </Tag>
       </div>
     </Tag>
-    <ClickToRender />
-  </TagConsumer>
+  </RootTag>
 </template>
-```
-
-### 示例组件的 TagTree
-
-```ts
-// rootConsumerRef的tagTree
-{
-  name: "_root_",
-  instance: null,
-  children: [
-    {
-      name: "infoBox",
-      instance: ...,
-      children: [
-        {
-          name: "confirm",
-          instance: xxx,
-          children: []
-        }
-      ]
-    }
-  ]
-}
-
-// contentConsumerRef的tagTree
-{
-  name: "_root_",
-  instance: null,
-  children: [
-    {
-      name: "content",
-      instance: xxx,
-      children: []
-    }
-  ]
-}
 ```
 
 ## 在 Mask 组件中使用（消费方）
@@ -64,11 +24,11 @@
 defineProps({
   path: string[],
   visible: boolean,
-  tagConsumerRef: componentInstance
 })
 /** 根据 path 路径查找 instance */
-const instance = tagConsumerRef.value?.find(["infoBox", "confirm"])
+const { find } = useTagFinder()
 
+const instance = find(path)
 /** 高亮逻辑 */
 const highlightComponentStyle = () => {
   ...

--- a/docs/develop/guidance/feature_Tagging.md
+++ b/docs/develop/guidance/feature_Tagging.md
@@ -1,0 +1,47 @@
+# Tagging 伪代码
+
+## 全局注册（单例）
+
+```ts
+// 通过 provide 全局注册单例
+const app = createApp(App);
+//
+app.provide("Tagging", new Tagging());
+```
+
+## 语义化标注（标注方）
+
+```vue
+<template>
+  <RectComponent data-tag="RectComponent">
+    <ButtonComponent data-tag="ButtonComponent" />
+    <InputComponent data-tag="InputComponent" />
+    ...
+  </RectComponent>
+</template>
+```
+
+## 在 Mask 组件中使用（消费方）
+
+```vue
+<script lang="ts" setup>
+// 组件内注入
+const tagging = inject("Tagging");
+
+// 传入keys参数，查找为 key = ‘RectComponent’ 下的 key = ‘ButtonComponent’ 的组件，类似于CSS类选择器
+const element = tagging.getElementByKeys(["RectComponent", "ButtonComponent"]);
+
+const highlightElement = () => {
+  const lightElementStyle = {
+    ...
+    ...
+  }
+
+  element.style = highlightElement
+}
+</script>
+
+<template>
+  <div class="mask" v-if="visible">...</div>
+</template>
+```

--- a/docs/develop/guidance/module_Mask.md
+++ b/docs/develop/guidance/module_Mask.md
@@ -1,0 +1,6 @@
+```ts
+type Props = {
+  visible: boolean; // 是否显示蒙层
+  tags: string[]; // 需要高亮组件的查找路径
+};
+```

--- a/docs/develop/guidance/module_Mask.md
+++ b/docs/develop/guidance/module_Mask.md
@@ -2,6 +2,5 @@
 type Props = {
   visible: boolean; // 是否显示蒙层
   path: string[]; // 需要高亮组件的查找路径
-  tagConsumerRef: componentInstance; // 要调用的tagConsumer组件的示例
 };
 ```

--- a/docs/develop/guidance/module_Mask.md
+++ b/docs/develop/guidance/module_Mask.md
@@ -6,5 +6,10 @@ type Props = {
 
 type Expose = {
   zIndex: number; // 蒙层的层级，用于stepPlayer的素材确定层级
+  lightElemntSize: {
+    // 高亮组件的大小
+    width: number;
+    height: number;
+  };
 };
 ```

--- a/docs/develop/guidance/module_Mask.md
+++ b/docs/develop/guidance/module_Mask.md
@@ -4,11 +4,15 @@ type Props = {
   highlightElementPath: string; // 需要高亮组件的查找路径
 };
 
-type Slots = {
+type DefaultSlotProps = {
   left: number; // 高亮区域的左边距
   top: number; // 高亮区域的上边距
   width: number; // 高亮区域的宽度
   hight: number; // 高亮区域的高度
   // 注意区别高亮区域与高亮组件，高亮区域相对于高亮组件有padding值。
+};
+
+type Slots = {
+  default: (props: DefaultSlotProps) => VNode;
 };
 ```

--- a/docs/develop/guidance/module_Mask.md
+++ b/docs/develop/guidance/module_Mask.md
@@ -3,4 +3,8 @@ type Props = {
   visible: boolean; // 是否显示蒙层
   path: string[]; // 需要高亮组件的查找路径
 };
+
+type Expose = {
+  zIndex: number; // 蒙层的层级，用于stepPlayer的素材确定层级
+};
 ```

--- a/docs/develop/guidance/module_Mask.md
+++ b/docs/develop/guidance/module_Mask.md
@@ -1,15 +1,14 @@
 ```ts
 type Props = {
   visible: boolean; // 是否显示蒙层
-  path: string[]; // 需要高亮组件的查找路径
+  highlightElementPath: string; // 需要高亮组件的查找路径
 };
 
-type Expose = {
-  zIndex: number; // 蒙层的层级，用于stepPlayer的素材确定层级
-  lightElemntSize: {
-    // 高亮组件的大小
-    width: number;
-    height: number;
-  };
+type Slots = {
+  left: number; // 高亮区域的左边距
+  top: number; // 高亮区域的上边距
+  width: number; // 高亮区域的宽度
+  hight: number; // 高亮区域的高度
+  // 注意区别高亮区域与高亮组件，高亮区域相对于高亮组件有padding值。
 };
 ```

--- a/docs/develop/guidance/module_Mask.md
+++ b/docs/develop/guidance/module_Mask.md
@@ -1,6 +1,7 @@
 ```ts
 type Props = {
   visible: boolean; // 是否显示蒙层
-  tags: string[]; // 需要高亮组件的查找路径
+  path: string[]; // 需要高亮组件的查找路径
+  tagConsumerRef: componentInstance; // 要调用的tagConsumer组件的示例
 };
 ```

--- a/docs/develop/guidance/module_Tagging.md
+++ b/docs/develop/guidance/module_Tagging.md
@@ -1,20 +1,33 @@
 ```typescript
+/** 节点  */
+export interface TagNode {
+  e: Component;
+  children?: Record<string, TagNode>;
+}
+
 /** Tag 类 */
 export class Tagging {
-  /** key 和 element 的映射 */
-  private tags: Map<string, HTMLElement>;
+  /**  */
+  private tagTree: Record<string, TagNode>;
 
-  /** 添加一个标注  */
-  addTag(key: string, element: HTMLElement): void;
+  contrustor() {
+    /* 遍历组件树，收集tag，初始化tagTree */
+  }
 
-  /** 移除标注 */
-  removeTag(key: string): void;
+  /** 添加一个标注
+   * @param key: 添加组件的key值
+   * @param component: 被添加的组件
+   * @param keys: 添加到的目标节点，不传时添加到根节点
+   */
+  addTag(key: string, component: Component, keys?: string[]): void;
 
-  /** 获取所有标注 */
-  getAllTags(): TagInfo[];
+  /** 移除标注
+   * @param keys: 要移除的目标节点
+   */
+  removeTag(keys: string[]): void;
 
   /** 通过查找路径keys获取目标组件 */
-  getElementByKeys(keys: string[]): HTMLElement | null;
+  getElementByKeys(keys: string[]): Component | null;
 
   /** 清空所有标注 */
   clearAllTags(): void;

--- a/docs/develop/guidance/module_Tagging.md
+++ b/docs/develop/guidance/module_Tagging.md
@@ -1,0 +1,22 @@
+```typescript
+/** Tag 类 */
+export class Tagging {
+  /** key 和 element 的映射 */
+  private tags: Map<string, HTMLElement>;
+
+  /** 添加一个标注  */
+  addTag(key: string, element: HTMLElement): void;
+
+  /** 移除标注 */
+  removeTag(key: string): void;
+
+  /** 获取所有标注 */
+  getAllTags(): TagInfo[];
+
+  /** 通过查找路径keys获取目标组件 */
+  getElementByKeys(keys: string[]): HTMLElement | null;
+
+  /** 清空所有标注 */
+  clearAllTags(): void;
+}
+```

--- a/docs/develop/guidance/module_Tagging.md
+++ b/docs/develop/guidance/module_Tagging.md
@@ -1,65 +1,21 @@
-## 全局内容
+## 对外接口
+
+1. Tag 标注
+
+Tag 标注用于给组件添加标注
 
 ```ts
-/** 节点信息 */
-export type TagNode = {
-  name: string,
-  instance: any,
-  children: TagNode[]
-}
-
-/** 每个节点对子节点提供的上下文 */
-export type TagContext = {
-  addChild: (node: TagNode) => void, // 挂载时，子节点注册到父节点
-  removeChild: (node: TagNode) => void, // 卸载时，子节点从父节点中移除
-}
-
-/** 提供一个全局tagApi，
- * 1. 供RootTag把自己的find方法注册，
- * 2. 供useTagFinder使用find方法 */
-export type tagApi = {
-  find: (path: string[]): any | null
-}
-```
-
-## Tag 标注方
-
-```ts
-/** 节点的标注信息 */
 type Props = {
   name: string;
 };
-
-/** 当前节点对子节点提供TagContext，用于子节点向当前节点注册 */
-type Provide = {
-  currentContext: TagContext;
-};
-
-/** 当前节点对需要向父节点注册的信息 */
-type Inject = {
-  selfNode: TagNode;
-};
 ```
 
-## RootTag 消费方
+2. useTag
+
+useTag 用于对外暴露 TagRoot 的方法
 
 ```ts
-/** 跟节点对子节点提供TagContext，用于子节点向跟节点注册 */
-type Provide = {
-  currentContext: TagContext;
-};
-
-/** 解释：
- * RootTag 需要把自己的 find 方法传给全局tagApi :
- * 如：tagApi.value.find = find
- */
-```
-
-## useTagFinder 消费方
-
-```ts
-/**
- * useTagFinder 通过 全局的tagApi 返回 tagApi.find 方法
- */
-export function find: (path: string[]) => any | null
+interface UseTagReturnType {
+  getElement(path: string): HTMLElement;
+}
 ```

--- a/docs/develop/guidance/module_Tagging.md
+++ b/docs/develop/guidance/module_Tagging.md
@@ -1,8 +1,8 @@
 ## 对外接口
 
-1. Tag 标注
+1. Tag
 
-Tag 标注用于给组件添加标注
+`<Tag />` 是一个用于给组件添加标注的 vue component
 
 ```ts
 type Props = {
@@ -10,12 +10,26 @@ type Props = {
 };
 ```
 
-2. useTag
+2. TagRoot
 
-useTag 用于对外暴露 TagRoot 的方法
+`<TagRoot />` 是一个用于收集`<Tag/>`上报的节点信息并构建`tagTree`，会向外提供方法的 vue component。全局应该仅存在一个`<TagRoot>`组件在作为所有`<Tag/>`组件的根组件。
+
+3. useTagRoot
+
+useTagRoot 是一个用于对外暴露 `<TagRoot />` 的方法的函数
 
 ```ts
 interface UseTagReturnType {
+  // 通过传入path路径 准确返回目标元素或者null值
   getElement(path: string): HTMLElement;
 }
+
+function useTagRoot(): UseTagReturnType;
 ```
+
+`path`: 是一个或者多个`<Tag />`的`name`的组合，通过传入`path`参数可以返回对应的目标元素或者返回`null`值。
+如：
+
+- `"name1 name2 name3"`会准确返回 `name3` 所包裹的元素
+- 如果树节点数为 0，则会返回一个`null`值
+- 如果找不到目标元素，则会返回一个`null`值

--- a/docs/develop/guidance/module_Tagging.md
+++ b/docs/develop/guidance/module_Tagging.md
@@ -1,19 +1,28 @@
-## Tag 标注方
+## 全局内容
 
 ```ts
 /** 节点信息 */
-export interface TagNode {
-  name: string;
-  instance: any;
-  children: TagNode[];
+export type TagNode = {
+  name: string,
+  instance: any,
+  children: TagNode[]
 }
 
 /** 每个节点对子节点提供的上下文 */
-export interface TagContext {
-  addChild: (node: TagNode) => void; // 挂载时，子节点注册到父节点
-  removeChild: (node: TagNode) => void; // 卸载时，子节点从父节点中移除
+export type TagContext = {
+  addChild: (node: TagNode) => void, // 挂载时，子节点注册到父节点
+  removeChild: (node: TagNode) => void, // 卸载时，子节点从父节点中移除
+}
+
+/** 提供一个全局tagApi，
+ * 1. 供RootTag把自己的find方法注册，
+ * 2. 供useTagFinder使用find方法 */
+export type tagApi = {
+  find: (path: string[]): any | null
 }
 ```
+
+## Tag 标注方
 
 ```ts
 /** 节点的标注信息 */
@@ -32,20 +41,25 @@ type Inject = {
 };
 ```
 
-## TagConsumer 消费方
+## RootTag 消费方
 
 ```ts
-/** 对如Mask模块提供的方法 */
-type Expose = {
-  find(path: string[]) => TagNode.instance
-}
-
 /** 跟节点对子节点提供TagContext，用于子节点向跟节点注册 */
 type Provide = {
-  currentContext: TagContext
-}
+  currentContext: TagContext;
+};
 
-/** 注意：TagConsumer如果存在嵌套情况，当前的TagConsumer不会向上上报自己tagTree。
- * 即：父TagConsumer或者Tag不知道子TagConsumer的存在，他们之间维护的tagTree是独立的
+/** 解释：
+ * RootTag 需要把自己的 find 方法传给全局tagApi :
+ * 如：tagApi.value.find = find
  */
+```
+
+## useTagFinder 消费方
+
+```ts
+/**
+ * useTagFinder 通过 全局的tagApi 返回 tagApi.find 方法
+ */
+export function find: (path: string[]) => any | null
 ```

--- a/docs/develop/guidance/module_Tagging.md
+++ b/docs/develop/guidance/module_Tagging.md
@@ -1,35 +1,51 @@
-```typescript
-/** 节点  */
+## Tag 标注方
+
+```ts
+/** 节点信息 */
 export interface TagNode {
-  e: Component;
-  children?: Record<string, TagNode>;
+  name: string;
+  instance: any;
+  children: TagNode[];
 }
 
-/** Tag 类 */
-export class Tagging {
-  /**  */
-  private tagTree: Record<string, TagNode>;
-
-  contrustor() {
-    /* 遍历组件树，收集tag，初始化tagTree */
-  }
-
-  /** 添加一个标注
-   * @param key: 添加组件的key值
-   * @param component: 被添加的组件
-   * @param keys: 添加到的目标节点，不传时添加到根节点
-   */
-  addTag(key: string, component: Component, keys?: string[]): void;
-
-  /** 移除标注
-   * @param keys: 要移除的目标节点
-   */
-  removeTag(keys: string[]): void;
-
-  /** 通过查找路径keys获取目标组件 */
-  getElementByKeys(keys: string[]): Component | null;
-
-  /** 清空所有标注 */
-  clearAllTags(): void;
+/** 每个节点对子节点提供的上下文 */
+export interface TagContext {
+  addChild: (node: TagNode) => void; // 挂载时，子节点注册到父节点
+  removeChild: (node: TagNode) => void; // 卸载时，子节点从父节点中移除
 }
+```
+
+```ts
+/** 节点的标注信息 */
+type Props = {
+  name: string;
+};
+
+/** 当前节点对子节点提供TagContext，用于子节点向当前节点注册 */
+type Provide = {
+  currentContext: TagContext;
+};
+
+/** 当前节点对需要向父节点注册的信息 */
+type Inject = {
+  selfNode: TagNode;
+};
+```
+
+## TagConsumer 消费方
+
+```ts
+/** 对如Mask模块提供的方法 */
+type Expose = {
+  find(path: string[]) => TagNode.instance
+}
+
+/** 跟节点对子节点提供TagContext，用于子节点向跟节点注册 */
+type Provide = {
+  currentContext: TagContext
+}
+
+/** 注意：TagConsumer如果存在嵌套情况，当前的TagConsumer不会向上上报自己tagTree。
+ * 即：父TagConsumer或者Tag不知道子TagConsumer的存在，他们之间维护的tagTree是独立的
+ */
 ```


### PR DESCRIPTION
以下修改来自于：https://github.com/goplus/builder/pull/1331#discussion_r1955476192

- Tagging

  - 标注方
  - 消费方
  - 单例全局唯一

- Mask

```ts
type Props = {
  visible: boolean; // 是否显示蒙层
  tags: string[]; // 需要高亮组件的查找路径
};
```

考虑了 tag选择器 的形式查找元素，通过传入key数组找到目标组件。