### PR TITLE
refactor(spx-backend): extract authentication logic into dedicated authn module

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -218,7 +218,7 @@ paths:
 
         #### Visibility rules
 
-        | Authed (as alice) | Owner | Visibility | Access |
+        | Authenticated (as alice) | Owner | Visibility | Access |
         |-------------|-------------|------------------|-----------|
         | false | * | | All users' public projects (force `visibility=public`) |
         | false | * | public | All users' public projects |
@@ -673,7 +673,7 @@ paths:
 
         #### Visibility rules
 
-        | Authed (as alice) | Owner | Visibility | Access |
+        | Authenticated (as alice) | Owner | Visibility | Access |
         |-------------|-------------|------------------|-----------|
         | false | * | | All users' public assets (force `visibility=public`) |
         | false | * | public | All users' public assets |

--- a/spx-backend/cmd/spx-backend/delete_asset_#id.yap
+++ b/spx-backend/cmd/spx-backend/delete_asset_#id.yap
@@ -4,7 +4,7 @@
 //   DELETE /asset/:id
 
 ctx := &Context
-if _, isAuthed := ensureAuthedUser(ctx); !isAuthed {
+if _, ok := ensureAuthenticatedUser(ctx); !ok {
 	return
 }
 

--- a/spx-backend/cmd/spx-backend/delete_project_#owner_#name.yap
+++ b/spx-backend/cmd/spx-backend/delete_project_#owner_#name.yap
@@ -8,7 +8,7 @@ import (
 )
 
 ctx := &Context
-if _, isAuthed := ensureAuthedUser(ctx); !isAuthed {
+if _, ok := ensureAuthenticatedUser(ctx); !ok {
 	return
 }
 

--- a/spx-backend/cmd/spx-backend/delete_project_#owner_#name_liking.yap
+++ b/spx-backend/cmd/spx-backend/delete_project_#owner_#name_liking.yap
@@ -8,7 +8,7 @@ import (
 )
 
 ctx := &Context
-if _, isAuthed := ensureAuthedUser(ctx); !isAuthed {
+if _, ok := ensureAuthenticatedUser(ctx); !ok {
 	return
 }
 

--- a/spx-backend/cmd/spx-backend/delete_user_#username_following.yap
+++ b/spx-backend/cmd/spx-backend/delete_user_#username_following.yap
@@ -4,7 +4,7 @@
 //   DELETE /user/:username/following
 
 ctx := &Context
-if _, isAuthed := ensureAuthedUser(ctx); !isAuthed {
+if _, ok := ensureAuthenticatedUser(ctx); !ok {
 	return
 }
 

--- a/spx-backend/cmd/spx-backend/get_assets_list.yap
+++ b/spx-backend/cmd/spx-backend/get_assets_list.yap
@@ -17,11 +17,11 @@ if keyword := ${keyword}; keyword != "" {
 
 switch owner := ${owner}; owner {
 case "":
-	mAuthedUser, isAuthed := ensureAuthedUser(ctx)
-	if !isAuthed {
+	mUser, ok := ensureAuthenticatedUser(ctx)
+	if !ok {
 		return
 	}
-	params.Owner = &mAuthedUser.Username
+	params.Owner = &mUser.Username
 case "*":
 	params.Owner = nil
 default:

--- a/spx-backend/cmd/spx-backend/get_project_#owner_#name_liking.yap
+++ b/spx-backend/cmd/spx-backend/get_project_#owner_#name_liking.yap
@@ -8,7 +8,7 @@ import (
 )
 
 ctx := &Context
-if _, isAuthed := ensureAuthedUser(ctx); !isAuthed {
+if _, ok := ensureAuthenticatedUser(ctx); !ok {
 	return
 }
 

--- a/spx-backend/cmd/spx-backend/get_projects_list.yap
+++ b/spx-backend/cmd/spx-backend/get_projects_list.yap
@@ -16,11 +16,11 @@ params := controller.NewListProjectsParams()
 
 switch owner := ${owner}; owner {
 case "":
-	mAuthedUser, isAuthed := ensureAuthedUser(ctx)
-	if !isAuthed {
+	mUser, ok := ensureAuthenticatedUser(ctx)
+	if !ok {
 		return
 	}
-	params.Owner = &mAuthedUser.Username
+	params.Owner = &mUser.Username
 case "*":
 	params.Owner = nil
 default:

--- a/spx-backend/cmd/spx-backend/get_user_#username_following.yap
+++ b/spx-backend/cmd/spx-backend/get_user_#username_following.yap
@@ -4,7 +4,7 @@
 //   GET /user/:username/following
 
 ctx := &Context
-if _, isAuthed := ensureAuthedUser(ctx); !isAuthed {
+if _, ok := ensureAuthenticatedUser(ctx); !ok {
 	return
 }
 

--- a/spx-backend/cmd/spx-backend/get_util_upinfo.yap
+++ b/spx-backend/cmd/spx-backend/get_util_upinfo.yap
@@ -4,7 +4,7 @@
 //   GET /util/upinfo
 
 ctx := &Context
-if _, isAuthed := ensureAuthedUser(ctx); !isAuthed {
+if _, ok := ensureAuthenticatedUser(ctx); !ok {
 	return
 }
 

--- a/spx-backend/cmd/spx-backend/main.yap
+++ b/spx-backend/cmd/spx-backend/main.yap
@@ -8,6 +8,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/goplus/builder/spx-backend/internal/authn"
 	"github.com/goplus/builder/spx-backend/internal/controller"
 	"github.com/goplus/builder/spx-backend/internal/model"
 	"github.com/goplus/builder/spx-backend/internal/log"
@@ -36,7 +37,11 @@ if port == "" {
 }
 logger.Printf("Listening to %s", port)
 
-h := handler(NewUserMiddleware(ctrl), NewReqIDMiddleware(), NewCORSMiddleware())
+h := handler(
+	authn.Middleware(ctrl.Authenticator()),
+	NewReqIDMiddleware(),
+	NewCORSMiddleware(),
+)
 server := &http.Server{Addr: port, Handler: h}
 
 stopCtx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)

--- a/spx-backend/cmd/spx-backend/middleware.go
+++ b/spx-backend/cmd/spx-backend/middleware.go
@@ -3,10 +3,7 @@ package main
 import (
 	"net/http"
 	"os"
-	"strings"
 
-	"github.com/goplus/builder/spx-backend/internal/controller"
-	"github.com/goplus/builder/spx-backend/internal/log"
 	"github.com/qiniu/x/reqid"
 )
 
@@ -39,31 +36,6 @@ func NewReqIDMiddleware() func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			ctx := reqid.NewContextWith(r.Context(), w, r)
 			next.ServeHTTP(w, r.WithContext(ctx))
-		})
-	}
-}
-
-// NewUserMiddleware creates a new user middleware.
-func NewUserMiddleware(ctrl *controller.Controller) func(next http.Handler) http.Handler {
-	return func(next http.Handler) http.Handler {
-		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			ctx := r.Context()
-			logger := log.GetReqLogger(ctx)
-
-			authorization := r.Header.Get("Authorization")
-			if authorization != "" {
-				token := strings.TrimPrefix(authorization, "Bearer ")
-				mAuthedUser, err := ctrl.AuthedUserFromToken(r.Context(), token)
-				if err != nil {
-					logger.Printf("failed to get user from token: %v", err)
-				} else if mAuthedUser == nil {
-					logger.Printf("no user info")
-				} else {
-					r = r.WithContext(controller.NewContextWithAuthedUser(ctx, mAuthedUser))
-				}
-			}
-
-			next.ServeHTTP(w, r)
 		})
 	}
 }

--- a/spx-backend/cmd/spx-backend/middleware_test.go
+++ b/spx-backend/cmd/spx-backend/middleware_test.go
@@ -87,5 +87,3 @@ func TestNewReqIDMiddleware(t *testing.T) {
 		assert.Equal(t, "foobar", string(respBody))
 	})
 }
-
-// TODO: Add tests for [NewUserMiddleware].

--- a/spx-backend/cmd/spx-backend/post_ai_interaction_turn.yap
+++ b/spx-backend/cmd/spx-backend/post_ai_interaction_turn.yap
@@ -11,7 +11,7 @@ ctx := &Context
 
 // FIXME: Uncomment the following line to ensure the user is authenticated once
 // https://github.com/goplus/builder/issues/1673 is fixed.
-// if _, isAuthed := ensureAuthedUser(ctx); !isAuthed {
+// if _, ok := ensureAuthenticatedUser(ctx); !ok {
 // 	return
 // }
 

--- a/spx-backend/cmd/spx-backend/post_aigc_matting.yap
+++ b/spx-backend/cmd/spx-backend/post_aigc_matting.yap
@@ -8,7 +8,7 @@ import (
 )
 
 ctx := &Context
-if _, isAuthed := ensureAuthedUser(ctx); !isAuthed {
+if _, ok := ensureAuthenticatedUser(ctx); !ok {
 	return
 }
 

--- a/spx-backend/cmd/spx-backend/post_asset.yap
+++ b/spx-backend/cmd/spx-backend/post_asset.yap
@@ -8,7 +8,7 @@ import (
 )
 
 ctx := &Context
-if _, isAuthed := ensureAuthedUser(ctx); !isAuthed {
+if _, ok := ensureAuthenticatedUser(ctx); !ok {
 	return
 }
 

--- a/spx-backend/cmd/spx-backend/post_copilot_message.yap
+++ b/spx-backend/cmd/spx-backend/post_copilot_message.yap
@@ -8,7 +8,7 @@ import (
 )
 
 ctx := &Context
-if _, isAuthed := ensureAuthedUser(ctx); !isAuthed {
+if _, ok := ensureAuthenticatedUser(ctx); !ok {
 	return
 }
 

--- a/spx-backend/cmd/spx-backend/post_copilot_stream_message.yap
+++ b/spx-backend/cmd/spx-backend/post_copilot_stream_message.yap
@@ -8,7 +8,7 @@ import (
 )
 
 ctx := &Context
-if _, isAuthed := ensureAuthedUser(ctx); !isAuthed {
+if _, ok := ensureAuthenticatedUser(ctx); !ok {
 	return
 }
 

--- a/spx-backend/cmd/spx-backend/post_project-release.yap
+++ b/spx-backend/cmd/spx-backend/post_project-release.yap
@@ -8,7 +8,7 @@ import (
 )
 
 ctx := &Context
-if _, isAuthed := ensureAuthedUser(ctx); !isAuthed {
+if _, ok := ensureAuthenticatedUser(ctx); !ok {
 	return
 }
 

--- a/spx-backend/cmd/spx-backend/post_project.yap
+++ b/spx-backend/cmd/spx-backend/post_project.yap
@@ -8,7 +8,7 @@ import (
 )
 
 ctx := &Context
-if _, isAuthed := ensureAuthedUser(ctx); !isAuthed {
+if _, ok := ensureAuthenticatedUser(ctx); !ok {
 	return
 }
 

--- a/spx-backend/cmd/spx-backend/post_project_#owner_#name_liking.yap
+++ b/spx-backend/cmd/spx-backend/post_project_#owner_#name_liking.yap
@@ -8,7 +8,7 @@ import (
 )
 
 ctx := &Context
-if _, isAuthed := ensureAuthedUser(ctx); !isAuthed {
+if _, ok := ensureAuthenticatedUser(ctx); !ok {
 	return
 }
 

--- a/spx-backend/cmd/spx-backend/post_project_#owner_#name_view.yap
+++ b/spx-backend/cmd/spx-backend/post_project_#owner_#name_view.yap
@@ -8,7 +8,7 @@ import (
 )
 
 ctx := &Context
-if _, isAuthed := ensureAuthedUser(ctx); !isAuthed {
+if _, ok := ensureAuthenticatedUser(ctx); !ok {
 	return
 }
 

--- a/spx-backend/cmd/spx-backend/post_user_#username_following.yap
+++ b/spx-backend/cmd/spx-backend/post_user_#username_following.yap
@@ -4,7 +4,7 @@
 //   POST /user/:username/following
 
 ctx := &Context
-if _, isAuthed := ensureAuthedUser(ctx); !isAuthed {
+if _, ok := ensureAuthenticatedUser(ctx); !ok {
 	return
 }
 

--- a/spx-backend/cmd/spx-backend/post_workflow_stream_message.yap
+++ b/spx-backend/cmd/spx-backend/post_workflow_stream_message.yap
@@ -8,7 +8,7 @@ import (
 )
 
 ctx := &Context
-if _, isAuthed := ensureAuthedUser(ctx); !isAuthed {
+if _, ok := ensureAuthenticatedUser(ctx); !ok {
 	return
 }
 

--- a/spx-backend/cmd/spx-backend/put_asset_#id.yap
+++ b/spx-backend/cmd/spx-backend/put_asset_#id.yap
@@ -8,7 +8,7 @@ import (
 )
 
 ctx := &Context
-if _, isAuthed := ensureAuthedUser(ctx); !isAuthed {
+if _, ok := ensureAuthenticatedUser(ctx); !ok {
 	return
 }
 

--- a/spx-backend/cmd/spx-backend/put_project_#owner_#name.yap
+++ b/spx-backend/cmd/spx-backend/put_project_#owner_#name.yap
@@ -8,7 +8,7 @@ import (
 )
 
 ctx := &Context
-if _, isAuthed := ensureAuthedUser(ctx); !isAuthed {
+if _, ok := ensureAuthenticatedUser(ctx); !ok {
 	return
 }
 

--- a/spx-backend/cmd/spx-backend/put_user.yap
+++ b/spx-backend/cmd/spx-backend/put_user.yap
@@ -8,11 +8,11 @@ import (
 )
 
 ctx := &Context
-if _, isAuthed := ensureAuthedUser(ctx); !isAuthed {
+if _, ok := ensureAuthenticatedUser(ctx); !ok {
 	return
 }
 
-params := &controller.UpdateAuthedUserParams{}
+params := &controller.UpdateAuthenticatedUserParams{}
 if !parseJSON(ctx, params) {
 	return
 }
@@ -21,7 +21,7 @@ if ok, msg := params.Validate(); !ok {
 	return
 }
 
-user, err := ctrl.UpdateAuthedUser(ctx.Context(), params)
+user, err := ctrl.UpdateAuthenticatedUser(ctx.Context(), params)
 if err != nil {
 	replyWithInnerError(ctx, err)
 	return

--- a/spx-backend/cmd/spx-backend/xgo_autogen.go
+++ b/spx-backend/cmd/spx-backend/xgo_autogen.go
@@ -5,6 +5,7 @@ package main
 import (
 	"context"
 	"errors"
+	"github.com/goplus/builder/spx-backend/internal/authn"
 	"github.com/goplus/builder/spx-backend/internal/controller"
 	"github.com/goplus/builder/spx-backend/internal/log"
 	"github.com/goplus/yap"
@@ -147,59 +148,59 @@ type put_user struct {
 	yap.Handler
 	*AppV2
 }
-//line cmd/spx-backend/main.yap:26
+//line cmd/spx-backend/main.yap:27
 func (this *AppV2) MainEntry() {
-//line cmd/spx-backend/main.yap:26:1
+//line cmd/spx-backend/main.yap:27:1
 	logger := log.GetLogger()
-//line cmd/spx-backend/main.yap:28:1
-	this.ctrl, this.err = controller.New(context.Background())
 //line cmd/spx-backend/main.yap:29:1
-	if this.err != nil {
+	this.ctrl, this.err = controller.New(context.Background())
 //line cmd/spx-backend/main.yap:30:1
+	if this.err != nil {
+//line cmd/spx-backend/main.yap:31:1
 		logger.Fatalln("Failed to create a new controller:", this.err)
 	}
-//line cmd/spx-backend/main.yap:33:1
-	port := os.Getenv("PORT")
 //line cmd/spx-backend/main.yap:34:1
-	if port == "" {
+	port := os.Getenv("PORT")
 //line cmd/spx-backend/main.yap:35:1
+	if port == "" {
+//line cmd/spx-backend/main.yap:36:1
 		port = ":8080"
 	}
-//line cmd/spx-backend/main.yap:37:1
+//line cmd/spx-backend/main.yap:38:1
 	logger.Printf("Listening to %s", port)
-//line cmd/spx-backend/main.yap:39:1
-	h := this.Handler(NewUserMiddleware(this.ctrl), NewReqIDMiddleware(), NewCORSMiddleware())
 //line cmd/spx-backend/main.yap:40:1
-	server := &http.Server{Addr: port, Handler: h}
-//line cmd/spx-backend/main.yap:42:1
-	stopCtx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
-//line cmd/spx-backend/main.yap:43:1
-	defer stop()
-//line cmd/spx-backend/main.yap:44:1
-	var serverErr error
+	h := this.Handler(authn.Middleware(this.ctrl.Authenticator()), NewReqIDMiddleware(), NewCORSMiddleware())
 //line cmd/spx-backend/main.yap:45:1
-	go func() {
-//line cmd/spx-backend/main.yap:46:1
-		serverErr = server.ListenAndServe()
+	server := &http.Server{Addr: port, Handler: h}
 //line cmd/spx-backend/main.yap:47:1
+	stopCtx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+//line cmd/spx-backend/main.yap:48:1
+	defer stop()
+//line cmd/spx-backend/main.yap:49:1
+	var serverErr error
+//line cmd/spx-backend/main.yap:50:1
+	go func() {
+//line cmd/spx-backend/main.yap:51:1
+		serverErr = server.ListenAndServe()
+//line cmd/spx-backend/main.yap:52:1
 		stop()
 	}()
-//line cmd/spx-backend/main.yap:49:1
+//line cmd/spx-backend/main.yap:54:1
 	<-stopCtx.Done()
-//line cmd/spx-backend/main.yap:50:1
+//line cmd/spx-backend/main.yap:55:1
 	if serverErr != nil && !errors.Is(serverErr, http.ErrServerClosed) {
-//line cmd/spx-backend/main.yap:51:1
+//line cmd/spx-backend/main.yap:56:1
 		logger.Fatalln("Server error:", serverErr)
 	}
-//line cmd/spx-backend/main.yap:54:1
+//line cmd/spx-backend/main.yap:59:1
 	shutdownCtx, cancel := context.WithTimeout(context.Background(), time.Minute)
-//line cmd/spx-backend/main.yap:55:1
+//line cmd/spx-backend/main.yap:60:1
 	defer cancel()
-//line cmd/spx-backend/main.yap:56:1
+//line cmd/spx-backend/main.yap:61:1
 	if
-//line cmd/spx-backend/main.yap:56:1
+//line cmd/spx-backend/main.yap:61:1
 	err := server.Shutdown(shutdownCtx); err != nil {
-//line cmd/spx-backend/main.yap:57:1
+//line cmd/spx-backend/main.yap:62:1
 		logger.Fatalln("Failed to gracefully shut down:", err)
 	}
 }
@@ -244,7 +245,7 @@ func (this *delete_asset_id) Main(_xgo_arg0 *yap.Context) {
 //line cmd/spx-backend/delete_asset_#id.yap:7:1
 	if
 //line cmd/spx-backend/delete_asset_#id.yap:7:1
-	_, isAuthed := ensureAuthedUser(ctx); !isAuthed {
+	_, ok := ensureAuthenticatedUser(ctx); !ok {
 //line cmd/spx-backend/delete_asset_#id.yap:8:1
 		return
 	}
@@ -275,7 +276,7 @@ func (this *delete_project_owner_name) Main(_xgo_arg0 *yap.Context) {
 //line cmd/spx-backend/delete_project_#owner_#name.yap:11:1
 	if
 //line cmd/spx-backend/delete_project_#owner_#name.yap:11:1
-	_, isAuthed := ensureAuthedUser(ctx); !isAuthed {
+	_, ok := ensureAuthenticatedUser(ctx); !ok {
 //line cmd/spx-backend/delete_project_#owner_#name.yap:12:1
 		return
 	}
@@ -308,7 +309,7 @@ func (this *delete_project_owner_name_liking) Main(_xgo_arg0 *yap.Context) {
 //line cmd/spx-backend/delete_project_#owner_#name_liking.yap:11:1
 	if
 //line cmd/spx-backend/delete_project_#owner_#name_liking.yap:11:1
-	_, isAuthed := ensureAuthedUser(ctx); !isAuthed {
+	_, ok := ensureAuthenticatedUser(ctx); !ok {
 //line cmd/spx-backend/delete_project_#owner_#name_liking.yap:12:1
 		return
 	}
@@ -341,7 +342,7 @@ func (this *delete_user_username_following) Main(_xgo_arg0 *yap.Context) {
 //line cmd/spx-backend/delete_user_#username_following.yap:7:1
 	if
 //line cmd/spx-backend/delete_user_#username_following.yap:7:1
-	_, isAuthed := ensureAuthedUser(ctx); !isAuthed {
+	_, ok := ensureAuthenticatedUser(ctx); !ok {
 //line cmd/spx-backend/delete_user_#username_following.yap:8:1
 		return
 	}
@@ -409,14 +410,14 @@ func (this *get_assets_list) Main(_xgo_arg0 *yap.Context) {
 //line cmd/spx-backend/get_assets_list.yap:19:1
 	case "":
 //line cmd/spx-backend/get_assets_list.yap:20:1
-		mAuthedUser, isAuthed := ensureAuthedUser(ctx)
+		mUser, ok := ensureAuthenticatedUser(ctx)
 //line cmd/spx-backend/get_assets_list.yap:21:1
-		if !isAuthed {
+		if !ok {
 //line cmd/spx-backend/get_assets_list.yap:22:1
 			return
 		}
 //line cmd/spx-backend/get_assets_list.yap:24:1
-		params.Owner = &mAuthedUser.Username
+		params.Owner = &mUser.Username
 //line cmd/spx-backend/get_assets_list.yap:25:1
 	case "*":
 //line cmd/spx-backend/get_assets_list.yap:26:1
@@ -631,7 +632,7 @@ func (this *get_project_owner_name_liking) Main(_xgo_arg0 *yap.Context) {
 //line cmd/spx-backend/get_project_#owner_#name_liking.yap:11:1
 	if
 //line cmd/spx-backend/get_project_#owner_#name_liking.yap:11:1
-	_, isAuthed := ensureAuthedUser(ctx); !isAuthed {
+	_, ok := ensureAuthenticatedUser(ctx); !ok {
 //line cmd/spx-backend/get_project_#owner_#name_liking.yap:12:1
 		return
 	}
@@ -676,14 +677,14 @@ func (this *get_projects_list) Main(_xgo_arg0 *yap.Context) {
 //line cmd/spx-backend/get_projects_list.yap:18:1
 	case "":
 //line cmd/spx-backend/get_projects_list.yap:19:1
-		mAuthedUser, isAuthed := ensureAuthedUser(ctx)
+		mUser, ok := ensureAuthenticatedUser(ctx)
 //line cmd/spx-backend/get_projects_list.yap:20:1
-		if !isAuthed {
+		if !ok {
 //line cmd/spx-backend/get_projects_list.yap:21:1
 			return
 		}
 //line cmd/spx-backend/get_projects_list.yap:23:1
-		params.Owner = &mAuthedUser.Username
+		params.Owner = &mUser.Username
 //line cmd/spx-backend/get_projects_list.yap:24:1
 	case "*":
 //line cmd/spx-backend/get_projects_list.yap:25:1
@@ -872,7 +873,7 @@ func (this *get_user_username_following) Main(_xgo_arg0 *yap.Context) {
 //line cmd/spx-backend/get_user_#username_following.yap:7:1
 	if
 //line cmd/spx-backend/get_user_#username_following.yap:7:1
-	_, isAuthed := ensureAuthedUser(ctx); !isAuthed {
+	_, ok := ensureAuthenticatedUser(ctx); !ok {
 //line cmd/spx-backend/get_user_#username_following.yap:8:1
 		return
 	}
@@ -976,7 +977,7 @@ func (this *get_util_upinfo) Main(_xgo_arg0 *yap.Context) {
 //line cmd/spx-backend/get_util_upinfo.yap:7:1
 	if
 //line cmd/spx-backend/get_util_upinfo.yap:7:1
-	_, isAuthed := ensureAuthedUser(ctx); !isAuthed {
+	_, ok := ensureAuthenticatedUser(ctx); !ok {
 //line cmd/spx-backend/get_util_upinfo.yap:8:1
 		return
 	}
@@ -1047,7 +1048,7 @@ func (this *post_aigc_matting) Main(_xgo_arg0 *yap.Context) {
 //line cmd/spx-backend/post_aigc_matting.yap:11:1
 	if
 //line cmd/spx-backend/post_aigc_matting.yap:11:1
-	_, isAuthed := ensureAuthedUser(ctx); !isAuthed {
+	_, ok := ensureAuthenticatedUser(ctx); !ok {
 //line cmd/spx-backend/post_aigc_matting.yap:12:1
 		return
 	}
@@ -1094,7 +1095,7 @@ func (this *post_asset) Main(_xgo_arg0 *yap.Context) {
 //line cmd/spx-backend/post_asset.yap:11:1
 	if
 //line cmd/spx-backend/post_asset.yap:11:1
-	_, isAuthed := ensureAuthedUser(ctx); !isAuthed {
+	_, ok := ensureAuthenticatedUser(ctx); !ok {
 //line cmd/spx-backend/post_asset.yap:12:1
 		return
 	}
@@ -1141,7 +1142,7 @@ func (this *post_copilot_message) Main(_xgo_arg0 *yap.Context) {
 //line cmd/spx-backend/post_copilot_message.yap:11:1
 	if
 //line cmd/spx-backend/post_copilot_message.yap:11:1
-	_, isAuthed := ensureAuthedUser(ctx); !isAuthed {
+	_, ok := ensureAuthenticatedUser(ctx); !ok {
 //line cmd/spx-backend/post_copilot_message.yap:12:1
 		return
 	}
@@ -1188,7 +1189,7 @@ func (this *post_copilot_stream_message) Main(_xgo_arg0 *yap.Context) {
 //line cmd/spx-backend/post_copilot_stream_message.yap:11:1
 	if
 //line cmd/spx-backend/post_copilot_stream_message.yap:11:1
-	_, isAuthed := ensureAuthedUser(ctx); !isAuthed {
+	_, ok := ensureAuthenticatedUser(ctx); !ok {
 //line cmd/spx-backend/post_copilot_stream_message.yap:12:1
 		return
 	}
@@ -1239,7 +1240,7 @@ func (this *post_project_release) Main(_xgo_arg0 *yap.Context) {
 //line cmd/spx-backend/post_project-release.yap:11:1
 	if
 //line cmd/spx-backend/post_project-release.yap:11:1
-	_, isAuthed := ensureAuthedUser(ctx); !isAuthed {
+	_, ok := ensureAuthenticatedUser(ctx); !ok {
 //line cmd/spx-backend/post_project-release.yap:12:1
 		return
 	}
@@ -1286,7 +1287,7 @@ func (this *post_project) Main(_xgo_arg0 *yap.Context) {
 //line cmd/spx-backend/post_project.yap:11:1
 	if
 //line cmd/spx-backend/post_project.yap:11:1
-	_, isAuthed := ensureAuthedUser(ctx); !isAuthed {
+	_, ok := ensureAuthenticatedUser(ctx); !ok {
 //line cmd/spx-backend/post_project.yap:12:1
 		return
 	}
@@ -1333,7 +1334,7 @@ func (this *post_project_owner_name_liking) Main(_xgo_arg0 *yap.Context) {
 //line cmd/spx-backend/post_project_#owner_#name_liking.yap:11:1
 	if
 //line cmd/spx-backend/post_project_#owner_#name_liking.yap:11:1
-	_, isAuthed := ensureAuthedUser(ctx); !isAuthed {
+	_, ok := ensureAuthenticatedUser(ctx); !ok {
 //line cmd/spx-backend/post_project_#owner_#name_liking.yap:12:1
 		return
 	}
@@ -1366,7 +1367,7 @@ func (this *post_project_owner_name_view) Main(_xgo_arg0 *yap.Context) {
 //line cmd/spx-backend/post_project_#owner_#name_view.yap:11:1
 	if
 //line cmd/spx-backend/post_project_#owner_#name_view.yap:11:1
-	_, isAuthed := ensureAuthedUser(ctx); !isAuthed {
+	_, ok := ensureAuthenticatedUser(ctx); !ok {
 //line cmd/spx-backend/post_project_#owner_#name_view.yap:12:1
 		return
 	}
@@ -1399,7 +1400,7 @@ func (this *post_user_username_following) Main(_xgo_arg0 *yap.Context) {
 //line cmd/spx-backend/post_user_#username_following.yap:7:1
 	if
 //line cmd/spx-backend/post_user_#username_following.yap:7:1
-	_, isAuthed := ensureAuthedUser(ctx); !isAuthed {
+	_, ok := ensureAuthenticatedUser(ctx); !ok {
 //line cmd/spx-backend/post_user_#username_following.yap:8:1
 		return
 	}
@@ -1470,7 +1471,7 @@ func (this *post_workflow_stream_message) Main(_xgo_arg0 *yap.Context) {
 //line cmd/spx-backend/post_workflow_stream_message.yap:11:1
 	if
 //line cmd/spx-backend/post_workflow_stream_message.yap:11:1
-	_, isAuthed := ensureAuthedUser(ctx); !isAuthed {
+	_, ok := ensureAuthenticatedUser(ctx); !ok {
 //line cmd/spx-backend/post_workflow_stream_message.yap:12:1
 		return
 	}
@@ -1521,7 +1522,7 @@ func (this *put_asset_id) Main(_xgo_arg0 *yap.Context) {
 //line cmd/spx-backend/put_asset_#id.yap:11:1
 	if
 //line cmd/spx-backend/put_asset_#id.yap:11:1
-	_, isAuthed := ensureAuthedUser(ctx); !isAuthed {
+	_, ok := ensureAuthenticatedUser(ctx); !ok {
 //line cmd/spx-backend/put_asset_#id.yap:12:1
 		return
 	}
@@ -1568,7 +1569,7 @@ func (this *put_project_owner_name) Main(_xgo_arg0 *yap.Context) {
 //line cmd/spx-backend/put_project_#owner_#name.yap:11:1
 	if
 //line cmd/spx-backend/put_project_#owner_#name.yap:11:1
-	_, isAuthed := ensureAuthedUser(ctx); !isAuthed {
+	_, ok := ensureAuthenticatedUser(ctx); !ok {
 //line cmd/spx-backend/put_project_#owner_#name.yap:12:1
 		return
 	}
@@ -1617,12 +1618,12 @@ func (this *put_user) Main(_xgo_arg0 *yap.Context) {
 //line cmd/spx-backend/put_user.yap:11:1
 	if
 //line cmd/spx-backend/put_user.yap:11:1
-	_, isAuthed := ensureAuthedUser(ctx); !isAuthed {
+	_, ok := ensureAuthenticatedUser(ctx); !ok {
 //line cmd/spx-backend/put_user.yap:12:1
 		return
 	}
 //line cmd/spx-backend/put_user.yap:15:1
-	params := &controller.UpdateAuthedUserParams{}
+	params := &controller.UpdateAuthenticatedUserParams{}
 //line cmd/spx-backend/put_user.yap:16:1
 	if !parseJSON(ctx, params) {
 //line cmd/spx-backend/put_user.yap:17:1
@@ -1638,7 +1639,7 @@ func (this *put_user) Main(_xgo_arg0 *yap.Context) {
 		return
 	}
 //line cmd/spx-backend/put_user.yap:24:1
-	user, err := this.ctrl.UpdateAuthedUser(ctx.Context(), params)
+	user, err := this.ctrl.UpdateAuthenticatedUser(ctx.Context(), params)
 //line cmd/spx-backend/put_user.yap:25:1
 	if err != nil {
 //line cmd/spx-backend/put_user.yap:26:1

--- a/spx-backend/internal/authn/authn.go
+++ b/spx-backend/internal/authn/authn.go
@@ -1,0 +1,14 @@
+package authn
+
+import (
+	"context"
+
+	"github.com/goplus/builder/spx-backend/internal/model"
+)
+
+// Authenticator defines the interface for user authentication.
+type Authenticator interface {
+	// Authenticate attempts to authenticate a user from token. It returns
+	// nil user and nil error for invalid tokens (soft fail).
+	Authenticate(ctx context.Context, token string) (*model.User, error)
+}

--- a/spx-backend/internal/authn/casdoor/casdoor.go
+++ b/spx-backend/internal/authn/casdoor/casdoor.go
@@ -1,0 +1,86 @@
+package casdoor
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/casdoor/casdoor-go-sdk/casdoorsdk"
+	"github.com/goplus/builder/spx-backend/internal/authn"
+	"github.com/goplus/builder/spx-backend/internal/model"
+	"gorm.io/gorm"
+)
+
+// Config is the configuration for the Casdoor authenticator.
+type Config struct {
+	Endpoint         string
+	ClientID         string
+	ClientSecret     string
+	Certificate      string
+	OrganizationName string
+	ApplicationName  string
+}
+
+// client defines the interface for Casdoor client operations.
+type client interface {
+	ParseJwtToken(token string) (*casdoorsdk.Claims, error)
+	GetUser(name string) (*casdoorsdk.User, error)
+}
+
+// authenticator implements [authn.Authenticator] using Casdoor.
+type authenticator struct {
+	client client
+	db     *gorm.DB
+}
+
+// New creates a new Casdoor authenticator.
+func New(cfg Config, db *gorm.DB) authn.Authenticator {
+	client := casdoorsdk.NewClientWithConf(&casdoorsdk.AuthConfig{
+		Endpoint:         cfg.Endpoint,
+		ClientId:         cfg.ClientID,
+		ClientSecret:     cfg.ClientSecret,
+		Certificate:      cfg.Certificate,
+		OrganizationName: cfg.OrganizationName,
+		ApplicationName:  cfg.ApplicationName,
+	})
+	return &authenticator{
+		client: client,
+		db:     db,
+	}
+}
+
+// Authenticate implements [authn.Authenticator].
+func (a *authenticator) Authenticate(ctx context.Context, token string) (*model.User, error) {
+	claims, err := a.client.ParseJwtToken(token)
+	if err != nil {
+		return nil, errors.Join(authn.ErrUnauthorized, fmt.Errorf("failed to parse token: %w", err))
+	}
+	mUser, err := model.FirstOrCreateUser(ctx, a.db, model.CreateUserParams{
+		Username:    claims.Name,
+		DisplayName: claims.DisplayName,
+		Avatar:      claims.Avatar,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// Sync user info from Casdoor.
+	casdoorUser, err := a.client.GetUser(mUser.Username)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get user %q from casdoor: %w", mUser.Username, err)
+	}
+	mUserUpdates := map[string]any{}
+	if mUser.DisplayName != casdoorUser.DisplayName {
+		mUserUpdates["display_name"] = casdoorUser.DisplayName
+	}
+	if mUser.Avatar != casdoorUser.Avatar {
+		mUserUpdates["avatar"] = casdoorUser.Avatar
+	}
+	if len(mUserUpdates) > 0 {
+		if err := a.db.WithContext(ctx).Model(&mUser).Updates(mUserUpdates).Error; err != nil {
+			return nil, fmt.Errorf("failed to update user %q: %w", mUser.Username, err)
+		}
+	}
+
+	return mUser, nil
+}

--- a/spx-backend/internal/authn/casdoor/casdoor_test.go
+++ b/spx-backend/internal/authn/casdoor/casdoor_test.go
@@ -1,0 +1,390 @@
+package casdoor
+
+import (
+	"context"
+	"database/sql/driver"
+	"errors"
+	"regexp"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/casdoor/casdoor-go-sdk/casdoorsdk"
+	"github.com/goplus/builder/spx-backend/internal/authn"
+	"github.com/goplus/builder/spx-backend/internal/model"
+	"github.com/goplus/builder/spx-backend/internal/model/modeltest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+type mockClient struct {
+	parseJwtTokenFunc func(token string) (*casdoorsdk.Claims, error)
+	getUserFunc       func(name string) (*casdoorsdk.User, error)
+}
+
+func newMockClient() *mockClient {
+	return &mockClient{}
+}
+
+func (mc *mockClient) ParseJwtToken(token string) (*casdoorsdk.Claims, error) {
+	if mc.parseJwtTokenFunc != nil {
+		return mc.parseJwtTokenFunc(token)
+	}
+	return &casdoorsdk.Claims{
+		User: casdoorsdk.User{
+			Name:        "test-user",
+			DisplayName: "Test User",
+			Avatar:      "https://example.com/avatar.png",
+		},
+	}, nil
+}
+
+func (mc *mockClient) GetUser(name string) (*casdoorsdk.User, error) {
+	if mc.getUserFunc != nil {
+		return mc.getUserFunc(name)
+	}
+	return &casdoorsdk.User{
+		Name:        name,
+		DisplayName: "Test User",
+		Avatar:      "https://example.com/avatar.png",
+	}, nil
+}
+
+func newTestConfig() Config {
+	return Config{
+		Endpoint:         "https://example.com",
+		ClientID:         "test-client-id",
+		ClientSecret:     "test-client-secret",
+		Certificate:      "test-certificate",
+		OrganizationName: "test-org",
+		ApplicationName:  "test-app",
+	}
+}
+
+func newTestClaims() *casdoorsdk.Claims {
+	return &casdoorsdk.Claims{
+		User: casdoorsdk.User{
+			Name:        "test-user",
+			DisplayName: "Test User",
+			Avatar:      "https://example.com/avatar.png",
+		},
+	}
+}
+
+func newTestUser() *model.User {
+	return &model.User{
+		Model:       model.Model{ID: 1},
+		Username:    "test-user",
+		DisplayName: "Test User",
+		Avatar:      "https://example.com/avatar.png",
+	}
+}
+
+func setupTestAuthenticator(
+	t *testing.T,
+	db *gorm.DB,
+	parseTokenFunc func(token string) (*casdoorsdk.Claims, error),
+	getUserFunc func(name string) (*casdoorsdk.User, error),
+) authn.Authenticator {
+	client := newMockClient()
+	client.parseJwtTokenFunc = parseTokenFunc
+	client.getUserFunc = getUserFunc
+	auth := New(newTestConfig(), db).(*authenticator)
+	auth.client = client
+	return auth
+}
+
+func setupMockDBForUser(t *testing.T, db *gorm.DB, dbMock sqlmock.Sqlmock, claims *casdoorsdk.Claims, user *model.User) {
+	userDBColumns, err := modeltest.ExtractDBColumns(db, model.User{})
+	require.NoError(t, err)
+	generateUserDBRows, err := modeltest.NewDBRowsGenerator(db, model.User{})
+	require.NoError(t, err)
+
+	dbMock.ExpectQuery("SELECT \\* FROM `user` WHERE username = \\? AND `user`\\.`deleted_at` IS NULL ORDER BY `user`\\.`id` LIMIT \\?").
+		WithArgs(claims.Name, 1).
+		WillReturnRows(sqlmock.NewRows(userDBColumns).AddRows(generateUserDBRows(*user)...))
+}
+
+func setupMockDBForUserUpdate(t *testing.T, db *gorm.DB, dbMock sqlmock.Sqlmock, user *model.User, updates map[string]any) {
+	if len(updates) > 0 {
+		dbMock.ExpectBegin()
+		args := make([]driver.Value, 0)
+		for range updates {
+			args = append(args, sqlmock.AnyArg())
+		}
+		args = append(args, sqlmock.AnyArg()) // for updated_at timestamp
+		args = append(args, user.ID)          // for WHERE clause
+
+		dbMock.ExpectExec("UPDATE `user` SET .+ WHERE `user`\\.`deleted_at` IS NULL AND `id` = \\?").
+			WithArgs(args...).
+			WillReturnResult(sqlmock.NewResult(1, 1))
+		dbMock.ExpectCommit()
+	}
+}
+
+func TestNew(t *testing.T) {
+	t.Run("Normal", func(t *testing.T) {
+		db, _, closeDB, err := modeltest.NewMockDB()
+		require.NoError(t, err)
+		defer closeDB()
+
+		auth := New(newTestConfig(), db)
+
+		assert.NotNil(t, auth)
+		assert.IsType(t, &authenticator{}, auth)
+	})
+}
+
+func TestAuthenticatorAuthenticate(t *testing.T) {
+	t.Run("Normal", func(t *testing.T) {
+		db, dbMock, closeDB, err := modeltest.NewMockDB()
+		require.NoError(t, err)
+		defer closeDB()
+
+		expectedClaims := newTestClaims()
+		expectedUser := newTestUser()
+		expectedCasdoorUser := &casdoorsdk.User{
+			Name:        "test-user",
+			DisplayName: "Test User",
+			Avatar:      "https://example.com/avatar.png",
+		}
+
+		auth := setupTestAuthenticator(t, db,
+			func(token string) (*casdoorsdk.Claims, error) {
+				return expectedClaims, nil
+			},
+			func(name string) (*casdoorsdk.User, error) {
+				return expectedCasdoorUser, nil
+			})
+
+		setupMockDBForUser(t, db, dbMock, expectedClaims, expectedUser)
+		setupMockDBForUserUpdate(t, db, dbMock, expectedUser, map[string]any{})
+
+		user, err := auth.Authenticate(context.Background(), "valid-token")
+		require.NoError(t, err)
+		require.NotNil(t, user)
+		assert.Equal(t, expectedClaims.Name, user.Username)
+		assert.Equal(t, expectedClaims.DisplayName, user.DisplayName)
+		assert.Equal(t, expectedClaims.Avatar, user.Avatar)
+
+		require.NoError(t, dbMock.ExpectationsWereMet())
+	})
+
+	t.Run("UserInfoSync", func(t *testing.T) {
+		db, dbMock, closeDB, err := modeltest.NewMockDB()
+		require.NoError(t, err)
+		defer closeDB()
+
+		expectedClaims := newTestClaims()
+		expectedUser := &model.User{
+			Model:       model.Model{ID: 1},
+			Username:    "test-user",
+			DisplayName: "Old Display Name",
+			Avatar:      "https://example.com/old-avatar.png",
+		}
+		expectedCasdoorUser := &casdoorsdk.User{
+			Name:        "test-user",
+			DisplayName: "New Display Name",
+			Avatar:      "https://example.com/new-avatar.png",
+		}
+
+		auth := setupTestAuthenticator(t, db,
+			func(token string) (*casdoorsdk.Claims, error) {
+				return expectedClaims, nil
+			},
+			func(name string) (*casdoorsdk.User, error) {
+				return expectedCasdoorUser, nil
+			})
+
+		setupMockDBForUser(t, db, dbMock, expectedClaims, expectedUser)
+		setupMockDBForUserUpdate(t, db, dbMock, expectedUser, map[string]any{
+			"display_name": "New Display Name",
+			"avatar":       "https://example.com/new-avatar.png",
+		})
+
+		user, err := auth.Authenticate(context.Background(), "valid-token")
+		require.NoError(t, err)
+		require.NotNil(t, user)
+		assert.Equal(t, expectedClaims.Name, user.Username)
+
+		require.NoError(t, dbMock.ExpectationsWereMet())
+	})
+
+	t.Run("PartialUserInfoSync", func(t *testing.T) {
+		db, dbMock, closeDB, err := modeltest.NewMockDB()
+		require.NoError(t, err)
+		defer closeDB()
+
+		expectedClaims := newTestClaims()
+		expectedUser := &model.User{
+			Model:       model.Model{ID: 1},
+			Username:    "test-user",
+			DisplayName: "Old Display Name",
+			Avatar:      "https://example.com/avatar.png",
+		}
+		expectedCasdoorUser := &casdoorsdk.User{
+			Name:        "test-user",
+			DisplayName: "New Display Name",
+			Avatar:      "https://example.com/avatar.png",
+		}
+
+		auth := setupTestAuthenticator(t, db,
+			func(token string) (*casdoorsdk.Claims, error) {
+				return expectedClaims, nil
+			},
+			func(name string) (*casdoorsdk.User, error) {
+				return expectedCasdoorUser, nil
+			})
+
+		setupMockDBForUser(t, db, dbMock, expectedClaims, expectedUser)
+		setupMockDBForUserUpdate(t, db, dbMock, expectedUser, map[string]any{
+			"display_name": "New Display Name",
+		})
+
+		user, err := auth.Authenticate(context.Background(), "valid-token")
+		require.NoError(t, err)
+		require.NotNil(t, user)
+
+		require.NoError(t, dbMock.ExpectationsWereMet())
+	})
+
+	t.Run("ParseTokenFailure", func(t *testing.T) {
+		db, _, closeDB, err := modeltest.NewMockDB()
+		require.NoError(t, err)
+		defer closeDB()
+
+		expectedErr := errors.New("invalid token")
+		auth := setupTestAuthenticator(t, db,
+			func(token string) (*casdoorsdk.Claims, error) {
+				return nil, expectedErr
+			}, nil)
+
+		user, err := auth.Authenticate(context.Background(), "invalid-token")
+		require.Error(t, err)
+		assert.Nil(t, user)
+		assert.ErrorIs(t, err, authn.ErrUnauthorized)
+		assert.Contains(t, err.Error(), "failed to parse token")
+		assert.Contains(t, err.Error(), expectedErr.Error())
+	})
+
+	t.Run("FirstOrCreateUserFailure", func(t *testing.T) {
+		db, dbMock, closeDB, err := modeltest.NewMockDB()
+		require.NoError(t, err)
+		defer closeDB()
+
+		expectedClaims := newTestClaims()
+		auth := setupTestAuthenticator(t, db,
+			func(token string) (*casdoorsdk.Claims, error) {
+				return expectedClaims, nil
+			}, nil)
+
+		dbMockStmt := db.Session(&gorm.Session{DryRun: true}).
+			Where("username = ?", expectedClaims.Name).
+			First(&model.User{}).
+			Statement
+		dbMockArgs := modeltest.ToDriverValueSlice(dbMockStmt.Vars...)
+		expectedDBErr := errors.New("database connection failed")
+		dbMock.ExpectQuery(regexp.QuoteMeta(dbMockStmt.SQL.String())).
+			WithArgs(dbMockArgs...).
+			WillReturnError(expectedDBErr)
+
+		user, err := auth.Authenticate(context.Background(), "valid-token")
+		require.Error(t, err)
+		assert.Nil(t, user)
+		assert.Contains(t, err.Error(), expectedClaims.Name)
+		assert.Contains(t, err.Error(), expectedDBErr.Error())
+
+		require.NoError(t, dbMock.ExpectationsWereMet())
+	})
+
+	t.Run("GetUserFailure", func(t *testing.T) {
+		db, dbMock, closeDB, err := modeltest.NewMockDB()
+		require.NoError(t, err)
+		defer closeDB()
+
+		expectedClaims := newTestClaims()
+		expectedUser := newTestUser()
+		expectedGetUserErr := errors.New("failed to get user from casdoor")
+
+		auth := setupTestAuthenticator(t, db,
+			func(token string) (*casdoorsdk.Claims, error) {
+				return expectedClaims, nil
+			},
+			func(name string) (*casdoorsdk.User, error) {
+				return nil, expectedGetUserErr
+			})
+
+		setupMockDBForUser(t, db, dbMock, expectedClaims, expectedUser)
+
+		user, err := auth.Authenticate(context.Background(), "valid-token")
+		require.Error(t, err)
+		assert.Nil(t, user)
+		assert.Contains(t, err.Error(), "failed to get user")
+		assert.Contains(t, err.Error(), expectedClaims.Name)
+		assert.Contains(t, err.Error(), expectedGetUserErr.Error())
+
+		require.NoError(t, dbMock.ExpectationsWereMet())
+	})
+
+	t.Run("UserUpdateFailure", func(t *testing.T) {
+		db, dbMock, closeDB, err := modeltest.NewMockDB()
+		require.NoError(t, err)
+		defer closeDB()
+
+		expectedClaims := newTestClaims()
+		expectedUser := &model.User{
+			Model:       model.Model{ID: 1},
+			Username:    "test-user",
+			DisplayName: "Old Display Name",
+			Avatar:      "https://example.com/avatar.png",
+		}
+		expectedCasdoorUser := &casdoorsdk.User{
+			Name:        "test-user",
+			DisplayName: "New Display Name",
+			Avatar:      "https://example.com/avatar.png",
+		}
+		expectedUpdateErr := errors.New("database update failed")
+
+		auth := setupTestAuthenticator(t, db,
+			func(token string) (*casdoorsdk.Claims, error) {
+				return expectedClaims, nil
+			},
+			func(name string) (*casdoorsdk.User, error) {
+				return expectedCasdoorUser, nil
+			})
+
+		setupMockDBForUser(t, db, dbMock, expectedClaims, expectedUser)
+		dbMock.ExpectBegin()
+		args := []driver.Value{sqlmock.AnyArg(), sqlmock.AnyArg(), expectedUser.ID}
+		dbMock.ExpectExec("UPDATE `user` SET .+ WHERE `user`\\.`deleted_at` IS NULL AND `id` = \\?").
+			WithArgs(args...).
+			WillReturnError(expectedUpdateErr)
+		dbMock.ExpectRollback()
+
+		user, err := auth.Authenticate(context.Background(), "valid-token")
+		require.Error(t, err)
+		assert.Nil(t, user)
+		assert.Contains(t, err.Error(), "failed to update user")
+		assert.Contains(t, err.Error(), expectedUser.Username)
+		assert.Contains(t, err.Error(), expectedUpdateErr.Error())
+
+		require.NoError(t, dbMock.ExpectationsWereMet())
+	})
+
+	t.Run("EmptyToken", func(t *testing.T) {
+		db, _, closeDB, err := modeltest.NewMockDB()
+		require.NoError(t, err)
+		defer closeDB()
+
+		auth := setupTestAuthenticator(t, db,
+			func(token string) (*casdoorsdk.Claims, error) {
+				return nil, errors.New("empty token")
+			}, nil)
+
+		user, err := auth.Authenticate(context.Background(), "")
+		require.Error(t, err)
+		assert.Nil(t, user)
+		assert.ErrorIs(t, err, authn.ErrUnauthorized)
+		assert.Contains(t, err.Error(), "failed to parse token")
+	})
+}

--- a/spx-backend/internal/authn/context.go
+++ b/spx-backend/internal/authn/context.go
@@ -1,0 +1,21 @@
+package authn
+
+import (
+	"context"
+
+	"github.com/goplus/builder/spx-backend/internal/model"
+)
+
+// userContextKey is the context key type for authenticated users.
+type userContextKey struct{}
+
+// NewContextWithUser creates a new context with the authenticated user.
+func NewContextWithUser(ctx context.Context, mUser *model.User) context.Context {
+	return context.WithValue(ctx, userContextKey{}, mUser)
+}
+
+// UserFromContext gets the authenticated user from context.
+func UserFromContext(ctx context.Context) (mUser *model.User, ok bool) {
+	mUser, ok = ctx.Value(userContextKey{}).(*model.User)
+	return
+}

--- a/spx-backend/internal/authn/context_test.go
+++ b/spx-backend/internal/authn/context_test.go
@@ -1,0 +1,64 @@
+package authn
+
+import (
+	"context"
+	"testing"
+
+	"github.com/goplus/builder/spx-backend/internal/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestUser() *model.User {
+	return &model.User{
+		Model:       model.Model{ID: 1},
+		Username:    "test-user",
+		DisplayName: "Test User",
+		Avatar:      "https://example.com/avatar.png",
+	}
+}
+
+func TestNewContextWithUser(t *testing.T) {
+	t.Run("Normal", func(t *testing.T) {
+		mExpectedUser := newTestUser()
+		ctx := NewContextWithUser(context.Background(), mExpectedUser)
+
+		mUser, ok := ctx.Value(userContextKey{}).(*model.User)
+		require.True(t, ok)
+		require.NotNil(t, mUser)
+		assert.Equal(t, *mExpectedUser, *mUser)
+	})
+
+	t.Run("NilUser", func(t *testing.T) {
+		ctx := NewContextWithUser(context.Background(), nil)
+
+		value := ctx.Value(userContextKey{})
+		assert.Nil(t, value)
+	})
+}
+
+func TestUserFromContext(t *testing.T) {
+	t.Run("Normal", func(t *testing.T) {
+		mExpectedUser := newTestUser()
+		ctx := NewContextWithUser(context.Background(), mExpectedUser)
+
+		mUser, ok := UserFromContext(ctx)
+		require.True(t, ok)
+		require.NotNil(t, mUser)
+		assert.Equal(t, *mExpectedUser, *mUser)
+	})
+
+	t.Run("NoUser", func(t *testing.T) {
+		mUser, ok := UserFromContext(context.Background())
+		require.False(t, ok)
+		require.Nil(t, mUser)
+	})
+
+	t.Run("WrongContextValue", func(t *testing.T) {
+		ctx := context.WithValue(context.Background(), userContextKey{}, "not-a-user")
+
+		mUser, ok := UserFromContext(ctx)
+		require.False(t, ok)
+		require.Nil(t, mUser)
+	})
+}

--- a/spx-backend/internal/authn/helper.go
+++ b/spx-backend/internal/authn/helper.go
@@ -1,0 +1,29 @@
+package authn
+
+import (
+	"context"
+	"errors"
+
+	"github.com/goplus/builder/spx-backend/internal/model"
+)
+
+var (
+	// ErrUnauthorized indicates the request is unauthorized.
+	ErrUnauthorized = errors.New("unauthorized")
+
+	// ErrForbidden indicates the request is forbidden.
+	ErrForbidden = errors.New("forbidden")
+)
+
+// EnsureUser ensures there is an authenticated user in the context and it
+// matches the expected user.
+func EnsureUser(ctx context.Context, expectedUserID int64) (*model.User, error) {
+	mUser, ok := UserFromContext(ctx)
+	if !ok {
+		return nil, ErrUnauthorized
+	}
+	if mUser.ID != expectedUserID {
+		return nil, ErrForbidden
+	}
+	return mUser, nil
+}

--- a/spx-backend/internal/authn/helper_test.go
+++ b/spx-backend/internal/authn/helper_test.go
@@ -1,0 +1,57 @@
+package authn
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEnsureUser(t *testing.T) {
+	t.Run("Normal", func(t *testing.T) {
+		mExpectedUser := newTestUser()
+		ctx := NewContextWithUser(context.Background(), mExpectedUser)
+
+		mUser, err := EnsureUser(ctx, 1)
+		require.NoError(t, err)
+		require.NotNil(t, mUser)
+		assert.Equal(t, *mExpectedUser, *mUser)
+	})
+
+	t.Run("ErrUnauthorized", func(t *testing.T) {
+		_, err := EnsureUser(context.Background(), 1)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrUnauthorized)
+	})
+
+	t.Run("ErrForbidden", func(t *testing.T) {
+		mExpectedUser := newTestUser()
+		ctx := NewContextWithUser(context.Background(), mExpectedUser)
+
+		_, err := EnsureUser(ctx, 65535)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrForbidden)
+	})
+
+	t.Run("DifferentUserID", func(t *testing.T) {
+		mExpectedUser := newTestUser()
+		mExpectedUser.ID = 42
+		ctx := NewContextWithUser(context.Background(), mExpectedUser)
+
+		_, err := EnsureUser(ctx, 1)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrForbidden)
+	})
+
+	t.Run("MatchingUserID", func(t *testing.T) {
+		mExpectedUser := newTestUser()
+		mExpectedUser.ID = 100
+		ctx := NewContextWithUser(context.Background(), mExpectedUser)
+
+		mUser, err := EnsureUser(ctx, 100)
+		require.NoError(t, err)
+		require.NotNil(t, mUser)
+		assert.Equal(t, int64(100), mUser.ID)
+	})
+}

--- a/spx-backend/internal/authn/middleware.go
+++ b/spx-backend/internal/authn/middleware.go
@@ -1,0 +1,33 @@
+package authn
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/goplus/builder/spx-backend/internal/log"
+)
+
+// Middleware implements [Authenticator] that follows soft fail strategy.
+func Middleware(a Authenticator) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ctx := r.Context()
+			logger := log.GetReqLogger(ctx)
+
+			authorization := r.Header.Get("Authorization")
+			if authorization != "" {
+				token := strings.TrimPrefix(authorization, "Bearer ")
+				mUser, err := a.Authenticate(ctx, token)
+				if err != nil {
+					logger.Printf("failed to get user from token: %v", err)
+				} else if mUser == nil {
+					logger.Printf("no user info")
+				} else {
+					r = r.WithContext(NewContextWithUser(ctx, mUser))
+				}
+			}
+
+			next.ServeHTTP(w, r)
+		})
+	}
+}

--- a/spx-backend/internal/authn/middleware_test.go
+++ b/spx-backend/internal/authn/middleware_test.go
@@ -1,0 +1,182 @@
+package authn
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/goplus/builder/spx-backend/internal/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockAuthenticator implements Authenticator interface for testing.
+type mockAuthenticator struct {
+	authenticateFunc func(ctx context.Context, token string) (*model.User, error)
+}
+
+func (m *mockAuthenticator) Authenticate(ctx context.Context, token string) (*model.User, error) {
+	if m.authenticateFunc != nil {
+		return m.authenticateFunc(ctx, token)
+	}
+	return newTestUser(), nil
+}
+
+// newMockAuthenticator creates a mock authenticator.
+func newMockAuthenticator() *mockAuthenticator {
+	return &mockAuthenticator{}
+}
+
+// testHandler is a simple handler that checks for authenticated user.
+func testHandler(t *testing.T, expectAuthenticated bool) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		mUser, ok := UserFromContext(r.Context())
+		if expectAuthenticated {
+			require.True(t, ok)
+			require.NotNil(t, mUser)
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte("authenticated"))
+		} else {
+			require.False(t, ok)
+			require.Nil(t, mUser)
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte("not authenticated"))
+		}
+	}
+}
+
+func TestMiddleware(t *testing.T) {
+	t.Run("NoAuthorizationHeader", func(t *testing.T) {
+		auth := newMockAuthenticator()
+		middleware := Middleware(auth)
+		handler := middleware(testHandler(t, false))
+
+		req := httptest.NewRequest("GET", "/test", nil)
+		recorder := httptest.NewRecorder()
+
+		handler.ServeHTTP(recorder, req)
+
+		assert.Equal(t, http.StatusOK, recorder.Code)
+		assert.Equal(t, "not authenticated", recorder.Body.String())
+	})
+
+	t.Run("ValidBearerToken", func(t *testing.T) {
+		auth := newMockAuthenticator()
+		expectedUser := newTestUser()
+		auth.authenticateFunc = func(ctx context.Context, token string) (*model.User, error) {
+			assert.Equal(t, "valid-token", token)
+			return expectedUser, nil
+		}
+
+		middleware := Middleware(auth)
+		handler := middleware(testHandler(t, true))
+
+		req := httptest.NewRequest("GET", "/test", nil)
+		req.Header.Set("Authorization", "Bearer valid-token")
+		recorder := httptest.NewRecorder()
+
+		handler.ServeHTTP(recorder, req)
+
+		assert.Equal(t, http.StatusOK, recorder.Code)
+		assert.Equal(t, "authenticated", recorder.Body.String())
+	})
+
+	t.Run("InvalidToken", func(t *testing.T) {
+		auth := newMockAuthenticator()
+		auth.authenticateFunc = func(ctx context.Context, token string) (*model.User, error) {
+			assert.Equal(t, "invalid-token", token)
+			return nil, errors.New("invalid token")
+		}
+
+		middleware := Middleware(auth)
+		handler := middleware(testHandler(t, false))
+
+		req := httptest.NewRequest("GET", "/test", nil)
+		req.Header.Set("Authorization", "Bearer invalid-token")
+		recorder := httptest.NewRecorder()
+
+		handler.ServeHTTP(recorder, req)
+
+		assert.Equal(t, http.StatusOK, recorder.Code)
+		assert.Equal(t, "not authenticated", recorder.Body.String())
+	})
+
+	t.Run("NilUserFromAuthenticator", func(t *testing.T) {
+		auth := newMockAuthenticator()
+		auth.authenticateFunc = func(ctx context.Context, token string) (*model.User, error) {
+			assert.Equal(t, "token-with-nil-user", token)
+			return nil, nil
+		}
+
+		middleware := Middleware(auth)
+		handler := middleware(testHandler(t, false))
+
+		req := httptest.NewRequest("GET", "/test", nil)
+		req.Header.Set("Authorization", "Bearer token-with-nil-user")
+		recorder := httptest.NewRecorder()
+
+		handler.ServeHTTP(recorder, req)
+
+		assert.Equal(t, http.StatusOK, recorder.Code)
+		assert.Equal(t, "not authenticated", recorder.Body.String())
+	})
+
+	t.Run("AuthorizationWithoutBearer", func(t *testing.T) {
+		auth := newMockAuthenticator()
+		expectedUser := newTestUser()
+		auth.authenticateFunc = func(ctx context.Context, token string) (*model.User, error) {
+			assert.Equal(t, "Basic dXNlcjpwYXNz", token)
+			return expectedUser, nil
+		}
+
+		middleware := Middleware(auth)
+		handler := middleware(testHandler(t, true))
+
+		req := httptest.NewRequest("GET", "/test", nil)
+		req.Header.Set("Authorization", "Basic dXNlcjpwYXNz")
+		recorder := httptest.NewRecorder()
+
+		handler.ServeHTTP(recorder, req)
+
+		assert.Equal(t, http.StatusOK, recorder.Code)
+		assert.Equal(t, "authenticated", recorder.Body.String())
+	})
+
+	t.Run("EmptyAuthorizationHeader", func(t *testing.T) {
+		auth := newMockAuthenticator()
+		middleware := Middleware(auth)
+		handler := middleware(testHandler(t, false))
+
+		req := httptest.NewRequest("GET", "/test", nil)
+		req.Header.Set("Authorization", "")
+		recorder := httptest.NewRecorder()
+
+		handler.ServeHTTP(recorder, req)
+
+		assert.Equal(t, http.StatusOK, recorder.Code)
+		assert.Equal(t, "not authenticated", recorder.Body.String())
+	})
+
+	t.Run("BearerWithoutToken", func(t *testing.T) {
+		auth := newMockAuthenticator()
+		expectedUser := newTestUser()
+		auth.authenticateFunc = func(ctx context.Context, token string) (*model.User, error) {
+			assert.Equal(t, "", token)
+			return expectedUser, nil
+		}
+
+		middleware := Middleware(auth)
+		handler := middleware(testHandler(t, true))
+
+		req := httptest.NewRequest("GET", "/test", nil)
+		req.Header.Set("Authorization", "Bearer ")
+		recorder := httptest.NewRecorder()
+
+		handler.ServeHTTP(recorder, req)
+
+		assert.Equal(t, http.StatusOK, recorder.Code)
+		assert.Equal(t, "authenticated", recorder.Body.String())
+	})
+}

--- a/spx-backend/internal/controller/controller_test.go
+++ b/spx-backend/internal/controller/controller_test.go
@@ -1,12 +1,14 @@
 package controller
 
 import (
+	"context"
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
-	"github.com/casdoor/casdoor-go-sdk/casdoorsdk"
 	"github.com/goplus/builder/spx-backend/internal/aigc"
+	"github.com/goplus/builder/spx-backend/internal/authn"
 	"github.com/goplus/builder/spx-backend/internal/log"
+	"github.com/goplus/builder/spx-backend/internal/model"
 	"github.com/goplus/builder/spx-backend/internal/model/modeltest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -16,78 +18,51 @@ func setTestEnv(t *testing.T) {
 	t.Setenv("GOP_SPX_DSN", "root:root@tcp(mysql.example.com:3306)/builder?charset=utf8&parseTime=True")
 	t.Setenv("AIGC_ENDPOINT", "https://aigc.example.com")
 
-	t.Setenv("KODO_AK", "fake-kodo-ak")
-	t.Setenv("KODO_SK", "fake-kodo-sk")
+	t.Setenv("KODO_AK", "test-kodo-ak")
+	t.Setenv("KODO_SK", "test-kodo-sk")
 	t.Setenv("KODO_BUCKET", "builder")
 	t.Setenv("KODO_BUCKET_REGION", "earth")
 	t.Setenv("KODO_BASE_URL", "https://kodo.example.com")
-
-	t.Setenv("GOP_CASDOOR_ENDPOINT", "https://casdoor.example.com")
-	t.Setenv("GOP_CASDOOR_CLIENTID", "fake-client-id")
-	t.Setenv("GOP_CASDOOR_CLIENTSECRET", "fake-client-secret")
-	t.Setenv("GOP_CASDOOR_CERTIFICATE", `-----BEGIN CERTIFICATE-----
-MIIDDDCCAfSgAwIBAgIPJTPotE6tfuppFEL608kZMA0GCSqGSIb3DQEBCwUAMCYx
-DzANBgNVBAoTBkdvUGx1czETMBEGA1UEAxMKZ29wbHVzLm9yZzAgFw0yNDA1Mjcx
-NjU3MjBaGA8yMTI0MDUwMzE2NTcyMFowJjEPMA0GA1UEChMGR29QbHVzMRMwEQYD
-VQQDEwpnb3BsdXMub3JnMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA
-0YRGxHFxL8Nkw5EiUhKaqB6NV4NuE98Nj6YL941GPLBeQLijyfJ2ErpWIqz7Hwzn
-NVo76qPSKi/BpGw+EL4EgiWokW+Aw4lElkd7gnd/annQ3W6AC9v0bN7FPZUfpFAH
-NmhveFfM5K78GXQqCEFeV+kxqxym4qhtCCK7Tb0uJ1dalX2INiANMJ5YfKWmjrkG
-Mh9fGzw0+SL9gB1gkREap1Z2vwRD2HEuQd4J5G1YFyFkrISbI4X8xTVn6dSPUbCk
-2aM9Fmg/ExD9mt7m3Klxm6iOnLojs1cRlFcexQtTjPbTnyKWtWSzF9WIegZC7aL9
-MwKN0mqvXyE8wnv4M/l72wIDAQABozUwMzAOBgNVHQ8BAf8EBAMCBaAwEwYDVR0l
-BAwwCgYIKwYBBQUHAwEwDAYDVR0TAQH/BAIwADANBgkqhkiG9w0BAQsFAAOCAQEA
-TpnkzMMKWceK7LScYuIcXEqCOwmzhT6yNRNTHzplta7NznjCVCL+kGffRlUQhdsN
-pVGKPWbisd6y43IaokrkWOEPwhdWNa2rK9U7zYhI+9gGbqO02gJUw/gFIEjwO84J
-uPrfGhKFB+ckitTWslFGf1d/Dt/MYS544QlB06IW8f+AM7z0sohh5nGH8lQIOmLC
-7zQdehTX3TTuydAgBmU7a8oiM10t4Xw5alyy23Mo1qzZaZ1qHc2feJ8r9w1codAt
-3c666GQTCYyifHL1dV2F5KullyFZ86SiOw3VDQ9D34Yd6YMvtBMkAjh7UZxMvun2
-VTh1XIl/IELBoZ+rQXozGA==
------END CERTIFICATE-----`)
-	t.Setenv("GOP_CASDOOR_ORGANIZATIONNAME", "fake-organization")
-	t.Setenv("GOP_CASDOOR_APPLICATIONNAME", "fake-application")
 }
 
-type mockCasdoorClient struct {
-	casdoorClient casdoorClient
-	jwt           string
-}
+const testUserToken = "test-user-token"
 
-func newMockCasdoorClient(casdoorClient casdoorClient, jwt string) *mockCasdoorClient {
-	return &mockCasdoorClient{casdoorClient: casdoorClient, jwt: jwt}
-}
+type mockAuthenticator struct{}
 
-func (m *mockCasdoorClient) ParseJwtToken(token string) (*casdoorsdk.Claims, error) {
-	return m.casdoorClient.ParseJwtToken(token)
-}
-
-func (m *mockCasdoorClient) GetUser(name string) (*casdoorsdk.User, error) {
-	claims, err := m.casdoorClient.ParseJwtToken(m.jwt)
-	if err != nil {
-		return nil, err
+func (mockAuthenticator) Authenticate(ctx context.Context, token string) (*model.User, error) {
+	if token == testUserToken {
+		return &model.User{
+			Model:              model.Model{ID: 1},
+			Username:           "test-user",
+			DisplayName:        "",
+			Avatar:             "",
+			Description:        "Test description",
+			FollowerCount:      10,
+			FollowingCount:     5,
+			ProjectCount:       3,
+			PublicProjectCount: 2,
+			LikedProjectCount:  15,
+		}, nil
 	}
-	return &claims.User, nil
+	return nil, authn.ErrUnauthorized
 }
-
-const fakeUserToken = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9." +
-	"eyJvd25lciI6IkdvUGx1cyIsIm5hbWUiOiJmYWtlLW5hbWUiLCJpZCI6IjEiLCJpc3MiOiJHb1BsdXMiLCJzdWIiOiIxIiwiZXhwIjo0ODcwNDI5MDQwfQ." +
-	"X0T-v-RJggMRy3Mmui2FoRH-_4DQsNA6DekUx1BfIljTZaEbHbuW59dSlKQ-i2MuYD7_8mI18vZqT3iysbKQ1T70NF97B_A130ML3pulZWlj1ZokgjCkVug25QRbq_N7JMd4apJZFlyZj8Bd2VfqtAKMlJJ4HzKzNXB-GBogDVlKeu4xJ1BiXO2rHL1PNa5KyKLSSMXmuP_Wc108RXZ0BiKDE30IG1fvcyvudXcetmltuWjuU6JRj3FGedxuVEqZLXqcm13dCxHnuFV1x1XU9KExcDvVyVB91FpBe5npzYp6WMX0fx9vU1b4eJ69EZoeMdMolhmvYInT1G8r1PEmbg"
 
 func newTestController(t *testing.T) (ctrl *Controller, dbMock sqlmock.Sqlmock, closeDB func() error) {
 	setTestEnv(t)
 
-	logger := log.GetLogger()
-	kodoConfig := newKodoConfig(logger)
-	aigcClient := aigc.NewAigcClient(mustEnv(logger, "AIGC_ENDPOINT"))
-	casdoorClient := newMockCasdoorClient(newCasdoorClient(logger), fakeUserToken)
-
 	db, dbMock, closeDB, err := modeltest.NewMockDB()
 	require.NoError(t, err)
+
+	logger := log.GetLogger()
+	kodoConfig := newKodoConfig(logger)
+	authenticator := &mockAuthenticator{}
+	aigcClient := aigc.NewAigcClient(mustEnv(logger, "AIGC_ENDPOINT"))
+
 	return &Controller{
 		db:            db,
 		kodo:          kodoConfig,
+		authenticator: authenticator,
 		aigcClient:    aigcClient,
-		casdoorClient: casdoorClient,
 	}, dbMock, closeDB
 }
 

--- a/spx-backend/internal/controller/copilot.go
+++ b/spx-backend/internal/controller/copilot.go
@@ -31,7 +31,7 @@ func (p *GenerateMessageParams) Validate() (ok bool, msg string) {
 
 type GenerateMessageResult copilot.Message
 
-// GenerateStream generates response message based on input messages.
+// GenerateMessageStream generates response message based on input messages.
 func (ctrl *Controller) GenerateMessageStream(ctx context.Context, params *GenerateMessageParams) (io.ReadCloser, error) {
 	logger := log.GetReqLogger(ctx)
 

--- a/spx-backend/internal/controller/project_test.go
+++ b/spx-backend/internal/controller/project_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/goplus/builder/spx-backend/internal/authn"
 	"github.com/goplus/builder/spx-backend/internal/model"
 	"github.com/goplus/builder/spx-backend/internal/model/modeltest"
 	"github.com/stretchr/testify/assert"
@@ -423,19 +424,19 @@ func TestControllerEnsureProject(t *testing.T) {
 		defer closeDB()
 
 		ctx := newContextWithTestUser(context.Background())
-		mAuthedUser, isAuthed := AuthedUserFromContext(ctx)
-		require.True(t, isAuthed)
+		mUser, ok := authn.UserFromContext(ctx)
+		require.True(t, ok)
 
 		mProject := model.Project{
 			Model:      model.Model{ID: 1},
-			OwnerID:    mAuthedUser.ID,
+			OwnerID:    mUser.ID,
 			Name:       "testproject",
 			Visibility: model.VisibilityPublic,
 		}
 
 		dbMockStmt := ctrl.db.Session(&gorm.Session{DryRun: true}).
 			Joins("JOIN user ON user.id = project.owner_id").
-			Where("user.username = ?", mAuthedUser.Username).
+			Where("user.username = ?", mUser.Username).
 			Where("project.name = ?", mProject.Name).
 			First(&model.Project{}).
 			Statement
@@ -445,15 +446,15 @@ func TestControllerEnsureProject(t *testing.T) {
 			WillReturnRows(sqlmock.NewRows(projectDBColumns).AddRows(generateProjectDBRows(mProject)...))
 
 		dbMockStmt = ctrl.db.Session(&gorm.Session{DryRun: true}).
-			Where("`user`.`id` = ?", mAuthedUser.ID).
+			Where("`user`.`id` = ?", mUser.ID).
 			Find(&model.User{}).
 			Statement
 		dbMockArgs = modeltest.ToDriverValueSlice(dbMockStmt.Vars...)
 		dbMock.ExpectQuery(regexp.QuoteMeta(dbMockStmt.SQL.String())).
 			WithArgs(dbMockArgs...).
-			WillReturnRows(sqlmock.NewRows(userDBColumns).AddRows(generateUserDBRows(*mAuthedUser)...))
+			WillReturnRows(sqlmock.NewRows(userDBColumns).AddRows(generateUserDBRows(*mUser)...))
 
-		project, err := ctrl.ensureProject(ctx, ProjectFullName{Owner: mAuthedUser.Username, Project: mProject.Name}, false)
+		project, err := ctrl.ensureProject(ctx, ProjectFullName{Owner: mUser.Username, Project: mProject.Name}, false)
 		require.NoError(t, err)
 		assert.Equal(t, mProject.ID, project.ID)
 		assert.Equal(t, mProject.Name, project.Name)
@@ -466,14 +467,14 @@ func TestControllerEnsureProject(t *testing.T) {
 		defer closeDB()
 
 		ctx := newContextWithTestUser(context.Background())
-		mAuthedUser, isAuthed := AuthedUserFromContext(ctx)
-		require.True(t, isAuthed)
+		mUser, ok := authn.UserFromContext(ctx)
+		require.True(t, ok)
 
 		mProjectName := "nonexistent"
 
 		dbMockStmt := ctrl.db.Session(&gorm.Session{DryRun: true}).
 			Joins("JOIN user ON user.id = project.owner_id").
-			Where("user.username = ?", mAuthedUser.Username).
+			Where("user.username = ?", mUser.Username).
 			Where("project.name = ?", mProjectName).
 			First(&model.Project{}).
 			Statement
@@ -482,7 +483,7 @@ func TestControllerEnsureProject(t *testing.T) {
 			WithArgs(dbMockArgs...).
 			WillReturnError(gorm.ErrRecordNotFound)
 
-		_, err := ctrl.ensureProject(ctx, ProjectFullName{Owner: mAuthedUser.Username, Project: mProjectName}, false)
+		_, err := ctrl.ensureProject(ctx, ProjectFullName{Owner: mUser.Username, Project: mProjectName}, false)
 		require.Error(t, err)
 		assert.ErrorIs(t, err, gorm.ErrRecordNotFound)
 
@@ -494,14 +495,14 @@ func TestControllerEnsureProject(t *testing.T) {
 		defer closeDB()
 
 		ctx := newContextWithTestUser(context.Background())
-		mAuthedUser, isAuthed := AuthedUserFromContext(ctx)
-		require.True(t, isAuthed)
+		mUser, ok := authn.UserFromContext(ctx)
+		require.True(t, ok)
 
 		mProjectOwnerUsername := "otheruser"
 
 		mProject := model.Project{
 			Model:      model.Model{ID: 1},
-			OwnerID:    mAuthedUser.ID + 1,
+			OwnerID:    mUser.ID + 1,
 			Name:       "privateproject",
 			Visibility: model.VisibilityPrivate,
 		}
@@ -531,7 +532,7 @@ func TestControllerEnsureProject(t *testing.T) {
 
 		_, err := ctrl.ensureProject(ctx, ProjectFullName{Owner: mProjectOwnerUsername, Project: mProject.Name}, false)
 		require.Error(t, err)
-		assert.ErrorIs(t, err, ErrForbidden)
+		assert.ErrorIs(t, err, authn.ErrForbidden)
 
 		require.NoError(t, dbMock.ExpectationsWereMet())
 	})
@@ -541,14 +542,14 @@ func TestControllerEnsureProject(t *testing.T) {
 		defer closeDB()
 
 		ctx := newContextWithTestUser(context.Background())
-		mAuthedUser, isAuthed := AuthedUserFromContext(ctx)
-		require.True(t, isAuthed)
+		mUser, ok := authn.UserFromContext(ctx)
+		require.True(t, ok)
 
 		mProjectOwnerUsername := "otheruser"
 
 		mProject := model.Project{
 			Model:      model.Model{ID: 1},
-			OwnerID:    mAuthedUser.ID + 1,
+			OwnerID:    mUser.ID + 1,
 			Name:       "publicproject",
 			Visibility: model.VisibilityPublic,
 		}
@@ -578,7 +579,7 @@ func TestControllerEnsureProject(t *testing.T) {
 
 		_, err := ctrl.ensureProject(ctx, ProjectFullName{Owner: mProjectOwnerUsername, Project: mProject.Name}, true)
 		require.Error(t, err)
-		assert.ErrorIs(t, err, ErrForbidden)
+		assert.ErrorIs(t, err, authn.ErrForbidden)
 
 		require.NoError(t, dbMock.ExpectationsWereMet())
 	})
@@ -679,8 +680,8 @@ func TestControllerCreateProject(t *testing.T) {
 		defer closeDB()
 
 		ctx := newContextWithTestUser(context.Background())
-		mAuthedUser, isAuthed := AuthedUserFromContext(ctx)
-		require.True(t, isAuthed)
+		mUser, ok := authn.UserFromContext(ctx)
+		require.True(t, ok)
 
 		params := &CreateProjectParams{
 			Name:        "testproject",
@@ -693,7 +694,7 @@ func TestControllerCreateProject(t *testing.T) {
 
 		dbMockStmt := ctrl.db.Session(&gorm.Session{DryRun: true, SkipDefaultTransaction: true}).
 			Create(&model.Project{
-				OwnerID:     mAuthedUser.ID,
+				OwnerID:     mUser.ID,
 				Name:        params.Name,
 				Version:     1,
 				Files:       params.Files,
@@ -709,7 +710,7 @@ func TestControllerCreateProject(t *testing.T) {
 			WillReturnResult(sqlmock.NewResult(1, 1))
 
 		dbMockStmt = ctrl.db.Session(&gorm.Session{DryRun: true, SkipDefaultTransaction: true}).
-			Model(&model.User{Model: mAuthedUser.Model}).
+			Model(&model.User{Model: mUser.Model}).
 			UpdateColumns(map[string]any{
 				"project_count":        gorm.Expr("project_count + 1"),
 				"public_project_count": gorm.Expr("public_project_count + 1"),
@@ -730,7 +731,7 @@ func TestControllerCreateProject(t *testing.T) {
 			WithArgs(dbMockArgs...).
 			WillReturnRows(sqlmock.NewRows(projectDBColumns).AddRows(generateProjectDBRows(model.Project{
 				Model:       model.Model{ID: 1},
-				OwnerID:     mAuthedUser.ID,
+				OwnerID:     mUser.ID,
 				Name:        params.Name,
 				Files:       params.Files,
 				Visibility:  model.ParseVisibility(params.Visibility),
@@ -738,13 +739,13 @@ func TestControllerCreateProject(t *testing.T) {
 			})...))
 
 		dbMockStmt = ctrl.db.Session(&gorm.Session{DryRun: true}).
-			Where("`user`.`id` = ?", mAuthedUser.ID).
+			Where("`user`.`id` = ?", mUser.ID).
 			Find(&model.User{}).
 			Statement
 		dbMockArgs = modeltest.ToDriverValueSlice(dbMockStmt.Vars...)
 		dbMock.ExpectQuery(regexp.QuoteMeta(dbMockStmt.SQL.String())).
 			WithArgs(dbMockArgs...).
-			WillReturnRows(sqlmock.NewRows(userDBColumns).AddRows(generateUserDBRows(*mAuthedUser)...))
+			WillReturnRows(sqlmock.NewRows(userDBColumns).AddRows(generateUserDBRows(*mUser)...))
 
 		projectDTO, err := ctrl.CreateProject(ctx, params)
 		require.NoError(t, err)
@@ -760,14 +761,14 @@ func TestControllerCreateProject(t *testing.T) {
 		defer closeDB()
 
 		ctx := newContextWithTestUser(context.Background())
-		mAuthedUser, isAuthed := AuthedUserFromContext(ctx)
-		require.True(t, isAuthed)
+		mUser, ok := authn.UserFromContext(ctx)
+		require.True(t, ok)
 
 		mSourceProjectOwnerUsername := "otheruser"
 
 		mSourceProject := model.Project{
 			Model:        model.Model{ID: 2},
-			OwnerID:      mAuthedUser.ID + 1,
+			OwnerID:      mUser.ID + 1,
 			Name:         "sourceproject",
 			Visibility:   model.VisibilityPublic,
 			Description:  "Source project description",
@@ -813,7 +814,7 @@ func TestControllerCreateProject(t *testing.T) {
 
 		dbMockStmt = ctrl.db.Session(&gorm.Session{DryRun: true, SkipDefaultTransaction: true}).
 			Create(&model.Project{
-				OwnerID:              mAuthedUser.ID,
+				OwnerID:              mUser.ID,
 				RemixedFromReleaseID: sql.NullInt64{Int64: mSourceProjectRelease.ID, Valid: true},
 				Name:                 params.Name,
 				Version:              1,
@@ -832,7 +833,7 @@ func TestControllerCreateProject(t *testing.T) {
 			WillReturnResult(sqlmock.NewResult(3, 1))
 
 		dbMockStmt = ctrl.db.Session(&gorm.Session{DryRun: true, SkipDefaultTransaction: true}).
-			Model(&model.User{Model: mAuthedUser.Model}).
+			Model(&model.User{Model: mUser.Model}).
 			UpdateColumns(map[string]any{
 				"project_count":        gorm.Expr("project_count + 1"),
 				"public_project_count": gorm.Expr("public_project_count + 1"),
@@ -875,7 +876,7 @@ func TestControllerCreateProject(t *testing.T) {
 			WithArgs(dbMockArgs...).
 			WillReturnRows(sqlmock.NewRows(projectDBColumns).AddRows(generateProjectDBRows(model.Project{
 				Model:                model.Model{ID: 3},
-				OwnerID:              mAuthedUser.ID,
+				OwnerID:              mUser.ID,
 				Name:                 params.Name,
 				Files:                mSourceProjectRelease.Files,
 				Visibility:           model.ParseVisibility(params.Visibility),
@@ -886,13 +887,13 @@ func TestControllerCreateProject(t *testing.T) {
 			})...))
 
 		dbMockStmt = ctrl.db.Session(&gorm.Session{DryRun: true}).
-			Where("`user`.`id` = ?", mAuthedUser.ID).
+			Where("`user`.`id` = ?", mUser.ID).
 			Find(&model.User{}).
 			Statement
 		dbMockArgs = modeltest.ToDriverValueSlice(dbMockStmt.Vars...)
 		dbMock.ExpectQuery(regexp.QuoteMeta(dbMockStmt.SQL.String())).
 			WithArgs(dbMockArgs...).
-			WillReturnRows(sqlmock.NewRows(userDBColumns).AddRows(generateUserDBRows(*mAuthedUser)...))
+			WillReturnRows(sqlmock.NewRows(userDBColumns).AddRows(generateUserDBRows(*mUser)...))
 
 		dbMockStmt = ctrl.db.Session(&gorm.Session{DryRun: true}).
 			Where("`project_release`.`id` = ?", mSourceProjectRelease.ID).
@@ -948,7 +949,7 @@ func TestControllerCreateProject(t *testing.T) {
 
 		_, err := ctrl.CreateProject(context.Background(), params)
 		require.Error(t, err)
-		assert.ErrorIs(t, err, ErrUnauthorized)
+		assert.ErrorIs(t, err, authn.ErrUnauthorized)
 	})
 
 	t.Run("CreateFailed", func(t *testing.T) {
@@ -956,8 +957,8 @@ func TestControllerCreateProject(t *testing.T) {
 		defer closeDB()
 
 		ctx := newContextWithTestUser(context.Background())
-		mAuthedUser, isAuthed := AuthedUserFromContext(ctx)
-		require.True(t, isAuthed)
+		mUser, ok := authn.UserFromContext(ctx)
+		require.True(t, ok)
 
 		params := &CreateProjectParams{
 			Name:       "testproject",
@@ -968,7 +969,7 @@ func TestControllerCreateProject(t *testing.T) {
 
 		dbMockStmt := ctrl.db.Session(&gorm.Session{DryRun: true, SkipDefaultTransaction: true}).
 			Create(&model.Project{
-				OwnerID:    mAuthedUser.ID,
+				OwnerID:    mUser.ID,
 				Name:       params.Name,
 				Version:    1,
 				Visibility: model.ParseVisibility(params.Visibility),
@@ -1098,20 +1099,20 @@ func TestControllerListProjects(t *testing.T) {
 		defer closeDB()
 
 		ctx := newContextWithTestUser(context.Background())
-		mAuthedUser, isAuthed := AuthedUserFromContext(ctx)
-		require.True(t, isAuthed)
+		mUser, ok := authn.UserFromContext(ctx)
+		require.True(t, ok)
 
 		mProjects := []model.Project{
 			{
 				Model:       model.Model{ID: 1},
-				OwnerID:     mAuthedUser.ID,
+				OwnerID:     mUser.ID,
 				Name:        "project1",
 				Visibility:  model.VisibilityPublic,
 				Description: "Description 1",
 			},
 			{
 				Model:       model.Model{ID: 2},
-				OwnerID:     mAuthedUser.ID,
+				OwnerID:     mUser.ID,
 				Name:        "project2",
 				Visibility:  model.VisibilityPublic,
 				Description: "Description 2",
@@ -1123,7 +1124,7 @@ func TestControllerListProjects(t *testing.T) {
 
 		dbMockStmt := ctrl.db.Session(&gorm.Session{DryRun: true}).
 			Model(&model.Project{}).
-			Where(ctrl.db.Where("project.owner_id = ?", mAuthedUser.ID).Or("project.visibility = ?", model.VisibilityPublic)).
+			Where(ctrl.db.Where("project.owner_id = ?", mUser.ID).Or("project.visibility = ?", model.VisibilityPublic)).
 			Count(new(int64)).
 			Statement
 		dbMockArgs := modeltest.ToDriverValueSlice(dbMockStmt.Vars...)
@@ -1132,7 +1133,7 @@ func TestControllerListProjects(t *testing.T) {
 			WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(2))
 
 		dbMockStmt = ctrl.db.Session(&gorm.Session{DryRun: true}).
-			Where(ctrl.db.Where("project.owner_id = ?", mAuthedUser.ID).Or("project.visibility = ?", model.VisibilityPublic)).
+			Where(ctrl.db.Where("project.owner_id = ?", mUser.ID).Or("project.visibility = ?", model.VisibilityPublic)).
 			Order("project.created_at asc, project.id").
 			Offset(params.Pagination.Offset()).
 			Limit(params.Pagination.Size).
@@ -1146,13 +1147,13 @@ func TestControllerListProjects(t *testing.T) {
 			))
 
 		dbMockStmt = ctrl.db.Session(&gorm.Session{DryRun: true}).
-			Where("`user`.`id` = ?", mAuthedUser.ID).
+			Where("`user`.`id` = ?", mUser.ID).
 			Find(&model.User{}).
 			Statement
 		dbMockArgs = modeltest.ToDriverValueSlice(dbMockStmt.Vars...)
 		dbMock.ExpectQuery(regexp.QuoteMeta(dbMockStmt.SQL.String())).
 			WithArgs(dbMockArgs...).
-			WillReturnRows(sqlmock.NewRows(userDBColumns).AddRows(generateUserDBRows(*mAuthedUser)...))
+			WillReturnRows(sqlmock.NewRows(userDBColumns).AddRows(generateUserDBRows(*mUser)...))
 
 		result, err := ctrl.ListProjects(ctx, params)
 		require.NoError(t, err)
@@ -1169,13 +1170,13 @@ func TestControllerListProjects(t *testing.T) {
 		defer closeDB()
 
 		ctx := newContextWithTestUser(context.Background())
-		mAuthedUser, isAuthed := AuthedUserFromContext(ctx)
-		require.True(t, isAuthed)
+		mUser, ok := authn.UserFromContext(ctx)
+		require.True(t, ok)
 
 		mProjects := []model.Project{
 			{
 				Model:       model.Model{ID: 1},
-				OwnerID:     mAuthedUser.ID,
+				OwnerID:     mUser.ID,
 				Name:        "project1",
 				Visibility:  model.VisibilityPublic,
 				Description: "Description 1",
@@ -1183,7 +1184,7 @@ func TestControllerListProjects(t *testing.T) {
 		}
 
 		params := NewListProjectsParams()
-		params.Owner = &mAuthedUser.Username
+		params.Owner = &mUser.Username
 
 		dbMockStmt := ctrl.db.Session(&gorm.Session{DryRun: true}).
 			Model(&model.Project{}).
@@ -1212,13 +1213,13 @@ func TestControllerListProjects(t *testing.T) {
 			))
 
 		dbMockStmt = ctrl.db.Session(&gorm.Session{DryRun: true}).
-			Where("`user`.`id` = ?", mAuthedUser.ID).
+			Where("`user`.`id` = ?", mUser.ID).
 			Find(&model.User{}).
 			Statement
 		dbMockArgs = modeltest.ToDriverValueSlice(dbMockStmt.Vars...)
 		dbMock.ExpectQuery(regexp.QuoteMeta(dbMockStmt.SQL.String())).
 			WithArgs(dbMockArgs...).
-			WillReturnRows(sqlmock.NewRows(userDBColumns).AddRows(generateUserDBRows(*mAuthedUser)...))
+			WillReturnRows(sqlmock.NewRows(userDBColumns).AddRows(generateUserDBRows(*mUser)...))
 
 		result, err := ctrl.ListProjects(ctx, params)
 		require.NoError(t, err)
@@ -1234,13 +1235,13 @@ func TestControllerListProjects(t *testing.T) {
 		defer closeDB()
 
 		ctx := newContextWithTestUser(context.Background())
-		mAuthedUser, isAuthed := AuthedUserFromContext(ctx)
-		require.True(t, isAuthed)
+		mUser, ok := authn.UserFromContext(ctx)
+		require.True(t, ok)
 
 		mProjects := []model.Project{
 			{
 				Model:       model.Model{ID: 1},
-				OwnerID:     mAuthedUser.ID,
+				OwnerID:     mUser.ID,
 				Name:        "test_project",
 				Visibility:  model.VisibilityPublic,
 				Description: "Test Description",
@@ -1254,7 +1255,7 @@ func TestControllerListProjects(t *testing.T) {
 		dbMockStmt := ctrl.db.Session(&gorm.Session{DryRun: true}).
 			Model(&model.Project{}).
 			Where("project.name LIKE ?", "%"+*params.Keyword+"%").
-			Where(ctrl.db.Where("project.owner_id = ?", mAuthedUser.ID).Or("project.visibility = ?", model.VisibilityPublic)).
+			Where(ctrl.db.Where("project.owner_id = ?", mUser.ID).Or("project.visibility = ?", model.VisibilityPublic)).
 			Count(new(int64)).
 			Statement
 		dbMockArgs := modeltest.ToDriverValueSlice(dbMockStmt.Vars...)
@@ -1264,7 +1265,7 @@ func TestControllerListProjects(t *testing.T) {
 
 		dbMockStmt = ctrl.db.Session(&gorm.Session{DryRun: true}).
 			Where("project.name LIKE ?", "%"+*params.Keyword+"%").
-			Where(ctrl.db.Where("project.owner_id = ?", mAuthedUser.ID).Or("project.visibility = ?", model.VisibilityPublic)).
+			Where(ctrl.db.Where("project.owner_id = ?", mUser.ID).Or("project.visibility = ?", model.VisibilityPublic)).
 			Order("project.created_at asc, project.id").
 			Offset(params.Pagination.Offset()).
 			Limit(params.Pagination.Size).
@@ -1278,13 +1279,13 @@ func TestControllerListProjects(t *testing.T) {
 			))
 
 		dbMockStmt = ctrl.db.Session(&gorm.Session{DryRun: true}).
-			Where("`user`.`id` = ?", mAuthedUser.ID).
+			Where("`user`.`id` = ?", mUser.ID).
 			Find(&model.User{}).
 			Statement
 		dbMockArgs = modeltest.ToDriverValueSlice(dbMockStmt.Vars...)
 		dbMock.ExpectQuery(regexp.QuoteMeta(dbMockStmt.SQL.String())).
 			WithArgs(dbMockArgs...).
-			WillReturnRows(sqlmock.NewRows(userDBColumns).AddRows(generateUserDBRows(*mAuthedUser)...))
+			WillReturnRows(sqlmock.NewRows(userDBColumns).AddRows(generateUserDBRows(*mUser)...))
 
 		result, err := ctrl.ListProjects(ctx, params)
 		require.NoError(t, err)
@@ -1300,8 +1301,8 @@ func TestControllerListProjects(t *testing.T) {
 		defer closeDB()
 
 		ctx := newContextWithTestUser(context.Background())
-		mAuthedUser, isAuthed := AuthedUserFromContext(ctx)
-		require.True(t, isAuthed)
+		mUser, ok := authn.UserFromContext(ctx)
+		require.True(t, ok)
 
 		params := NewListProjectsParams()
 		liker := "liker_user"
@@ -1310,7 +1311,7 @@ func TestControllerListProjects(t *testing.T) {
 		mProjects := []model.Project{
 			{
 				Model:       model.Model{ID: 1},
-				OwnerID:     mAuthedUser.ID,
+				OwnerID:     mUser.ID,
 				Name:        "liked_project",
 				Visibility:  model.VisibilityPublic,
 				Description: "Liked Project",
@@ -1321,7 +1322,7 @@ func TestControllerListProjects(t *testing.T) {
 			Model(&model.Project{}).
 			Joins("JOIN user_project_relationship AS liker_relationship ON liker_relationship.project_id = project.id").
 			Joins("JOIN user AS liker ON liker.id = liker_relationship.user_id").
-			Where(ctrl.db.Where("project.owner_id = ?", mAuthedUser.ID).Or("project.visibility = ?", model.VisibilityPublic)).
+			Where(ctrl.db.Where("project.owner_id = ?", mUser.ID).Or("project.visibility = ?", model.VisibilityPublic)).
 			Where("liker.username = ?", *params.Liker).
 			Where("liker_relationship.liked_at IS NOT NULL").
 			Count(new(int64)).
@@ -1334,7 +1335,7 @@ func TestControllerListProjects(t *testing.T) {
 		dbMockStmt = ctrl.db.Session(&gorm.Session{DryRun: true}).
 			Joins("JOIN user_project_relationship AS liker_relationship ON liker_relationship.project_id = project.id").
 			Joins("JOIN user AS liker ON liker.id = liker_relationship.user_id").
-			Where(ctrl.db.Where("project.owner_id = ?", mAuthedUser.ID).Or("project.visibility = ?", model.VisibilityPublic)).
+			Where(ctrl.db.Where("project.owner_id = ?", mUser.ID).Or("project.visibility = ?", model.VisibilityPublic)).
 			Where("liker.username = ?", *params.Liker).
 			Where("liker_relationship.liked_at IS NOT NULL").
 			Order("project.created_at asc, project.id").
@@ -1348,13 +1349,13 @@ func TestControllerListProjects(t *testing.T) {
 			WillReturnRows(sqlmock.NewRows(projectDBColumns).AddRows(generateProjectDBRows(mProjects...)...))
 
 		dbMockStmt = ctrl.db.Session(&gorm.Session{DryRun: true}).
-			Where("`user`.`id` = ?", mAuthedUser.ID).
+			Where("`user`.`id` = ?", mUser.ID).
 			Find(&model.User{}).
 			Statement
 		dbMockArgs = modeltest.ToDriverValueSlice(dbMockStmt.Vars...)
 		dbMock.ExpectQuery(regexp.QuoteMeta(dbMockStmt.SQL.String())).
 			WithArgs(dbMockArgs...).
-			WillReturnRows(sqlmock.NewRows(userDBColumns).AddRows(generateUserDBRows(*mAuthedUser)...))
+			WillReturnRows(sqlmock.NewRows(userDBColumns).AddRows(generateUserDBRows(*mUser)...))
 
 		result, err := ctrl.ListProjects(ctx, params)
 		require.NoError(t, err)
@@ -1370,13 +1371,13 @@ func TestControllerListProjects(t *testing.T) {
 		defer closeDB()
 
 		ctx := newContextWithTestUser(context.Background())
-		mAuthedUser, isAuthed := AuthedUserFromContext(ctx)
-		require.True(t, isAuthed)
+		mUser, ok := authn.UserFromContext(ctx)
+		require.True(t, ok)
 
 		mProjects := []model.Project{
 			{
 				Model:       model.Model{ID: 1},
-				OwnerID:     mAuthedUser.ID,
+				OwnerID:     mUser.ID,
 				Name:        "popular_project",
 				Visibility:  model.VisibilityPublic,
 				Description: "Popular Project",
@@ -1384,7 +1385,7 @@ func TestControllerListProjects(t *testing.T) {
 			},
 			{
 				Model:       model.Model{ID: 2},
-				OwnerID:     mAuthedUser.ID,
+				OwnerID:     mUser.ID,
 				Name:        "less_popular_project",
 				Visibility:  model.VisibilityPublic,
 				Description: "Less Popular Project",
@@ -1398,7 +1399,7 @@ func TestControllerListProjects(t *testing.T) {
 
 		dbMockStmt := ctrl.db.Session(&gorm.Session{DryRun: true}).
 			Model(&model.Project{}).
-			Where(ctrl.db.Where("project.owner_id = ?", mAuthedUser.ID).Or("project.visibility = ?", model.VisibilityPublic)).
+			Where(ctrl.db.Where("project.owner_id = ?", mUser.ID).Or("project.visibility = ?", model.VisibilityPublic)).
 			Count(new(int64)).
 			Statement
 		dbMockArgs := modeltest.ToDriverValueSlice(dbMockStmt.Vars...)
@@ -1407,7 +1408,7 @@ func TestControllerListProjects(t *testing.T) {
 			WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(2))
 
 		dbMockStmt = ctrl.db.Session(&gorm.Session{DryRun: true}).
-			Where(ctrl.db.Where("project.owner_id = ?", mAuthedUser.ID).Or("project.visibility = ?", model.VisibilityPublic)).
+			Where(ctrl.db.Where("project.owner_id = ?", mUser.ID).Or("project.visibility = ?", model.VisibilityPublic)).
 			Order("project.like_count desc, project.id").
 			Offset(params.Pagination.Offset()).
 			Limit(params.Pagination.Size).
@@ -1421,13 +1422,13 @@ func TestControllerListProjects(t *testing.T) {
 			))
 
 		dbMockStmt = ctrl.db.Session(&gorm.Session{DryRun: true}).
-			Where("`user`.`id` = ?", mAuthedUser.ID).
+			Where("`user`.`id` = ?", mUser.ID).
 			Find(&model.User{}).
 			Statement
 		dbMockArgs = modeltest.ToDriverValueSlice(dbMockStmt.Vars...)
 		dbMock.ExpectQuery(regexp.QuoteMeta(dbMockStmt.SQL.String())).
 			WithArgs(dbMockArgs...).
-			WillReturnRows(sqlmock.NewRows(userDBColumns).AddRows(generateUserDBRows(*mAuthedUser)...))
+			WillReturnRows(sqlmock.NewRows(userDBColumns).AddRows(generateUserDBRows(*mUser)...))
 
 		result, err := ctrl.ListProjects(ctx, params)
 		require.NoError(t, err)
@@ -1446,12 +1447,12 @@ func TestControllerListProjects(t *testing.T) {
 		ctx := newContextWithTestUser(context.Background())
 
 		params := NewListProjectsParams()
-		mAuthedUser, isAuthed := AuthedUserFromContext(ctx)
-		require.True(t, isAuthed)
+		mUser, ok := authn.UserFromContext(ctx)
+		require.True(t, ok)
 
 		dbMockStmt := ctrl.db.Session(&gorm.Session{DryRun: true}).
 			Model(&model.Project{}).
-			Where(ctrl.db.Where("project.owner_id = ?", mAuthedUser.ID).Or("project.visibility = ?", model.VisibilityPublic)).
+			Where(ctrl.db.Where("project.owner_id = ?", mUser.ID).Or("project.visibility = ?", model.VisibilityPublic)).
 			Count(new(int64)).
 			Statement
 		dbMockArgs := modeltest.ToDriverValueSlice(dbMockStmt.Vars...)
@@ -1473,12 +1474,12 @@ func TestControllerListProjects(t *testing.T) {
 		ctx := newContextWithTestUser(context.Background())
 
 		params := NewListProjectsParams()
-		mAuthedUser, isAuthed := AuthedUserFromContext(ctx)
-		require.True(t, isAuthed)
+		mUser, ok := authn.UserFromContext(ctx)
+		require.True(t, ok)
 
 		dbMockStmt := ctrl.db.Session(&gorm.Session{DryRun: true}).
 			Model(&model.Project{}).
-			Where(ctrl.db.Where("project.owner_id = ?", mAuthedUser.ID).Or("project.visibility = ?", model.VisibilityPublic)).
+			Where(ctrl.db.Where("project.owner_id = ?", mUser.ID).Or("project.visibility = ?", model.VisibilityPublic)).
 			Count(new(int64)).
 			Statement
 		dbMockArgs := modeltest.ToDriverValueSlice(dbMockStmt.Vars...)
@@ -1487,7 +1488,7 @@ func TestControllerListProjects(t *testing.T) {
 			WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
 
 		dbMockStmt = ctrl.db.Session(&gorm.Session{DryRun: true}).
-			Where(ctrl.db.Where("project.owner_id = ?", mAuthedUser.ID).Or("project.visibility = ?", model.VisibilityPublic)).
+			Where(ctrl.db.Where("project.owner_id = ?", mUser.ID).Or("project.visibility = ?", model.VisibilityPublic)).
 			Order("project.created_at asc, project.id").
 			Offset(params.Pagination.Offset()).
 			Limit(params.Pagination.Size).
@@ -1510,13 +1511,13 @@ func TestControllerListProjects(t *testing.T) {
 		defer closeDB()
 
 		ctx := newContextWithTestUser(context.Background())
-		mAuthedUser, isAuthed := AuthedUserFromContext(ctx)
-		require.True(t, isAuthed)
+		mUser, ok := authn.UserFromContext(ctx)
+		require.True(t, ok)
 
 		mProjects := []model.Project{
 			{
 				Model:                model.Model{ID: 1},
-				OwnerID:              mAuthedUser.ID,
+				OwnerID:              mUser.ID,
 				Name:                 "remixed_project",
 				Visibility:           model.VisibilityPublic,
 				Description:          "Remixed Project",
@@ -1534,7 +1535,7 @@ func TestControllerListProjects(t *testing.T) {
 			Joins("JOIN user AS remixed_from_user ON remixed_from_user.id = remixed_from_project.owner_id").
 			Where("remixed_from_user.username = ?", "original_user").
 			Where("remixed_from_project.name = ?", "original_project").
-			Where(ctrl.db.Where("project.owner_id = ?", mAuthedUser.ID).Or("project.visibility = ?", model.VisibilityPublic)).
+			Where(ctrl.db.Where("project.owner_id = ?", mUser.ID).Or("project.visibility = ?", model.VisibilityPublic)).
 			Count(new(int64)).
 			Statement
 		dbMockArgs := modeltest.ToDriverValueSlice(dbMockStmt.Vars...)
@@ -1548,7 +1549,7 @@ func TestControllerListProjects(t *testing.T) {
 			Joins("JOIN user AS remixed_from_user ON remixed_from_user.id = remixed_from_project.owner_id").
 			Where("remixed_from_user.username = ?", "original_user").
 			Where("remixed_from_project.name = ?", "original_project").
-			Where(ctrl.db.Where("project.owner_id = ?", mAuthedUser.ID).Or("project.visibility = ?", model.VisibilityPublic)).
+			Where(ctrl.db.Where("project.owner_id = ?", mUser.ID).Or("project.visibility = ?", model.VisibilityPublic)).
 			Order("project.created_at asc, project.id").
 			Offset(params.Pagination.Offset()).
 			Limit(params.Pagination.Size).
@@ -1562,13 +1563,13 @@ func TestControllerListProjects(t *testing.T) {
 			))
 
 		dbMockStmt = ctrl.db.Session(&gorm.Session{DryRun: true}).
-			Where("`user`.`id` = ?", mAuthedUser.ID).
+			Where("`user`.`id` = ?", mUser.ID).
 			Find(&model.User{}).
 			Statement
 		dbMockArgs = modeltest.ToDriverValueSlice(dbMockStmt.Vars...)
 		dbMock.ExpectQuery(regexp.QuoteMeta(dbMockStmt.SQL.String())).
 			WithArgs(dbMockArgs...).
-			WillReturnRows(sqlmock.NewRows(userDBColumns).AddRows(generateUserDBRows(*mAuthedUser)...))
+			WillReturnRows(sqlmock.NewRows(userDBColumns).AddRows(generateUserDBRows(*mUser)...))
 
 		dbMockStmt = ctrl.db.Session(&gorm.Session{DryRun: true}).
 			Where("`project_release`.`id` = ?", 1).
@@ -1609,12 +1610,12 @@ func TestControllerGetProject(t *testing.T) {
 		defer closeDB()
 
 		ctx := newContextWithTestUser(context.Background())
-		mAuthedUser, isAuthed := AuthedUserFromContext(ctx)
-		require.True(t, isAuthed)
+		mUser, ok := authn.UserFromContext(ctx)
+		require.True(t, ok)
 
 		mProject := model.Project{
 			Model:       model.Model{ID: 1},
-			OwnerID:     mAuthedUser.ID,
+			OwnerID:     mUser.ID,
 			Name:        "testproject",
 			Visibility:  model.VisibilityPublic,
 			Description: "Test project description",
@@ -1622,7 +1623,7 @@ func TestControllerGetProject(t *testing.T) {
 
 		dbMockStmt := ctrl.db.Session(&gorm.Session{DryRun: true}).
 			Joins("JOIN user ON user.id = project.owner_id").
-			Where("user.username = ?", mAuthedUser.Username).
+			Where("user.username = ?", mUser.Username).
 			Where("project.name = ?", mProject.Name).
 			First(&model.Project{}).
 			Statement
@@ -1632,15 +1633,15 @@ func TestControllerGetProject(t *testing.T) {
 			WillReturnRows(sqlmock.NewRows(projectDBColumns).AddRows(generateProjectDBRows(mProject)...))
 
 		dbMockStmt = ctrl.db.Session(&gorm.Session{DryRun: true}).
-			Where("`user`.`id` = ?", mAuthedUser.ID).
+			Where("`user`.`id` = ?", mUser.ID).
 			Find(&model.User{}).
 			Statement
 		dbMockArgs = modeltest.ToDriverValueSlice(dbMockStmt.Vars...)
 		dbMock.ExpectQuery(regexp.QuoteMeta(dbMockStmt.SQL.String())).
 			WithArgs(dbMockArgs...).
-			WillReturnRows(sqlmock.NewRows(userDBColumns).AddRows(generateUserDBRows(*mAuthedUser)...))
+			WillReturnRows(sqlmock.NewRows(userDBColumns).AddRows(generateUserDBRows(*mUser)...))
 
-		projectDTO, err := ctrl.GetProject(ctx, ProjectFullName{Owner: mAuthedUser.Username, Project: mProject.Name})
+		projectDTO, err := ctrl.GetProject(ctx, ProjectFullName{Owner: mUser.Username, Project: mProject.Name})
 		require.NoError(t, err)
 		assert.Equal(t, mProject.Name, projectDTO.Name)
 		assert.Equal(t, mProject.Visibility.String(), projectDTO.Visibility)
@@ -1654,14 +1655,14 @@ func TestControllerGetProject(t *testing.T) {
 		defer closeDB()
 
 		ctx := newContextWithTestUser(context.Background())
-		mAuthedUser, isAuthed := AuthedUserFromContext(ctx)
-		require.True(t, isAuthed)
+		mUser, ok := authn.UserFromContext(ctx)
+		require.True(t, ok)
 
 		mProjectName := "nonexistent"
 
 		dbMockStmt := ctrl.db.Session(&gorm.Session{DryRun: true}).
 			Joins("JOIN user ON user.id = project.owner_id").
-			Where("user.username = ?", mAuthedUser.Username).
+			Where("user.username = ?", mUser.Username).
 			Where("project.name = ?", mProjectName).
 			First(&model.Project{}).
 			Statement
@@ -1670,7 +1671,7 @@ func TestControllerGetProject(t *testing.T) {
 			WithArgs(dbMockArgs...).
 			WillReturnError(gorm.ErrRecordNotFound)
 
-		_, err := ctrl.GetProject(ctx, ProjectFullName{Owner: mAuthedUser.Username, Project: mProjectName})
+		_, err := ctrl.GetProject(ctx, ProjectFullName{Owner: mUser.Username, Project: mProjectName})
 		require.Error(t, err)
 		assert.ErrorIs(t, err, gorm.ErrRecordNotFound)
 
@@ -1682,14 +1683,14 @@ func TestControllerGetProject(t *testing.T) {
 		defer closeDB()
 
 		ctx := newContextWithTestUser(context.Background())
-		mAuthedUser, isAuthed := AuthedUserFromContext(ctx)
-		require.True(t, isAuthed)
+		mUser, ok := authn.UserFromContext(ctx)
+		require.True(t, ok)
 
 		mProjectOwnerUsername := "otheruser"
 
 		mProject := model.Project{
 			Model:      model.Model{ID: 1},
-			OwnerID:    mAuthedUser.ID + 1,
+			OwnerID:    mUser.ID + 1,
 			Name:       "privateproject",
 			Visibility: model.VisibilityPrivate,
 		}
@@ -1719,7 +1720,7 @@ func TestControllerGetProject(t *testing.T) {
 
 		_, err := ctrl.GetProject(ctx, ProjectFullName{Owner: mProjectOwnerUsername, Project: mProject.Name})
 		require.Error(t, err)
-		assert.ErrorIs(t, err, ErrForbidden)
+		assert.ErrorIs(t, err, authn.ErrForbidden)
 
 		require.NoError(t, dbMock.ExpectationsWereMet())
 	})
@@ -1767,12 +1768,12 @@ func TestControllerUpdateProject(t *testing.T) {
 		defer closeDB()
 
 		ctx := newContextWithTestUser(context.Background())
-		mAuthedUser, isAuthed := AuthedUserFromContext(ctx)
-		require.True(t, isAuthed)
+		mUser, ok := authn.UserFromContext(ctx)
+		require.True(t, ok)
 
 		mProject := model.Project{
 			Model:       model.Model{ID: 1},
-			OwnerID:     mAuthedUser.ID,
+			OwnerID:     mUser.ID,
 			Name:        "testproject",
 			Visibility:  model.VisibilityPrivate,
 			Description: "Original description",
@@ -1785,7 +1786,7 @@ func TestControllerUpdateProject(t *testing.T) {
 
 		dbMockStmt := ctrl.db.Session(&gorm.Session{DryRun: true}).
 			Joins("JOIN user ON user.id = project.owner_id").
-			Where("user.username = ?", mAuthedUser.Username).
+			Where("user.username = ?", mUser.Username).
 			Where("project.name = ?", mProject.Name).
 			First(&model.Project{}).
 			Statement
@@ -1795,13 +1796,13 @@ func TestControllerUpdateProject(t *testing.T) {
 			WillReturnRows(sqlmock.NewRows(projectDBColumns).AddRows(generateProjectDBRows(mProject)...))
 
 		dbMockStmt = ctrl.db.Session(&gorm.Session{DryRun: true}).
-			Where("`user`.`id` = ?", mAuthedUser.ID).
+			Where("`user`.`id` = ?", mUser.ID).
 			Find(&model.User{}).
 			Statement
 		dbMockArgs = modeltest.ToDriverValueSlice(dbMockStmt.Vars...)
 		dbMock.ExpectQuery(regexp.QuoteMeta(dbMockStmt.SQL.String())).
 			WithArgs(dbMockArgs...).
-			WillReturnRows(sqlmock.NewRows(userDBColumns).AddRows(generateUserDBRows(*mAuthedUser)...))
+			WillReturnRows(sqlmock.NewRows(userDBColumns).AddRows(generateUserDBRows(*mUser)...))
 
 		dbMock.ExpectBegin()
 
@@ -1828,7 +1829,7 @@ func TestControllerUpdateProject(t *testing.T) {
 			WillReturnResult(sqlmock.NewResult(0, 1))
 
 		dbMockStmt = ctrl.db.Session(&gorm.Session{DryRun: true, SkipDefaultTransaction: true}).
-			Model(&model.User{Model: mAuthedUser.Model}).
+			Model(&model.User{Model: mUser.Model}).
 			UpdateColumn("public_project_count", gorm.Expr("public_project_count + 1")).
 			Statement
 		dbMockArgs = modeltest.ToDriverValueSlice(dbMockStmt.Vars...)
@@ -1838,7 +1839,7 @@ func TestControllerUpdateProject(t *testing.T) {
 
 		dbMock.ExpectCommit()
 
-		mUpdatedProject, err := ctrl.UpdateProject(ctx, ProjectFullName{Owner: mAuthedUser.Username, Project: mProject.Name}, params)
+		mUpdatedProject, err := ctrl.UpdateProject(ctx, ProjectFullName{Owner: mUser.Username, Project: mProject.Name}, params)
 		require.NoError(t, err)
 		assert.Equal(t, params.Visibility, mUpdatedProject.Visibility)
 		assert.Equal(t, params.Description, mUpdatedProject.Description)
@@ -1851,8 +1852,8 @@ func TestControllerUpdateProject(t *testing.T) {
 		defer closeDB()
 
 		ctx := newContextWithTestUser(context.Background())
-		mAuthedUser, isAuthed := AuthedUserFromContext(ctx)
-		require.True(t, isAuthed)
+		mUser, ok := authn.UserFromContext(ctx)
+		require.True(t, ok)
 
 		mProjectName := "nonexistent"
 
@@ -1862,7 +1863,7 @@ func TestControllerUpdateProject(t *testing.T) {
 
 		dbMockStmt := ctrl.db.Session(&gorm.Session{DryRun: true}).
 			Joins("JOIN user ON user.id = project.owner_id").
-			Where("user.username = ?", mAuthedUser.Username).
+			Where("user.username = ?", mUser.Username).
 			Where("project.name = ?", mProjectName).
 			First(&model.Project{}).
 			Statement
@@ -1871,7 +1872,7 @@ func TestControllerUpdateProject(t *testing.T) {
 			WithArgs(dbMockArgs...).
 			WillReturnError(gorm.ErrRecordNotFound)
 
-		_, err := ctrl.UpdateProject(ctx, ProjectFullName{Owner: mAuthedUser.Username, Project: mProjectName}, params)
+		_, err := ctrl.UpdateProject(ctx, ProjectFullName{Owner: mUser.Username, Project: mProjectName}, params)
 		require.Error(t, err)
 		assert.ErrorIs(t, err, gorm.ErrRecordNotFound)
 
@@ -1883,14 +1884,14 @@ func TestControllerUpdateProject(t *testing.T) {
 		defer closeDB()
 
 		ctx := newContextWithTestUser(context.Background())
-		mAuthedUser, isAuthed := AuthedUserFromContext(ctx)
-		require.True(t, isAuthed)
+		mUser, ok := authn.UserFromContext(ctx)
+		require.True(t, ok)
 
 		mProjectOwnerUsername := "otheruser"
 
 		mProject := model.Project{
 			Model:      model.Model{ID: 1},
-			OwnerID:    mAuthedUser.ID + 1,
+			OwnerID:    mUser.ID + 1,
 			Name:       "otherproject",
 			Visibility: model.VisibilityPublic,
 		}
@@ -1924,7 +1925,7 @@ func TestControllerUpdateProject(t *testing.T) {
 
 		_, err := ctrl.UpdateProject(ctx, ProjectFullName{Owner: mProjectOwnerUsername, Project: mProject.Name}, params)
 		require.Error(t, err)
-		assert.ErrorIs(t, err, ErrForbidden)
+		assert.ErrorIs(t, err, authn.ErrForbidden)
 
 		require.NoError(t, dbMock.ExpectationsWereMet())
 	})
@@ -1934,12 +1935,12 @@ func TestControllerUpdateProject(t *testing.T) {
 		defer closeDB()
 
 		ctx := newContextWithTestUser(context.Background())
-		mAuthedUser, isAuthed := AuthedUserFromContext(ctx)
-		require.True(t, isAuthed)
+		mUser, ok := authn.UserFromContext(ctx)
+		require.True(t, ok)
 
 		mProject := model.Project{
 			Model:       model.Model{ID: 1},
-			OwnerID:     mAuthedUser.ID,
+			OwnerID:     mUser.ID,
 			Name:        "testproject",
 			Visibility:  model.VisibilityPublic,
 			Description: "Original description",
@@ -1952,7 +1953,7 @@ func TestControllerUpdateProject(t *testing.T) {
 
 		dbMockStmt := ctrl.db.Session(&gorm.Session{DryRun: true}).
 			Joins("JOIN user ON user.id = project.owner_id").
-			Where("user.username = ?", mAuthedUser.Username).
+			Where("user.username = ?", mUser.Username).
 			Where("project.name = ?", mProject.Name).
 			First(&model.Project{}).
 			Statement
@@ -1962,15 +1963,15 @@ func TestControllerUpdateProject(t *testing.T) {
 			WillReturnRows(sqlmock.NewRows(projectDBColumns).AddRows(generateProjectDBRows(mProject)...))
 
 		dbMockStmt = ctrl.db.Session(&gorm.Session{DryRun: true}).
-			Where("`user`.`id` = ?", mAuthedUser.ID).
+			Where("`user`.`id` = ?", mUser.ID).
 			Find(&model.User{}).
 			Statement
 		dbMockArgs = modeltest.ToDriverValueSlice(dbMockStmt.Vars...)
 		dbMock.ExpectQuery(regexp.QuoteMeta(dbMockStmt.SQL.String())).
 			WithArgs(dbMockArgs...).
-			WillReturnRows(sqlmock.NewRows(userDBColumns).AddRows(generateUserDBRows(*mAuthedUser)...))
+			WillReturnRows(sqlmock.NewRows(userDBColumns).AddRows(generateUserDBRows(*mUser)...))
 
-		mUpdatedProject, err := ctrl.UpdateProject(ctx, ProjectFullName{Owner: mAuthedUser.Username, Project: mProject.Name}, params)
+		mUpdatedProject, err := ctrl.UpdateProject(ctx, ProjectFullName{Owner: mUser.Username, Project: mProject.Name}, params)
 		require.NoError(t, err)
 		assert.Equal(t, mProject.Visibility.String(), mUpdatedProject.Visibility)
 		assert.Equal(t, mProject.Description, mUpdatedProject.Description)
@@ -1997,19 +1998,19 @@ func TestControllerDeleteProject(t *testing.T) {
 		defer closeDB()
 
 		ctx := newContextWithTestUser(context.Background())
-		mAuthedUser, isAuthed := AuthedUserFromContext(ctx)
-		require.True(t, isAuthed)
+		mUser, ok := authn.UserFromContext(ctx)
+		require.True(t, ok)
 
 		mProject := model.Project{
 			Model:      model.Model{ID: 1},
-			OwnerID:    mAuthedUser.ID,
+			OwnerID:    mUser.ID,
 			Name:       "testproject",
 			Visibility: model.VisibilityPublic,
 		}
 
 		dbMockStmt := ctrl.db.Session(&gorm.Session{DryRun: true}).
 			Joins("JOIN user ON user.id = project.owner_id").
-			Where("user.username = ?", mAuthedUser.Username).
+			Where("user.username = ?", mUser.Username).
 			Where("project.name = ?", mProject.Name).
 			First(&model.Project{}).
 			Statement
@@ -2019,13 +2020,13 @@ func TestControllerDeleteProject(t *testing.T) {
 			WillReturnRows(sqlmock.NewRows(projectDBColumns).AddRows(generateProjectDBRows(mProject)...))
 
 		dbMockStmt = ctrl.db.Session(&gorm.Session{DryRun: true}).
-			Where("`user`.`id` = ?", mAuthedUser.ID).
+			Where("`user`.`id` = ?", mUser.ID).
 			Find(&model.User{}).
 			Statement
 		dbMockArgs = modeltest.ToDriverValueSlice(dbMockStmt.Vars...)
 		dbMock.ExpectQuery(regexp.QuoteMeta(dbMockStmt.SQL.String())).
 			WithArgs(dbMockArgs...).
-			WillReturnRows(sqlmock.NewRows(userDBColumns).AddRows(generateUserDBRows(*mAuthedUser)...))
+			WillReturnRows(sqlmock.NewRows(userDBColumns).AddRows(generateUserDBRows(*mUser)...))
 
 		dbMock.ExpectBegin()
 
@@ -2048,7 +2049,7 @@ func TestControllerDeleteProject(t *testing.T) {
 			WillReturnResult(sqlmock.NewResult(0, 1))
 
 		dbMockStmt = ctrl.db.Session(&gorm.Session{DryRun: true, SkipDefaultTransaction: true}).
-			Model(&model.User{Model: mAuthedUser.Model}).
+			Model(&model.User{Model: mUser.Model}).
 			UpdateColumns(map[string]any{
 				"project_count":        gorm.Expr("project_count - 1"),
 				"public_project_count": gorm.Expr("public_project_count - 1"),
@@ -2109,7 +2110,7 @@ func TestControllerDeleteProject(t *testing.T) {
 
 		dbMock.ExpectCommit()
 
-		err := ctrl.DeleteProject(ctx, ProjectFullName{Owner: mAuthedUser.Username, Project: mProject.Name})
+		err := ctrl.DeleteProject(ctx, ProjectFullName{Owner: mUser.Username, Project: mProject.Name})
 		require.NoError(t, err)
 
 		require.NoError(t, dbMock.ExpectationsWereMet())
@@ -2120,14 +2121,14 @@ func TestControllerDeleteProject(t *testing.T) {
 		defer closeDB()
 
 		ctx := newContextWithTestUser(context.Background())
-		mAuthedUser, isAuthed := AuthedUserFromContext(ctx)
-		require.True(t, isAuthed)
+		mUser, ok := authn.UserFromContext(ctx)
+		require.True(t, ok)
 
 		mProjectName := "nonexistent"
 
 		dbMockStmt := ctrl.db.Session(&gorm.Session{DryRun: true}).
 			Joins("JOIN user ON user.id = project.owner_id").
-			Where("user.username = ?", mAuthedUser.Username).
+			Where("user.username = ?", mUser.Username).
 			Where("project.name = ?", mProjectName).
 			First(&model.Project{}).
 			Statement
@@ -2136,7 +2137,7 @@ func TestControllerDeleteProject(t *testing.T) {
 			WithArgs(dbMockArgs...).
 			WillReturnError(gorm.ErrRecordNotFound)
 
-		err := ctrl.DeleteProject(ctx, ProjectFullName{Owner: mAuthedUser.Username, Project: mProjectName})
+		err := ctrl.DeleteProject(ctx, ProjectFullName{Owner: mUser.Username, Project: mProjectName})
 		require.Error(t, err)
 		assert.ErrorIs(t, err, gorm.ErrRecordNotFound)
 
@@ -2148,14 +2149,14 @@ func TestControllerDeleteProject(t *testing.T) {
 		defer closeDB()
 
 		ctx := newContextWithTestUser(context.Background())
-		mAuthedUser, isAuthed := AuthedUserFromContext(ctx)
-		require.True(t, isAuthed)
+		mUser, ok := authn.UserFromContext(ctx)
+		require.True(t, ok)
 
 		mProjectOwnerUsername := "otheruser"
 
 		mProject := model.Project{
 			Model:      model.Model{ID: 1},
-			OwnerID:    mAuthedUser.ID + 1,
+			OwnerID:    mUser.ID + 1,
 			Name:       "testproject",
 			Visibility: model.VisibilityPublic,
 		}
@@ -2185,7 +2186,7 @@ func TestControllerDeleteProject(t *testing.T) {
 
 		err := ctrl.DeleteProject(ctx, ProjectFullName{Owner: mProjectOwnerUsername, Project: mProject.Name})
 		require.Error(t, err)
-		assert.ErrorIs(t, err, ErrForbidden)
+		assert.ErrorIs(t, err, authn.ErrForbidden)
 
 		require.NoError(t, dbMock.ExpectationsWereMet())
 	})
@@ -2195,19 +2196,19 @@ func TestControllerDeleteProject(t *testing.T) {
 		defer closeDB()
 
 		ctx := newContextWithTestUser(context.Background())
-		mAuthedUser, isAuthed := AuthedUserFromContext(ctx)
-		require.True(t, isAuthed)
+		mUser, ok := authn.UserFromContext(ctx)
+		require.True(t, ok)
 
 		mProject := model.Project{
 			Model:      model.Model{ID: 1},
-			OwnerID:    mAuthedUser.ID,
+			OwnerID:    mUser.ID,
 			Name:       "testproject",
 			Visibility: model.VisibilityPublic,
 		}
 
 		dbMockStmt := ctrl.db.Session(&gorm.Session{DryRun: true}).
 			Joins("JOIN user ON user.id = project.owner_id").
-			Where("user.username = ?", mAuthedUser.Username).
+			Where("user.username = ?", mUser.Username).
 			Where("project.name = ?", mProject.Name).
 			First(&model.Project{}).
 			Statement
@@ -2217,13 +2218,13 @@ func TestControllerDeleteProject(t *testing.T) {
 			WillReturnRows(sqlmock.NewRows(projectDBColumns).AddRows(generateProjectDBRows(mProject)...))
 
 		dbMockStmt = ctrl.db.Session(&gorm.Session{DryRun: true}).
-			Where("`user`.`id` = ?", mAuthedUser.ID).
+			Where("`user`.`id` = ?", mUser.ID).
 			Find(&model.User{}).
 			Statement
 		dbMockArgs = modeltest.ToDriverValueSlice(dbMockStmt.Vars...)
 		dbMock.ExpectQuery(regexp.QuoteMeta(dbMockStmt.SQL.String())).
 			WithArgs(dbMockArgs...).
-			WillReturnRows(sqlmock.NewRows(userDBColumns).AddRows(generateUserDBRows(*mAuthedUser)...))
+			WillReturnRows(sqlmock.NewRows(userDBColumns).AddRows(generateUserDBRows(*mUser)...))
 
 		dbMock.ExpectBegin()
 
@@ -2247,7 +2248,7 @@ func TestControllerDeleteProject(t *testing.T) {
 
 		dbMock.ExpectRollback()
 
-		projectFullName := ProjectFullName{Owner: mAuthedUser.Username, Project: mProject.Name}
+		projectFullName := ProjectFullName{Owner: mUser.Username, Project: mProject.Name}
 		err := ctrl.DeleteProject(ctx, projectFullName)
 		require.Error(t, err)
 		assert.EqualError(t, err, fmt.Sprintf("failed to delete project %q: %s", projectFullName, "delete failed"))
@@ -2274,8 +2275,8 @@ func TestControllerRecordProjectView(t *testing.T) {
 		defer closeDB()
 
 		ctx := newContextWithTestUser(context.Background())
-		mAuthedUser, isAuthed := AuthedUserFromContext(ctx)
-		require.True(t, isAuthed)
+		mUser, ok := authn.UserFromContext(ctx)
+		require.True(t, ok)
 
 		mProjectOwnerUsername := "otheruser"
 
@@ -2297,7 +2298,7 @@ func TestControllerRecordProjectView(t *testing.T) {
 			WillReturnRows(sqlmock.NewRows(projectDBColumns).AddRows(generateProjectDBRows(mProject)...))
 
 		dbMockStmt = ctrl.db.Session(&gorm.Session{DryRun: true}).
-			Where("user_id = ?", mAuthedUser.ID).
+			Where("user_id = ?", mUser.ID).
 			Where("project_id = ?", mProject.ID).
 			First(&model.UserProjectRelationship{}).
 			Statement
@@ -2310,7 +2311,7 @@ func TestControllerRecordProjectView(t *testing.T) {
 
 		dbMockStmt = ctrl.db.Session(&gorm.Session{DryRun: true, SkipDefaultTransaction: true}).
 			Create(&model.UserProjectRelationship{
-				UserID:    mAuthedUser.ID,
+				UserID:    mUser.ID,
 				ProjectID: mProject.ID,
 			}).
 			Statement
@@ -2362,8 +2363,8 @@ func TestControllerRecordProjectView(t *testing.T) {
 		defer closeDB()
 
 		ctx := newContextWithTestUser(context.Background())
-		mAuthedUser, isAuthed := AuthedUserFromContext(ctx)
-		require.True(t, isAuthed)
+		mUser, ok := authn.UserFromContext(ctx)
+		require.True(t, ok)
 
 		mProjectOwnerUsername := "otheruser"
 
@@ -2387,7 +2388,7 @@ func TestControllerRecordProjectView(t *testing.T) {
 			WillReturnRows(sqlmock.NewRows(projectDBColumns).AddRows(generateProjectDBRows(mProject)...))
 
 		dbMockStmt = ctrl.db.Session(&gorm.Session{DryRun: true}).
-			Where("user_id = ?", mAuthedUser.ID).
+			Where("user_id = ?", mUser.ID).
 			Where("project_id = ?", mProject.ID).
 			First(&model.UserProjectRelationship{}).
 			Statement
@@ -2396,7 +2397,7 @@ func TestControllerRecordProjectView(t *testing.T) {
 			WithArgs(dbMockArgs...).
 			WillReturnRows(sqlmock.NewRows(userProjectRelationshipDBColumns).AddRows(generateUserProjectRelationshipDBRows(model.UserProjectRelationship{
 				Model:        model.Model{ID: 1},
-				UserID:       mAuthedUser.ID,
+				UserID:       mUser.ID,
 				ProjectID:    mProject.ID,
 				LastViewedAt: sql.NullTime{Valid: true, Time: recentViewTime},
 			})...))
@@ -2413,7 +2414,7 @@ func TestControllerRecordProjectView(t *testing.T) {
 
 		err := ctrl.RecordProjectView(context.Background(), ProjectFullName{Owner: "otheruser", Project: "testproject"})
 		require.Error(t, err)
-		assert.ErrorIs(t, err, ErrUnauthorized)
+		assert.ErrorIs(t, err, authn.ErrUnauthorized)
 	})
 
 	t.Run("ProjectNotFound", func(t *testing.T) {
@@ -2462,8 +2463,8 @@ func TestControllerLikeProject(t *testing.T) {
 		defer closeDB()
 
 		ctx := newContextWithTestUser(context.Background())
-		mAuthedUser, isAuthed := AuthedUserFromContext(ctx)
-		require.True(t, isAuthed)
+		mUser, ok := authn.UserFromContext(ctx)
+		require.True(t, ok)
 
 		mProjectOwnerUsername := "otheruser"
 
@@ -2485,7 +2486,7 @@ func TestControllerLikeProject(t *testing.T) {
 			WillReturnRows(sqlmock.NewRows(projectDBColumns).AddRows(generateProjectDBRows(mProject)...))
 
 		dbMockStmt = ctrl.db.Session(&gorm.Session{DryRun: true}).
-			Where("user_id = ?", mAuthedUser.ID).
+			Where("user_id = ?", mUser.ID).
 			Where("project_id = ?", mProject.ID).
 			First(&model.UserProjectRelationship{}).
 			Statement
@@ -2498,7 +2499,7 @@ func TestControllerLikeProject(t *testing.T) {
 
 		dbMockStmt = ctrl.db.Session(&gorm.Session{DryRun: true, SkipDefaultTransaction: true}).
 			Create(&model.UserProjectRelationship{
-				UserID:    mAuthedUser.ID,
+				UserID:    mUser.ID,
 				ProjectID: mProject.ID,
 			}).
 			Statement
@@ -2527,7 +2528,7 @@ func TestControllerLikeProject(t *testing.T) {
 			WillReturnResult(sqlmock.NewResult(0, 1))
 
 		dbMockStmt = ctrl.db.Session(&gorm.Session{DryRun: true, SkipDefaultTransaction: true}).
-			Model(&model.User{Model: mAuthedUser.Model}).
+			Model(&model.User{Model: mUser.Model}).
 			UpdateColumn("liked_project_count", gorm.Expr("liked_project_count + 1")).
 			Statement
 		dbMockArgs = modeltest.ToDriverValueSlice(dbMockStmt.Vars...)
@@ -2557,8 +2558,8 @@ func TestControllerLikeProject(t *testing.T) {
 		defer closeDB()
 
 		ctx := newContextWithTestUser(context.Background())
-		mAuthedUser, isAuthed := AuthedUserFromContext(ctx)
-		require.True(t, isAuthed)
+		mUser, ok := authn.UserFromContext(ctx)
+		require.True(t, ok)
 
 		mProjectOwnerUsername := "otheruser"
 
@@ -2580,7 +2581,7 @@ func TestControllerLikeProject(t *testing.T) {
 			WillReturnRows(sqlmock.NewRows(projectDBColumns).AddRows(generateProjectDBRows(mProject)...))
 
 		dbMockStmt = ctrl.db.Session(&gorm.Session{DryRun: true}).
-			Where("user_id = ?", mAuthedUser.ID).
+			Where("user_id = ?", mUser.ID).
 			Where("project_id = ?", mProject.ID).
 			First(&model.UserProjectRelationship{}).
 			Statement
@@ -2589,7 +2590,7 @@ func TestControllerLikeProject(t *testing.T) {
 			WithArgs(dbMockArgs...).
 			WillReturnRows(sqlmock.NewRows(userProjectRelationshipDBColumns).AddRows(generateUserProjectRelationshipDBRows(model.UserProjectRelationship{
 				Model:     model.Model{ID: 1},
-				UserID:    mAuthedUser.ID,
+				UserID:    mUser.ID,
 				ProjectID: mProject.ID,
 				LikedAt:   sql.NullTime{Valid: true, Time: time.Now()},
 			})...))
@@ -2606,7 +2607,7 @@ func TestControllerLikeProject(t *testing.T) {
 
 		err := ctrl.LikeProject(context.Background(), ProjectFullName{Owner: "otheruser", Project: "testproject"})
 		require.Error(t, err)
-		assert.ErrorIs(t, err, ErrUnauthorized)
+		assert.ErrorIs(t, err, authn.ErrUnauthorized)
 	})
 
 	t.Run("ProjectNotFound", func(t *testing.T) {
@@ -2651,8 +2652,8 @@ func TestControllerHasLikedProject(t *testing.T) {
 		defer closeDB()
 
 		ctx := newContextWithTestUser(context.Background())
-		mAuthedUser, isAuthed := AuthedUserFromContext(ctx)
-		require.True(t, isAuthed)
+		mUser, ok := authn.UserFromContext(ctx)
+		require.True(t, ok)
 
 		mProjectOwnerUsername := "otheruser"
 
@@ -2675,7 +2676,7 @@ func TestControllerHasLikedProject(t *testing.T) {
 
 		dbMockStmt = ctrl.db.Session(&gorm.Session{DryRun: true}).
 			Select("id").
-			Where("user_id = ?", mAuthedUser.ID).
+			Where("user_id = ?", mUser.ID).
 			Where("project_id = ?", mProject.ID).
 			Where("liked_at IS NOT NULL").
 			First(&model.UserProjectRelationship{}).
@@ -2697,8 +2698,8 @@ func TestControllerHasLikedProject(t *testing.T) {
 		defer closeDB()
 
 		ctx := newContextWithTestUser(context.Background())
-		mAuthedUser, isAuthed := AuthedUserFromContext(ctx)
-		require.True(t, isAuthed)
+		mUser, ok := authn.UserFromContext(ctx)
+		require.True(t, ok)
 
 		mProjectOwnerUsername := "otheruser"
 
@@ -2721,7 +2722,7 @@ func TestControllerHasLikedProject(t *testing.T) {
 
 		dbMockStmt = ctrl.db.Session(&gorm.Session{DryRun: true}).
 			Select("id").
-			Where("user_id = ?", mAuthedUser.ID).
+			Where("user_id = ?", mUser.ID).
 			Where("project_id = ?", mProject.ID).
 			Where("liked_at IS NOT NULL").
 			First(&model.UserProjectRelationship{}).
@@ -2793,8 +2794,8 @@ func TestControllerUnlikeProject(t *testing.T) {
 		defer closeDB()
 
 		ctx := newContextWithTestUser(context.Background())
-		mAuthedUser, isAuthed := AuthedUserFromContext(ctx)
-		require.True(t, isAuthed)
+		mUser, ok := authn.UserFromContext(ctx)
+		require.True(t, ok)
 
 		mProjectOwnerUsername := "otheruser"
 
@@ -2816,7 +2817,7 @@ func TestControllerUnlikeProject(t *testing.T) {
 			WillReturnRows(sqlmock.NewRows(projectDBColumns).AddRows(generateProjectDBRows(mProject)...))
 
 		dbMockStmt = ctrl.db.Session(&gorm.Session{DryRun: true}).
-			Where("user_id = ?", mAuthedUser.ID).
+			Where("user_id = ?", mUser.ID).
 			Where("project_id = ?", mProject.ID).
 			First(&model.UserProjectRelationship{}).
 			Statement
@@ -2825,7 +2826,7 @@ func TestControllerUnlikeProject(t *testing.T) {
 			WithArgs(dbMockArgs...).
 			WillReturnRows(sqlmock.NewRows(userProjectRelationshipDBColumns).AddRows(generateUserProjectRelationshipDBRows(model.UserProjectRelationship{
 				Model:     model.Model{ID: 1},
-				UserID:    mAuthedUser.ID,
+				UserID:    mUser.ID,
 				ProjectID: mProject.ID,
 				LikedAt:   sql.NullTime{Valid: true, Time: time.Now()},
 			})...))
@@ -2846,7 +2847,7 @@ func TestControllerUnlikeProject(t *testing.T) {
 			WillReturnResult(sqlmock.NewResult(0, 1))
 
 		dbMockStmt = ctrl.db.Session(&gorm.Session{DryRun: true, SkipDefaultTransaction: true}).
-			Model(&model.User{Model: mAuthedUser.Model}).
+			Model(&model.User{Model: mUser.Model}).
 			UpdateColumn("liked_project_count", gorm.Expr("liked_project_count - 1")).
 			Statement
 		dbMockArgs = modeltest.ToDriverValueSlice(dbMockStmt.Vars...)
@@ -2876,8 +2877,8 @@ func TestControllerUnlikeProject(t *testing.T) {
 		defer closeDB()
 
 		ctx := newContextWithTestUser(context.Background())
-		mAuthedUser, isAuthed := AuthedUserFromContext(ctx)
-		require.True(t, isAuthed)
+		mUser, ok := authn.UserFromContext(ctx)
+		require.True(t, ok)
 
 		mProjectOwnerUsername := "otheruser"
 
@@ -2899,7 +2900,7 @@ func TestControllerUnlikeProject(t *testing.T) {
 			WillReturnRows(sqlmock.NewRows(projectDBColumns).AddRows(generateProjectDBRows(mProject)...))
 
 		dbMockStmt = ctrl.db.Session(&gorm.Session{DryRun: true}).
-			Where("user_id = ?", mAuthedUser.ID).
+			Where("user_id = ?", mUser.ID).
 			Where("project_id = ?", mProject.ID).
 			First(&model.UserProjectRelationship{}).
 			Statement
@@ -2908,7 +2909,7 @@ func TestControllerUnlikeProject(t *testing.T) {
 			WithArgs(dbMockArgs...).
 			WillReturnRows(sqlmock.NewRows(userProjectRelationshipDBColumns).AddRows(generateUserProjectRelationshipDBRows(model.UserProjectRelationship{
 				Model:     model.Model{ID: 1},
-				UserID:    mAuthedUser.ID,
+				UserID:    mUser.ID,
 				ProjectID: mProject.ID,
 				LikedAt:   sql.NullTime{Valid: false},
 			})...))
@@ -2925,7 +2926,7 @@ func TestControllerUnlikeProject(t *testing.T) {
 
 		err := ctrl.UnlikeProject(context.Background(), ProjectFullName{Owner: "otheruser", Project: "testproject"})
 		require.Error(t, err)
-		assert.ErrorIs(t, err, ErrUnauthorized)
+		assert.ErrorIs(t, err, authn.ErrUnauthorized)
 	})
 
 	t.Run("ProjectNotFound", func(t *testing.T) {

--- a/spx-backend/internal/controller/workflow.go
+++ b/spx-backend/internal/controller/workflow.go
@@ -19,7 +19,7 @@ type WorkflowMessageParams struct {
 	GenerateMessageParams
 }
 
-// GenerateStream generates response message based on input messages.
+// WorkflowMessageStream generates response message based on input messages.
 func (ctrl *Controller) WorkflowMessageStream(ctx context.Context, params *WorkflowMessageParams) (io.ReadCloser, error) {
 	logger := log.GetReqLogger(ctx)
 

--- a/spx-backend/internal/model/user_test.go
+++ b/spx-backend/internal/model/user_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
-	"github.com/casdoor/casdoor-go-sdk/casdoorsdk"
 	"github.com/goplus/builder/spx-backend/internal/model/modeltest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -23,17 +22,17 @@ func TestFirstOrCreateUser(t *testing.T) {
 	generateUserDBRows, err := modeltest.NewDBRowsGenerator(db, User{})
 	require.NoError(t, err)
 
-	expectedCasdoorUser := casdoorsdk.User{
-		Name:        "john",
+	expectedParams := CreateUserParams{
+		Username:    "john",
 		DisplayName: "John Doe",
 		Avatar:      "https://example.com/avatar.jpg",
 	}
 
 	mExpectedUser := User{
 		Model:              Model{ID: 1},
-		Username:           expectedCasdoorUser.Name,
-		DisplayName:        expectedCasdoorUser.DisplayName,
-		Avatar:             expectedCasdoorUser.Avatar,
+		Username:           expectedParams.Username,
+		DisplayName:        expectedParams.DisplayName,
+		Avatar:             expectedParams.Avatar,
 		Description:        "I'm John",
 		FollowerCount:      10,
 		FollowingCount:     5,
@@ -56,7 +55,7 @@ func TestFirstOrCreateUser(t *testing.T) {
 			WithArgs(dbMockArgs...).
 			WillReturnRows(sqlmock.NewRows(userDBColumns).AddRows(generateUserDBRows(mExpectedUser)...))
 
-		mUser, err := FirstOrCreateUser(context.Background(), db, &expectedCasdoorUser)
+		mUser, err := FirstOrCreateUser(context.Background(), db, expectedParams)
 		require.NoError(t, err)
 		assert.Equal(t, mExpectedUser, *mUser)
 
@@ -104,7 +103,7 @@ func TestFirstOrCreateUser(t *testing.T) {
 			WithArgs(dbMockArgs...).
 			WillReturnRows(sqlmock.NewRows(userDBColumns).AddRows(generateUserDBRows(mExpectedUser)...))
 
-		mUser, err := FirstOrCreateUser(context.Background(), db, &expectedCasdoorUser)
+		mUser, err := FirstOrCreateUser(context.Background(), db, expectedParams)
 		require.NoError(t, err)
 		assert.Equal(t, mExpectedUser, *mUser)
 


### PR DESCRIPTION
- Create dedicated authn module with `Authenticator` interface and Casdoor integration.
- Implement authentication middleware with soft-fail strategy.
- Replace inline authentication logic in controller with authn module usage.
- Extract user creation parameters into `model.CreateUserParams`.