### PR TITLE
feat(spx-backend): introduce context-based `authz.ConsumeQuota` helper func

### DIFF
--- a/spx-backend/cmd/spx-backend/main.yap
+++ b/spx-backend/cmd/spx-backend/main.yap
@@ -24,8 +24,7 @@ const (
 )
 
 var (
-	authorizer *authz.Authorizer
-	ctrl       *controller.Controller
+	ctrl *controller.Controller
 )
 
 logger := log.GetLogger()
@@ -56,7 +55,7 @@ if cfg.Redis.Addr != "" {
 	logger.Println("using no-op quota tracker")
 }
 pdp := embpdp.New(quotaTracker)
-authorizer = authz.New(db, pdp, quotaTracker)
+authorizer := authz.New(db, pdp, quotaTracker)
 
 // Initialize controller.
 ctrl, err = controller.New(context.Background(), db, cfg)

--- a/spx-backend/cmd/spx-backend/post_asset.yap
+++ b/spx-backend/cmd/spx-backend/post_asset.yap
@@ -23,7 +23,7 @@ if ok, msg := params.Validate(); !ok {
 	return
 }
 
-if !authz.UserCanManageAssets(ctx.Context()) {
+if !authz.CanManageAssets(ctx.Context()) {
 	if params.Visibility == model.VisibilityPublic {
 		replyWithCodeMsg(ctx, errorForbidden, "You are not allowed to create public assets")
 		return

--- a/spx-backend/cmd/spx-backend/post_copilot_message.yap
+++ b/spx-backend/cmd/spx-backend/post_copilot_message.yap
@@ -10,8 +10,7 @@ import (
 )
 
 ctx := &Context
-mUser, ok := ensureAuthenticatedUser(ctx)
-if !ok {
+if _, ok := ensureAuthenticatedUser(ctx); !ok {
 	return
 }
 
@@ -32,7 +31,7 @@ if ok, msg := params.Validate(); !ok {
 	return
 }
 
-canUsePremium := authz.UserCanUsePremiumLLM(ctx.Context())
+canUsePremium := authz.CanUsePremiumLLM(ctx.Context())
 result, err := ctrl.GenerateMessage(ctx.Context(), params, canUsePremium)
 if err != nil {
 	replyWithInnerError(ctx, err)
@@ -40,7 +39,7 @@ if err != nil {
 }
 
 // Consume quota after successful generation.
-if err := authorizer.ConsumeQuota(ctx.Context(), mUser.ID, authz.ResourceCopilotMessage, 1); err != nil {
+if err := authz.ConsumeQuota(ctx.Context(), authz.ResourceCopilotMessage, 1); err != nil {
 	logger := log.GetReqLogger(ctx.Context())
 	logger.Printf("failed to consume copilot quota: %v", err)
 }

--- a/spx-backend/cmd/spx-backend/post_copilot_stream_message.yap
+++ b/spx-backend/cmd/spx-backend/post_copilot_stream_message.yap
@@ -10,8 +10,7 @@ import (
 )
 
 ctx := &Context
-mUser, ok := ensureAuthenticatedUser(ctx)
-if !ok {
+if _, ok := ensureAuthenticatedUser(ctx); !ok {
 	return
 }
 
@@ -32,7 +31,7 @@ if ok, msg := params.Validate(); !ok {
 	return
 }
 
-canUsePremium := authz.UserCanUsePremiumLLM(ctx.Context())
+canUsePremium := authz.CanUsePremiumLLM(ctx.Context())
 read, err := ctrl.GenerateMessageStream(ctx.Context(), params, canUsePremium)
 if err != nil {
 	replyWithInnerError(ctx, err)
@@ -40,7 +39,7 @@ if err != nil {
 }
 
 // Consume quota after successful stream initiation.
-if err := authorizer.ConsumeQuota(ctx.Context(), mUser.ID, authz.ResourceCopilotMessage, 1); err != nil {
+if err := authz.ConsumeQuota(ctx.Context(), authz.ResourceCopilotMessage, 1); err != nil {
 	logger := log.GetReqLogger(ctx.Context())
 	logger.Printf("failed to consume copilot quota: %v", err)
 }

--- a/spx-backend/cmd/spx-backend/post_workflow_stream_message.yap
+++ b/spx-backend/cmd/spx-backend/post_workflow_stream_message.yap
@@ -10,8 +10,7 @@ import (
 )
 
 ctx := &Context
-mUser, ok := ensureAuthenticatedUser(ctx)
-if !ok {
+if _, ok := ensureAuthenticatedUser(ctx); !ok {
 	return
 }
 
@@ -32,7 +31,7 @@ if ok, msg := params.Validate(); !ok {
 	return
 }
 
-canUsePremium := authz.UserCanUsePremiumLLM(ctx.Context())
+canUsePremium := authz.CanUsePremiumLLM(ctx.Context())
 read, err := ctrl.WorkflowMessageStream(ctx.Context(), params, canUsePremium)
 if err != nil {
 	replyWithInnerError(ctx, err)
@@ -40,7 +39,7 @@ if err != nil {
 }
 
 // Consume quota after successful workflow initiation.
-if err := authorizer.ConsumeQuota(ctx.Context(), mUser.ID, authz.ResourceCopilotMessage, 1); err != nil {
+if err := authz.ConsumeQuota(ctx.Context(), authz.ResourceCopilotMessage, 1); err != nil {
 	logger := log.GetReqLogger(ctx.Context())
 	logger.Printf("failed to consume copilot quota: %v", err)
 }

--- a/spx-backend/cmd/spx-backend/put_asset_#id.yap
+++ b/spx-backend/cmd/spx-backend/put_asset_#id.yap
@@ -23,7 +23,7 @@ if ok, msg := params.Validate(); !ok {
 	return
 }
 
-if !authz.UserCanManageAssets(ctx.Context()) {
+if !authz.CanManageAssets(ctx.Context()) {
 	if params.Visibility == model.VisibilityPublic {
 		replyWithCodeMsg(ctx, errorForbidden, "You are not allowed to make assets public")
 		return

--- a/spx-backend/internal/authz/context.go
+++ b/spx-backend/internal/authz/context.go
@@ -2,6 +2,20 @@ package authz
 
 import "context"
 
+// authorizerContextKey is the context key type for authorizers.
+type authorizerContextKey struct{}
+
+// newContextWithAuthorizer creates a new context with the authorizer.
+func newContextWithAuthorizer(ctx context.Context, authorizer *Authorizer) context.Context {
+	return context.WithValue(ctx, authorizerContextKey{}, authorizer)
+}
+
+// authorizerFromContext gets the authorizer from context.
+func authorizerFromContext(ctx context.Context) (*Authorizer, bool) {
+	authorizer, ok := ctx.Value(authorizerContextKey{}).(*Authorizer)
+	return authorizer, ok
+}
+
 // userCapabilitiesContextKey is the context key type for user capabilities.
 type userCapabilitiesContextKey struct{}
 

--- a/spx-backend/internal/authz/helper_test.go
+++ b/spx-backend/internal/authz/helper_test.go
@@ -2,12 +2,16 @@ package authz
 
 import (
 	"context"
+	"errors"
 	"testing"
 
+	"github.com/goplus/builder/spx-backend/internal/authn"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
 )
 
-func TestUserCanManageAssets(t *testing.T) {
+func TestCanManageAssets(t *testing.T) {
 	t.Run("HasPermission", func(t *testing.T) {
 		ctx := NewContextWithUserCapabilities(context.Background(), UserCapabilities{
 			CanManageAssets:         true,
@@ -16,7 +20,7 @@ func TestUserCanManageAssets(t *testing.T) {
 			CopilotMessageQuotaLeft: 50,
 		})
 
-		result := UserCanManageAssets(ctx)
+		result := CanManageAssets(ctx)
 		assert.True(t, result)
 	})
 
@@ -28,33 +32,33 @@ func TestUserCanManageAssets(t *testing.T) {
 			CopilotMessageQuotaLeft: 50,
 		})
 
-		result := UserCanManageAssets(ctx)
+		result := CanManageAssets(ctx)
 		assert.False(t, result)
 	})
 
 	t.Run("NoCapabilities", func(t *testing.T) {
 		ctx := context.Background()
 
-		result := UserCanManageAssets(ctx)
+		result := CanManageAssets(ctx)
 		assert.False(t, result)
 	})
 
 	t.Run("WrongContextValue", func(t *testing.T) {
 		ctx := context.WithValue(context.Background(), userCapabilitiesContextKey{}, "not-capabilities")
 
-		result := UserCanManageAssets(ctx)
+		result := CanManageAssets(ctx)
 		assert.False(t, result)
 	})
 
 	t.Run("ZeroCapabilities", func(t *testing.T) {
 		ctx := NewContextWithUserCapabilities(context.Background(), UserCapabilities{})
 
-		result := UserCanManageAssets(ctx)
+		result := CanManageAssets(ctx)
 		assert.False(t, result)
 	})
 }
 
-func TestUserCanUsePremiumLLM(t *testing.T) {
+func TestCanUsePremiumLLM(t *testing.T) {
 	t.Run("HasPermission", func(t *testing.T) {
 		ctx := NewContextWithUserCapabilities(context.Background(), UserCapabilities{
 			CanManageAssets:         false,
@@ -63,7 +67,7 @@ func TestUserCanUsePremiumLLM(t *testing.T) {
 			CopilotMessageQuotaLeft: 800,
 		})
 
-		result := UserCanUsePremiumLLM(ctx)
+		result := CanUsePremiumLLM(ctx)
 		assert.True(t, result)
 	})
 
@@ -75,28 +79,104 @@ func TestUserCanUsePremiumLLM(t *testing.T) {
 			CopilotMessageQuotaLeft: 30,
 		})
 
-		result := UserCanUsePremiumLLM(ctx)
+		result := CanUsePremiumLLM(ctx)
 		assert.False(t, result)
 	})
 
 	t.Run("NoCapabilities", func(t *testing.T) {
 		ctx := context.Background()
 
-		result := UserCanUsePremiumLLM(ctx)
+		result := CanUsePremiumLLM(ctx)
 		assert.False(t, result)
 	})
 
 	t.Run("WrongContextValue", func(t *testing.T) {
 		ctx := context.WithValue(context.Background(), userCapabilitiesContextKey{}, "not-capabilities")
 
-		result := UserCanUsePremiumLLM(ctx)
+		result := CanUsePremiumLLM(ctx)
 		assert.False(t, result)
 	})
 
 	t.Run("ZeroCapabilities", func(t *testing.T) {
 		ctx := NewContextWithUserCapabilities(context.Background(), UserCapabilities{})
 
-		result := UserCanUsePremiumLLM(ctx)
+		result := CanUsePremiumLLM(ctx)
 		assert.False(t, result)
+	})
+}
+
+func TestConsumeQuota(t *testing.T) {
+	t.Run("Normal", func(t *testing.T) {
+		quotaTracker := &mockQuotaTracker{}
+		quotaTracker.incrementUsageFunc = func(ctx context.Context, userID int64, resource Resource, amount int64) error {
+			assert.Equal(t, int64(123), userID)
+			assert.Equal(t, ResourceCopilotMessage, resource)
+			assert.Equal(t, int64(2), amount)
+			return nil
+		}
+
+		pdp := &mockPolicyDecisionPoint{}
+		authorizer := New(&gorm.DB{}, pdp, quotaTracker)
+
+		testUser := newTestUser()
+		ctx := context.Background()
+		ctx = authn.NewContextWithUser(ctx, testUser)
+		ctx = newContextWithAuthorizer(ctx, authorizer)
+
+		err := ConsumeQuota(ctx, ResourceCopilotMessage, 2)
+		assert.NoError(t, err)
+	})
+
+	t.Run("NoAuthorizer", func(t *testing.T) {
+		testUser := newTestUser()
+		ctx := context.Background()
+		ctx = authn.NewContextWithUser(ctx, testUser)
+
+		err := ConsumeQuota(ctx, ResourceCopilotMessage, 1)
+		require.Error(t, err)
+		assert.EqualError(t, err, "missing authorizer in context")
+	})
+
+	t.Run("NoUser", func(t *testing.T) {
+		quotaTracker := &mockQuotaTracker{}
+		pdp := &mockPolicyDecisionPoint{}
+		authorizer := New(&gorm.DB{}, pdp, quotaTracker)
+
+		ctx := context.Background()
+		ctx = newContextWithAuthorizer(ctx, authorizer)
+
+		err := ConsumeQuota(ctx, ResourceCopilotMessage, 1)
+		require.Error(t, err)
+		assert.EqualError(t, err, "missing authenticated user in context")
+	})
+
+	t.Run("QuotaTrackerError", func(t *testing.T) {
+		quotaTracker := &mockQuotaTracker{}
+		quotaTracker.incrementUsageFunc = func(ctx context.Context, userID int64, resource Resource, amount int64) error {
+			return errors.New("quota exceeded")
+		}
+
+		pdp := &mockPolicyDecisionPoint{}
+		authorizer := New(&gorm.DB{}, pdp, quotaTracker)
+
+		testUser := newTestUser()
+		ctx := context.Background()
+		ctx = authn.NewContextWithUser(ctx, testUser)
+		ctx = newContextWithAuthorizer(ctx, authorizer)
+
+		err := ConsumeQuota(ctx, ResourceCopilotMessage, 1)
+		require.Error(t, err)
+		assert.EqualError(t, err, "quota exceeded")
+	})
+
+	t.Run("WrongAuthorizerContextValue", func(t *testing.T) {
+		testUser := newTestUser()
+		ctx := context.Background()
+		ctx = authn.NewContextWithUser(ctx, testUser)
+		ctx = context.WithValue(ctx, authorizerContextKey{}, "not-authorizer")
+
+		err := ConsumeQuota(ctx, ResourceCopilotMessage, 1)
+		require.Error(t, err)
+		assert.EqualError(t, err, "missing authorizer in context")
 	})
 }


### PR DESCRIPTION
- Add `authz.ConsumeQuota` helper that extracts user and authorizer from context, eliminating need to maintain authorizer instances.
- Inject authorizer instance into request context via middleware for seamless access.
- Remove `authz.Authorizer.ConsumeQuota` method in favor of simplified context-based approach.
- Rename `authz.UserCanManageAssets` to `authz.CanManageAssets` and `authz.UserCanUsePremiumLLM` to `authz.CanUsePremiumLLM` for consistent AuthZ API naming.