### PR TITLE
Debug ProjectRunner for Safari

### DIFF
--- a/spx-gui/src/components/community/project/OwnerInfo.vue
+++ b/spx-gui/src/components/community/project/OwnerInfo.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { useExternalUrl } from '@/utils/utils'
 import { useUser } from '@/stores/user'
 import UserLink from '../user/UserLink.vue'
 
@@ -7,11 +8,12 @@ const props = defineProps<{
 }>()
 
 const { data: user } = useUser(() => props.owner)
+const avatarUrl = useExternalUrl(() => user.value?.avatar)
 </script>
 
 <template>
   <UserLink class="owner-info" :user="user?.username ?? null">
-    <i class="avatar" :style="user != null ? { backgroundImage: `url(${user.avatar})` } : null"></i>
+    <i class="avatar" :style="user != null ? { backgroundImage: `url(${avatarUrl})` } : null"></i>
     {{ user?.displayName }}
   </UserLink>
 </template>

--- a/spx-gui/src/components/community/user/UserAvatar.vue
+++ b/spx-gui/src/components/community/user/UserAvatar.vue
@@ -2,14 +2,15 @@
   <UserLink
     class="user-avatar"
     :class="`size-${size}`"
-    :style="userInfo != null ? { backgroundImage: `url(${userInfo.avatar})` } : null"
+    :style="userInfo != null ? { backgroundImage: `url(${avatarUrl})` } : null"
     :user="userInfo?.username ?? null"
   ></UserLink>
 </template>
 
 <script setup lang="ts">
-import UserLink from './UserLink.vue'
+import { useExternalUrl } from '@/utils/utils'
 import { useUser } from '@/stores/user'
+import UserLink from './UserLink.vue'
 
 export type Size = 'small' | 'medium'
 
@@ -24,6 +25,7 @@ const props = withDefaults(
 )
 
 const { data: userInfo } = useUser(() => props.user)
+const avatarUrl = useExternalUrl(() => userInfo.value?.avatar)
 </script>
 
 <style lang="scss" scoped>

--- a/spx-gui/src/components/project/ProjectItem.vue
+++ b/spx-gui/src/components/project/ProjectItem.vue
@@ -99,7 +99,7 @@ import { useMessageHandle } from '@/utils/exception'
 import { humanizeCount, humanizeExactCount, humanizeTime, humanizeExactTime, useAsyncComputed } from '@/utils/utils'
 import { getProjectEditorRoute, getProjectPageRoute } from '@/router'
 import { Visibility, type ProjectData } from '@/apis/project'
-import { getPublishedContent, universalUrlToWebUrl } from '@/models/common/cloud'
+import { createFileWithUniversalUrl, getPublishedContent } from '@/models/common/cloud'
 import { useUserStore } from '@/stores/user'
 import { useIsLikingProject } from '@/stores/liking'
 import { UIImg, UIDropdown, UIIcon, UIMenu, UIMenuItem } from '@/components/ui'
@@ -140,10 +140,11 @@ const to = computed(() => {
   return props.context === 'edit' ? getProjectEditorRoute(name) : getProjectPageRoute(owner, name)
 })
 
-const thumbnailUrl = useAsyncComputed(async () => {
-  const thumbnail = getPublishedContent(props.project)?.thumbnail ?? props.project.thumbnail
-  if (thumbnail === '') return null
-  return universalUrlToWebUrl(thumbnail)
+const thumbnailUrl = useAsyncComputed(async (onCleanup) => {
+  const thumbnailUniversalUrl = getPublishedContent(props.project)?.thumbnail ?? props.project.thumbnail
+  if (thumbnailUniversalUrl === '') return null
+  const thumbnail = createFileWithUniversalUrl(thumbnailUniversalUrl)
+  return thumbnail.url(onCleanup)
 })
 
 const { data: liking } = useIsLikingProject(() => ({

--- a/spx-gui/src/models/common/cloud.ts
+++ b/spx-gui/src/models/common/cloud.ts
@@ -116,7 +116,7 @@ function getUniversalUrl(file: File): UniversalUrl | null {
   return file.meta.universalUrl ?? null
 }
 
-function createFileWithUniversalUrl(url: UniversalUrl, name = filename(url)) {
+export function createFileWithUniversalUrl(url: UniversalUrl, name = filename(url)) {
   return new File(name, async () => {
     const webUrl = await universalUrlToWebUrl(url)
     const resp = await fetch(webUrl)

--- a/spx-gui/src/utils/utils.test.ts
+++ b/spx-gui/src/utils/utils.test.ts
@@ -7,7 +7,8 @@ import {
   memoizeAsync,
   localStorageRef,
   humanizeListWithLimit,
-  humanizeFileSize
+  humanizeFileSize,
+  isCrossOriginUrl
 } from './utils'
 import { sleep } from './test'
 
@@ -265,5 +266,30 @@ describe('humanizeFileSize', () => {
     expect(humanizeFileSize(1536)).toEqual({ en: '1.5 KB', zh: '1.5 KB' })
     expect(humanizeFileSize(10485760)).toEqual({ en: '10 MB', zh: '10 MB' })
     expect(humanizeFileSize(10737418240)).toEqual({ en: '10 GB', zh: '10 GB' })
+  })
+})
+
+describe('isCrossOriginUrl', () => {
+  it('should work well', () => {
+    expect(isCrossOriginUrl('https://example.com/image.png', 'https://example2.com')).toBe(true)
+    expect(isCrossOriginUrl('https://example.com/image.png', 'https://example.com')).toBe(false)
+    expect(isCrossOriginUrl('https://example.com/image.png', 'http://example.com')).toBe(true)
+    expect(isCrossOriginUrl('https://example.com/image.png', 'https://example.com:8080')).toBe(true)
+  })
+  it('should handle relative URLs', () => {
+    expect(isCrossOriginUrl('/image.png', 'https://example.com')).toBe(false)
+    expect(isCrossOriginUrl('image.png', 'https://example.com')).toBe(false)
+  })
+  it('should work well with object URLs', () => {
+    expect(
+      isCrossOriginUrl('blob:https://example.com/12345678-1234-1234-1234-123456789012', 'https://example.com')
+    ).toBe(false)
+    expect(
+      isCrossOriginUrl('blob:https://example.com/12345678-1234-1234-1234-123456789012', 'https://example2.com')
+    ).toBe(true)
+  })
+  it('should work well with data URLs', () => {
+    expect(isCrossOriginUrl('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUA', 'https://example.com')).toBe(false)
+    expect(isCrossOriginUrl('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUA', 'https://example2.com')).toBe(false)
   })
 })

--- a/spx-gui/vite.config.ts
+++ b/spx-gui/vite.config.ts
@@ -41,7 +41,7 @@ export default defineConfig(({ mode }) => {
     test: { environment: 'happy-dom' },
     server: {
       headers: {
-        'Cross-Origin-Embedder-Policy': 'credentialless',
+        'Cross-Origin-Embedder-Policy': 'require-corp',
         'Cross-Origin-Opener-Policy': 'same-origin',
       },
     },
@@ -68,7 +68,7 @@ export default defineConfig(({ mode }) => {
             },
             {
               key: 'Cross-Origin-Embedder-Policy',
-              value: 'credentialless'
+              value: 'require-corp'
             },
             {
               key: 'Cross-Origin-Opener-Policy',


### PR DESCRIPTION
close #1737.

* Use `COEP: require-corp` instead of `COEP: credentialless` to accomplish [cross-origin isolated](https://developer.mozilla.org/en-US/docs/Web/API/Window/crossOriginIsolated), as Safari does not support `COEP: credentialless`
* Update code of consuming external URLs to suit `COEP: require-corp`
* Fix `ProjectRunnerV2.rerun` in Safari

Related:

* https://github.com/goplus/builder/pull/1083