### PR TITLE
Extend accept info for `InputSlot`

### DIFF
--- a/spx-gui/src/components/editor/code-editor/code-editor.ts
+++ b/spx-gui/src/components/editor/code-editor/code-editor.ts
@@ -163,7 +163,7 @@ class InputHelperProvider implements IInputHelperProvider {
       return [
         {
           kind: InputSlotKind.Value,
-          acceptType: InputType.String,
+          accept: { type: InputType.String },
           input: {
             kind: InputKind.InPlace,
             type: InputType.String,

--- a/spx-gui/src/components/editor/code-editor/common.ts
+++ b/spx-gui/src/components/editor/code-editor/common.ts
@@ -48,6 +48,14 @@ export enum ResourceReferenceKind {
  */
 export type ResourceURI = string
 
+/**
+ * URI of the resource context. Examples:
+ * - `spx://resources/sprites`
+ * - `spx://resources/sounds`
+ * - `spx://resources/sprites/<sName>/costumes`
+ */
+export type ResourceContextURI = string
+
 const resourceURIPrefix = 'spx://resources/'
 
 export function isResourceUri(uri: string): uri is ResourceURI {
@@ -637,11 +645,34 @@ export type Input<T extends InputTypedValue = InputTypedValue> =
       name: string
     }
 
+export type InputSlotAccept =
+  | {
+      /** Input type accepted by the slot */
+      type:
+        | InputType.Integer
+        | InputType.Decimal
+        | InputType.String
+        | InputType.Boolean
+        | InputType.SpxDirection
+        | InputType.SpxColor
+        | InputType.SpxEffectKind
+        | InputType.SpxKey
+        | InputType.SpxPlayAction
+        | InputType.SpxSpecialObj
+        | InputType.Unknown
+    }
+  | {
+      /** Input type accepted by the slot */
+      type: InputType.SpxResourceName
+      /** Resource context */
+      resourceContext: ResourceContextURI
+    }
+
 export type InputSlot = {
   /** Kind of the slot */
   kind: InputSlotKind
-  /** Input type accepted by the slot. */
-  acceptType: InputType
+  /** Info describing what inputs are accepted by the slot */
+  accept: InputSlotAccept
   /** Current input in the slot */
   input: Input
   /** Names for user predefined identifiers available for the slot */

--- a/spx-gui/src/components/editor/code-editor/lsp/spxls/commands.ts
+++ b/spx-gui/src/components/editor/code-editor/lsp/spxls/commands.ts
@@ -1,5 +1,5 @@
 import type * as lsp from 'vscode-languageserver-protocol'
-import type { DefinitionIdentifier, Input, InputSlotKind, InputType, ResourceIdentifier } from '../../common'
+import type { DefinitionIdentifier, Input, InputSlotAccept, InputSlotKind, ResourceIdentifier } from '../../common'
 
 export namespace spxGetDefinitions {
   export const command = 'spx.getDefinitions'
@@ -25,8 +25,8 @@ export namespace spxGetInputSlots {
   type SpxInputSlot = {
     /** Kind of the slot */
     kind: InputSlotKind
-    /** Input type accepted by the slot. */
-    acceptType: InputType
+    /** Info describing what inputs are accepted by the slot */
+    accept: InputSlotAccept
     /** Current input in the slot */
     input: Input
     /** Names for available user-predefined identifiers */


### PR DESCRIPTION
* Replaced the `acceptType` property with a new `accept` property in `InputSlot`, which uses the newly introduced `InputSlotAccept` type to provide more detailed information about accepted input types
* Added a `ResourceContextURI` type to represent URIs for resource contexts
