### PR TITLE
fix: Update bubble arrow direction and adjust bubble content styling

### DIFF
--- a/spx-gui/src/components/guidance/step/FollowingStep.vue
+++ b/spx-gui/src/components/guidance/step/FollowingStep.vue
@@ -352,17 +352,16 @@ function getBubbleBgStyle(highlightRect: HighlightRect) {
   let transform = ''
 
   switch (arrowDirection) {
+    case 'left-top':
+      break
     case 'left-bottom':
       transform = 'scale(1, -1)'
       break
-    case 'right-bottom':
-      transform = 'scale(-1, -1)'
-      break
-    case 'left-top':
-      transform = 'scale(1, 1)'
-      break
     case 'right-top':
       transform = 'scale(-1, 1)'
+      break
+    case 'right-bottom':
+      transform = 'scale(-1, -1)'
       break
   }
 

--- a/spx-gui/src/components/guidance/step/FollowingStep.vue
+++ b/spx-gui/src/components/guidance/step/FollowingStep.vue
@@ -233,7 +233,7 @@ function calculateGuidePositions(highlightRect: HighlightRect) {
       left: niuxiaoqiPosition.left + niuxiaoqiSize.width,
       top: niuxiaoqiPosition.top - bubbleSize.height
     }
-    bubbleArrowDirection = 'left-down'
+    bubbleArrowDirection = 'left-top'
   } else if (!isLeft && isTop) {
     // 右上象限
     arrowPosition = {
@@ -249,7 +249,7 @@ function calculateGuidePositions(highlightRect: HighlightRect) {
       left: niuxiaoqiPosition.left - bubbleSize.width,
       top: niuxiaoqiPosition.top - bubbleSize.height
     }
-    bubbleArrowDirection = 'right-down'
+    bubbleArrowDirection = 'right-top'
   } else if (isLeft && !isTop) {
     // 左下象限
     arrowPosition = {
@@ -265,7 +265,7 @@ function calculateGuidePositions(highlightRect: HighlightRect) {
       left: niuxiaoqiPosition.left + niuxiaoqiSize.width,
       top: niuxiaoqiPosition.top + niuxiaoqiSize.height
     }
-    bubbleArrowDirection = 'left-top'
+    bubbleArrowDirection = 'left-bottom'
   } else {
     // 右下象限
     arrowPosition = {
@@ -353,16 +353,16 @@ function getBubbleBgStyle(highlightRect: HighlightRect) {
 
   switch (arrowDirection) {
     case 'left-bottom':
-      transform = ''
-      break
-    case 'right-bottom':
       transform = 'scale(1, -1)'
       break
+    case 'right-bottom':
+      transform = 'scale(-1, -1)'
+      break
     case 'left-top':
-      transform = 'scale(-1, 1)'
+      transform = 'scale(1, 1)'
       break
     case 'right-top':
-      transform = 'scale(-1, -1)'
+      transform = 'scale(-1, 1)'
       break
   }
 
@@ -401,15 +401,14 @@ function getBubbleBgStyle(highlightRect: HighlightRect) {
 .bubble-content {
   position: absolute;
   top: 0;
-  left: -0.8rem;
   width: 100%;
   height: 100%;
   display: flex;
   justify-content: center;
   align-items: center;
-  padding: 20px;
+  padding: 10%;
   box-sizing: border-box;
-  font-size: 1rem;
+  font-size: 100%;
   color: #333;
   text-align: center;
   pointer-events: none;


### PR DESCRIPTION
- [x] 之前测试不够精确，现在把四个象限的气泡方向计算又思考了下，原图的箭头是朝左下的，所以在左上角不用transform，左下是y轴反转，右上是x轴反转，右下是x、y轴反转。