### PR TITLE
Fix retrying for project editor

### DIFF
--- a/spx-gui/src/utils/query.ts
+++ b/spx-gui/src/utils/query.ts
@@ -166,7 +166,7 @@ export async function composeQuery<T>(
   queryRet: QueryRet<T>,
   subReportParams?: SubReporterParams
 ): Promise<T> {
-  if (ctx.source === 'refetch') {
+  if (ctx.source === 'refetch' || queryRet.error != null) {
     queryRet.refetch(ctx.signal)
   } else {
     toValue(queryRet.isLoading) // Trigger dependency collection


### PR DESCRIPTION
If error encountered during project-loading in page project-editor, the `Retry` button does not trigger re-loading of the project as expected.