### PR TITLE
Debug user avatar loading

### DIFF
--- a/spx-gui/src/components/community/user/EditProfileModal.vue
+++ b/spx-gui/src/components/community/user/EditProfileModal.vue
@@ -1,6 +1,7 @@
 <script lang="ts" setup>
 import { computed } from 'vue'
 import { useMessageHandle } from '@/utils/exception'
+import { useExternalUrl } from '@/utils/utils'
 import { useI18n } from '@/utils/i18n'
 import { type User } from '@/apis/user'
 import { UIImg, UIFormModal, UIForm, UIFormItem, UITextInput, UIButton, useForm } from '@/components/ui'
@@ -20,6 +21,7 @@ const emit = defineEmits<{
 const { t } = useI18n()
 
 const coverImgUrl = computed(() => getCoverImgUrl(props.user.username))
+const avatarUrl = useExternalUrl(() => props.user.avatar)
 
 const form = useForm({
   description: [props.user.description, validateDescription]
@@ -50,7 +52,7 @@ const handleSubmit = useMessageHandle(async () => {
     @update:visible="handleCancel"
   >
     <div class="cover" :style="{ backgroundImage: `url(${coverImgUrl})` }"></div>
-    <UIImg class="avatar" :src="user.avatar" />
+    <UIImg class="avatar" :src="avatarUrl" />
     <UIForm :form="form" has-success-feedback @submit="handleSubmit.fn">
       <UIFormItem :label="$t({ en: 'Name', zh: '名字' })">
         <UITextInput :value="user.displayName" disabled />

--- a/spx-gui/src/components/community/user/UserHeader.vue
+++ b/spx-gui/src/components/community/user/UserHeader.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import { type User } from '@/apis/user'
+import { useExternalUrl } from '@/utils/utils'
 import { useMessageHandle } from '@/utils/exception'
 import { useUserStore } from '@/stores/user'
 import { UIButton, UIImg, useModal } from '@/components/ui'
@@ -16,6 +17,7 @@ const props = defineProps<{
 }>()
 
 const isSignedInUser = computed(() => props.user.username === useUserStore().getSignedInUser()?.name)
+const avatarUrl = useExternalUrl(() => props.user.avatar)
 const coverImgUrl = computed(() => getCoverImgUrl(props.user.username))
 
 const invokeEditProfileModal = useModal(EditProfileModal)
@@ -29,7 +31,7 @@ const handleEditProfile = useMessageHandle(async () => invokeEditProfileModal({ 
 <template>
   <CommunityCard class="user-header">
     <div class="cover" :style="{ backgroundImage: `url(${coverImgUrl})` }"></div>
-    <UIImg class="avatar" :src="user.avatar" />
+    <UIImg class="avatar" :src="avatarUrl" />
     <div class="content">
       <div class="info">
         <h2 class="name">

--- a/spx-gui/src/components/editor/code-editor/ui/copilot/UserMessage.vue
+++ b/spx-gui/src/components/editor/code-editor/ui/copilot/UserMessage.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { useExternalUrl } from '@/utils/utils'
 import { useEditorCtx } from '@/components/editor/EditorContextProvider.vue'
 import type { BasicMarkdownString } from '../../common'
 import MarkdownView from '../markdown/MarkdownView.vue'
@@ -8,11 +9,12 @@ defineProps<{
 }>()
 
 const editorCtx = useEditorCtx()
+const avatarUrl = useExternalUrl(() => editorCtx.userInfo.avatar)
 </script>
 
 <template>
   <section class="user-message">
-    <img class="avatar" :src="editorCtx.userInfo.avatar" />
+    <img class="avatar" :src="avatarUrl ?? undefined" />
     <MarkdownView class="content" v-bind="content" />
   </section>
 </template>

--- a/spx-gui/src/components/navbar/NavbarProfile.vue
+++ b/spx-gui/src/components/navbar/NavbarProfile.vue
@@ -7,7 +7,7 @@
   <UIDropdown v-else placement="bottom-end" :offset="{ x: -4, y: 8 }">
     <template #trigger>
       <div class="avatar">
-        <img class="avatar-img" :src="userInfo.avatar" />
+        <img class="avatar-img" :src="avatarUrl ?? undefined" />
       </div>
     </template>
     <UIMenu class="user-menu">
@@ -65,7 +65,7 @@
 import { computed } from 'vue'
 import { useRouter } from 'vue-router'
 import { useNetwork } from '@/utils/network'
-import { useSpxVersion } from '@/utils/utils'
+import { useExternalUrl, useSpxVersion } from '@/utils/utils'
 import { useMessageHandle } from '@/utils/exception'
 import { getUserPageRoute } from '@/router'
 import { AssetType } from '@/apis/asset'
@@ -81,6 +81,7 @@ const router = useRouter()
 const { controls } = useCopilotCtx()
 
 const userInfo = computed(() => userStore.getSignedInUser())
+const avatarUrl = useExternalUrl(() => userInfo.value?.avatar)
 
 const handleAskCopilotAgent = useMessageHandle(
   async () => {


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/1cefa6e9-163f-45a0-bfac-9b1d83125beb)

```
GET https://thirdwx.qlogo.cn/mmopen/vi_32/DYAIOgq83eo3arn6GG9ibmYYlticQj02YgJ6xfIbQnIlL4SzdEd7al3wSwpKwtPwbianHHTdffsEPfOGTeZGJa9HQ/132 net::ERR_BLOCKED_BY_RESPONSE.NotSameOriginAfterDefaultedToSameOriginByCoep 200 (OK)
```

Follow up for https://github.com/goplus/builder/pull/1741.

在 https://github.com/goplus/builder/pull/1741#discussion_r2113396615 我们提到

> 这个在后续的维护中不会是大的负担是因为，如果需要做特别处理而没有，那么在开发时就会立刻发现（COEP 会 block 对应的请求，即使是本地开发模式）

这个并不完全正确，即使代码没有做特殊处理，但如果外部 URL 对应的服务（如本地或测试环境 avatar 对应的 `avatars.githubusercontent.com`）返回了 `cross-origin-resource-policy: cross-origin`，那么问题并不会暴露，直到遇到这样的 URL：其对应的外部服务不返回该响应头，才会暴露问题