### PR TITLE
Use `Math.floor` instead of `toFixed` for percentage

### DIFF
--- a/spx-gui/src/components/ui/loading/UIDetailedLoading.vue
+++ b/spx-gui/src/components/ui/loading/UIDetailedLoading.vue
@@ -48,7 +48,7 @@ watch(
     </div>
     <div class="text">
       <slot></slot>
-      <span>{{ (percentage * 100).toFixed(0) }}%</span>
+      <span>{{ Math.floor(percentage * 100) }}%</span>
     </div>
   </div>
 </template>


### PR DESCRIPTION
To avoid `100%` while loading not finished.