### PR TITLE
Avoid permission denied for `cp` in `build-wasm.sh`

### DIFF
--- a/spx-gui/build-wasm.sh
+++ b/spx-gui/build-wasm.sh
@@ -4,7 +4,7 @@ set -e
 echo "Run this script from 'spx-gui' directory"
 
 # Copy Go wasm_exec.js
-cp "$(go env GOROOT)/lib/wasm/wasm_exec.js" src/assets/wasm/wasm_exec.js
+cp -f "$(go env GOROOT)/lib/wasm/wasm_exec.js" src/assets/wasm/wasm_exec.js
 
 # Build and copy ispx.wasm
 ( cd ../tools/ispx && ./build.sh )


### PR DESCRIPTION
The file `src/assets/wasm/wasm_exec.js` from `$(go env GOROOT)/lib/wasm/wasm_exec.js` is not writable by default.

```
(base) ➜  spx-gui git:(build-wasm-script) ll src/assets/wasm 
total 142968
-rwxr-xr-x  1 nighca  staff    53M Jun  9 11:50 ispx.wasm
-rw-r--r--  1 nighca  staff   9.7K Jun  9 11:50 spxls-pkgdata.zip
-rwxr-xr-x  1 nighca  staff    17M Jun  9 11:50 spxls.wasm
-r--r--r--  1 nighca  staff    17K Jun  9 11:50 wasm_exec.js
```

It causes error when trying to run `build-wasm.sh` if `src/assets/wasm/wasm_exec.js` already exists:

```
cp: src/assets/wasm/wasm_exec.js: Permission denied
```

Here we use `cp -f` to avoid the failure.