### PR TITLE
Use `acc.xbuilder.com` instead of `acc.goplus.org`

### DIFF
--- a/spx-gui/.env.production
+++ b/spx-gui/.env.production
@@ -12,7 +12,7 @@ VITE_VERCEL_PROXIED_API_BASE_URL="https://api.xbuilder.com"
 VITE_USERCONTENT_BASE_URL="https://builder-usercontent.gopluscdn.com"
 VITE_USERCONTENT_UPLOAD_BASE_URL="https://upload-na0.qiniup.com"
 
-VITE_CASDOOR_ENDPOINT="https://acc.goplus.org"
+VITE_CASDOOR_ENDPOINT="https://acc.xbuilder.com"
 VITE_CASDOOR_CLIENT_ID="4ff910257e9cdd89b6b8"
 VITE_CASDOOR_APP_NAME="goplus-builder"
 VITE_CASDOOR_ORGANIZATION_NAME="GoPlus"


### PR DESCRIPTION
update #1742.

Related:

* https://github.com/goplus/casdoor/pull/11
* https://github.com/goplus/builder/issues/1734