### PR TITLE
fix: Improve event listener setup with element waiting logic

### DIFF
--- a/spx-gui/src/components/guidance/step/FollowingStep.vue
+++ b/spx-gui/src/components/guidance/step/FollowingStep.vue
@@ -154,24 +154,13 @@ watch(
 )
 
 const targetPath = computed(() => {
-  if (!props.step.taggingHandler || props.step.type !== 'following') {
-    return null
-  }
+  if (!props.step.taggingHandler || props.step.type !== 'following') return null
 
-  const entries = Object.entries(props.step.taggingHandler).filter(([path]) => !!path)
-
-  return entries.length > 0
-    ? {
-        path: entries[0][0],
-        handlerType: entries[0][1]
-      }
-    : null
+  const entry = Object.entries(props.step.taggingHandler).find(([path]) => !!path)
+  return entry ? { path: entry[0], handlerType: entry[1] } : null
 })
 
-const targetElement = computed(() => {
-  if (!targetPath.value) return null
-  return getElement(targetPath.value.path)
-})
+const targetElement = computed(() => (targetPath.value ? getElement(targetPath.value.path) : null))
 
 watch(
   targetElement,

--- a/spx-gui/src/components/guidance/step/FollowingStep.vue
+++ b/spx-gui/src/components/guidance/step/FollowingStep.vue
@@ -190,6 +190,7 @@ watch(
   },
   { immediate: true }
 )
+
 async function handleTargetElementSubmit() {
   clearAllEventListeners()
   emit('followingStepCompleted')


### PR DESCRIPTION
@nighca 寒星老师我这边做了一点修改，您看看
![image](https://github.com/user-attachments/assets/5007d948-6364-4b3b-8ac4-7afaafe74d4a)
在rename-modal-form的步骤时，会发生要监听的元素获取不到的情况。但是我发现MaskWithHighLight是能正常获取的，所以问题出在FollowingStep里，具体原因如下：
1. 触发事件处理器
2. 事件处理器调用API创建模态框
3. Vue开始渲染模态框组件
4. 同时FollowingStep检测到步骤变化并尝试查找新元素
5. 此时模态框尚未渲染完成，因此查找失败
因此我加上了异步重试机制，使用 Promise.all 并行处理所有路径。