### PR TITLE
Adjust position for ContextMenu trigger

### DIFF
--- a/spx-gui/src/components/editor/code-editor/ui/context-menu/ContextMenuTrigger.vue
+++ b/spx-gui/src/components/editor/code-editor/ui/context-menu/ContextMenuTrigger.vue
@@ -30,9 +30,8 @@ function handleClick(e: MouseEvent) {
 
 <style lang="scss" scoped>
 .context-menu-trigger {
-  position: absolute;
-  left: 0;
-  top: 0;
+  position: fixed;
+  margin-left: -20px;
   display: flex;
   padding: 0;
   border: none;

--- a/spx-gui/src/components/editor/code-editor/ui/context-menu/ContextMenuUI.vue
+++ b/spx-gui/src/components/editor/code-editor/ui/context-menu/ContextMenuUI.vue
@@ -1,16 +1,45 @@
 <script setup lang="ts">
+import { ref, watchEffect, type CSSProperties } from 'vue'
+import type { Position } from '../../common'
+import { toAbsolutePosition } from '../common'
+import { useCodeEditorUICtx } from '../CodeEditorUI.vue'
 import type { ContextMenuController } from '.'
 import ContextMenu from './ContextMenu.vue'
 import ContextMenuTrigger from './ContextMenuTrigger.vue'
 
-defineProps<{
+const props = defineProps<{
   controller: ContextMenuController
 }>()
+
+const codeEditorUICtx = useCodeEditorUICtx()
+
+const triggerPos = ref<CSSProperties | null>(null)
+
+watchEffect((onCleanup) => {
+  const triggerData = props.controller.triggerData
+  if (triggerData == null) return
+  const lineHeadPos: Position = {
+    line: triggerData.selection.start.line,
+    column: 1
+  }
+  const aPos = toAbsolutePosition(lineHeadPos, codeEditorUICtx.ui.editor)
+  if (aPos == null) return
+  triggerPos.value = {
+    left: aPos.left + 'px',
+    top: aPos.top + 'px'
+  }
+  onCleanup(() => {
+    triggerPos.value = null
+  })
+})
 </script>
 
 <template>
   <ContextMenu :data="controller.menuData" :controller="controller" />
-  <Teleport :to="controller.triggerWidgetEl">
-    <ContextMenuTrigger v-if="controller.triggerData != null" :data="controller.triggerData" :controller="controller" />
-  </Teleport>
+  <ContextMenuTrigger
+    v-if="triggerPos != null"
+    :style="triggerPos"
+    :data="controller.triggerData!"
+    :controller="controller"
+  />
 </template>

--- a/spx-gui/src/components/editor/code-editor/ui/context-menu/index.ts
+++ b/spx-gui/src/components/editor/code-editor/ui/context-menu/index.ts
@@ -1,4 +1,4 @@
-import { shallowRef, watch } from 'vue'
+import { shallowRef } from 'vue'
 import { Disposable } from '@/utils/disposable'
 import { timeout } from '@/utils/utils'
 import { Cancelled } from '@/utils/exception'
@@ -12,7 +12,7 @@ import {
   builtInCommandPaste,
   type InternalAction
 } from '../code-editor-ui'
-import { toMonacoPosition, fromMonacoPosition, fromMonacoSelection } from '../common'
+import { fromMonacoPosition, fromMonacoSelection } from '../common'
 
 export type ContextMenuContext = BaseContext
 
@@ -95,31 +95,6 @@ export class ContextMenuController extends Disposable {
     return { selection: this.ui.selection! }
   }
 
-  triggerWidgetEl = document.createElement('div')
-
-  private triggerWidget = {
-    getId: () => `context-menu-trigger-for-${this.ui.id}`,
-    getDomNode: () => this.triggerWidgetEl,
-    getPosition: () => {
-      const monaco = this.ui.monaco
-      const triggerData = this.triggerData
-      let position: monaco.IPosition | null = null
-      if (triggerData != null) {
-        position = toMonacoPosition({
-          line: triggerData.selection.position.line,
-          column: 0
-        })
-      }
-      return {
-        position,
-        preference: [
-          monaco.editor.ContentWidgetPositionPreference.ABOVE,
-          monaco.editor.ContentWidgetPositionPreference.BELOW
-        ]
-      }
-    }
-  } satisfies monaco.editor.IContentWidget
-
   private hideMenu() {
     this.menuMgr.stop()
   }
@@ -148,15 +123,6 @@ export class ContextMenuController extends Disposable {
 
   init() {
     const { editor, monaco } = this.ui
-
-    editor.addContentWidget(this.triggerWidget)
-    this.addDisposer(() => editor.removeContentWidget(this.triggerWidget))
-    this.addDisposer(
-      watch(
-        () => this.triggerWidget.getPosition(),
-        () => editor.layoutContentWidget(this.triggerWidget)
-      )
-    )
 
     const MTT = monaco.editor.MouseTargetType
     this.addDisposable(


### PR DESCRIPTION
close #1376.

> 沟通后调整为把按钮往左移，移出代码编辑区，这样不会遮盖代码
> 
> 不往上方移是因为，那样的话，按钮跟被选中的文本既不在水平方向上对齐也不在垂直方向上对齐，很难建立 context menu 与被选中文本的联系