### PR TITLE
refactor(spx-backend): extract configuration management from controller

### DIFF
--- a/spx-backend/cmd/spx-backend/main.yap
+++ b/spx-backend/cmd/spx-backend/main.yap
@@ -2,16 +2,17 @@ import (
 	"context"
 	"errors"
 	"net/http"
-	"os"
 	"os/signal"
 	"strconv"
 	"syscall"
 	"time"
 
 	"github.com/goplus/builder/spx-backend/internal/authn"
+	"github.com/goplus/builder/spx-backend/internal/authn/casdoor"
+	"github.com/goplus/builder/spx-backend/internal/config"
 	"github.com/goplus/builder/spx-backend/internal/controller"
-	"github.com/goplus/builder/spx-backend/internal/model"
 	"github.com/goplus/builder/spx-backend/internal/log"
+	"github.com/goplus/builder/spx-backend/internal/model"
 )
 
 const (
@@ -21,24 +22,38 @@ const (
 
 var (
 	ctrl *controller.Controller
-	err error
+	err  error
 )
 
 logger := log.GetLogger()
 
-ctrl, err = controller.New(context.Background())
+// Load configuration.
+cfg, err := config.Load(logger)
 if err != nil {
-	logger.Fatalln("Failed to create a new controller:", err)
+	logger.Fatalln("failed to load configuration:", err)
 }
 
-port := os.Getenv("PORT")
-if port == "" {
-	port = ":8080"
+// Initialize database.
+db, err := model.OpenDB(context.Background(), cfg.Database.DSN, 0, 0)
+if err != nil {
+	logger.Fatalln("failed to open database:", err)
 }
-logger.Printf("Listening to %s", port)
+// TODO: Configure connection pool and timeouts.
+
+// Initialize controller.
+ctrl, err = controller.New(context.Background(), db, cfg)
+if err != nil {
+	logger.Fatalln("failed to create a new controller:", err)
+}
+
+// Initialize authenticator.
+authenticator := casdoor.New(db, cfg.Casdoor)
+
+port := cfg.Server.GetPort()
+logger.Printf("listening to %s", port)
 
 h := handler(
-	authn.Middleware(ctrl.Authenticator()),
+	authn.Middleware(authenticator),
 	NewReqIDMiddleware(),
 	NewCORSMiddleware(),
 )
@@ -53,11 +68,11 @@ go func() {
 }()
 <-stopCtx.Done()
 if serverErr != nil && !errors.Is(serverErr, http.ErrServerClosed) {
-	logger.Fatalln("Server error:", serverErr)
+	logger.Fatalln("server error:", serverErr)
 }
 
 shutdownCtx, cancel := context.WithTimeout(context.Background(), time.Minute)
 defer cancel()
 if err := server.Shutdown(shutdownCtx); err != nil {
-	logger.Fatalln("Failed to gracefully shut down:", err)
+	logger.Fatalln("failed to gracefully shut down:", err)
 }

--- a/spx-backend/internal/authn/casdoor/casdoor.go
+++ b/spx-backend/internal/authn/casdoor/casdoor.go
@@ -7,19 +7,11 @@ import (
 
 	"github.com/casdoor/casdoor-go-sdk/casdoorsdk"
 	"github.com/goplus/builder/spx-backend/internal/authn"
+	"github.com/goplus/builder/spx-backend/internal/config"
 	"github.com/goplus/builder/spx-backend/internal/model"
 	"gorm.io/gorm"
 )
 
-// Config is the configuration for the Casdoor authenticator.
-type Config struct {
-	Endpoint         string
-	ClientID         string
-	ClientSecret     string
-	Certificate      string
-	OrganizationName string
-	ApplicationName  string
-}
 
 // client defines the interface for Casdoor client operations.
 type client interface {
@@ -34,7 +26,7 @@ type authenticator struct {
 }
 
 // New creates a new Casdoor authenticator.
-func New(cfg Config, db *gorm.DB) authn.Authenticator {
+func New(db *gorm.DB, cfg config.CasdoorConfig) authn.Authenticator {
 	client := casdoorsdk.NewClientWithConf(&casdoorsdk.AuthConfig{
 		Endpoint:         cfg.Endpoint,
 		ClientId:         cfg.ClientID,

--- a/spx-backend/internal/authn/casdoor/casdoor_test.go
+++ b/spx-backend/internal/authn/casdoor/casdoor_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/casdoor/casdoor-go-sdk/casdoorsdk"
 	"github.com/goplus/builder/spx-backend/internal/authn"
+	"github.com/goplus/builder/spx-backend/internal/config"
 	"github.com/goplus/builder/spx-backend/internal/model"
 	"github.com/goplus/builder/spx-backend/internal/model/modeltest"
 	"github.com/stretchr/testify/assert"
@@ -50,8 +51,8 @@ func (mc *mockClient) GetUser(name string) (*casdoorsdk.User, error) {
 	}, nil
 }
 
-func newTestConfig() Config {
-	return Config{
+func newTestConfig() config.CasdoorConfig {
+	return config.CasdoorConfig{
 		Endpoint:         "https://example.com",
 		ClientID:         "test-client-id",
 		ClientSecret:     "test-client-secret",
@@ -89,7 +90,7 @@ func setupTestAuthenticator(
 	client := newMockClient()
 	client.parseJwtTokenFunc = parseTokenFunc
 	client.getUserFunc = getUserFunc
-	auth := New(newTestConfig(), db).(*authenticator)
+	auth := New(db, newTestConfig()).(*authenticator)
 	auth.client = client
 	return auth
 }
@@ -128,7 +129,7 @@ func TestNew(t *testing.T) {
 		require.NoError(t, err)
 		defer closeDB()
 
-		auth := New(newTestConfig(), db)
+		auth := New(db, newTestConfig())
 
 		assert.NotNil(t, auth)
 		assert.IsType(t, &authenticator{}, auth)

--- a/spx-backend/internal/config/config.go
+++ b/spx-backend/internal/config/config.go
@@ -1,0 +1,88 @@
+package config
+
+// Config holds all configuration for the application.
+type Config struct {
+	Server   ServerConfig
+	Database DatabaseConfig
+	Kodo     KodoConfig
+	Casdoor  CasdoorConfig
+	OpenAI   OpenAIConfig
+	AIGC     AIGCConfig
+}
+
+// ServerConfig holds server configuration.
+type ServerConfig struct {
+	Port string
+}
+
+// GetPort returns the server port, defaulting to ":8080" if not set.
+func (c *ServerConfig) GetPort() string {
+	if c.Port != "" {
+		return c.Port
+	}
+	return ":8080"
+}
+
+// DatabaseConfig holds database configuration.
+type DatabaseConfig struct {
+	DSN string
+}
+
+// KodoConfig holds Kodo storage configuration.
+type KodoConfig struct {
+	AccessKey    string
+	SecretKey    string
+	Bucket       string
+	BucketRegion string
+	BaseURL      string
+}
+
+// CasdoorConfig holds Casdoor authentication configuration.
+type CasdoorConfig struct {
+	Endpoint         string
+	ClientID         string
+	ClientSecret     string
+	Certificate      string
+	OrganizationName string
+	ApplicationName  string
+}
+
+// OpenAIConfig holds OpenAI API configuration.
+type OpenAIConfig struct {
+	APIKey      string
+	APIEndpoint string
+	ModelID     string
+
+	PremiumAPIKey      string
+	PremiumAPIEndpoint string
+	PremiumModelID     string
+}
+
+// GetPremiumAPIKey returns the premium API key, falling back to standard API key.
+func (c *OpenAIConfig) GetPremiumAPIKey() string {
+	if c.PremiumAPIKey != "" {
+		return c.PremiumAPIKey
+	}
+	return c.APIKey
+}
+
+// GetPremiumAPIEndpoint returns the premium API endpoint, falling back to standard endpoint.
+func (c *OpenAIConfig) GetPremiumAPIEndpoint() string {
+	if c.PremiumAPIEndpoint != "" {
+		return c.PremiumAPIEndpoint
+	}
+	return c.APIEndpoint
+}
+
+// GetPremiumModelID returns the premium model ID, falling back to standard model ID.
+func (c *OpenAIConfig) GetPremiumModelID() string {
+	if c.PremiumModelID != "" {
+		return c.PremiumModelID
+	}
+	return c.ModelID
+}
+
+// AIGCConfig holds AIGC service configuration.
+type AIGCConfig struct {
+	Endpoint string
+}

--- a/spx-backend/internal/config/config_test.go
+++ b/spx-backend/internal/config/config_test.go
@@ -1,0 +1,77 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestServerConfigGetPort(t *testing.T) {
+	t.Run("WithCustomPort", func(t *testing.T) {
+		cfg := &ServerConfig{
+			Port: ":9090",
+		}
+		assert.Equal(t, ":9090", cfg.GetPort())
+	})
+
+	t.Run("WithoutCustomPort", func(t *testing.T) {
+		cfg := &ServerConfig{
+			Port: "",
+		}
+		assert.Equal(t, ":8080", cfg.GetPort())
+	})
+}
+
+func TestOpenAIConfigGetPremiumAPIKey(t *testing.T) {
+	t.Run("WithPremiumKey", func(t *testing.T) {
+		cfg := &OpenAIConfig{
+			APIKey:        "standard-key",
+			PremiumAPIKey: "premium-key",
+		}
+		assert.Equal(t, "premium-key", cfg.GetPremiumAPIKey())
+	})
+
+	t.Run("WithoutPremiumKey", func(t *testing.T) {
+		cfg := &OpenAIConfig{
+			APIKey:        "standard-key",
+			PremiumAPIKey: "",
+		}
+		assert.Equal(t, "standard-key", cfg.GetPremiumAPIKey())
+	})
+}
+
+func TestOpenAIConfigGetPremiumAPIEndpoint(t *testing.T) {
+	t.Run("WithPremiumEndpoint", func(t *testing.T) {
+		cfg := &OpenAIConfig{
+			APIEndpoint:        "https://api.openai.com/v1",
+			PremiumAPIEndpoint: "https://premium.openai.com/v1",
+		}
+		assert.Equal(t, "https://premium.openai.com/v1", cfg.GetPremiumAPIEndpoint())
+	})
+
+	t.Run("WithoutPremiumEndpoint", func(t *testing.T) {
+		cfg := &OpenAIConfig{
+			APIEndpoint:        "https://api.openai.com/v1",
+			PremiumAPIEndpoint: "",
+		}
+		assert.Equal(t, "https://api.openai.com/v1", cfg.GetPremiumAPIEndpoint())
+	})
+}
+
+func TestOpenAIConfigGetPremiumModelID(t *testing.T) {
+	t.Run("WithPremiumModel", func(t *testing.T) {
+		cfg := &OpenAIConfig{
+			ModelID:        "gpt-3.5-turbo",
+			PremiumModelID: "gpt-4",
+		}
+		assert.Equal(t, "gpt-4", cfg.GetPremiumModelID())
+	})
+
+	t.Run("WithoutPremiumModel", func(t *testing.T) {
+		cfg := &OpenAIConfig{
+			ModelID:        "gpt-3.5-turbo",
+			PremiumModelID: "",
+		}
+		assert.Equal(t, "gpt-3.5-turbo", cfg.GetPremiumModelID())
+	})
+}

--- a/spx-backend/internal/config/loader.go
+++ b/spx-backend/internal/config/loader.go
@@ -1,0 +1,64 @@
+package config
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+
+	"github.com/joho/godotenv"
+	"github.com/qiniu/x/log"
+)
+
+// Load loads the configuration from environment variables.
+func Load(logger *log.Logger) (*Config, error) {
+	// Load .env file if it exists.
+	if err := godotenv.Load(); err != nil && !errors.Is(err, fs.ErrNotExist) {
+		logger.Printf("failed to load env: %v", err)
+		return nil, err
+	}
+
+	config := &Config{
+		Server: ServerConfig{
+			Port: os.Getenv("PORT"),
+		},
+		Database: DatabaseConfig{
+			DSN: mustEnv(logger, "GOP_SPX_DSN"),
+		},
+		Kodo: KodoConfig{
+			AccessKey:    mustEnv(logger, "KODO_AK"),
+			SecretKey:    mustEnv(logger, "KODO_SK"),
+			Bucket:       mustEnv(logger, "KODO_BUCKET"),
+			BucketRegion: mustEnv(logger, "KODO_BUCKET_REGION"),
+			BaseURL:      mustEnv(logger, "KODO_BASE_URL"),
+		},
+		Casdoor: CasdoorConfig{
+			Endpoint:         mustEnv(logger, "GOP_CASDOOR_ENDPOINT"),
+			ClientID:         mustEnv(logger, "GOP_CASDOOR_CLIENTID"),
+			ClientSecret:     mustEnv(logger, "GOP_CASDOOR_CLIENTSECRET"),
+			Certificate:      mustEnv(logger, "GOP_CASDOOR_CERTIFICATE"),
+			OrganizationName: mustEnv(logger, "GOP_CASDOOR_ORGANIZATIONNAME"),
+			ApplicationName:  mustEnv(logger, "GOP_CASDOOR_APPLICATIONNAME"),
+		},
+		OpenAI: OpenAIConfig{
+			APIKey:             mustEnv(logger, "OPENAI_API_KEY"),
+			APIEndpoint:        mustEnv(logger, "OPENAI_API_ENDPOINT"),
+			ModelID:            mustEnv(logger, "OPENAI_MODEL_ID"),
+			PremiumAPIKey:      os.Getenv("OPENAI_PREMIUM_API_KEY"),
+			PremiumAPIEndpoint: os.Getenv("OPENAI_PREMIUM_API_ENDPOINT"),
+			PremiumModelID:     os.Getenv("OPENAI_PREMIUM_MODEL_ID"),
+		},
+		AIGC: AIGCConfig{
+			Endpoint: mustEnv(logger, "AIGC_ENDPOINT"),
+		},
+	}
+	return config, nil
+}
+
+// mustEnv gets the environment variable value or exits the program.
+func mustEnv(logger *log.Logger, key string) string {
+	value := os.Getenv(key)
+	if value == "" {
+		logger.Fatalf("missing required environment variable: %s", key)
+	}
+	return value
+}

--- a/spx-backend/internal/controller/aigc.go
+++ b/spx-backend/internal/controller/aigc.go
@@ -68,7 +68,7 @@ func (ctrl *Controller) Matting(ctx context.Context, params *MattingParams) (*Ma
 	var aigcResult struct {
 		ImageUrl string `json:"image_url"`
 	}
-	err := ctrl.aigcClient.Call(ctx, http.MethodPost, "/matting", &aigcParams, &aigcResult)
+	err := ctrl.aigc.Call(ctx, http.MethodPost, "/matting", &aigcParams, &aigcResult)
 	if err != nil {
 		logger.Printf("failed to call: %v", err)
 		return nil, err


### PR DESCRIPTION
- Create dedicated `config` package with structured configuration types.
- Remove duplicate `casdoor.Config` and unify with `config.CasdoorConfig`.
- Decouple authenticator initialization from controller.
- Simplify controller by removing global resource management responsibilities.
- Rename `kodoConfig` to `kodoClient` for better semantic clarity.

Fixes #1818