### PR TITLE
fix(tools/spxls): correct identification of builtin objects with empty package paths

### DIFF
--- a/tools/spxls/internal/server/compile.go
+++ b/tools/spxls/internal/server/compile.go
@@ -385,14 +385,12 @@ func (r *compileResult) spxDefinitionsFor(obj types.Object, selectorTypeName str
 	if obj == nil {
 		return nil
 	}
-	pkg := obj.Pkg()
-	if pkg == nil {
-		// Builtin definitions are not in any package.
+	if isBuiltinObject(obj) {
 		return []SpxDefinition{GetSpxBuiltinDefinition(obj)}
 	}
 
 	var pkgDoc *pkgdoc.PkgDoc
-	if pkgPath := pkg.Path(); pkgPath == "main" {
+	if pkgPath := obj.Pkg().Path(); pkgPath == "main" {
 		pkgDoc = r.mainPkgDoc
 	} else {
 		pkgDoc, _ = pkgdata.GetPkgDoc(pkgPath)

--- a/tools/spxls/internal/server/hover_test.go
+++ b/tools/spxls/internal/server/hover_test.go
@@ -478,4 +478,27 @@ onTouchStart ["MySprite"], => {}
 		require.NoError(t, err)
 		require.Nil(t, hover)
 	})
+
+	t.Run("Append", func(t *testing.T) {
+		s := New(newMapFSWithoutModTime(map[string][]byte{
+			"main.spx": []byte(`
+var nums []int
+nums = append(nums, 1)
+`),
+		}), nil)
+
+		hover, err := s.textDocumentHover(&HoverParams{
+			TextDocumentPositionParams: TextDocumentPositionParams{
+				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+				Position:     Position{Line: 2, Character: 7},
+			},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, hover)
+		assert.Contains(t, hover.Contents.Value, `def-id="gop:builtin?append"`)
+		assert.Equal(t, Range{
+			Start: Position{Line: 2, Character: 7},
+			End:   Position{Line: 2, Character: 13},
+		}, hover.Range)
+	})
 }

--- a/tools/spxls/internal/server/util.go
+++ b/tools/spxls/internal/server/util.go
@@ -252,6 +252,13 @@ func isSpxPkgObject(obj types.Object) bool {
 	return obj != nil && obj.Pkg() == GetSpxPkg()
 }
 
+// isBuiltinObject reports whether the given object is a builtin object.
+func isBuiltinObject(obj types.Object) bool {
+	// Builtin objects do not belong to any package. But in the type system,
+	// they may have non-nil package with an empty path, e.g., append.
+	return obj != nil && (obj.Pkg() == nil || obj.Pkg().Path() == "")
+}
+
 // isMainPkgObject reports whether the given object is defined in the main package.
 func isMainPkgObject(obj types.Object) bool {
 	return obj != nil && obj.Pkg() != nil && obj.Pkg().Path() == "main"


### PR DESCRIPTION
Fixes #1383