### PR TITLE
feat(spx-gui): integrate Authorization System and simplify user state management

### DIFF
--- a/spx-gui/package-lock.json
+++ b/spx-gui/package-lock.json
@@ -52,8 +52,6 @@
         "naive-ui": "^2.38.1",
         "nanoid": "^5.0.5",
         "npm": "^10.3.0",
-        "pinia": "^2.1.7",
-        "pinia-plugin-persistedstate": "^3.2.1",
         "prettier": "^3.2.2",
         "property-information": "^6.5.0",
         "qiniu-js": "^3.4.2",
@@ -11421,6 +11419,8 @@
       "version": "2.1.7",
       "resolved": "https://registry.npmjs.org/pinia/-/pinia-2.1.7.tgz",
       "integrity": "sha512-+C2AHFtcFqjPih0zpYuvof37SFxMQ7OEG2zV9jRI12i9BOy3YQVAHwdKtyyc8pDcDyIc33WCIsZaCFWU7WWxGQ==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@vue/devtools-api": "^6.5.0",
         "vue-demi": ">=0.14.5"
@@ -11442,19 +11442,13 @@
         }
       }
     },
-    "node_modules/pinia-plugin-persistedstate": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/pinia-plugin-persistedstate/-/pinia-plugin-persistedstate-3.2.1.tgz",
-      "integrity": "sha512-MK++8LRUsGF7r45PjBFES82ISnPzyO6IZx3CH5vyPseFLZCk1g2kgx6l/nW8pEBKxxd4do0P6bJw+mUSZIEZUQ==",
-      "peerDependencies": {
-        "pinia": "^2.0.0"
-      }
-    },
     "node_modules/pinia/node_modules/vue-demi": {
       "version": "0.14.7",
       "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.7.tgz",
       "integrity": "sha512-EOG8KXDQNwkJILkx/gPcoL/7vH+hORoBaKgGe+6W7VFMvCYJfmF2dGbvgDroVnI8LU7/kTu8mbjRZGBU1z9NTA==",
       "hasInstallScript": true,
+      "optional": true,
+      "peer": true,
       "bin": {
         "vue-demi-fix": "bin/vue-demi-fix.js",
         "vue-demi-switch": "bin/vue-demi-switch.js"

--- a/spx-gui/package.json
+++ b/spx-gui/package.json
@@ -58,8 +58,6 @@
     "naive-ui": "^2.38.1",
     "nanoid": "^5.0.5",
     "npm": "^10.3.0",
-    "pinia": "^2.1.7",
-    "pinia-plugin-persistedstate": "^3.2.1",
     "prettier": "^3.2.2",
     "property-information": "^6.5.0",
     "qiniu-js": "^3.4.2",

--- a/spx-gui/src/apis/user.ts
+++ b/spx-gui/src/apis/user.ts
@@ -16,16 +16,38 @@ export type User = {
   avatar: string
   /** Brief bio or description of the user */
   description: string
+  /** Subscription plan of the user */
+  plan: 'free' | 'plus'
+}
+
+export type SignedInUser = User & {
+  /** Capabilities and quotas of the user */
+  capabilities: UserCapabilities
+}
+
+export type UserCapabilities = {
+  /** Whether user can manage asset library */
+  canManageAssets: boolean
+  /** Whether user can access premium LLM models */
+  canUsePremiumLLM: boolean
+  /** Total quota for Copilot messages */
+  copilotMessageQuota: number
+  /** Remaining quota for Copilot messages */
+  copilotMessageQuotaLeft: number
 }
 
 export async function getUser(name: string): Promise<User> {
   return await (client.get(`/user/${encodeURIComponent(name)}`) as Promise<User>)
 }
 
+export async function getSignedInUser(): Promise<SignedInUser> {
+  return await (client.get(`/user`) as Promise<SignedInUser>)
+}
+
 export type UpdateSignedInUserParams = Pick<User, 'description'>
 
 export async function updateSignedInUser(params: UpdateSignedInUserParams) {
-  return await (client.put(`/user`, params) as Promise<User>)
+  return await (client.put(`/user`, params) as Promise<SignedInUser>)
 }
 
 export type ListUserParams = PaginationParams & {

--- a/spx-gui/src/components/agent-copilot/CopilotProvider.vue
+++ b/spx-gui/src/components/agent-copilot/CopilotProvider.vue
@@ -94,7 +94,7 @@ import { ToolRegistry } from './mcp/registry'
 import { Collector } from './mcp/collector'
 import CopilotUI from './CopilotUI.vue'
 import { z } from 'zod'
-import { useUserStore } from '@/stores/user'
+import { getSignedInUsername } from '@/stores/user'
 import { createProjectToolDescription, CreateProjectArgsSchema } from './mcp/definitions'
 import { getProject, Visibility } from '@/apis/project'
 import { useRouter } from 'vue-router'
@@ -179,20 +179,17 @@ async function createProject(options: CreateProjectOptions) {
   const projectName = options.projectName
 
   // Check if user is signed in
-  const userStore = useUserStore()
-  const signedInUser = computed(() => userStore.getSignedInUser())
-  if (signedInUser.value == null) {
+  const signedInUsername = getSignedInUsername()
+  if (signedInUsername == null) {
     return {
       success: false,
       message: 'Please sign in to create a project'
     }
   }
 
-  const username = signedInUser.value.name
-
   try {
     // Check if project already exists
-    const project = await getProject(username, options.projectName)
+    const project = await getProject(signedInUsername, options.projectName)
     if (project != null) {
       return {
         success: false,
@@ -203,7 +200,7 @@ async function createProject(options: CreateProjectOptions) {
     // Handle error checking project existence
   }
 
-  const project = new Project(username, projectName)
+  const project = new Project(signedInUsername, projectName)
   project.setVisibility(Visibility.Private)
 
   try {

--- a/spx-gui/src/components/agent-copilot/UserMessage.vue
+++ b/spx-gui/src/components/agent-copilot/UserMessage.vue
@@ -1,17 +1,17 @@
 <script setup lang="ts">
 import MarkdownView from './markdown/MarkdownView.vue'
-import { useUserStore } from '@/stores/user'
+import { useSignedInUser } from '@/stores/user'
 
 const props = defineProps<{
   content: string
 }>()
 
-const userInfo = useUserStore().getSignedInUser() || { avatar: '' }
+const { data: signedInUser } = useSignedInUser()
 </script>
 
 <template>
   <section class="user-message">
-    <img class="avatar" :src="userInfo?.avatar || ''" />
+    <img class="avatar" :src="signedInUser?.avatar || ''" />
     <MarkdownView class="content" :value="props.content" />
   </section>
 </template>

--- a/spx-gui/src/components/asset/library/AssetSaveModal.vue
+++ b/spx-gui/src/components/asset/library/AssetSaveModal.vue
@@ -23,7 +23,7 @@ import type { AssetModel, PartialAssetData } from '@/models/common/asset'
 import { backdrop2Asset, sound2Asset, sprite2Asset } from '@/models/common/asset'
 import { useI18n } from '@/utils/i18n'
 import { useQuery } from '@/utils/query'
-import { useUserStore } from '@/stores/user'
+import { useSignedInUser } from '@/stores/user'
 import { categoryAll, getAssetCategories } from './category'
 import BackdropPreview from './BackdropPreview.vue'
 import SpritePreview from './SpritePreview.vue'
@@ -39,15 +39,15 @@ const emit = defineEmits<{
   resolved: []
 }>()
 
-const userStore = useUserStore()
+const { data: signedInUser } = useSignedInUser()
 
 const user = computed(() => {
-  const u = userStore.getSignedInUser()
+  const u = signedInUser.value
   if (u == null) throw new Error('user is not signed in')
   return u
 })
 
-const advancedLibraryEnabled = computed(() => user.value.advancedLibraryEnabled)
+const advancedLibraryEnabled = computed(() => user.value.capabilities.canManageAssets)
 
 const { t } = useI18n()
 
@@ -60,7 +60,7 @@ const {
   async () => {
     if (!advancedLibraryEnabled.value) return null
     const metadata = props.model.assetMetadata
-    if (metadata == null || metadata.owner !== user.value.name) return null
+    if (metadata == null || metadata.owner !== user.value.username) return null
     return getAsset(metadata.id).catch((e) => {
       console.warn('failed to get existed asset', e)
       return null

--- a/spx-gui/src/components/community/home/banner/GuestBanner.vue
+++ b/spx-gui/src/components/community/home/banner/GuestBanner.vue
@@ -1,12 +1,10 @@
 <script setup lang="ts">
-import { useUserStore } from '@/stores/user'
+import { initiateSignIn } from '@/stores/user'
 import { UIButton } from '@/components/ui'
 import CommunityCard from '../../CommunityCard.vue'
 
-const userStore = useUserStore()
-
 function handleJoin() {
-  userStore.initiateSignIn()
+  initiateSignIn()
 }
 </script>
 

--- a/spx-gui/src/components/community/user/FollowButton.vue
+++ b/spx-gui/src/components/community/user/FollowButton.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed } from 'vue'
-import { useUserStore } from '@/stores/user'
+import { getSignedInUsername } from '@/stores/user'
 import { UIButton } from '@/components/ui'
 import { useMessageHandle } from '@/utils/exception'
 import { useEnsureSignedIn } from '@/utils/user'
@@ -11,11 +11,9 @@ const props = defineProps<{
   name: string
 }>()
 
-const userStore = useUserStore()
-
 const followable = computed(() => {
-  const signedInUser = userStore.getSignedInUser()
-  return signedInUser != null && props.name !== signedInUser.name
+  const signedInUsername = getSignedInUsername()
+  return signedInUsername != null && props.name !== signedInUsername
 })
 
 const { data: following } = useIsFollowing(() => props.name)

--- a/spx-gui/src/components/community/user/UserHeader.vue
+++ b/spx-gui/src/components/community/user/UserHeader.vue
@@ -3,7 +3,7 @@ import { computed } from 'vue'
 import { type User } from '@/apis/user'
 import { useExternalUrl } from '@/utils/utils'
 import { useMessageHandle } from '@/utils/exception'
-import { useUserStore } from '@/stores/user'
+import { getSignedInUsername } from '@/stores/user'
 import { UIButton, UIImg, useModal } from '@/components/ui'
 import CommunityCard from '@/components/community/CommunityCard.vue'
 import TextView from '../TextView.vue'
@@ -16,7 +16,7 @@ const props = defineProps<{
   user: User
 }>()
 
-const isSignedInUser = computed(() => props.user.username === useUserStore().getSignedInUser()?.name)
+const isSignedInUser = computed(() => props.user.username === getSignedInUsername())
 const avatarUrl = useExternalUrl(() => props.user.avatar)
 const coverImgUrl = computed(() => getCoverImgUrl(props.user.username))
 

--- a/spx-gui/src/components/editor/code-editor/ui/copilot/UserMessage.vue
+++ b/spx-gui/src/components/editor/code-editor/ui/copilot/UserMessage.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { useExternalUrl } from '@/utils/utils'
-import { useUserStore } from '@/stores/user'
+import { useSignedInUser } from '@/stores/user'
 import type { BasicMarkdownString } from '../../common'
 import MarkdownView from '../markdown/MarkdownView.vue'
 
@@ -8,9 +8,9 @@ defineProps<{
   content: BasicMarkdownString
 }>()
 
-const userStore = useUserStore()
+const { data: signedInUser } = useSignedInUser()
 // TODO: Disable copilot for unsigned-in users or provide a default avatar
-const avatarUrl = useExternalUrl(() => userStore.getSignedInUser()?.avatar)
+const avatarUrl = useExternalUrl(() => signedInUser.value?.avatar)
 </script>
 
 <template>

--- a/spx-gui/src/components/editor/editing.test.ts
+++ b/spx-gui/src/components/editor/editing.test.ts
@@ -3,7 +3,6 @@ import { afterEach, beforeEach, describe, expect, vi, it } from 'vitest'
 import { flushPromises } from '@vue/test-utils'
 import { timeout } from '@/utils/utils'
 import { fromText, type Files } from '@/models/common/file'
-import type { UserInfo } from '@/stores/user'
 import { Editing, type EditableProject, SavingState, EditingMode, type LocalStorage } from './editing'
 
 function mockFile(name = 'mocked') {
@@ -36,16 +35,6 @@ function mockProject({
   }
 }
 
-function mockUserInfo(name = 'user'): UserInfo {
-  return {
-    id: '123',
-    name,
-    displayName: name,
-    avatar: '',
-    advancedLibraryEnabled: false
-  }
-}
-
 function mockLocalStorage() {
   return {
     clear: vi.fn().mockResolvedValue(undefined)
@@ -55,17 +44,17 @@ function mockLocalStorage() {
 function mockEditing({
   project = mockProject({}),
   isOnline = () => true,
-  userInfo = () => mockUserInfo(),
+  signedInUsername: username = () => 'user',
   localCacheKey = 'LOCAL_CACHE_KEY',
   localStorage = mockLocalStorage()
 }: Partial<{
   project: EditableProject
   isOnline: WatchSource<boolean>
-  userInfo: WatchSource<UserInfo | null>
+  signedInUsername: WatchSource<string | null>
   localCacheKey: string
   localStorage: LocalStorage
 }>) {
-  return new Editing(project, isOnline, userInfo, localCacheKey, localStorage)
+  return new Editing(project, isOnline, username, localCacheKey, localStorage)
 }
 
 describe('Editing', () => {
@@ -196,7 +185,7 @@ describe('Editing', () => {
     const project = mockProject({ files, owner: 'project-owner' })
     const editing = mockEditing({
       project,
-      userInfo: () => mockUserInfo('different-user') // Different user from project owner
+      signedInUsername: () => 'different-user' // Different user from project owner
     })
     editing.start()
 

--- a/spx-gui/src/components/editor/editing.ts
+++ b/spx-gui/src/components/editor/editing.ts
@@ -4,7 +4,6 @@ import { timeout, until } from '@/utils/utils'
 import { Cancelled, capture } from '@/utils/exception'
 import type { Files } from '@/models/common/file'
 import * as localHelper from '@/models/common/local'
-import type { UserInfo } from '@/stores/user'
 
 export interface EditableProject {
   owner?: string
@@ -95,7 +94,7 @@ export class Editing extends Disposable {
   constructor(
     private project: EditableProject,
     private isOnline: WatchSource<boolean>,
-    private userInfo: WatchSource<UserInfo | null>,
+    private signedInUsername: WatchSource<string | null>,
     private localCacheKey: string,
     private localStorage: LocalStorage = localHelper
   ) {
@@ -103,8 +102,8 @@ export class Editing extends Disposable {
   }
 
   get mode(): EditingMode {
-    const userInfo = toValue(this.userInfo)
-    if (userInfo == null || userInfo.name !== this.project.owner) {
+    const username = toValue(this.signedInUsername)
+    if (username == null || username !== this.project.owner) {
       return EditingMode.EffectFree
     }
     return EditingMode.AutoSave

--- a/spx-gui/src/components/editor/editor-state.test.ts
+++ b/spx-gui/src/components/editor/editor-state.test.ts
@@ -9,23 +9,12 @@ import { Monitor } from '@/models/widget/monitor'
 import { Costume } from '@/models/costume'
 import { Animation } from '@/models/animation'
 import { fromText } from '@/models/common/file'
-import type { UserInfo } from '@/stores/user/signed-in'
 import type * as editing from './editing'
 
 import { EditorState, type IRouter, type Selected } from './editor-state'
 
 function mockFile(name = 'mocked') {
   return fromText(name, Math.random() + '')
-}
-
-function mockUserInfo(name = 'user'): UserInfo {
-  return {
-    id: '123',
-    name,
-    displayName: name,
-    avatar: '',
-    advancedLibraryEnabled: false
-  }
 }
 
 function mockLocalStorage(): editing.LocalStorage {
@@ -114,11 +103,11 @@ function mockRouter() {
 function createEditorState(
   project: Project = createEmptyProject(),
   isOnline: WatchSource<boolean> = ref(true),
-  userInfo: WatchSource<UserInfo | null> = ref(mockUserInfo()),
+  signedInUsername: WatchSource<string | null> = ref('user'),
   localCacheKey: string = 'test-cache-key',
   localStorage: editing.LocalStorage = mockLocalStorage()
 ): EditorState {
-  return new EditorState(project, isOnline, userInfo, localCacheKey, localStorage)
+  return new EditorState(project, isOnline, signedInUsername, localCacheKey, localStorage)
 }
 
 describe('EditorState', () => {

--- a/spx-gui/src/components/editor/editor-state.ts
+++ b/spx-gui/src/components/editor/editor-state.ts
@@ -11,7 +11,6 @@ import { Backdrop } from '@/models/backdrop'
 import { isWidget } from '@/models/widget'
 import { Costume } from '@/models/costume'
 import { Animation } from '@/models/animation'
-import type { UserInfo } from '@/stores/user/signed-in'
 import { StageEditorState, type Selected as StageEditorSelected } from './stage/StageEditor.vue'
 import { SpriteEditorState, type Selected as SpriteEditorSelected } from './sprite/SpriteEditor.vue'
 import { Runtime } from './runtime'
@@ -43,13 +42,15 @@ export class EditorState extends Disposable {
   constructor(
     private project: Project,
     isOnline: WatchSource<boolean>,
-    userInfo: WatchSource<UserInfo | null>,
+    signedInUsername: WatchSource<string | null>,
     localCacheKey: string,
     localStorage?: editing.LocalStorage
   ) {
     super()
     this.addDisposable((this.runtime = new Runtime(project)))
-    this.addDisposable((this.editing = new editing.Editing(project, isOnline, userInfo, localCacheKey, localStorage)))
+    this.addDisposable(
+      (this.editing = new editing.Editing(project, isOnline, signedInUsername, localCacheKey, localStorage))
+    )
     this.stageState = new StageEditorState(project.stage)
 
     this.addDisposer(

--- a/spx-gui/src/components/editor/navbar/EditorNavbar.vue
+++ b/spx-gui/src/components/editor/navbar/EditorNavbar.vue
@@ -115,7 +115,7 @@ import { useI18n, type LocaleMessage } from '@/utils/i18n'
 import { useNetwork } from '@/utils/network'
 import { selectFile } from '@/utils/file'
 import { type Project } from '@/models/project'
-import { useUser, useUserStore } from '@/stores/user'
+import { getSignedInUsername, useUser } from '@/stores/user'
 import { Visibility } from '@/apis/common'
 import { getProjectPageRoute } from '@/router'
 import { usePublishProject, useRemoveProject, useUnpublishProject } from '@/components/project'
@@ -149,13 +149,11 @@ const { isOnline } = useNetwork()
 const i18n = useI18n()
 const router = useRouter()
 const confirm = useConfirmDialog()
-const userStore = useUserStore()
-
 const canManageProject = computed(() => {
   if (props.project == null) return false
-  const signedInUser = userStore.getSignedInUser()
-  if (signedInUser == null) return false
-  if (props.project.owner !== signedInUser.name) return false
+  const signedInUsername = getSignedInUsername()
+  if (signedInUsername == null) return false
+  if (props.project.owner !== signedInUsername) return false
   return true
 })
 
@@ -164,8 +162,8 @@ const projectOwnerRet = useUser(() => props.project?.owner ?? null)
 const ownerInfoToDisplay = computed(() => {
   const owner = projectOwnerRet.data.value
   if (owner == null) return null
-  const signedInUser = userStore.getSignedInUser()
-  if (signedInUser == null || signedInUser.name !== owner.username) return owner
+  const signedInUsername = getSignedInUsername()
+  if (signedInUsername == null || signedInUsername !== owner.username) return owner
   return null
 })
 

--- a/spx-gui/src/components/navbar/NavbarProfile.vue
+++ b/spx-gui/src/components/navbar/NavbarProfile.vue
@@ -1,10 +1,10 @@
 <template>
-  <div v-if="!userInfo" class="sign-in">
+  <div v-if="!signedInUser" class="sign-in">
     <UIButton
       v-radar="{ name: 'Sign in button', desc: 'Click to sign in' }"
       type="secondary"
       :disabled="!isOnline"
-      @click="userStore.initiateSignIn()"
+      @click="initiateSignIn()"
       >{{ $t({ en: 'Sign in', zh: '登录' }) }}</UIButton
     >
   </div>
@@ -17,7 +17,7 @@
     <UIMenu class="user-menu">
       <UIMenuGroup>
         <UIMenuItem :interactive="false">
-          {{ userInfo.displayName || userInfo.name }}
+          {{ signedInUser?.displayName || signedInUser?.username }}
         </UIMenuItem>
       </UIMenuGroup>
       <UIMenuGroup>
@@ -36,7 +36,7 @@
           {{ $t({ en: 'Use SPX v2', zh: '使用 SPX v2' }) }}
         </UIMenuItem>
       </UIMenuGroup>
-      <UIMenuGroup v-if="userInfo.advancedLibraryEnabled">
+      <UIMenuGroup v-if="signedInUser?.capabilities.canManageAssets">
         <UIMenuItem @click="manageAssets(AssetType.Sprite)">
           {{ $t({ en: 'Manage sprites', zh: '管理精灵' }) }}
         </UIMenuItem>
@@ -45,9 +45,6 @@
         </UIMenuItem>
         <UIMenuItem @click="manageAssets(AssetType.Backdrop)">
           {{ $t({ en: 'Manage backdrops', zh: '管理背景' }) }}
-        </UIMenuItem>
-        <UIMenuItem @click="handleDisableAdvancedLibrary">
-          {{ $t({ en: 'Disable advanced library features', zh: '禁用高级素材库功能' }) }}
         </UIMenuItem>
       </UIMenuGroup>
       <UIMenuGroup v-if="isDeveloperMode">
@@ -66,26 +63,24 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue'
 import { useRouter } from 'vue-router'
 import { useNetwork } from '@/utils/network'
 import { useExternalUrl, useSpxVersion } from '@/utils/utils'
 import { useMessageHandle } from '@/utils/exception'
 import { getUserPageRoute } from '@/router'
 import { AssetType } from '@/apis/asset'
-import { useUserStore } from '@/stores/user'
+import { initiateSignIn, signOut, useSignedInUser } from '@/stores/user'
 import { UIButton, UIDropdown, UIMenu, UIMenuGroup, UIMenuItem } from '@/components/ui'
 import { useAssetLibraryManagement } from '@/components/asset'
 import { isDeveloperMode } from '@/utils/developer-mode'
 import { useAgentCopilotCtx } from '@/components/agent-copilot/CopilotProvider.vue'
 
-const userStore = useUserStore()
 const { isOnline } = useNetwork()
 const router = useRouter()
 const { controls } = useAgentCopilotCtx()
 
-const userInfo = computed(() => userStore.getSignedInUser())
-const avatarUrl = useExternalUrl(() => userInfo.value?.avatar)
+const { data: signedInUser } = useSignedInUser()
+const avatarUrl = useExternalUrl(() => signedInUser.value?.avatar)
 
 const handleAskCopilotAgent = useMessageHandle(
   async () => {
@@ -100,11 +95,11 @@ const handleAskCopilotAgent = useMessageHandle(
 ).fn
 
 function handleUserPage() {
-  router.push(getUserPageRoute(userInfo.value!.name))
+  router.push(getUserPageRoute(signedInUser.value!.username))
 }
 
 function handleProjects() {
-  router.push(getUserPageRoute(userInfo.value!.name, 'projects'))
+  router.push(getUserPageRoute(signedInUser.value!.username, 'projects'))
 }
 
 const spxVersion = useSpxVersion()
@@ -131,10 +126,6 @@ const handleUseSpxV2 = useMessageHandle(
   }
 ).fn
 
-function handleDisableAdvancedLibrary() {
-  userStore.disableAdvancedLibrary()
-}
-
 const manageAssetLibrary = useAssetLibraryManagement()
 const manageAssets = useMessageHandle(manageAssetLibrary).fn
 const handleUseMcpDebuggerUtils = useMessageHandle(
@@ -150,7 +141,7 @@ const handleUseMcpDebuggerUtils = useMessageHandle(
 ).fn
 
 function handleSignOut() {
-  userStore.signOut()
+  signOut()
   router.go(0) // Reload the page to trigger navigation guards.
 }
 </script>

--- a/spx-gui/src/components/project/ProjectItem.vue
+++ b/spx-gui/src/components/project/ProjectItem.vue
@@ -118,7 +118,7 @@ import { humanizeCount, humanizeExactCount, humanizeTime, humanizeExactTime, use
 import { getProjectEditorRoute, getProjectPageRoute } from '@/router'
 import { Visibility, type ProjectData } from '@/apis/project'
 import { createFileWithUniversalUrl, getPublishedContent } from '@/models/common/cloud'
-import { useUserStore } from '@/stores/user'
+import { getSignedInUsername } from '@/stores/user'
 import { useIsLikingProject } from '@/stores/liking'
 import { UIImg, UIDropdown, UIIcon, UIMenu, UIMenuItem } from '@/components/ui'
 import UserAvatar from '@/components/community/user/UserAvatar.vue'
@@ -148,8 +148,7 @@ const emit = defineEmits<{
   removed: []
 }>()
 
-const userStore = useUserStore()
-const isOwner = computed(() => props.project.owner === userStore.getSignedInUser()?.name)
+const isOwner = computed(() => props.project.owner === getSignedInUsername())
 const operatable = computed(() => props.context === 'mine' && isOwner.value)
 
 const router = useRouter()

--- a/spx-gui/src/components/project/runner/v1/IframeDisplay.vue
+++ b/spx-gui/src/components/project/runner/v1/IframeDisplay.vue
@@ -11,7 +11,7 @@ import wasmExecUrl from '@/assets/wasm/wasm_exec.js?url'
 import ispxWasmUrl from '@/assets/wasm/ispx.wasm?url'
 import ispxRunnerHtml from './ispx/runner.html?raw'
 import { apiBaseUrl } from '@/utils/env'
-import { useUserStore } from '@/stores/user'
+import { ensureAccessToken } from '@/stores/user'
 
 // preload resources (for example, wasm files) to accelerate the loading
 export function preload() {
@@ -71,9 +71,8 @@ watch(iframe, () => {
 
     iframeWindow.setAIInteractionAPIEndpoint(apiBaseUrl + '/ai/interaction')
 
-    const userStore = useUserStore()
-    await userStore.ensureAccessToken()
-    iframeWindow.setAIInteractionAPITokenProvider(async () => (await userStore.ensureAccessToken()) ?? '')
+    await ensureAccessToken()
+    iframeWindow.setAIInteractionAPITokenProvider(async () => (await ensureAccessToken()) ?? '')
     iframeWindow.startWithZipBuffer(props.zipData)
     startWithZipBufferReporter.report(1)
     const canvas = iframeWindow.document.querySelector('canvas')

--- a/spx-gui/src/components/project/runner/v2/ProjectRunnerV2.vue
+++ b/spx-gui/src/components/project/runner/v2/ProjectRunnerV2.vue
@@ -13,12 +13,10 @@ import { hashFiles } from '@/models/common/hash'
 import type { Project } from '@/models/project'
 import { UIImg, UIDetailedLoading } from '@/components/ui'
 import { apiBaseUrl } from '@/utils/env'
-import { useUserStore } from '@/stores/user'
+import { ensureAccessToken } from '@/stores/user'
 
 const runnerBaseUrl = `/spx_${spxVersion}`
 const runnerUrl = `${runnerBaseUrl}/runner.html`
-
-const userStore = useUserStore()
 
 const props = defineProps<{ project: Project }>()
 
@@ -180,7 +178,7 @@ defineExpose({
         iframeWindow.setAIInteractionAPIEndpoint(apiBaseUrl + '/ai/interaction')
 
         // Set up token provider for AI Interaction.
-        iframeWindow.setAIInteractionAPITokenProvider(async () => (await userStore.ensureAccessToken()) ?? '')
+        iframeWindow.setAIInteractionAPITokenProvider(async () => (await ensureAccessToken()) ?? '')
       })
       signal?.throwIfAborted()
       startGameReporter.report(1)

--- a/spx-gui/src/main.ts
+++ b/spx-gui/src/main.ts
@@ -14,7 +14,7 @@ import 'dayjs/locale/zh'
 import { initI18n } from './i18n'
 import App from './App.vue'
 import { initRouter } from './router'
-import { initUserStore, useUserStore } from './stores/user'
+import { initUserState, ensureAccessToken } from './stores/user'
 import { setTokenProvider } from './apis/common'
 import { CustomTransformer } from './components/editor/preview/stage-viewer/custom-transformer'
 import { initDeveloperMode } from './utils/developer-mode'
@@ -28,8 +28,7 @@ dayjs.extend(utc)
 dayjs.extend(timezone)
 
 function initApiClient() {
-  const userStore = useUserStore()
-  setTokenProvider(userStore.ensureAccessToken)
+  setTokenProvider(ensureAccessToken)
 }
 
 function initSentry(app: VueApp<Element>, router: Router) {
@@ -63,7 +62,7 @@ function initSentry(app: VueApp<Element>, router: Router) {
 async function initApp() {
   const app = createApp(App)
 
-  initUserStore(app)
+  initUserState()
   const router = initRouter(app)
   initSentry(app, router)
   initApiClient()

--- a/spx-gui/src/pages/community/home.vue
+++ b/spx-gui/src/pages/community/home.vue
@@ -1,12 +1,12 @@
 <template>
   <CenteredWrapper class="home-page">
-    <GuestBanner v-if="!userStore.isSignedIn()" class="guest-banner" />
+    <GuestBanner v-if="!isSignedIn()" class="guest-banner" />
     <ProjectsSection
       v-else
       v-radar="{ name: 'Your projects', desc: 'Section showing user\'s own projects' }"
       context="home"
       :num-in-row="numInRow"
-      :link-to="userStore.isSignedIn() ? myProjectsRoute : null"
+      :link-to="isSignedIn() ? myProjectsRoute : null"
       :query-ret="myProjects"
     >
       <template #title>
@@ -87,7 +87,7 @@
       <ProjectItem v-for="project in communityRemixingProjects.data.value" :key="project.id" :project="project" />
     </ProjectsSection>
     <ProjectsSection
-      v-if="userStore.isSignedIn()"
+      v-if="isSignedIn()"
       v-radar="{ name: 'Following created', desc: 'Section showing projects created by users you follow' }"
       context="home"
       :num-in-row="numInRow"
@@ -121,7 +121,7 @@ import { useQuery } from '@/utils/query'
 import { usePageTitle } from '@/utils/utils'
 import { ExploreOrder, exploreProjects, listProject } from '@/apis/project'
 import { getExploreRoute, getUserPageRoute } from '@/router'
-import { useUserStore } from '@/stores/user'
+import { isSignedIn, getSignedInUsername } from '@/stores/user'
 import { useResponsive } from '@/components/ui'
 import ProjectsSection from '@/components/community/ProjectsSection.vue'
 import CenteredWrapper from '@/components/community/CenteredWrapper.vue'
@@ -134,17 +134,16 @@ usePageTitle([])
 const isDesktopLarge = useResponsive('desktop-large')
 const numInRow = computed(() => (isDesktopLarge.value ? 5 : 4))
 
-const userStore = useUserStore()
-const signedInUser = computed(() => userStore.getSignedInUser())
+const signedInUsername = computed(() => getSignedInUsername())
 
 const myProjectsRoute = computed(() => {
-  if (signedInUser.value == null) return ''
-  return getUserPageRoute(signedInUser.value.name, 'projects')
+  if (signedInUsername.value == null) return ''
+  return getUserPageRoute(signedInUsername.value, 'projects')
 })
 
 const myProjects = useQuery(
   async () => {
-    if (signedInUser.value == null) return []
+    if (signedInUsername.value == null) return []
     const { data: projects } = await listProject({
       pageIndex: 1,
       pageSize: numInRow.value,
@@ -171,13 +170,13 @@ const communityRemixingProjects = useQuery(
 )
 
 const followingCreatedRoute = computed(() => {
-  if (signedInUser.value == null) return ''
+  if (signedInUsername.value == null) return ''
   return getExploreRoute(ExploreOrder.FollowingCreated)
 })
 
 const followingCreatedProjects = useQuery(
   async () => {
-    if (signedInUser.value == null) return []
+    if (signedInUsername.value == null) return []
     return exploreProjects({ order: ExploreOrder.FollowingCreated, count: numInRow.value })
   },
   { en: 'Failed to load projects', zh: '加载失败' }

--- a/spx-gui/src/pages/community/project.vue
+++ b/spx-gui/src/pages/community/project.vue
@@ -11,7 +11,7 @@ import { ownerAll, recordProjectView, stringifyProjectFullName, stringifyRemixSo
 import { listProject } from '@/apis/project'
 import { listReleases } from '@/apis/project-release'
 import { Project } from '@/models/project'
-import { useUser, useUserStore } from '@/stores/user'
+import { useUser, isSignedIn, getSignedInUsername } from '@/stores/user'
 import { getOwnProjectEditorRoute, getProjectEditorRoute, getUserPageRoute } from '@/router'
 import {
   UIIcon,
@@ -45,7 +45,6 @@ const props = defineProps<{
 }>()
 
 const router = useRouter()
-const userStore = useUserStore()
 
 const {
   data: project,
@@ -83,7 +82,7 @@ usePageTitle(() => {
 
 watch(
   () => [props.owner, props.name],
-  () => userStore.isSignedIn() && recordProjectView(props.owner, props.name),
+  () => isSignedIn() && recordProjectView(props.owner, props.name),
   { immediate: true }
 )
 
@@ -95,7 +94,7 @@ watch(
   }
 )
 
-const isOwner = computed(() => props.owner === userStore.getSignedInUser()?.name)
+const isOwner = computed(() => props.owner === getSignedInUsername())
 const { data: liking } = useIsLikingProject(() => ({ owner: props.owner, name: props.name }))
 
 const projectRunnerRef = ref<InstanceType<typeof ProjectRunner> | null>(null)
@@ -255,7 +254,7 @@ const removeProject = useRemoveProject()
 const handleRemove = useMessageHandle(
   async () => {
     await removeProject(props.owner, props.name)
-    await router.push(getUserPageRoute(userStore.getSignedInUser()!.name, 'projects'))
+    await router.push(getUserPageRoute(getSignedInUsername()!, 'projects'))
   },
   { en: 'Failed to remove project', zh: '删除项目失败' },
   { en: 'Project removed', zh: '项目已删除' }

--- a/spx-gui/src/pages/community/user/overview.vue
+++ b/spx-gui/src/pages/community/user/overview.vue
@@ -4,7 +4,7 @@ import { getUserPageRoute } from '@/router'
 import { useQuery } from '@/utils/query'
 import { usePageTitle } from '@/utils/utils'
 import { Visibility, listProject, ownerAll } from '@/apis/project'
-import { useUser, useUserStore } from '@/stores/user'
+import { getSignedInUsername, useUser } from '@/stores/user'
 import { useResponsive } from '@/components/ui'
 import CommunityCard from '@/components/community/CommunityCard.vue'
 import ProjectsSection from '@/components/community/ProjectsSection.vue'
@@ -17,8 +17,7 @@ const props = defineProps<{
 
 const isDesktopLarge = useResponsive('desktop-large')
 const numInRow = computed(() => (isDesktopLarge.value ? 5 : 4))
-const userStore = useUserStore()
-const isSignedInUser = computed(() => props.name === userStore.getSignedInUser()?.name)
+const isSignedInUser = computed(() => props.name === getSignedInUsername())
 
 const { data: user } = useUser(() => props.name)
 usePageTitle(() => {

--- a/spx-gui/src/pages/community/user/projects.vue
+++ b/spx-gui/src/pages/community/user/projects.vue
@@ -8,7 +8,7 @@ import { usePageTitle } from '@/utils/utils'
 import { useEnsureSignedIn } from '@/utils/user'
 import { Visibility, listProject, type ListProjectParams } from '@/apis/project'
 import { getOwnProjectEditorRoute } from '@/router'
-import { useUser, useUserStore } from '@/stores/user'
+import { getSignedInUsername, useUser } from '@/stores/user'
 import { UISelect, UISelectOption, UIPagination, UIButton, useResponsive } from '@/components/ui'
 import { useCreateProject } from '@/components/project'
 import ListResultWrapper from '@/components/common/ListResultWrapper.vue'
@@ -19,7 +19,7 @@ const props = defineProps<{
   name: string
 }>()
 
-const isSignedInUser = computed(() => props.name === useUserStore().getSignedInUser()?.name)
+const isSignedInUser = computed(() => props.name === getSignedInUsername())
 
 const { data: user } = useUser(() => props.name)
 usePageTitle(() => {

--- a/spx-gui/src/pages/editor/index.vue
+++ b/spx-gui/src/pages/editor/index.vue
@@ -20,7 +20,7 @@
 <script setup lang="ts">
 import { onMounted, onUnmounted, computed } from 'vue'
 import { onBeforeRouteLeave, useRouter } from 'vue-router'
-import { useUserStore } from '@/stores/user'
+import { getSignedInUsername } from '@/stores/user'
 import { Project } from '@/models/project'
 import { getProjectEditorRoute } from '@/router'
 import { Cancelled } from '@/utils/exception'
@@ -52,8 +52,7 @@ usePageTitle(() => ({
 
 const LOCAL_CACHE_KEY = 'XBUILDER_CACHED_PROJECT'
 
-const userStore = useUserStore()
-const userInfo = computed(() => userStore.getSignedInUser())
+const signedInUsername = computed(() => getSignedInUsername())
 const copilotCtx = useAgentCopilotCtx()
 
 const router = useRouter()
@@ -104,7 +103,7 @@ const project = projectQueryRet.data
 const stateQueryRet = useQuery(async (ctx) => {
   const project = await composeQuery(ctx, projectQueryRet)
   ctx.signal.throwIfAborted()
-  const state = new EditorState(project, isOnline, userInfo, LOCAL_CACHE_KEY)
+  const state = new EditorState(project, isOnline, signedInUsername, LOCAL_CACHE_KEY)
   state.disposeOnSignal(ctx.signal)
   state.syncWithRouter(router)
   state.editing.start()

--- a/spx-gui/src/pages/sign-in/callback.vue
+++ b/spx-gui/src/pages/sign-in/callback.vue
@@ -5,18 +5,16 @@
 </template>
 <script setup lang="ts">
 import { usePageTitle } from '@/utils/utils'
-import { useUserStore } from '@/stores/user'
+import { completeSignIn } from '@/stores/user'
 
 const title = { en: 'Signing in...', zh: '登录中...' }
 
 usePageTitle(title)
 
-const userStore = useUserStore()
-
 try {
   const params = new URLSearchParams(location.search)
 
-  await userStore.completeSignIn()
+  await completeSignIn()
 
   const returnTo = params.get('returnTo')
   window.location.replace(returnTo != null ? returnTo : '/')

--- a/spx-gui/src/router.ts
+++ b/spx-gui/src/router.ts
@@ -2,7 +2,7 @@ import type { App } from 'vue'
 import { createRouter, createWebHistory, type RouteRecordRaw } from 'vue-router'
 import { searchKeywordQueryParamName } from '@/pages/community/search.vue'
 import type { ExploreOrder } from './apis/project'
-import { useUserStore } from './stores/user'
+import { initiateSignIn, isSignedIn, getSignedInUsername } from './stores/user'
 
 export function getProjectEditorRoute(ownerName: string, projectName: string, publish = false) {
   ownerName = encodeURIComponent(ownerName)
@@ -11,9 +11,9 @@ export function getProjectEditorRoute(ownerName: string, projectName: string, pu
 }
 
 export function getOwnProjectEditorRoute(projectName: string, publish = false) {
-  const user = useUserStore().getSignedInUser()
-  if (user == null) throw new Error('User not signed in')
-  return getProjectEditorRoute(user.name, projectName, publish)
+  const username = getSignedInUsername()
+  if (username == null) throw new Error('User not signed in')
+  return getProjectEditorRoute(username, projectName, publish)
 }
 
 export function getProjectPageRoute(owner: string, name: string) {
@@ -119,15 +119,14 @@ const routes: Array<RouteRecordRaw> = [
     path: '/editor/:projectName',
     redirect(to) {
       const { projectName } = to.params
-      const userStore = useUserStore()
-      const user = userStore.getSignedInUser()
+      const username = getSignedInUsername()
       // Route with `redirect` will not trigger the global `beforeEach` guard,
       // so we need to check sign-in status here.
-      if (user == null) {
-        userStore.initiateSignIn()
+      if (username == null) {
+        initiateSignIn()
         throw new Error('User not signed in') // prevent router from redirecting
       }
-      return getProjectEditorRoute(user.name, projectName as string)
+      return getProjectEditorRoute(username, projectName as string)
     }
   },
   {
@@ -154,10 +153,9 @@ const router = createRouter({
 })
 
 export const initRouter = (app: App) => {
-  const userStore = useUserStore()
   router.beforeEach((to, _, next) => {
-    if (to.meta.requiresSignIn && !userStore.isSignedIn()) {
-      userStore.initiateSignIn()
+    if (to.meta.requiresSignIn && !isSignedIn()) {
+      initiateSignIn()
     } else {
       next()
     }

--- a/spx-gui/src/stores/liking.ts
+++ b/spx-gui/src/stores/liking.ts
@@ -2,25 +2,24 @@ import { computed, toRef, type WatchSource } from 'vue'
 import { useQueryWithCache, useQueryCache } from '@/utils/query'
 import { useAction } from '@/utils/exception'
 import * as apis from '@/apis/project'
-import { useUserStore, type UserInfo } from './user'
+import { isSignedIn, getSignedInUsername } from './user'
 
-function getLikingQueryKey(signedInUser: UserInfo | null, owner: string, name: string) {
-  return ['liking', signedInUser?.name ?? null, owner, name]
+function getLikingQueryKey(owner: string, name: string) {
+  return ['liking', getSignedInUsername(), owner, name]
 }
 
 const staleTime = 5 * 60 * 1000 // 5min
 
 export function useIsLikingProject(project: WatchSource<{ owner: string; name: string }>) {
-  const userStore = useUserStore()
   const projectRef = toRef(project)
   const queryKey = computed(() => {
     const { owner, name } = projectRef.value
-    return getLikingQueryKey(userStore.getSignedInUser(), owner, name)
+    return getLikingQueryKey(owner, name)
   })
   return useQueryWithCache({
     queryKey,
     async queryFn() {
-      if (!userStore.isSignedIn()) return false
+      if (!isSignedIn()) return false
       return apis.isLiking(projectRef.value.owner, projectRef.value.name)
     },
     failureSummaryMessage: { en: 'Failed to check liking status', zh: '检查喜欢状态失败' },
@@ -29,12 +28,11 @@ export function useIsLikingProject(project: WatchSource<{ owner: string; name: s
 }
 
 export function useLikeProject() {
-  const userStore = useUserStore()
   const queryCache = useQueryCache()
   return useAction(
     async function likeProject(owner: string, name: string) {
       await apis.likeProject(owner, name)
-      const queryKey = getLikingQueryKey(userStore.getSignedInUser(), owner, name)
+      const queryKey = getLikingQueryKey(owner, name)
       queryCache.invalidateWithOptimisticValue(queryKey, true)
     },
     { en: 'Failed to like', zh: '标记喜欢失败' }
@@ -42,12 +40,11 @@ export function useLikeProject() {
 }
 
 export function useUnlikeProject() {
-  const userStore = useUserStore()
   const queryCache = useQueryCache()
   return useAction(
     async function unlikeProject(owner: string, name: string) {
       await apis.unlikeProject(owner, name)
-      const queryKey = getLikingQueryKey(userStore.getSignedInUser(), owner, name)
+      const queryKey = getLikingQueryKey(owner, name)
       queryCache.invalidateWithOptimisticValue(queryKey, false)
     },
     { en: 'Failed to unlike', zh: '取消喜欢失败' }

--- a/spx-gui/src/stores/user/index.ts
+++ b/spx-gui/src/stores/user/index.ts
@@ -1,14 +1,9 @@
 import { computed, toRef, type WatchSource } from 'vue'
-import { useQueryWithCache, useQueryCache } from '@/utils/query'
-import { useAction } from '@/utils/exception'
+import { useQueryWithCache } from '@/utils/query'
 import * as apis from '@/apis/user'
-import { useUserStore } from './signed-in'
+import { getUserQueryKey } from './query-keys'
 
 export * from './signed-in'
-
-function getUserQueryKey(username: string) {
-  return ['user', username]
-}
 
 const staleTime = 5 * 60 * 1000 // 5min
 
@@ -27,17 +22,4 @@ export function useUser(username: WatchSource<string | null>) {
     },
     staleTime
   })
-}
-
-export function useUpdateSignedInUser() {
-  const userStore = useUserStore()
-  const queryCache = useQueryCache()
-  return useAction(
-    async function updateSignedInUser(params: apis.UpdateSignedInUserParams) {
-      const updated = await apis.updateSignedInUser(params)
-      queryCache.invalidate(getUserQueryKey(userStore.getSignedInUser()!.name))
-      return updated
-    },
-    { en: 'Failed to update profile', zh: '更新个人信息失败' }
-  )
 }

--- a/spx-gui/src/stores/user/query-keys.ts
+++ b/spx-gui/src/stores/user/query-keys.ts
@@ -1,0 +1,3 @@
+export function getUserQueryKey(username: string) {
+  return ['user', username]
+}

--- a/spx-gui/src/utils/query.ts
+++ b/spx-gui/src/utils/query.ts
@@ -125,6 +125,10 @@ export function useQueryWithCache<T>(options: QueryWithCacheOptions<T>): QueryRe
 export function useQueryCache<T>() {
   const queryClient = useVueQueryClient()
 
+  /**
+   * Invalidate all queries whose keys start with the provided queryKey.
+   * @see https://tanstack.com/query/latest/docs/framework/vue/guides/query-invalidation#query-matching-with-invalidatequeries
+   */
   function invalidate(queryKey: unknown[]) {
     return queryClient.invalidateQueries({ queryKey })
   }

--- a/spx-gui/src/utils/user.ts
+++ b/spx-gui/src/utils/user.ts
@@ -1,15 +1,14 @@
-import { useUserStore } from '@/stores/user'
+import { initiateSignIn, isSignedIn } from '@/stores/user'
 import { useI18n } from './i18n'
 import { useConfirmDialog } from '@/components/ui'
 import { Cancelled } from './exception'
 
 export function useEnsureSignedIn() {
-  const userStore = useUserStore()
   const { t } = useI18n()
   const withConfirm = useConfirmDialog()
 
   return async () => {
-    if (userStore.isSignedIn()) return
+    if (isSignedIn()) return
     await withConfirm({
       title: t({ en: 'Sign in to continue', zh: '登录以继续' }),
       content: t({
@@ -17,7 +16,7 @@ export function useEnsureSignedIn() {
         zh: '你需要先登录才能执行此操作。你想现在登录吗？'
       }),
       confirmText: t({ en: 'Sign in', zh: '登录' }),
-      confirmHandler: () => userStore.initiateSignIn()
+      confirmHandler: () => initiateSignIn()
     })
     throw new Cancelled('redirected to sign in')
   }


### PR DESCRIPTION
- Integrate with new `GET /user` endpoint for authenticated users.
- Add `UserCapabilities` type with `canManageAssets`, `canUsePremiumLLM`, and quota fields.
- Replace `advancedLibraryEnabled` with capabilities-based permissions.
- Remove Pinia dependency and replace `useUserStore()` with direct function exports.
- Remove redundant `UserInfo` and `UserInfoFromToken` types.
- Add `getSignedInUsername()` method for lightweight username access (no network request).
- Use `useSignedInUser()` hook only when full user data is needed.

Fixes #1749