### PR TITLE
chore(scripts): add Docker Compose for development database setup

### DIFF
--- a/scripts/docker-compose.dev-db.yaml
+++ b/scripts/docker-compose.dev-db.yaml
@@ -1,0 +1,143 @@
+# Development Database Docker Compose Configuration
+#
+# Usage:
+# 1. Start local database: docker-compose -f docker-compose.dev-db.yaml up db -d
+# 2. Clone test database: docker-compose -f docker-compose.dev-db.yaml --profile clone up db-clone
+#
+# Required environment variables:
+# - LDAP_USERNAME: VPN login username
+# - LDAP_PASSWORD: VPN login password
+# - SOURCE_MYSQL_HOST: Test environment MySQL host (default: 10.212.189.245)
+# - SOURCE_MYSQL_PORT: Test environment MySQL port (default: 3306)
+# - SOURCE_MYSQL_USER: Test environment MySQL username (default: root)
+# - SOURCE_MYSQL_PASSWORD: Test environment MySQL password (default: root)
+# - SOURCE_MYSQL_DATABASE: MySQL database name to clone (default: spx)
+# - LOCAL_MYSQL_PORT: Local MySQL port (default: 3306)
+
+services:
+  db:
+    image: mysql:8.4
+    container_name: db
+    environment:
+      - MYSQL_ROOT_PASSWORD=root
+    ports:
+      - "${LOCAL_MYSQL_PORT:-3306}:3306"
+    volumes:
+      - mysql_data:/var/lib/mysql
+    command:
+      - --character-set-server=utf8mb4
+      - --collation-server=utf8mb4_unicode_ci
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-u", "root", "-proot"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+
+  db-clone:
+    image: mysql:8.4
+    container_name: db-clone
+    depends_on:
+      db:
+        condition: service_healthy
+    privileged: true
+    cap_add:
+      - NET_ADMIN
+      - NET_RAW
+    devices:
+      - /dev/net/tun
+    environment:
+      - LDAP_USERNAME
+      - LDAP_PASSWORD
+      - SOURCE_MYSQL_HOST=${SOURCE_MYSQL_HOST:-10.212.189.245}
+      - SOURCE_MYSQL_PORT=${SOURCE_MYSQL_PORT:-3306}
+      - SOURCE_MYSQL_USER=${SOURCE_MYSQL_USER:-root}
+      - SOURCE_MYSQL_PASSWORD=${SOURCE_MYSQL_PASSWORD:-root}
+      - SOURCE_MYSQL_DATABASE=${SOURCE_MYSQL_DATABASE:-spx}
+    entrypoint: /bin/bash
+    command:
+      - -ce
+      - |
+        # Install packages
+        microdnf install -y procps-ng iproute dnf
+        dnf install -y epel-release
+        dnf install -y openconnect
+
+        # Disable IPv6
+        sysctl -w net.ipv6.conf.all.disable_ipv6=1
+        sysctl -w net.ipv6.conf.default.disable_ipv6=1
+        sysctl -w net.ipv6.conf.lo.disable_ipv6=1
+
+        # Setup VPN connection
+        echo "${LDAP_PASSWORD}" | openconnect \
+          --protocol=gp \
+          --user="${LDAP_USERNAME}" \
+          --passwd-on-stdin \
+          --interface=qiniu-vpn \
+          --disable-ipv6 \
+          --queue-len=15 \
+          --allow-insecure-crypto \
+          --background \
+          vpn.qiniu.io
+
+        # Wait for VPN interface
+        echo "Waiting for VPN connection..."
+        while [ ! -d /sys/class/net/qiniu-vpn ]; do sleep 1; done
+        echo "VPN connected successfully"
+
+        # Wait a bit more for routes to be established
+        sleep 5
+
+        # Test connectivity to source database
+        echo "Testing connectivity to source database: $${SOURCE_MYSQL_HOST}:$${SOURCE_MYSQL_PORT} as $${SOURCE_MYSQL_USER}"
+        mysql -h"$${SOURCE_MYSQL_HOST}" -P"$${SOURCE_MYSQL_PORT}" -u"$${SOURCE_MYSQL_USER}" -p"$${SOURCE_MYSQL_PASSWORD}" --ssl-mode=DISABLED -e "SELECT 1" > /dev/null
+        echo "Source database connection successful"
+
+        # Dump source database
+        echo "Dumping source database: $${SOURCE_MYSQL_DATABASE} (this may take a while...)"
+        mysqldump \
+          -h"$${SOURCE_MYSQL_HOST}" \
+          -P"$${SOURCE_MYSQL_PORT}" \
+          -u"$${SOURCE_MYSQL_USER}" \
+          -p"$${SOURCE_MYSQL_PASSWORD}" \
+          --ssl-mode=DISABLED \
+          --single-transaction \
+          --routines \
+          --triggers \
+          --events \
+          --hex-blob \
+          --opt \
+          --verbose \
+          "$${SOURCE_MYSQL_DATABASE}" > /tmp/source_db_dump.sql
+
+        echo "Database dump completed, size: $$(du -h /tmp/source_db_dump.sql | cut -f1)"
+
+        # Disconnect VPN to avoid routing conflicts
+        echo "Disconnecting VPN..."
+        pkill -f openconnect || true
+        sleep 2
+
+        # Test connectivity to target database
+        echo "Testing connectivity to target database..."
+        mysql -hdb -P3306 -uroot -proot -e "SELECT 1" > /dev/null
+        echo "Target database connection successful"
+
+        # Drop target database if exists and recreate
+        echo "Preparing target database: $${SOURCE_MYSQL_DATABASE}"
+        mysql -hdb -P3306 -uroot -proot << EOF
+        DROP DATABASE IF EXISTS \`$${SOURCE_MYSQL_DATABASE}\`;
+        CREATE DATABASE \`$${SOURCE_MYSQL_DATABASE}\` CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+        EOF
+
+        # Import to target database
+        echo "Importing to target database..."
+        mysql -hdb -P3306 -uroot -proot $${SOURCE_MYSQL_DATABASE} < /tmp/source_db_dump.sql
+
+        echo "Database clone completed successfully!"
+        echo "Local database is ready at localhost:${LOCAL_MYSQL_PORT:-3306}"
+    profiles:
+      - clone
+
+volumes:
+  mysql_data:
+    driver: local


### PR DESCRIPTION
- Add `scripts/docker-compose.dev-db.yaml` for local MySQL and database cloning.
- Support VPN connection to access test environment database.
- Automatically clone test database to local MySQL instance.