### PR TITLE
Fix ProjectA bug

### DIFF
--- a/spx-backend/internal/controller/project.go
+++ b/spx-backend/internal/controller/project.go
@@ -33,6 +33,7 @@ type ProjectDTO struct {
 	LikeCount     int64                `json:"likeCount"`
 	ReleaseCount  int64                `json:"releaseCount"`
 	RemixCount    int64                `json:"remixCount"`
+	Hidden        int8                 `json:"hidden"`
 }
 
 // toProjectDTO converts the model project to its DTO.
@@ -67,6 +68,7 @@ func toProjectDTO(mProject model.Project) ProjectDTO {
 		LikeCount:     mProject.LikeCount,
 		ReleaseCount:  mProject.ReleaseCount,
 		RemixCount:    mProject.RemixCount,
+		Hidden:        mProject.Hidden,
 	}
 }
 


### PR DESCRIPTION
@nighca  
### 此pr内容：
  修复了“ProjectA”在用户“项目列表”中展示的错误。之前获取项目信息时没有返回hidden字段，导致在“StoryLine”引导过程中，自动更新会默认将hidden字段设置为0，从而覆盖了“ProjectA”原本的hidden值。