### PR TITLE
refactor(spx-backend): improve type safety and validation for API parameters

### DIFF
--- a/spx-backend/cmd/spx-backend/get_assets_list.yap
+++ b/spx-backend/cmd/spx-backend/get_assets_list.yap
@@ -5,6 +5,7 @@
 
 import (
 	"github.com/goplus/builder/spx-backend/internal/controller"
+	"github.com/goplus/builder/spx-backend/internal/model"
 )
 
 ctx := &Context
@@ -29,7 +30,12 @@ default:
 }
 
 if typeParam := ctx.Param("type"); typeParam != "" {
-	params.Type = &typeParam
+	at, err := model.ParseAssetType(typeParam)
+	if err != nil {
+		replyWithCodeMsg(ctx, errorInvalidArgs, "invalid type")
+		return
+	}
+	params.Type = &at
 }
 
 if category := ${category}; category != "" {
@@ -41,7 +47,12 @@ if filesHash := ${filesHash}; filesHash != "" {
 }
 
 if visibility := ${visibility}; visibility != "" {
-	params.Visibility = &visibility
+	v, err := model.ParseVisibility(visibility)
+	if err != nil {
+		replyWithCodeMsg(ctx, errorInvalidArgs, "invalid visibility")
+		return
+	}
+	params.Visibility = &v
 }
 
 if orderBy := ${orderBy}; orderBy != "" {

--- a/spx-backend/cmd/spx-backend/get_projects_list.yap
+++ b/spx-backend/cmd/spx-backend/get_projects_list.yap
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/goplus/builder/spx-backend/internal/controller"
+	"github.com/goplus/builder/spx-backend/internal/model"
 )
 
 ctx := &Context
@@ -41,7 +42,12 @@ if keyword := ${keyword}; keyword != "" {
 }
 
 if visibility := ${visibility}; visibility != "" {
-	params.Visibility = &visibility
+	v, err := model.ParseVisibility(visibility)
+	if err != nil {
+		replyWithCodeMsg(ctx, errorInvalidArgs, "invalid visibility")
+		return
+	}
+	params.Visibility = &v
 }
 
 if liker := ${liker}; liker != "" {

--- a/spx-backend/cmd/spx-backend/xgo_autogen.go
+++ b/spx-backend/cmd/spx-backend/xgo_autogen.go
@@ -402,109 +402,127 @@ func (this *get_asset_id) Classclone() yap.HandlerProto {
 	_xgo_ret := *this
 	return &_xgo_ret
 }
-//line cmd/spx-backend/get_assets_list.yap:10
+//line cmd/spx-backend/get_assets_list.yap:11
 func (this *get_assets_list) Main(_xgo_arg0 *yap.Context) {
 	this.Handler.Main(_xgo_arg0)
-//line cmd/spx-backend/get_assets_list.yap:10:1
+//line cmd/spx-backend/get_assets_list.yap:11:1
 	ctx := &this.Context
-//line cmd/spx-backend/get_assets_list.yap:12:1
+//line cmd/spx-backend/get_assets_list.yap:13:1
 	params := controller.NewListAssetsParams()
-//line cmd/spx-backend/get_assets_list.yap:14:1
-	if
-//line cmd/spx-backend/get_assets_list.yap:14:1
-	keyword := this.Gop_Env("keyword"); keyword != "" {
 //line cmd/spx-backend/get_assets_list.yap:15:1
+	if
+//line cmd/spx-backend/get_assets_list.yap:15:1
+	keyword := this.Gop_Env("keyword"); keyword != "" {
+//line cmd/spx-backend/get_assets_list.yap:16:1
 		params.Keyword = &keyword
 	}
-//line cmd/spx-backend/get_assets_list.yap:18:1
-	switch
-//line cmd/spx-backend/get_assets_list.yap:18:1
-	owner := this.Gop_Env("owner"); owner {
 //line cmd/spx-backend/get_assets_list.yap:19:1
-	case "":
+	switch
+//line cmd/spx-backend/get_assets_list.yap:19:1
+	owner := this.Gop_Env("owner"); owner {
 //line cmd/spx-backend/get_assets_list.yap:20:1
-		mUser, ok := ensureAuthenticatedUser(ctx)
+	case "":
 //line cmd/spx-backend/get_assets_list.yap:21:1
-		if !ok {
+		mUser, ok := ensureAuthenticatedUser(ctx)
 //line cmd/spx-backend/get_assets_list.yap:22:1
+		if !ok {
+//line cmd/spx-backend/get_assets_list.yap:23:1
 			return
 		}
-//line cmd/spx-backend/get_assets_list.yap:24:1
-		params.Owner = &mUser.Username
 //line cmd/spx-backend/get_assets_list.yap:25:1
-	case "*":
+		params.Owner = &mUser.Username
 //line cmd/spx-backend/get_assets_list.yap:26:1
-		params.Owner = nil
+	case "*":
 //line cmd/spx-backend/get_assets_list.yap:27:1
-	default:
+		params.Owner = nil
 //line cmd/spx-backend/get_assets_list.yap:28:1
+	default:
+//line cmd/spx-backend/get_assets_list.yap:29:1
 		params.Owner = &owner
 	}
-//line cmd/spx-backend/get_assets_list.yap:31:1
-	if
-//line cmd/spx-backend/get_assets_list.yap:31:1
-	typeParam := ctx.Param("type"); typeParam != "" {
 //line cmd/spx-backend/get_assets_list.yap:32:1
-		params.Type = &typeParam
-	}
-//line cmd/spx-backend/get_assets_list.yap:35:1
 	if
+//line cmd/spx-backend/get_assets_list.yap:32:1
+	typeParam := ctx.Param("type"); typeParam != "" {
+//line cmd/spx-backend/get_assets_list.yap:33:1
+		at, err := model.ParseAssetType(typeParam)
+//line cmd/spx-backend/get_assets_list.yap:34:1
+		if err != nil {
 //line cmd/spx-backend/get_assets_list.yap:35:1
-	category := this.Gop_Env("category"); category != "" {
+			replyWithCodeMsg(ctx, errorInvalidArgs, "invalid type")
 //line cmd/spx-backend/get_assets_list.yap:36:1
+			return
+		}
+//line cmd/spx-backend/get_assets_list.yap:38:1
+		params.Type = &at
+	}
+//line cmd/spx-backend/get_assets_list.yap:41:1
+	if
+//line cmd/spx-backend/get_assets_list.yap:41:1
+	category := this.Gop_Env("category"); category != "" {
+//line cmd/spx-backend/get_assets_list.yap:42:1
 		params.Category = &category
 	}
-//line cmd/spx-backend/get_assets_list.yap:39:1
+//line cmd/spx-backend/get_assets_list.yap:45:1
 	if
-//line cmd/spx-backend/get_assets_list.yap:39:1
+//line cmd/spx-backend/get_assets_list.yap:45:1
 	filesHash := this.Gop_Env("filesHash"); filesHash != "" {
-//line cmd/spx-backend/get_assets_list.yap:40:1
+//line cmd/spx-backend/get_assets_list.yap:46:1
 		params.FilesHash = &filesHash
 	}
-//line cmd/spx-backend/get_assets_list.yap:43:1
+//line cmd/spx-backend/get_assets_list.yap:49:1
 	if
-//line cmd/spx-backend/get_assets_list.yap:43:1
+//line cmd/spx-backend/get_assets_list.yap:49:1
 	visibility := this.Gop_Env("visibility"); visibility != "" {
-//line cmd/spx-backend/get_assets_list.yap:44:1
-		params.Visibility = &visibility
+//line cmd/spx-backend/get_assets_list.yap:50:1
+		v, err := model.ParseVisibility(visibility)
+//line cmd/spx-backend/get_assets_list.yap:51:1
+		if err != nil {
+//line cmd/spx-backend/get_assets_list.yap:52:1
+			replyWithCodeMsg(ctx, errorInvalidArgs, "invalid visibility")
+//line cmd/spx-backend/get_assets_list.yap:53:1
+			return
+		}
+//line cmd/spx-backend/get_assets_list.yap:55:1
+		params.Visibility = &v
 	}
-//line cmd/spx-backend/get_assets_list.yap:47:1
+//line cmd/spx-backend/get_assets_list.yap:58:1
 	if
-//line cmd/spx-backend/get_assets_list.yap:47:1
+//line cmd/spx-backend/get_assets_list.yap:58:1
 	orderBy := this.Gop_Env("orderBy"); orderBy != "" {
-//line cmd/spx-backend/get_assets_list.yap:48:1
+//line cmd/spx-backend/get_assets_list.yap:59:1
 		params.OrderBy = controller.ListAssetsOrderBy(orderBy)
 	}
-//line cmd/spx-backend/get_assets_list.yap:50:1
+//line cmd/spx-backend/get_assets_list.yap:61:1
 	if
-//line cmd/spx-backend/get_assets_list.yap:50:1
+//line cmd/spx-backend/get_assets_list.yap:61:1
 	sortOrder := this.Gop_Env("sortOrder"); sortOrder != "" {
-//line cmd/spx-backend/get_assets_list.yap:51:1
+//line cmd/spx-backend/get_assets_list.yap:62:1
 		params.SortOrder = controller.SortOrder(sortOrder)
 	}
-//line cmd/spx-backend/get_assets_list.yap:54:1
+//line cmd/spx-backend/get_assets_list.yap:65:1
 	params.Pagination.Index = ctx.ParamInt("pageIndex", firstPageIndex)
-//line cmd/spx-backend/get_assets_list.yap:55:1
-	params.Pagination.Size = ctx.ParamInt("pageSize", defaultPageSize)
-//line cmd/spx-backend/get_assets_list.yap:56:1
-	if
-//line cmd/spx-backend/get_assets_list.yap:56:1
-	ok, msg := params.Validate(); !ok {
-//line cmd/spx-backend/get_assets_list.yap:57:1
-		replyWithCodeMsg(ctx, errorInvalidArgs, msg)
-//line cmd/spx-backend/get_assets_list.yap:58:1
-		return
-	}
-//line cmd/spx-backend/get_assets_list.yap:61:1
-	assets, err := this.ctrl.ListAssets(ctx.Context(), params)
-//line cmd/spx-backend/get_assets_list.yap:62:1
-	if err != nil {
-//line cmd/spx-backend/get_assets_list.yap:63:1
-		replyWithInnerError(ctx, err)
-//line cmd/spx-backend/get_assets_list.yap:64:1
-		return
-	}
 //line cmd/spx-backend/get_assets_list.yap:66:1
+	params.Pagination.Size = ctx.ParamInt("pageSize", defaultPageSize)
+//line cmd/spx-backend/get_assets_list.yap:67:1
+	if
+//line cmd/spx-backend/get_assets_list.yap:67:1
+	ok, msg := params.Validate(); !ok {
+//line cmd/spx-backend/get_assets_list.yap:68:1
+		replyWithCodeMsg(ctx, errorInvalidArgs, msg)
+//line cmd/spx-backend/get_assets_list.yap:69:1
+		return
+	}
+//line cmd/spx-backend/get_assets_list.yap:72:1
+	assets, err := this.ctrl.ListAssets(ctx.Context(), params)
+//line cmd/spx-backend/get_assets_list.yap:73:1
+	if err != nil {
+//line cmd/spx-backend/get_assets_list.yap:74:1
+		replyWithInnerError(ctx, err)
+//line cmd/spx-backend/get_assets_list.yap:75:1
+		return
+	}
+//line cmd/spx-backend/get_assets_list.yap:77:1
 	this.Json__1(assets)
 }
 func (this *get_assets_list) Classfname() string {
@@ -676,175 +694,184 @@ func (this *get_project_owner_name_liking) Classclone() yap.HandlerProto {
 	_xgo_ret := *this
 	return &_xgo_ret
 }
-//line cmd/spx-backend/get_projects_list.yap:13
+//line cmd/spx-backend/get_projects_list.yap:14
 func (this *get_projects_list) Main(_xgo_arg0 *yap.Context) {
 	this.Handler.Main(_xgo_arg0)
-//line cmd/spx-backend/get_projects_list.yap:13:1
+//line cmd/spx-backend/get_projects_list.yap:14:1
 	ctx := &this.Context
-//line cmd/spx-backend/get_projects_list.yap:15:1
+//line cmd/spx-backend/get_projects_list.yap:16:1
 	params := controller.NewListProjectsParams()
-//line cmd/spx-backend/get_projects_list.yap:17:1
-	switch
-//line cmd/spx-backend/get_projects_list.yap:17:1
-	owner := this.Gop_Env("owner"); owner {
 //line cmd/spx-backend/get_projects_list.yap:18:1
-	case "":
+	switch
+//line cmd/spx-backend/get_projects_list.yap:18:1
+	owner := this.Gop_Env("owner"); owner {
 //line cmd/spx-backend/get_projects_list.yap:19:1
-		mUser, ok := ensureAuthenticatedUser(ctx)
+	case "":
 //line cmd/spx-backend/get_projects_list.yap:20:1
-		if !ok {
+		mUser, ok := ensureAuthenticatedUser(ctx)
 //line cmd/spx-backend/get_projects_list.yap:21:1
+		if !ok {
+//line cmd/spx-backend/get_projects_list.yap:22:1
 			return
 		}
-//line cmd/spx-backend/get_projects_list.yap:23:1
-		params.Owner = &mUser.Username
 //line cmd/spx-backend/get_projects_list.yap:24:1
-	case "*":
+		params.Owner = &mUser.Username
 //line cmd/spx-backend/get_projects_list.yap:25:1
-		params.Owner = nil
+	case "*":
 //line cmd/spx-backend/get_projects_list.yap:26:1
-	default:
+		params.Owner = nil
 //line cmd/spx-backend/get_projects_list.yap:27:1
+	default:
+//line cmd/spx-backend/get_projects_list.yap:28:1
 		params.Owner = &owner
 	}
-//line cmd/spx-backend/get_projects_list.yap:30:1
-	if
-//line cmd/spx-backend/get_projects_list.yap:30:1
-	remixedFrom := this.Gop_Env("remixedFrom"); remixedFrom != "" {
 //line cmd/spx-backend/get_projects_list.yap:31:1
-		rs, err := controller.ParseRemixSource(remixedFrom)
+	if
+//line cmd/spx-backend/get_projects_list.yap:31:1
+	remixedFrom := this.Gop_Env("remixedFrom"); remixedFrom != "" {
 //line cmd/spx-backend/get_projects_list.yap:32:1
-		if err != nil {
+		rs, err := controller.ParseRemixSource(remixedFrom)
 //line cmd/spx-backend/get_projects_list.yap:33:1
-			replyWithCodeMsg(ctx, errorInvalidArgs, "invalid remixedFrom")
+		if err != nil {
 //line cmd/spx-backend/get_projects_list.yap:34:1
+			replyWithCodeMsg(ctx, errorInvalidArgs, "invalid remixedFrom")
+//line cmd/spx-backend/get_projects_list.yap:35:1
 			return
 		}
-//line cmd/spx-backend/get_projects_list.yap:36:1
+//line cmd/spx-backend/get_projects_list.yap:37:1
 		params.RemixedFrom = &rs
 	}
-//line cmd/spx-backend/get_projects_list.yap:39:1
-	if
-//line cmd/spx-backend/get_projects_list.yap:39:1
-	keyword := this.Gop_Env("keyword"); keyword != "" {
 //line cmd/spx-backend/get_projects_list.yap:40:1
+	if
+//line cmd/spx-backend/get_projects_list.yap:40:1
+	keyword := this.Gop_Env("keyword"); keyword != "" {
+//line cmd/spx-backend/get_projects_list.yap:41:1
 		params.Keyword = &keyword
 	}
-//line cmd/spx-backend/get_projects_list.yap:43:1
-	if
-//line cmd/spx-backend/get_projects_list.yap:43:1
-	visibility := this.Gop_Env("visibility"); visibility != "" {
 //line cmd/spx-backend/get_projects_list.yap:44:1
-		params.Visibility = &visibility
-	}
-//line cmd/spx-backend/get_projects_list.yap:47:1
 	if
+//line cmd/spx-backend/get_projects_list.yap:44:1
+	visibility := this.Gop_Env("visibility"); visibility != "" {
+//line cmd/spx-backend/get_projects_list.yap:45:1
+		v, err := model.ParseVisibility(visibility)
+//line cmd/spx-backend/get_projects_list.yap:46:1
+		if err != nil {
 //line cmd/spx-backend/get_projects_list.yap:47:1
-	liker := this.Gop_Env("liker"); liker != "" {
+			replyWithCodeMsg(ctx, errorInvalidArgs, "invalid visibility")
 //line cmd/spx-backend/get_projects_list.yap:48:1
+			return
+		}
+//line cmd/spx-backend/get_projects_list.yap:50:1
+		params.Visibility = &v
+	}
+//line cmd/spx-backend/get_projects_list.yap:53:1
+	if
+//line cmd/spx-backend/get_projects_list.yap:53:1
+	liker := this.Gop_Env("liker"); liker != "" {
+//line cmd/spx-backend/get_projects_list.yap:54:1
 		params.Liker = &liker
 	}
-//line cmd/spx-backend/get_projects_list.yap:51:1
+//line cmd/spx-backend/get_projects_list.yap:57:1
 	if
-//line cmd/spx-backend/get_projects_list.yap:51:1
+//line cmd/spx-backend/get_projects_list.yap:57:1
 	createdAfter := this.Gop_Env("createdAfter"); createdAfter != "" {
-//line cmd/spx-backend/get_projects_list.yap:52:1
+//line cmd/spx-backend/get_projects_list.yap:58:1
 		createdAfterTime, err := time.Parse(time.RFC3339Nano, createdAfter)
-//line cmd/spx-backend/get_projects_list.yap:53:1
+//line cmd/spx-backend/get_projects_list.yap:59:1
 		if err != nil {
-//line cmd/spx-backend/get_projects_list.yap:54:1
+//line cmd/spx-backend/get_projects_list.yap:60:1
 			replyWithCodeMsg(ctx, errorInvalidArgs, "invalid createdAfter")
-//line cmd/spx-backend/get_projects_list.yap:55:1
+//line cmd/spx-backend/get_projects_list.yap:61:1
 			return
 		}
-//line cmd/spx-backend/get_projects_list.yap:57:1
+//line cmd/spx-backend/get_projects_list.yap:63:1
 		params.CreatedAfter = &createdAfterTime
 	}
-//line cmd/spx-backend/get_projects_list.yap:60:1
+//line cmd/spx-backend/get_projects_list.yap:66:1
 	if
-//line cmd/spx-backend/get_projects_list.yap:60:1
+//line cmd/spx-backend/get_projects_list.yap:66:1
 	likesReceivedAfter := this.Gop_Env("likesReceivedAfter"); likesReceivedAfter != "" {
-//line cmd/spx-backend/get_projects_list.yap:61:1
+//line cmd/spx-backend/get_projects_list.yap:67:1
 		likesReceivedAfterTime, err := time.Parse(time.RFC3339Nano, likesReceivedAfter)
-//line cmd/spx-backend/get_projects_list.yap:62:1
+//line cmd/spx-backend/get_projects_list.yap:68:1
 		if err != nil {
-//line cmd/spx-backend/get_projects_list.yap:63:1
+//line cmd/spx-backend/get_projects_list.yap:69:1
 			replyWithCodeMsg(ctx, errorInvalidArgs, "invalid likesReceivedAfter")
-//line cmd/spx-backend/get_projects_list.yap:64:1
+//line cmd/spx-backend/get_projects_list.yap:70:1
 			return
 		}
-//line cmd/spx-backend/get_projects_list.yap:66:1
+//line cmd/spx-backend/get_projects_list.yap:72:1
 		params.LikesReceivedAfter = &likesReceivedAfterTime
 	}
-//line cmd/spx-backend/get_projects_list.yap:69:1
+//line cmd/spx-backend/get_projects_list.yap:75:1
 	if
-//line cmd/spx-backend/get_projects_list.yap:69:1
+//line cmd/spx-backend/get_projects_list.yap:75:1
 	remixesReceivedAfter := this.Gop_Env("remixesReceivedAfter"); remixesReceivedAfter != "" {
-//line cmd/spx-backend/get_projects_list.yap:70:1
+//line cmd/spx-backend/get_projects_list.yap:76:1
 		remixesReceivedAfterTime, err := time.Parse(time.RFC3339Nano, remixesReceivedAfter)
-//line cmd/spx-backend/get_projects_list.yap:71:1
+//line cmd/spx-backend/get_projects_list.yap:77:1
 		if err != nil {
-//line cmd/spx-backend/get_projects_list.yap:72:1
+//line cmd/spx-backend/get_projects_list.yap:78:1
 			replyWithCodeMsg(ctx, errorInvalidArgs, "invalid remixesReceivedAfter")
-//line cmd/spx-backend/get_projects_list.yap:73:1
+//line cmd/spx-backend/get_projects_list.yap:79:1
 			return
 		}
-//line cmd/spx-backend/get_projects_list.yap:75:1
+//line cmd/spx-backend/get_projects_list.yap:81:1
 		params.RemixesReceivedAfter = &remixesReceivedAfterTime
 	}
-//line cmd/spx-backend/get_projects_list.yap:78:1
+//line cmd/spx-backend/get_projects_list.yap:84:1
 	if
-//line cmd/spx-backend/get_projects_list.yap:78:1
+//line cmd/spx-backend/get_projects_list.yap:84:1
 	fromFollowees := this.Gop_Env("fromFollowees"); fromFollowees != "" {
-//line cmd/spx-backend/get_projects_list.yap:79:1
+//line cmd/spx-backend/get_projects_list.yap:85:1
 		fromFolloweesBool, err := strconv.ParseBool(fromFollowees)
-//line cmd/spx-backend/get_projects_list.yap:80:1
+//line cmd/spx-backend/get_projects_list.yap:86:1
 		if err != nil {
-//line cmd/spx-backend/get_projects_list.yap:81:1
+//line cmd/spx-backend/get_projects_list.yap:87:1
 			replyWithCodeMsg(ctx, errorInvalidArgs, "invalid fromFollowees")
-//line cmd/spx-backend/get_projects_list.yap:82:1
+//line cmd/spx-backend/get_projects_list.yap:88:1
 			return
 		}
-//line cmd/spx-backend/get_projects_list.yap:84:1
+//line cmd/spx-backend/get_projects_list.yap:90:1
 		params.FromFollowees = &fromFolloweesBool
 	}
-//line cmd/spx-backend/get_projects_list.yap:87:1
+//line cmd/spx-backend/get_projects_list.yap:93:1
 	if
-//line cmd/spx-backend/get_projects_list.yap:87:1
+//line cmd/spx-backend/get_projects_list.yap:93:1
 	orderBy := this.Gop_Env("orderBy"); orderBy != "" {
-//line cmd/spx-backend/get_projects_list.yap:88:1
+//line cmd/spx-backend/get_projects_list.yap:94:1
 		params.OrderBy = controller.ListProjectsOrderBy(orderBy)
 	}
-//line cmd/spx-backend/get_projects_list.yap:90:1
+//line cmd/spx-backend/get_projects_list.yap:96:1
 	if
-//line cmd/spx-backend/get_projects_list.yap:90:1
+//line cmd/spx-backend/get_projects_list.yap:96:1
 	sortOrder := this.Gop_Env("sortOrder"); sortOrder != "" {
-//line cmd/spx-backend/get_projects_list.yap:91:1
+//line cmd/spx-backend/get_projects_list.yap:97:1
 		params.SortOrder = controller.SortOrder(sortOrder)
 	}
-//line cmd/spx-backend/get_projects_list.yap:94:1
+//line cmd/spx-backend/get_projects_list.yap:100:1
 	params.Pagination.Index = this.ParamInt("pageIndex", firstPageIndex)
-//line cmd/spx-backend/get_projects_list.yap:95:1
-	params.Pagination.Size = this.ParamInt("pageSize", defaultPageSize)
-//line cmd/spx-backend/get_projects_list.yap:96:1
-	if
-//line cmd/spx-backend/get_projects_list.yap:96:1
-	ok, msg := params.Validate(); !ok {
-//line cmd/spx-backend/get_projects_list.yap:97:1
-		replyWithCodeMsg(ctx, errorInvalidArgs, msg)
-//line cmd/spx-backend/get_projects_list.yap:98:1
-		return
-	}
 //line cmd/spx-backend/get_projects_list.yap:101:1
-	projects, err := this.ctrl.ListProjects(ctx.Context(), params)
+	params.Pagination.Size = this.ParamInt("pageSize", defaultPageSize)
 //line cmd/spx-backend/get_projects_list.yap:102:1
-	if err != nil {
+	if
+//line cmd/spx-backend/get_projects_list.yap:102:1
+	ok, msg := params.Validate(); !ok {
 //line cmd/spx-backend/get_projects_list.yap:103:1
-		replyWithInnerError(ctx, err)
+		replyWithCodeMsg(ctx, errorInvalidArgs, msg)
 //line cmd/spx-backend/get_projects_list.yap:104:1
 		return
 	}
-//line cmd/spx-backend/get_projects_list.yap:106:1
+//line cmd/spx-backend/get_projects_list.yap:107:1
+	projects, err := this.ctrl.ListProjects(ctx.Context(), params)
+//line cmd/spx-backend/get_projects_list.yap:108:1
+	if err != nil {
+//line cmd/spx-backend/get_projects_list.yap:109:1
+		replyWithInnerError(ctx, err)
+//line cmd/spx-backend/get_projects_list.yap:110:1
+		return
+	}
+//line cmd/spx-backend/get_projects_list.yap:112:1
 	this.Json__1(projects)
 }
 func (this *get_projects_list) Classfname() string {

--- a/spx-backend/internal/authn/casdoor/casdoor.go
+++ b/spx-backend/internal/authn/casdoor/casdoor.go
@@ -12,7 +12,6 @@ import (
 	"gorm.io/gorm"
 )
 
-
 // client defines the interface for Casdoor client operations.
 type client interface {
 	ParseJwtToken(token string) (*casdoorsdk.Claims, error)
@@ -47,7 +46,7 @@ func (a *authenticator) Authenticate(ctx context.Context, token string) (*model.
 	if err != nil {
 		return nil, errors.Join(authn.ErrUnauthorized, fmt.Errorf("failed to parse token: %w", err))
 	}
-	mUser, err := model.FirstOrCreateUser(ctx, a.db, model.CreateUserParams{
+	mUser, err := model.FirstOrCreateUser(ctx, a.db, model.CreateUserAttrs{
 		Username:    claims.Name,
 		DisplayName: claims.DisplayName,
 		Avatar:      claims.Avatar,

--- a/spx-backend/internal/controller/asset_test.go
+++ b/spx-backend/internal/controller/asset_test.go
@@ -140,10 +140,10 @@ func TestCreateAssetParams(t *testing.T) {
 	t.Run("Valid", func(t *testing.T) {
 		params := &CreateAssetParams{
 			DisplayName: "Test Asset",
-			Type:        "sprite",
+			Type:        model.AssetTypeSprite,
 			Category:    "characters",
 			FilesHash:   "abc123",
-			Visibility:  "public",
+			Visibility:  model.VisibilityPublic,
 		}
 		ok, msg := params.Validate()
 		assert.True(t, ok)
@@ -153,10 +153,10 @@ func TestCreateAssetParams(t *testing.T) {
 	t.Run("MissingDisplayName", func(t *testing.T) {
 		params := &CreateAssetParams{
 			DisplayName: "",
-			Type:        "sprite",
+			Type:        model.AssetTypeSprite,
 			Category:    "characters",
 			FilesHash:   "abc123",
-			Visibility:  "public",
+			Visibility:  model.VisibilityPublic,
 		}
 		ok, msg := params.Validate()
 		assert.False(t, ok)
@@ -166,35 +166,22 @@ func TestCreateAssetParams(t *testing.T) {
 	t.Run("InvalidDisplayName", func(t *testing.T) {
 		params := &CreateAssetParams{
 			DisplayName: strings.Repeat("a", 256),
-			Type:        "sprite",
+			Type:        model.AssetTypeSprite,
 			Category:    "characters",
 			FilesHash:   "abc123",
-			Visibility:  "public",
+			Visibility:  model.VisibilityPublic,
 		}
 		ok, msg := params.Validate()
 		assert.False(t, ok)
 		assert.Equal(t, "invalid displayName", msg)
 	})
 
-	t.Run("InvalidType", func(t *testing.T) {
-		params := &CreateAssetParams{
-			DisplayName: "Test Asset",
-			Type:        "invalid",
-			Category:    "characters",
-			FilesHash:   "abc123",
-			Visibility:  "public",
-		}
-		ok, msg := params.Validate()
-		assert.False(t, ok)
-		assert.Equal(t, "invalid type", msg)
-	})
-
 	t.Run("MissingCategory", func(t *testing.T) {
 		params := &CreateAssetParams{
 			DisplayName: "Test Asset",
-			Type:        "sprite",
+			Type:        model.AssetTypeSprite,
 			FilesHash:   "abc123",
-			Visibility:  "public",
+			Visibility:  model.VisibilityPublic,
 		}
 		ok, msg := params.Validate()
 		assert.False(t, ok)
@@ -204,26 +191,13 @@ func TestCreateAssetParams(t *testing.T) {
 	t.Run("MissingFilesHash", func(t *testing.T) {
 		params := &CreateAssetParams{
 			DisplayName: "Test Asset",
-			Type:        "sprite",
+			Type:        model.AssetTypeSprite,
 			Category:    "characters",
-			Visibility:  "public",
+			Visibility:  model.VisibilityPublic,
 		}
 		ok, msg := params.Validate()
 		assert.False(t, ok)
 		assert.Equal(t, "missing filesHash", msg)
-	})
-
-	t.Run("InvalidVisibility", func(t *testing.T) {
-		params := &CreateAssetParams{
-			DisplayName: "Test Asset",
-			Type:        "sprite",
-			Category:    "characters",
-			FilesHash:   "abc123",
-			Visibility:  "invalid",
-		}
-		ok, msg := params.Validate()
-		assert.False(t, ok)
-		assert.Equal(t, "invalid visibility", msg)
 	})
 }
 
@@ -250,10 +224,10 @@ func TestControllerCreateAsset(t *testing.T) {
 
 		params := &CreateAssetParams{
 			DisplayName: "Test Asset",
-			Type:        "sprite",
+			Type:        model.AssetTypeSprite,
 			Category:    "characters",
 			FilesHash:   "abc123",
-			Visibility:  "public",
+			Visibility:  model.VisibilityPublic,
 		}
 
 		dbMock.ExpectBegin()
@@ -262,10 +236,10 @@ func TestControllerCreateAsset(t *testing.T) {
 			Create(&model.Asset{
 				OwnerID:     mUser.ID,
 				DisplayName: params.DisplayName,
-				Type:        model.ParseAssetType(params.Type),
+				Type:        params.Type,
 				Category:    params.Category,
 				FilesHash:   params.FilesHash,
-				Visibility:  model.ParseVisibility(params.Visibility),
+				Visibility:  params.Visibility,
 			}).
 			Statement
 		dbMockArgs := modeltest.ToDriverValueSlice(dbMockStmt.Vars...)
@@ -287,10 +261,10 @@ func TestControllerCreateAsset(t *testing.T) {
 				Model:       model.Model{ID: 1},
 				OwnerID:     mUser.ID,
 				DisplayName: params.DisplayName,
-				Type:        model.ParseAssetType(params.Type),
+				Type:        params.Type,
 				Category:    params.Category,
 				FilesHash:   params.FilesHash,
-				Visibility:  model.ParseVisibility(params.Visibility),
+				Visibility:  params.Visibility,
 			})...))
 
 		dbMockStmt = ctrl.db.Session(&gorm.Session{DryRun: true}).
@@ -319,10 +293,10 @@ func TestControllerCreateAsset(t *testing.T) {
 
 		params := &CreateAssetParams{
 			DisplayName: "Test Asset",
-			Type:        "sprite",
+			Type:        model.AssetTypeSprite,
 			Category:    "characters",
 			FilesHash:   "abc123",
-			Visibility:  "public",
+			Visibility:  model.VisibilityPublic,
 		}
 
 		_, err := ctrl.CreateAsset(context.Background(), params)
@@ -348,24 +322,6 @@ func TestListAssetsParams(t *testing.T) {
 		ok, msg := params.Validate()
 		assert.True(t, ok)
 		assert.Empty(t, msg)
-	})
-
-	t.Run("InvalidType", func(t *testing.T) {
-		params := NewListAssetsParams()
-		invalidType := "invalid"
-		params.Type = &invalidType
-		ok, msg := params.Validate()
-		assert.False(t, ok)
-		assert.Equal(t, "invalid type", msg)
-	})
-
-	t.Run("InvalidVisibility", func(t *testing.T) {
-		params := NewListAssetsParams()
-		invalidVisibility := "invalid"
-		params.Visibility = &invalidVisibility
-		ok, msg := params.Validate()
-		assert.False(t, ok)
-		assert.Equal(t, "invalid visibility", msg)
 	})
 
 	t.Run("InvalidOrderBy", func(t *testing.T) {
@@ -542,10 +498,10 @@ func TestUpdateAssetParams(t *testing.T) {
 	t.Run("Valid", func(t *testing.T) {
 		params := &UpdateAssetParams{
 			DisplayName: "Updated Asset",
-			Type:        "sprite",
+			Type:        model.AssetTypeSprite,
 			Category:    "characters",
 			FilesHash:   "def456",
-			Visibility:  "public",
+			Visibility:  model.VisibilityPublic,
 		}
 		ok, msg := params.Validate()
 		assert.True(t, ok)
@@ -555,10 +511,10 @@ func TestUpdateAssetParams(t *testing.T) {
 	t.Run("MissingDisplayName", func(t *testing.T) {
 		params := &UpdateAssetParams{
 			DisplayName: "",
-			Type:        "sprite",
+			Type:        model.AssetTypeSprite,
 			Category:    "characters",
 			FilesHash:   "def456",
-			Visibility:  "public",
+			Visibility:  model.VisibilityPublic,
 		}
 		ok, msg := params.Validate()
 		assert.False(t, ok)
@@ -568,35 +524,22 @@ func TestUpdateAssetParams(t *testing.T) {
 	t.Run("InvalidDisplayName", func(t *testing.T) {
 		params := &UpdateAssetParams{
 			DisplayName: strings.Repeat("a", 256),
-			Type:        "sprite",
+			Type:        model.AssetTypeSprite,
 			Category:    "characters",
 			FilesHash:   "def456",
-			Visibility:  "public",
+			Visibility:  model.VisibilityPublic,
 		}
 		ok, msg := params.Validate()
 		assert.False(t, ok)
 		assert.Equal(t, "invalid displayName", msg)
 	})
 
-	t.Run("InvalidType", func(t *testing.T) {
-		params := &UpdateAssetParams{
-			DisplayName: "Updated Asset",
-			Type:        "invalid",
-			Category:    "characters",
-			FilesHash:   "def456",
-			Visibility:  "public",
-		}
-		ok, msg := params.Validate()
-		assert.False(t, ok)
-		assert.Equal(t, "invalid type", msg)
-	})
-
 	t.Run("MissingCategory", func(t *testing.T) {
 		params := &UpdateAssetParams{
 			DisplayName: "Updated Asset",
-			Type:        "sprite",
+			Type:        model.AssetTypeSprite,
 			FilesHash:   "def456",
-			Visibility:  "public",
+			Visibility:  model.VisibilityPublic,
 		}
 		ok, msg := params.Validate()
 		assert.False(t, ok)
@@ -606,26 +549,13 @@ func TestUpdateAssetParams(t *testing.T) {
 	t.Run("MissingFilesHash", func(t *testing.T) {
 		params := &UpdateAssetParams{
 			DisplayName: "Updated Asset",
-			Type:        "sprite",
+			Type:        model.AssetTypeSprite,
 			Category:    "characters",
-			Visibility:  "public",
+			Visibility:  model.VisibilityPublic,
 		}
 		ok, msg := params.Validate()
 		assert.False(t, ok)
 		assert.Equal(t, "missing filesHash", msg)
-	})
-
-	t.Run("InvalidVisibility", func(t *testing.T) {
-		params := &UpdateAssetParams{
-			DisplayName: "Updated Asset",
-			Type:        "sprite",
-			Category:    "characters",
-			FilesHash:   "def456",
-			Visibility:  "invalid",
-		}
-		ok, msg := params.Validate()
-		assert.False(t, ok)
-		assert.Equal(t, "invalid visibility", msg)
 	})
 }
 
@@ -662,10 +592,10 @@ func TestControllerUpdateAsset(t *testing.T) {
 
 		params := &UpdateAssetParams{
 			DisplayName: "Updated Asset",
-			Type:        "backdrop",
+			Type:        model.AssetTypeBackdrop,
 			Category:    "new-category",
 			FilesHash:   "new-hash",
-			Visibility:  "private",
+			Visibility:  model.VisibilityPrivate,
 		}
 
 		dbMockStmt := ctrl.db.Session(&gorm.Session{DryRun: true}).
@@ -692,10 +622,10 @@ func TestControllerUpdateAsset(t *testing.T) {
 			Model(&model.Asset{Model: mAsset.Model}).
 			Updates(map[string]any{
 				"display_name": params.DisplayName,
-				"type":         model.ParseAssetType(params.Type),
+				"type":         params.Type,
 				"category":     params.Category,
 				"files_hash":   params.FilesHash,
-				"visibility":   model.ParseVisibility(params.Visibility),
+				"visibility":   params.Visibility,
 			}).
 			Statement
 		dbMockArgs = modeltest.ToDriverValueSlice(dbMockStmt.Vars...)
@@ -727,10 +657,10 @@ func TestControllerUpdateAsset(t *testing.T) {
 
 		params := &UpdateAssetParams{
 			DisplayName: "Updated Asset",
-			Type:        "backdrop",
+			Type:        model.AssetTypeBackdrop,
 			Category:    "new-category",
 			FilesHash:   "new-hash",
-			Visibility:  "private",
+			Visibility:  model.VisibilityPrivate,
 		}
 
 		dbMockStmt := ctrl.db.Session(&gorm.Session{DryRun: true}).
@@ -769,10 +699,10 @@ func TestControllerUpdateAsset(t *testing.T) {
 
 		params := &UpdateAssetParams{
 			DisplayName: "Updated Asset",
-			Type:        "backdrop",
+			Type:        model.AssetTypeBackdrop,
 			Category:    "new-category",
 			FilesHash:   "new-hash",
-			Visibility:  "private",
+			Visibility:  model.VisibilityPrivate,
 		}
 
 		dbMockStmt := ctrl.db.Session(&gorm.Session{DryRun: true}).

--- a/spx-backend/internal/controller/project_release.go
+++ b/spx-backend/internal/controller/project_release.go
@@ -50,10 +50,11 @@ type ProjectReleaseFullName struct {
 	Release string
 }
 
-// ParseProjectReleaseFullName parses a project release full name from a string.
-func ParseProjectReleaseFullName(fullName string) (ProjectReleaseFullName, error) {
+// ParseProjectReleaseFullName parses the string representation of a project
+// release full name.
+func ParseProjectReleaseFullName(s string) (ProjectReleaseFullName, error) {
 	var prfn ProjectReleaseFullName
-	return prfn, prfn.UnmarshalText([]byte(fullName))
+	return prfn, prfn.UnmarshalText([]byte(s))
 }
 
 // String implements [fmt.Stringer].

--- a/spx-backend/internal/model/asset.go
+++ b/spx-backend/internal/model/asset.go
@@ -1,5 +1,7 @@
 package model
 
+import "fmt"
+
 // Asset is the model for assets.
 type Asset struct {
 	Model
@@ -42,29 +44,45 @@ const (
 	AssetTypeSound
 )
 
-// ParseAssetType parses the string representation of the asset type.
-func ParseAssetType(s string) AssetType {
-	switch s {
-	case "sprite":
-		return AssetTypeSprite
-	case "backdrop":
-		return AssetTypeBackdrop
-	case "sound":
-		return AssetTypeSound
-	}
-	return 255
+// ParseAssetType parses the string representation of an asset type.
+func ParseAssetType(s string) (AssetType, error) {
+	var at AssetType
+	return at, at.UnmarshalText([]byte(s))
 }
 
-// String implements [fmt.Stringer]. It returns the string representation of the
-// asset type.
+// String implements [fmt.Stringer].
 func (at AssetType) String() string {
+	if text, err := at.MarshalText(); err == nil {
+		return string(text)
+	}
+	return fmt.Sprintf("AssetType(%d)", at)
+}
+
+// MarshalText implements [encoding.TextMarshaler].
+func (at AssetType) MarshalText() ([]byte, error) {
 	switch at {
 	case AssetTypeSprite:
-		return "sprite"
+		return []byte("sprite"), nil
 	case AssetTypeBackdrop:
-		return "backdrop"
+		return []byte("backdrop"), nil
 	case AssetTypeSound:
-		return "sound"
+		return []byte("sound"), nil
+	default:
+		return nil, fmt.Errorf("invalid asset type: %d", at)
 	}
-	return "unknown"
+}
+
+// UnmarshalText implements [encoding.TextUnmarshaler].
+func (at *AssetType) UnmarshalText(text []byte) error {
+	switch string(text) {
+	case "sprite":
+		*at = AssetTypeSprite
+	case "backdrop":
+		*at = AssetTypeBackdrop
+	case "sound":
+		*at = AssetTypeSound
+	default:
+		return fmt.Errorf("invalid asset type: %s", text)
+	}
+	return nil
 }

--- a/spx-backend/internal/model/asset_test.go
+++ b/spx-backend/internal/model/asset_test.go
@@ -1,0 +1,124 @@
+package model
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseAssetType(t *testing.T) {
+	t.Run("Sprite", func(t *testing.T) {
+		at, err := ParseAssetType("sprite")
+		require.NoError(t, err)
+		assert.Equal(t, AssetTypeSprite, at)
+	})
+
+	t.Run("Backdrop", func(t *testing.T) {
+		at, err := ParseAssetType("backdrop")
+		require.NoError(t, err)
+		assert.Equal(t, AssetTypeBackdrop, at)
+	})
+
+	t.Run("Sound", func(t *testing.T) {
+		at, err := ParseAssetType("sound")
+		require.NoError(t, err)
+		assert.Equal(t, AssetTypeSound, at)
+	})
+
+	t.Run("Invalid", func(t *testing.T) {
+		_, err := ParseAssetType("invalid")
+		assert.EqualError(t, err, "invalid asset type: invalid")
+	})
+
+	t.Run("Empty", func(t *testing.T) {
+		_, err := ParseAssetType("")
+		assert.EqualError(t, err, "invalid asset type: ")
+	})
+}
+
+func TestAssetTypeString(t *testing.T) {
+	t.Run("Sprite", func(t *testing.T) {
+		at := AssetTypeSprite
+		assert.Equal(t, "sprite", at.String())
+	})
+
+	t.Run("Backdrop", func(t *testing.T) {
+		at := AssetTypeBackdrop
+		assert.Equal(t, "backdrop", at.String())
+	})
+
+	t.Run("Sound", func(t *testing.T) {
+		at := AssetTypeSound
+		assert.Equal(t, "sound", at.String())
+	})
+
+	t.Run("Invalid", func(t *testing.T) {
+		at := AssetType(255)
+		assert.Equal(t, "AssetType(255)", at.String())
+	})
+}
+
+func TestAssetTypeMarshalText(t *testing.T) {
+	t.Run("Sprite", func(t *testing.T) {
+		at := AssetTypeSprite
+		text, err := at.MarshalText()
+		require.NoError(t, err)
+		assert.Equal(t, []byte("sprite"), text)
+	})
+
+	t.Run("Backdrop", func(t *testing.T) {
+		at := AssetTypeBackdrop
+		text, err := at.MarshalText()
+		require.NoError(t, err)
+		assert.Equal(t, []byte("backdrop"), text)
+	})
+
+	t.Run("Sound", func(t *testing.T) {
+		at := AssetTypeSound
+		text, err := at.MarshalText()
+		require.NoError(t, err)
+		assert.Equal(t, []byte("sound"), text)
+	})
+
+	t.Run("Invalid", func(t *testing.T) {
+		at := AssetType(255)
+		_, err := at.MarshalText()
+		assert.EqualError(t, err, "invalid asset type: 255")
+	})
+}
+
+func TestAssetTypeUnmarshalText(t *testing.T) {
+	t.Run("Sprite", func(t *testing.T) {
+		var at AssetType
+		err := at.UnmarshalText([]byte("sprite"))
+		require.NoError(t, err)
+		assert.Equal(t, AssetTypeSprite, at)
+	})
+
+	t.Run("Backdrop", func(t *testing.T) {
+		var at AssetType
+		err := at.UnmarshalText([]byte("backdrop"))
+		require.NoError(t, err)
+		assert.Equal(t, AssetTypeBackdrop, at)
+	})
+
+	t.Run("Sound", func(t *testing.T) {
+		var at AssetType
+		err := at.UnmarshalText([]byte("sound"))
+		require.NoError(t, err)
+		assert.Equal(t, AssetTypeSound, at)
+	})
+
+	t.Run("Invalid", func(t *testing.T) {
+		var at AssetType
+		err := at.UnmarshalText([]byte("invalid"))
+		assert.EqualError(t, err, "invalid asset type: invalid")
+	})
+
+	t.Run("Empty", func(t *testing.T) {
+		var at AssetType
+		err := at.UnmarshalText([]byte(""))
+		assert.EqualError(t, err, "invalid asset type: ")
+	})
+}

--- a/spx-backend/internal/model/model.go
+++ b/spx-backend/internal/model/model.go
@@ -63,27 +63,43 @@ const (
 	VisibilityPublic
 )
 
-// ParseVisibility parses the string representation of the visibility.
-func ParseVisibility(s string) Visibility {
-	switch s {
-	case "private":
-		return VisibilityPrivate
-	case "public":
-		return VisibilityPublic
-	}
-	return 255
+// ParseVisibility parses the string representation of a visibility.
+func ParseVisibility(s string) (Visibility, error) {
+	var v Visibility
+	return v, v.UnmarshalText([]byte(s))
 }
 
-// String implements [fmt.Stringer]. It returns the string representation of the
-// visibility.
+// String implements [fmt.Stringer].
 func (v Visibility) String() string {
+	if text, err := v.MarshalText(); err == nil {
+		return string(text)
+	}
+	return fmt.Sprintf("Visibility(%d)", v)
+}
+
+// MarshalText implements [encoding.TextMarshaler].
+func (v Visibility) MarshalText() ([]byte, error) {
 	switch v {
 	case VisibilityPrivate:
-		return "private"
+		return []byte("private"), nil
 	case VisibilityPublic:
-		return "public"
+		return []byte("public"), nil
+	default:
+		return nil, fmt.Errorf("invalid visibility: %d", v)
 	}
-	return "unknown"
+}
+
+// UnmarshalText implements [encoding.TextUnmarshaler].
+func (v *Visibility) UnmarshalText(text []byte) error {
+	switch string(text) {
+	case "private":
+		*v = VisibilityPrivate
+	case "public":
+		*v = VisibilityPublic
+	default:
+		return fmt.Errorf("invalid visibility: %s", text)
+	}
+	return nil
 }
 
 // FileCollection is a map from relative path to universal URL. It is used to

--- a/spx-backend/internal/model/model_test.go
+++ b/spx-backend/internal/model/model_test.go
@@ -8,6 +8,97 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestParseVisibility(t *testing.T) {
+	t.Run("Private", func(t *testing.T) {
+		v, err := ParseVisibility("private")
+		require.NoError(t, err)
+		assert.Equal(t, VisibilityPrivate, v)
+	})
+
+	t.Run("Public", func(t *testing.T) {
+		v, err := ParseVisibility("public")
+		require.NoError(t, err)
+		assert.Equal(t, VisibilityPublic, v)
+	})
+
+	t.Run("Invalid", func(t *testing.T) {
+		_, err := ParseVisibility("invalid")
+		assert.EqualError(t, err, "invalid visibility: invalid")
+	})
+
+	t.Run("Empty", func(t *testing.T) {
+		_, err := ParseVisibility("")
+		assert.EqualError(t, err, "invalid visibility: ")
+	})
+}
+
+func TestVisibilityString(t *testing.T) {
+	t.Run("Private", func(t *testing.T) {
+		v := VisibilityPrivate
+		assert.Equal(t, "private", v.String())
+	})
+
+	t.Run("Public", func(t *testing.T) {
+		v := VisibilityPublic
+		assert.Equal(t, "public", v.String())
+	})
+
+	t.Run("Invalid", func(t *testing.T) {
+		v := Visibility(255)
+		assert.Equal(t, "Visibility(255)", v.String())
+	})
+}
+
+func TestVisibilityMarshalText(t *testing.T) {
+	t.Run("Private", func(t *testing.T) {
+		v := VisibilityPrivate
+		text, err := v.MarshalText()
+		require.NoError(t, err)
+		assert.Equal(t, []byte("private"), text)
+	})
+
+	t.Run("Public", func(t *testing.T) {
+		v := VisibilityPublic
+		text, err := v.MarshalText()
+		require.NoError(t, err)
+		assert.Equal(t, []byte("public"), text)
+	})
+
+	t.Run("Invalid", func(t *testing.T) {
+		v := Visibility(255)
+		_, err := v.MarshalText()
+		assert.EqualError(t, err, "invalid visibility: 255")
+	})
+}
+
+func TestVisibilityUnmarshalText(t *testing.T) {
+	t.Run("Private", func(t *testing.T) {
+		var v Visibility
+		err := v.UnmarshalText([]byte("private"))
+		require.NoError(t, err)
+		assert.Equal(t, VisibilityPrivate, v)
+	})
+
+	t.Run("Public", func(t *testing.T) {
+		var v Visibility
+		err := v.UnmarshalText([]byte("public"))
+		require.NoError(t, err)
+		assert.Equal(t, VisibilityPublic, v)
+	})
+
+	t.Run("Invalid", func(t *testing.T) {
+		var v Visibility
+		err := v.UnmarshalText([]byte("invalid"))
+		assert.EqualError(t, err, "invalid visibility: invalid")
+	})
+
+	t.Run("Empty", func(t *testing.T) {
+		var v Visibility
+		err := v.UnmarshalText([]byte(""))
+		assert.EqualError(t, err, "invalid visibility: ")
+	})
+}
+
 func TestFileCollectionScan(t *testing.T) {
 	t.Run("Normal", func(t *testing.T) {
 		var fc FileCollection

--- a/spx-backend/internal/model/user.go
+++ b/spx-backend/internal/model/user.go
@@ -48,22 +48,22 @@ func (User) TableName() string {
 	return "user"
 }
 
-// CreateUserParams holds parameters for creating a user with [FirstOrCreateUser].
-type CreateUserParams struct {
+// CreateUserAttrs holds attributes for creating a user with [FirstOrCreateUser].
+type CreateUserAttrs struct {
 	Username    string
 	DisplayName string
 	Avatar      string
 }
 
 // FirstOrCreateUser gets or creates a user.
-func FirstOrCreateUser(ctx context.Context, db *gorm.DB, params CreateUserParams) (*User, error) {
+func FirstOrCreateUser(ctx context.Context, db *gorm.DB, attrs CreateUserAttrs) (*User, error) {
 	var mUser User
 	if err := db.WithContext(ctx).
-		Where("username = ?", params.Username).
+		Where("username = ?", attrs.Username).
 		Attrs(User{
-			Username:    params.Username,
-			DisplayName: params.DisplayName,
-			Avatar:      params.Avatar,
+			Username:    attrs.Username,
+			DisplayName: attrs.DisplayName,
+			Avatar:      attrs.Avatar,
 		}).
 		Clauses(clause.OnConflict{
 			Columns:   []clause.Column{{Name: "username"}},
@@ -71,15 +71,15 @@ func FirstOrCreateUser(ctx context.Context, db *gorm.DB, params CreateUserParams
 		}).
 		FirstOrCreate(&mUser).
 		Error; err != nil {
-		return nil, fmt.Errorf("failed to get/create user %q: %w", params.Username, err)
+		return nil, fmt.Errorf("failed to get/create user %q: %w", attrs.Username, err)
 	}
 	if mUser.ID == 0 {
 		// Unfortunately, MySQL doesn't support the RETURNING clause.
 		if err := db.WithContext(ctx).
-			Where("username = ?", params.Username).
+			Where("username = ?", attrs.Username).
 			First(&mUser).
 			Error; err != nil {
-			return nil, fmt.Errorf("failed to get user %q: %w", params.Username, err)
+			return nil, fmt.Errorf("failed to get user %q: %w", attrs.Username, err)
 		}
 	}
 	return &mUser, nil

--- a/spx-backend/internal/model/user_test.go
+++ b/spx-backend/internal/model/user_test.go
@@ -22,7 +22,7 @@ func TestFirstOrCreateUser(t *testing.T) {
 	generateUserDBRows, err := modeltest.NewDBRowsGenerator(db, User{})
 	require.NoError(t, err)
 
-	expectedParams := CreateUserParams{
+	expectedAttrs := CreateUserAttrs{
 		Username:    "john",
 		DisplayName: "John Doe",
 		Avatar:      "https://example.com/avatar.jpg",
@@ -30,9 +30,9 @@ func TestFirstOrCreateUser(t *testing.T) {
 
 	mExpectedUser := User{
 		Model:              Model{ID: 1},
-		Username:           expectedParams.Username,
-		DisplayName:        expectedParams.DisplayName,
-		Avatar:             expectedParams.Avatar,
+		Username:           expectedAttrs.Username,
+		DisplayName:        expectedAttrs.DisplayName,
+		Avatar:             expectedAttrs.Avatar,
 		Description:        "I'm John",
 		FollowerCount:      10,
 		FollowingCount:     5,
@@ -55,7 +55,7 @@ func TestFirstOrCreateUser(t *testing.T) {
 			WithArgs(dbMockArgs...).
 			WillReturnRows(sqlmock.NewRows(userDBColumns).AddRows(generateUserDBRows(mExpectedUser)...))
 
-		mUser, err := FirstOrCreateUser(context.Background(), db, expectedParams)
+		mUser, err := FirstOrCreateUser(context.Background(), db, expectedAttrs)
 		require.NoError(t, err)
 		assert.Equal(t, mExpectedUser, *mUser)
 
@@ -103,7 +103,7 @@ func TestFirstOrCreateUser(t *testing.T) {
 			WithArgs(dbMockArgs...).
 			WillReturnRows(sqlmock.NewRows(userDBColumns).AddRows(generateUserDBRows(mExpectedUser)...))
 
-		mUser, err := FirstOrCreateUser(context.Background(), db, expectedParams)
+		mUser, err := FirstOrCreateUser(context.Background(), db, expectedAttrs)
 		require.NoError(t, err)
 		assert.Equal(t, mExpectedUser, *mUser)
 


### PR DESCRIPTION
- Replace string-based type fields with proper enum types in DTOs.
- Add proper JSON marshaling/unmarshaling for `model.AssetType` and `model.Visibility` enums.
- Remove redundant validation logic by leveraging type system.
- Update API handlers to use proper type parsing with error handling.
- Simplify parameter validation by eliminating string-based type checks.
- Rename `model.CreateUserParams` to `model.CreateUserAttrs` for consistency.