### PR TITLE
fix(tools/spxls): preserve floating comments following shadow entry declarations

### DIFF
--- a/tools/spxls/internal/server/format.go
+++ b/tools/spxls/internal/server/format.go
@@ -433,8 +433,7 @@ func (s *Server) formatSpxDecls(snapshot *vfs.MapFS, spxFile string) ([]byte, er
 	if shadowEntryPos.IsValid() {
 		ensureTrailingNewlines(2)
 		start := compileResult.fset.Position(shadowEntryPos).Offset
-		end := compileResult.fset.Position(astFile.ShadowEntry.End()).Offset
-		formattedBuf.Write(astFile.Code[start:end])
+		formattedBuf.Write(astFile.Code[start:])
 		ensureTrailingNewlines(1)
 	}
 

--- a/tools/spxls/internal/server/format_test.go
+++ b/tools/spxls/internal/server/format_test.go
@@ -420,6 +420,10 @@ func test() {
 const b = "123"
 
 // floating comment4
+
+run "assets", {Title: "My Game"}
+
+// floating comment5
 `),
 		}), nil)
 		params := &DocumentFormattingParams{
@@ -432,7 +436,7 @@ const b = "123"
 		assert.Contains(t, edits, TextEdit{
 			Range: Range{
 				Start: Position{Line: 0, Character: 0},
-				End:   Position{Line: 20, Character: 0},
+				End:   Position{Line: 24, Character: 0},
 			},
 			NewText: `import "fmt"
 
@@ -456,6 +460,10 @@ func test() {
 }
 
 // floating comment4
+
+run "assets", {Title: "My Game"}
+
+// floating comment5
 `,
 		})
 	})


### PR DESCRIPTION
Fixes #1397