### PR TITLE
Fix offset for CostumesPlayer

### DIFF
--- a/spx-gui/src/components/common/CostumesPlayer.vue
+++ b/spx-gui/src/components/common/CostumesPlayer.vue
@@ -50,8 +50,8 @@ function adjustDrawingOptions(canvas: HTMLCanvasElement, firstFrame: Frame) {
   const scale = Math.min(canvas.width / firstFrame.width, canvas.height / firstFrame.height)
   drawingOptionsRef.value = {
     scale,
-    offsetX: (canvas.width - firstFrame.width * scale) / 2,
-    offsetY: (canvas.height - firstFrame.height * scale) / 2
+    offsetX: (canvas.width - firstFrame.width * scale) / 2 + firstFrame.x * scale,
+    offsetY: (canvas.height - firstFrame.height * scale) / 2 + firstFrame.y * scale
   }
 }
 


### PR DESCRIPTION
在渲染某一帧（`drawFrame`）的时候，我们会基于该帧的 `x`、`y` 来调整该帧的实际渲染位置：

```ts
const x = offsetX - frame.x * scale
const y = offsetY - frame.y * scale
```

因此在使用第一帧（`firstFrame`）的信息来计算整体的 `offsetX`、`offsetY` 时，也应当把第一帧的 `x`、`y` 考虑在内；否则后续每帧在渲染时都会产生值为 `firstFrame.x`、`firstFrame.y` 的偏移