### PR TITLE
fix: Update bubble content styling and adjust positioning for large elements

### DIFF
--- a/spx-gui/src/components/guidance/step/FollowingStep.vue
+++ b/spx-gui/src/components/guidance/step/FollowingStep.vue
@@ -197,15 +197,12 @@ function calculateGuidePositions(highlightRect: HighlightRect) {
   const windowHeight = window.innerHeight
 
   // 确定高亮区域所在象限
-  console.log('highlightRect', highlightRect)
   const isLeft = highlightRect.left + highlightRect.width / 2 < windowWidth / 2
   const isTop = highlightRect.top + highlightRect.height / 2 < windowHeight / 2
 
   const widthRatio = highlightRect.width / windowWidth
   const heightRatio = highlightRect.height / windowHeight
-  console.log('widthRatio', widthRatio)
-  console.log('heightRatio', heightRatio)
-  const isLargeElement = highlightRect.width > 900 || widthRatio > 0.8
+  const isLargeElement = widthRatio > 0.8 || heightRatio > 0.7
 
   const scale = Math.min(windowWidth, windowHeight) / 1920
   const maxScale = 0.8 // 限制最大缩放比例

--- a/spx-gui/src/components/guidance/step/FollowingStep.vue
+++ b/spx-gui/src/components/guidance/step/FollowingStep.vue
@@ -37,7 +37,7 @@
           class="svg-fill"
         ></path>
       </svg>
-      <div class="bubble-content">
+      <div class="bubble-content" :style="getBubbleContentStyle(props.slotInfo)">
         {{ t({ zh: props.step.description.zh, en: props.step.description.en }) }}
       </div>
     </div>
@@ -197,8 +197,15 @@ function calculateGuidePositions(highlightRect: HighlightRect) {
   const windowHeight = window.innerHeight
 
   // 确定高亮区域所在象限
+  console.log('highlightRect', highlightRect)
   const isLeft = highlightRect.left + highlightRect.width / 2 < windowWidth / 2
   const isTop = highlightRect.top + highlightRect.height / 2 < windowHeight / 2
+
+  const widthRatio = highlightRect.width / windowWidth
+  const heightRatio = highlightRect.height / windowHeight
+  console.log('widthRatio', widthRatio)
+  console.log('heightRatio', heightRatio)
+  const isLargeElement = highlightRect.width > 900 || widthRatio > 0.8
 
   const scale = Math.min(windowWidth, windowHeight) / 1920
   const maxScale = 0.8 // 限制最大缩放比例
@@ -225,7 +232,26 @@ function calculateGuidePositions(highlightRect: HighlightRect) {
 
   let bubbleArrowDirection = 'left-down'
 
-  if (isLeft && isTop) {
+  if (isLargeElement) {
+    arrowPosition = {
+      left: highlightRect.left - arrowSize.width,
+      top: highlightRect.top
+    }
+
+    arrowRotation = 0
+
+    niuxiaoqiPosition = {
+      left: arrowPosition.left - niuxiaoqiSize.width,
+      top: arrowPosition.top + arrowSize.height
+    }
+
+    bubblePosition = {
+      left: niuxiaoqiPosition.left - (2 * bubbleSize.width) / 3,
+      top: niuxiaoqiPosition.top + niuxiaoqiSize.height + bubbleSize.height / 3
+    }
+
+    bubbleArrowDirection = 'large-element'
+  } else if (isLeft && isTop) {
     // 左上象限
     arrowPosition = {
       left: highlightRect.left + highlightRect.width,
@@ -359,6 +385,9 @@ function getBubbleBgStyle(highlightRect: HighlightRect) {
   let transform = ''
 
   switch (arrowDirection) {
+    case 'large-element':
+      transform = 'rotate(-90deg) scale(-1, 1)'
+      break
     case 'left-top':
       break
     case 'left-bottom':
@@ -377,6 +406,35 @@ function getBubbleBgStyle(highlightRect: HighlightRect) {
     transformOrigin: 'center center',
     width: '100%',
     height: '100%'
+  }
+}
+
+function getBubbleContentStyle(highlightRect: HighlightRect) {
+  if (!currentGuidePositions.value) {
+    currentGuidePositions.value = calculateGuidePositions(highlightRect)
+  }
+
+  let padding = '10%'
+  const arrowDirection = currentGuidePositions.value.bubbleStyle.arrowDirection
+
+  if (arrowDirection === 'large-element') {
+    padding = '20%'
+  }
+
+  return {
+    position: 'absolute' as const,
+    top: '0',
+    width: '100%',
+    height: '100%',
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: padding,
+    boxSizing: 'border-box' as const,
+    fontSize: '100%',
+    color: '#333',
+    textAlign: 'center' as const,
+    PointerEvents: 'none'
   }
 }
 </script>
@@ -402,21 +460,5 @@ function getBubbleBgStyle(highlightRect: HighlightRect) {
 
 .icon-fill {
   fill: #5c5c66;
-}
-
-.bubble-content {
-  position: absolute;
-  top: 0;
-  width: 100%;
-  height: 100%;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  padding: 10%;
-  box-sizing: border-box;
-  font-size: 100%;
-  color: #333;
-  text-align: center;
-  pointer-events: none;
 }
 </style>


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/a0099274-a686-435d-b204-d6b1ad2ef789)
因为之前没有对AssetLibrary这里的高亮引导UI做适配，导致引导UI会渲染到屏幕外面。
于是加了个大元素检测，如果与屏幕的宽比>0.8或者高比>0.7则使用不一样样式计算方式。并且为了处理气泡内文字可能会超出气泡，改用动态绑定来动态处理气泡内容的padding值。