### PR TITLE
Add TagSelector

### DIFF
--- a/spx-gui/src/components/common/MaskWithHighlight.vue
+++ b/spx-gui/src/components/common/MaskWithHighlight.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, onMounted, computed, onBeforeUnmount, watch, nextTick } from 'vue'
+import { ref, onMounted, computed, onBeforeUnmount } from 'vue'
 import { useTag } from '../../utils/tagging'
 import { useElementRect } from '../../utils/dom'
 

--- a/spx-gui/src/utils/tagging/TagSelector.vue
+++ b/spx-gui/src/utils/tagging/TagSelector.vue
@@ -77,7 +77,7 @@ onMounted(() => {
 
 onBeforeUnmount(() => {
   window.removeEventListener('mouseover', handleMouseOver)
-  window.removeEventListener('click', handleClick)
+  window.removeEventListener('click', handleClick, true)
   elementToNode = null
   nodeToPath = null
   currentPath.value = null

--- a/spx-gui/src/utils/tagging/TagSelector.vue
+++ b/spx-gui/src/utils/tagging/TagSelector.vue
@@ -1,0 +1,142 @@
+<script setup lang="ts">
+import { ref, watch, onBeforeUnmount, nextTick } from 'vue'
+import { useTag, type TagNode } from './index'
+
+const { getAllTagElements } = useTag()
+
+const props = defineProps<{
+  active: boolean
+}>()
+
+let elementToNode: Map<HTMLElement, TagNode> | null = null
+let nodeToPath: Map<TagNode, string> | null = null
+const currentPath = ref<string | null>(null)
+const currentElementRef = ref<HTMLElement | null>(null)
+const currentPathRef = ref<HTMLElement | null>(null)
+
+/**
+ * find the nearest tag element of the current element from the event target
+ * @param el HTMLElement
+ */
+function findNearestTagElement(el: HTMLElement): HTMLElement | null {
+  let current: HTMLElement | null = el
+  while (current) {
+    if (elementToNode?.has(current)) {
+      return current
+    }
+    current = current.parentElement
+  }
+  return null
+}
+
+/**
+ * handle mouseover event, show the path of the current element
+ * @param event MouseEvent
+ */
+function handleMouseOver(event: MouseEvent) {
+  const target = event.target as HTMLElement
+
+  const tagElement = findNearestTagElement(target)
+  if (tagElement) {
+    const node = elementToNode?.get(tagElement)
+
+    if (node) {
+      currentPath.value = nodeToPath?.get(node) || '未知路径'
+      nextTick(() => {
+        if (currentElementRef.value) {
+          createMaskToTaggedElement(tagElement)
+        } else {
+          console.error('currentElementRef is still null after nextTick')
+        }
+      })
+    }
+  } else {
+    currentPath.value = null
+  }
+}
+
+/**
+ * create a mask to the tagged element
+ * @param element HTMLElement
+ */
+function createMaskToTaggedElement(element: HTMLElement | null) {
+  if (!element) return
+  const { left, top, width, height } = element.getBoundingClientRect()
+
+  Object.assign(currentElementRef.value!.style, {
+    left: `${left - 6}px`,
+    top: `${top - 6}px`,
+    width: `${width + 12}px`,
+    height: `${height + 12}px`
+  })
+}
+
+/**
+ * copy current path to clipboard, triggered by pressing 'c' key
+ * @param e KeyboardEvent
+ */
+function copyToClipboard(e: KeyboardEvent) {
+  if (currentPath.value && e.key === 'c') {
+    navigator.clipboard.writeText(currentPath.value)
+  }
+}
+
+watch(
+  () => props.active,
+  (newVal) => {
+    if (newVal) {
+      const { elementToNode: eToNode, nodeToPath: nToPath } = getAllTagElements()
+      elementToNode = eToNode
+      nodeToPath = nToPath
+      window.addEventListener('mouseover', handleMouseOver)
+      window.addEventListener('keydown', copyToClipboard)
+    } else {
+      window.removeEventListener('mouseover', handleMouseOver)
+      window.removeEventListener('keydown', copyToClipboard)
+      elementToNode = null
+      nodeToPath = null
+      currentPath.value = null
+    }
+  },
+  { immediate: true }
+)
+
+onBeforeUnmount(() => {
+  window.removeEventListener('mouseover', handleMouseOver)
+  window.removeEventListener('keydown', copyToClipboard)
+})
+</script>
+
+<template>
+  <Teleport v-if="props.active" to="body">
+    <div v-if="currentPath" ref="currentElementRef" class="tagging-selector">
+      <span ref="currentPathRef" class="current-path">{{ currentPath }}</span>
+    </div>
+  </Teleport>
+</template>
+
+<style scoped>
+.tagging-selector {
+  position: fixed;
+  border: 2px solid #07c0cf;
+  border-radius: 5px;
+  border-top-left-radius: 0;
+  background: rgba(7, 192, 207, 0.5);
+  pointer-events: none;
+  transition: all 0.2s;
+  box-sizing: border-box;
+}
+
+.current-path {
+  color: white;
+  position: absolute;
+  bottom: 100%;
+  left: -2px;
+  background: rgba(7, 192, 207);
+  border: 2px solid #07c0cf;
+  white-space: nowrap;
+  padding: 2px 4px;
+  border-radius: 4px;
+  border-bottom-left-radius: 0;
+}
+</style>

--- a/spx-gui/src/utils/tagging/TagSelector.vue
+++ b/spx-gui/src/utils/tagging/TagSelector.vue
@@ -1,23 +1,18 @@
 <script setup lang="ts">
-import { ref, watch, onBeforeUnmount, nextTick } from 'vue'
+import { ref, onMounted, onBeforeUnmount, nextTick } from 'vue'
 import { useTag, type TagNode } from './index'
 
 const { getAllTagElements } = useTag()
 
-const props = defineProps<{
-  active: boolean
+const emit = defineEmits<{
+  (e: 'selected', path: string): void
 }>()
 
 let elementToNode: Map<HTMLElement, TagNode> | null = null
 let nodeToPath: Map<TagNode, string> | null = null
 const currentPath = ref<string | null>(null)
 const currentElementRef = ref<HTMLElement | null>(null)
-const currentPathRef = ref<HTMLElement | null>(null)
 
-/**
- * find the nearest tag element of the current element from the event target
- * @param el HTMLElement
- */
 function findNearestTagElement(el: HTMLElement): HTMLElement | null {
   let current: HTMLElement | null = el
   while (current) {
@@ -29,24 +24,16 @@ function findNearestTagElement(el: HTMLElement): HTMLElement | null {
   return null
 }
 
-/**
- * handle mouseover event, show the path of the current element
- * @param event MouseEvent
- */
 function handleMouseOver(event: MouseEvent) {
   const target = event.target as HTMLElement
-
   const tagElement = findNearestTagElement(target)
   if (tagElement) {
     const node = elementToNode?.get(tagElement)
-
     if (node) {
       currentPath.value = nodeToPath?.get(node) || '未知路径'
       nextTick(() => {
         if (currentElementRef.value) {
           createMaskToTaggedElement(tagElement)
-        } else {
-          console.error('currentElementRef is still null after nextTick')
         }
       })
     }
@@ -55,14 +42,23 @@ function handleMouseOver(event: MouseEvent) {
   }
 }
 
-/**
- * create a mask to the tagged element
- * @param element HTMLElement
- */
+function handleClick(event: MouseEvent) {
+  event.stopPropagation()
+  const target = event.target as HTMLElement
+  const tagElement = findNearestTagElement(target)
+  if (tagElement) {
+    const node = elementToNode?.get(tagElement)
+    if (node) {
+      const path = nodeToPath?.get(node) || 'unknown path'
+      currentPath.value = path
+      emit('selected', path)
+    }
+  }
+}
+
 function createMaskToTaggedElement(element: HTMLElement | null) {
   if (!element) return
   const { left, top, width, height } = element.getBoundingClientRect()
-
   Object.assign(currentElementRef.value!.style, {
     left: `${left - 6}px`,
     top: `${top - 6}px`,
@@ -71,46 +67,27 @@ function createMaskToTaggedElement(element: HTMLElement | null) {
   })
 }
 
-/**
- * copy current path to clipboard, triggered by pressing 'c' key
- * @param e KeyboardEvent
- */
-function copyToClipboard(e: KeyboardEvent) {
-  if (currentPath.value && e.key === 'c') {
-    navigator.clipboard.writeText(currentPath.value)
-  }
-}
-
-watch(
-  () => props.active,
-  (newVal) => {
-    if (newVal) {
-      const { elementToNode: eToNode, nodeToPath: nToPath } = getAllTagElements()
-      elementToNode = eToNode
-      nodeToPath = nToPath
-      window.addEventListener('mouseover', handleMouseOver)
-      window.addEventListener('keydown', copyToClipboard)
-    } else {
-      window.removeEventListener('mouseover', handleMouseOver)
-      window.removeEventListener('keydown', copyToClipboard)
-      elementToNode = null
-      nodeToPath = null
-      currentPath.value = null
-    }
-  },
-  { immediate: true }
-)
+onMounted(() => {
+  const { elementToNode: eToNode, nodeToPath: nToPath } = getAllTagElements()
+  elementToNode = eToNode
+  nodeToPath = nToPath
+  window.addEventListener('mouseover', handleMouseOver)
+  window.addEventListener('click', handleClick, true)
+})
 
 onBeforeUnmount(() => {
   window.removeEventListener('mouseover', handleMouseOver)
-  window.removeEventListener('keydown', copyToClipboard)
+  window.removeEventListener('click', handleClick)
+  elementToNode = null
+  nodeToPath = null
+  currentPath.value = null
 })
 </script>
 
 <template>
-  <Teleport v-if="props.active" to="body">
-    <div v-if="currentPath" ref="currentElementRef" class="tagging-selector">
-      <span ref="currentPathRef" class="current-path">{{ currentPath }}</span>
+  <Teleport to="body">
+    <div ref="currentElementRef" class="tagging-selector" v-if="currentPath">
+      <span class="current-path">{{ currentPath }}</span>
     </div>
   </Teleport>
 </template>

--- a/spx-gui/src/utils/tagging/TagSelector.vue
+++ b/spx-gui/src/utils/tagging/TagSelector.vue
@@ -86,7 +86,7 @@ onBeforeUnmount(() => {
 
 <template>
   <Teleport to="body">
-    <div ref="currentElementRef" class="tagging-selector" v-if="currentPath">
+    <div v-if="currentPath" ref="currentElementRef" class="tagging-selector">
       <span class="current-path">{{ currentPath }}</span>
     </div>
   </Teleport>

--- a/spx-gui/src/utils/tagging/index.ts
+++ b/spx-gui/src/utils/tagging/index.ts
@@ -2,26 +2,40 @@ import { ref, type App } from 'vue'
 import TagNode from './TagNode.vue'
 import TagRoot from './TagRoot.vue'
 
+/**
+ * Tag node.
+ * @property name - The name of the tag.
+ * @property instance - The instance of the tag.
+ * @property children - The children of the tag.
+ */
 export interface TagNode {
   name: string
   instance: any
   children: TagNode[]
 }
 
+/**
+ * Context for a tag node.
+ * @property addChild - Add a child node to the current node, it will happen when the child node is mounted.
+ * @property removeChild - Remove a child node from the current node, it will happen when the child node is unmounted.
+ */
 export interface TagContext {
   addChild: (node: TagNode) => void
   removeChild: (node: TagNode) => void
 }
 
-export interface TagApi {
-  getElement: (path: string) => HTMLElement | null
-}
-
+/**
+ * Tag context key, used to get the tag context from the component.
+ */
 export const TAG_CONTEXT_KEY = Symbol('tag_context')
 
+/**
+ * Tag root key, used to get api from the tag root component.
+ */
 export const tagApi = ref<{
   getElement: (path: string) => HTMLElement | null
   getInstance: (path: string) => unknown
+  getAllTagElements: () => any;
 } | null>(null)
 
 export function useTag() {
@@ -39,12 +53,30 @@ export function useTag() {
     return tagApi.value.getInstance(path)
   }
 
+  const getAllTagElements = () => {
+    if (!tagApi.value) {
+      throw new Error('TagRoot not mounted')
+    }
+    return tagApi.value.getAllTagElements()
+  }
+
   return {
     getElement,
-    getInstance
+    getInstance,
+    getAllTagElements,
   }
 }
 
+/**
+ * Initialize the tagging system.
+ * @param app 
+ * @example
+ * ```ts
+ * import { initTagging } from './utils/tagging'
+ * 
+ * initTagging(app)
+ * ```
+ */
 export function initTagging(app: App) {
   app.component('TagRoot', TagRoot)
   app.component('TagNode', TagNode)


### PR DESCRIPTION
1. tagApi添加`getAllTagElements`，返回`elementToNode`, `nodeToPath`的映射关系提供给`TagSelector`使用。
2. 添加一个新的`TagSelector`组件，用于可视化选择`path`，并支持将TagNode组件路径复制到剪贴板。

```ts
type props = {
    active: boolean;    // 是否使用TagSelector
}
```

## demo体验

体验地址：https://minorcell.github.io/tagging-demo/

![image](https://github.com/user-attachments/assets/0557a71b-31ca-48ea-93b4-dff70d844dda)
