### PR TITLE
refactor(apis/util): work around CDN back-to-origin slowness in `makeObjectUrls`

### DIFF
--- a/spx-gui/src/apis/util.ts
+++ b/spx-gui/src/apis/util.ts
@@ -2,6 +2,7 @@
  * @desc util-related APIs of spx-backend
  */
 
+import { usercontentBaseUrl } from '@/utils/env'
 import { client, type UniversalUrl, type UniversalToWebUrlMap } from './common'
 
 export type UpInfo = {
@@ -22,6 +23,17 @@ export function getUpInfo() {
 }
 
 export async function makeObjectUrls(objects: UniversalUrl[]): Promise<UniversalToWebUrlMap> {
-  const result = (await client.post('/util/fileurls', { objects: objects })) as { objectUrls: UniversalToWebUrlMap }
-  return result.objectUrls
+  return workAroundIssue1598(objects)
+
+  // const result = (await client.post('/util/fileurls', { objects: objects })) as { objectUrls: UniversalToWebUrlMap }
+  // return result.objectUrls
+}
+
+/** Workaround for https://github.com/goplus/builder/issues/1598 */
+function workAroundIssue1598(objects: UniversalUrl[]): UniversalToWebUrlMap {
+  return objects.reduce((map, universalUrl) => {
+    const url = new URL(universalUrl)
+    map[universalUrl] = url.protocol === 'kodo:' ? usercontentBaseUrl + url.pathname + url.search : universalUrl
+    return map
+  }, {} as UniversalToWebUrlMap)
 }


### PR DESCRIPTION
Fixes #1598