### PR TITLE
Better rendering for LLM generated markdown content

### DIFF
--- a/spx-gui/package-lock.json
+++ b/spx-gui/package-lock.json
@@ -7404,10 +7404,9 @@
       }
     },
     "node_modules/mdast-util-find-and-replace": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.1.tgz",
-      "integrity": "sha512-SG21kZHGC3XRTSUhtofZkBzZTJNM5ecCi0SK2IMKmSXR8vO3peL+kb1O0z7Zl83jKtutG4k5Wv/W7V3/YHvzPA==",
-      "license": "MIT",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
+      "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
       "dependencies": {
         "@types/mdast": "^4.0.0",
         "escape-string-regexp": "^5.0.0",

--- a/spx-gui/src/components/common/markdown-vue/MarkdownView.test.ts
+++ b/spx-gui/src/components/common/markdown-vue/MarkdownView.test.ts
@@ -1,0 +1,265 @@
+import { defineComponent, h } from 'vue'
+import { describe, expect, it } from 'vitest'
+import { renderToString } from '@vue/test-utils'
+import { useSlotText } from '@/utils/vnode'
+import MarkdowView, {
+  preprocessCustomRawComponents,
+  preprocessSelfClosingCustomComponents,
+  preprocessIncompleteTags
+} from './MarkdownView'
+
+describe('preprocessCustomRawComponents', () => {
+  it('should convert custom raw components to <pre> tags', () => {
+    const value = '<custom-raw-component>Content</custom-raw-component>'
+    const tagNames = ['custom-raw-component']
+    const result = preprocessCustomRawComponents(value, tagNames)
+    expect(result).toBe('<pre is="custom-raw-component">Content</pre>')
+  })
+  it('should handle multiple custom raw components', () => {
+    const value = '<custom-raw-1>Content 1</custom-raw-1><custom-raw-2>Content 2</custom-raw-2>'
+    const tagNames = ['custom-raw-1', 'custom-raw-2']
+    const result = preprocessCustomRawComponents(value, tagNames)
+    expect(result).toBe('<pre is="custom-raw-1">Content 1</pre><pre is="custom-raw-2">Content 2</pre>')
+  })
+  it('should not modify content without custom raw components', () => {
+    const value = '<div>Normal content</div>'
+    const tagNames = ['custom-raw-component']
+    const result = preprocessCustomRawComponents(value, tagNames)
+    expect(result).toBe('<div>Normal content</div>')
+  })
+  it('should handle empty value', () => {
+    const value = ''
+    const tagNames = ['custom-raw-component']
+    const result = preprocessCustomRawComponents(value, tagNames)
+    expect(result).toBe('')
+  })
+  it('should handle no tag names', () => {
+    const value = '<custom-raw-component>Content</custom-raw-component>'
+    const tagNames: string[] = []
+    const result = preprocessCustomRawComponents(value, tagNames)
+    expect(result).toBe('<custom-raw-component>Content</custom-raw-component>')
+  })
+  it('should handle tags with attributes', () => {
+    const value = '<custom-raw-component attr="value">Content</custom-raw-component>'
+    const tagNames = ['custom-raw-component']
+    const result = preprocessCustomRawComponents(value, tagNames)
+    expect(result).toBe('<pre is="custom-raw-component" attr="value">Content</pre>')
+  })
+  it('should handle self-closing tags', () => {
+    const value = '<custom-raw-component />'
+    const tagNames = ['custom-raw-component']
+    const result = preprocessCustomRawComponents(value, tagNames)
+    expect(result).toBe('<pre is="custom-raw-component" />')
+  })
+  it('should handle nested custom raw components', () => {
+    const value = '<custom-raw-component><nested-component>Content</nested-component></custom-raw-component>'
+    const tagNames = ['custom-raw-component']
+    const result = preprocessCustomRawComponents(value, tagNames)
+    expect(result).toBe('<pre is="custom-raw-component"><nested-component>Content</nested-component></pre>')
+  })
+  it('should handle multiple occurrences of the same tag', () => {
+    const value =
+      '<custom-raw-component>Content 1</custom-raw-component><custom-raw-component>Content 2</custom-raw-component>'
+    const tagNames = ['custom-raw-component']
+    const result = preprocessCustomRawComponents(value, tagNames)
+    expect(result).toBe('<pre is="custom-raw-component">Content 1</pre><pre is="custom-raw-component">Content 2</pre>')
+  })
+  it('should handle mixed content with custom raw components', () => {
+    const value = '<div>Normal content</div><custom-raw-component>Content</custom-raw-component>'
+    const tagNames = ['custom-raw-component']
+    const result = preprocessCustomRawComponents(value, tagNames)
+    expect(result).toBe('<div>Normal content</div><pre is="custom-raw-component">Content</pre>')
+  })
+  it('should handle custom raw components with special characters', () => {
+    const value = '<custom-raw-component>Content with special characters: !@#$%^&*()</custom-raw-component>'
+    const tagNames = ['custom-raw-component']
+    const result = preprocessCustomRawComponents(value, tagNames)
+    expect(result).toBe('<pre is="custom-raw-component">Content with special characters: !@#$%^&*()</pre>')
+  })
+  it('should handle custom raw components with empty content', () => {
+    const value = '<custom-raw-component></custom-raw-component>'
+    const tagNames = ['custom-raw-component']
+    const result = preprocessCustomRawComponents(value, tagNames)
+    expect(result).toBe('<pre is="custom-raw-component"></pre>')
+  })
+  it('should handle custom raw components with more than one attributes', () => {
+    const value = '<custom-raw-component attr1="value1" attr2="value2">Content</custom-raw-component>'
+    const tagNames = ['custom-raw-component']
+    const result = preprocessCustomRawComponents(value, tagNames)
+    expect(result).toBe('<pre is="custom-raw-component" attr1="value1" attr2="value2">Content</pre>')
+  })
+  it('should handle custom raw components with attributes mixed with more than one spaces', () => {
+    const value = '<custom-raw-component  attr1="value1"   attr2="value2">Content</custom-raw-component>'
+    const tagNames = ['custom-raw-component']
+    const result = preprocessCustomRawComponents(value, tagNames)
+    expect(result).toBe('<pre is="custom-raw-component"  attr1="value1"   attr2="value2">Content</pre>')
+  })
+  it('should handle custom raw components with attributes and self-closing tag', () => {
+    const value = '<custom-raw-component attr1="value1" attr2="value2" />'
+    const tagNames = ['custom-raw-component']
+    const result = preprocessCustomRawComponents(value, tagNames)
+    expect(result).toBe('<pre is="custom-raw-component" attr1="value1" attr2="value2" />')
+  })
+})
+
+describe('preprocessSelfClosingCustomComponents', () => {
+  it('should convert self-closing custom components to normal tags', () => {
+    const value = '<custom-self-closing-component />'
+    const tagNames = ['custom-self-closing-component']
+    const result = preprocessSelfClosingCustomComponents(value, tagNames)
+    expect(result).toBe('<custom-self-closing-component></custom-self-closing-component>')
+  })
+  it('should handle multiple self-closing custom components', () => {
+    const value = '<custom-self-closing-1 /><custom-self-closing-2 />'
+    const tagNames = ['custom-self-closing-1', 'custom-self-closing-2']
+    const result = preprocessSelfClosingCustomComponents(value, tagNames)
+    expect(result).toBe(
+      '<custom-self-closing-1></custom-self-closing-1><custom-self-closing-2></custom-self-closing-2>'
+    )
+  })
+  it('should not modify content without self-closing custom components', () => {
+    const value = '<div>Normal content</div>'
+    const tagNames = ['custom-self-closing-component']
+    const result = preprocessSelfClosingCustomComponents(value, tagNames)
+    expect(result).toBe('<div>Normal content</div>')
+  })
+  it('should handle empty value', () => {
+    const value = ''
+    const tagNames = ['custom-self-closing-component']
+    const result = preprocessSelfClosingCustomComponents(value, tagNames)
+    expect(result).toBe('')
+  })
+  it('should handle no tag names', () => {
+    const value = '<custom-self-closing-component />'
+    const tagNames: string[] = []
+    const result = preprocessSelfClosingCustomComponents(value, tagNames)
+    expect(result).toBe('<custom-self-closing-component />')
+  })
+  it('should handle tags with attributes', () => {
+    const value = '<custom-self-closing-component attr="value" />'
+    const tagNames = ['custom-self-closing-component']
+    const result = preprocessSelfClosingCustomComponents(value, tagNames)
+    expect(result).toBe('<custom-self-closing-component attr="value"></custom-self-closing-component>')
+  })
+})
+
+describe('preprocessIncompleteTags', () => {
+  it('should remove the last incomplete tag', () => {
+    const value = 'Before<custom-incomplete-component>Content'
+    const tagNames = ['custom-incomplete-component']
+    const result = preprocessIncompleteTags(value, tagNames)
+    expect(result).toBe('Before')
+  })
+  it('should remove the last incomplete tag 2', () => {
+    const value = 'Before<custom-incomplete-'
+    const tagNames = ['custom-incomplete-component']
+    const result = preprocessIncompleteTags(value, tagNames)
+    expect(result).toBe('Before')
+  })
+  it('should handle multiple incomplete tags', () => {
+    const value = 'Before<custom-incomplete-1>Content 1<custom-incomplete-2>Content 2'
+    const tagNames = ['custom-incomplete-1', 'custom-incomplete-2']
+    const result = preprocessIncompleteTags(value, tagNames)
+    expect(result).toBe('Before')
+  })
+  it('should not modify content without incomplete tags', () => {
+    const value = '<div>Normal content</div>'
+    const tagNames = ['custom-incomplete-component']
+    const result = preprocessIncompleteTags(value, tagNames)
+    expect(result).toBe('<div>Normal content</div>')
+  })
+  it('should handle empty value', () => {
+    const value = ''
+    const tagNames = ['custom-incomplete-component']
+    const result = preprocessIncompleteTags(value, tagNames)
+    expect(result).toBe('')
+  })
+  it('should handle no tag names', () => {
+    const value = '<custom-incomplete-component>Content'
+    const tagNames: string[] = []
+    const result = preprocessIncompleteTags(value, tagNames)
+    expect(result).toBe('<custom-incomplete-component>Content')
+  })
+})
+
+describe('MarkdownView', () => {
+  it('should render correctly', async () => {
+    const result = await renderToString(MarkdowView, {
+      props: {
+        value: '# Hello World'
+      }
+    })
+    expect(result).toBe('<div><h1>Hello World</h1></div>')
+  })
+  it('should handle custom components', async () => {
+    const testComp1 = {
+      template: '<div class="test-comp-1">{{content}}</div>',
+      props: ['content']
+    }
+    const result = await renderToString(MarkdowView, {
+      props: {
+        value: 'Before<test-comp-1 content="Hello" />After',
+        components: {
+          custom: {
+            'test-comp-1': testComp1
+          }
+        }
+      }
+    })
+    expect(result).toBe('<div><p>Before<div class="test-comp-1">Hello</div>After</p></div>')
+  })
+  it('should handle custom components with children', async () => {
+    const testComp1 = {
+      template: '<div class="test-comp-1"><slot /></div>'
+    }
+    const result = await renderToString(MarkdowView, {
+      props: {
+        value: 'Before<test-comp-1>Content</test-comp-1>After',
+        components: {
+          custom: {
+            'test-comp-1': testComp1
+          }
+        }
+      }
+    })
+    expect(result).toBe('<div><p>Before<div class="test-comp-1"><!--[-->Content<!--]--></div>After</p></div>')
+  })
+  it('should handle custom raw components', async () => {
+    const customRawComponent = defineComponent(
+      () => {
+        const innerText = useSlotText()
+        return function render() {
+          return h('div', { class: 'test-comp-1' }, [innerText.value])
+        }
+      },
+      {
+        props: []
+      }
+    )
+    const result = await renderToString(MarkdowView, {
+      props: {
+        value: `
+Before
+
+<custom-raw-component>
+Content1
+
+  Content2
+</custom-raw-component>
+
+After`,
+        components: {
+          customRaw: {
+            'custom-raw-component': customRawComponent
+          }
+        }
+      }
+    })
+    expect(result).toBe(`<div><p>Before</p>
+<div class="test-comp-1">Content1
+
+  Content2
+</div>
+<p>After</p></div>`)
+  })
+})

--- a/spx-gui/src/components/copilot/CopilotRoot.vue
+++ b/spx-gui/src/components/copilot/CopilotRoot.vue
@@ -103,11 +103,16 @@ class GetProjectSpritesTool implements ToolDefinition {
 }
 
 type LineRangeParams = {
-  lineStart: number // 1-based
-  lineEnd: number // 1-based
+  /** 1-based */
+  lineStart?: number
+  /** 1-based */
+  lineEnd?: number
 }
 
-function getLines(code: string, { lineStart, lineEnd }: LineRangeParams): Record<string, string> {
+const lineStartSchema = z.number().default(1).describe('Line number to start from, 1-based')
+const lineEndSchema = z.number().optional().describe('Line number to end at, 1-based')
+
+function getLines(code: string, { lineStart = 1, lineEnd }: LineRangeParams): Record<string, string> {
   return code
     .split(/\r?\n/)
     .slice(lineStart - 1, lineEnd)
@@ -120,8 +125,8 @@ function getLines(code: string, { lineStart, lineEnd }: LineRangeParams): Record
 const getProjectStageCodeParamsSchema = z.object({
   owner: z.string().describe('Owner of the project'),
   project: z.string().describe('Project name'),
-  lineStart: z.number().describe('Line number to start from, 1-based'),
-  lineEnd: z.number().describe('Line number to end at, 1-based')
+  lineStart: lineStartSchema,
+  lineEnd: lineEndSchema
 })
 
 class GetProjectStageCodeTool implements ToolDefinition {
@@ -144,8 +149,8 @@ const getProjectSpriteCodeParamsSchema = z.object({
   owner: z.string().describe('Owner of the project'),
   project: z.string().describe('Project name'),
   sprite: z.string().describe('Sprite name'),
-  lineStart: z.number().describe('Line number to start from, 1-based'),
-  lineEnd: z.number().describe('Line number to end at, 1-based')
+  lineStart: lineStartSchema,
+  lineEnd: lineEndSchema
 })
 
 class GetProjectSpriteCodeTool implements ToolDefinition {
@@ -277,24 +282,28 @@ copilot.registerCustomElement({
   tagName: toolUse.tagName,
   description: toolUse.detailedDescription,
   attributes: toolUse.attributes,
+  isRaw: toolUse.isRaw,
   component: toolUse.default
 })
 copilot.registerCustomElement({
   tagName: highlightLink.tagName,
   description: highlightLink.detailedDescription,
   attributes: highlightLink.attributes,
+  isRaw: highlightLink.isRaw,
   component: highlightLink.default
 })
 copilot.registerCustomElement({
   tagName: codeLink.tagName,
   description: codeLink.detailedDescription,
   attributes: codeLink.attributes,
+  isRaw: codeLink.isRaw,
   component: codeLink.default
 })
 copilot.registerCustomElement({
   tagName: codeChange.tagName,
   description: codeChange.detailedDescription,
   attributes: codeChange.attributes,
+  isRaw: codeChange.isRaw,
   component: codeChange.default
 })
 copilot.registerTool(new GetUINodeTextContentTool(radar))

--- a/spx-gui/src/components/copilot/CopilotUI.vue
+++ b/spx-gui/src/components/copilot/CopilotUI.vue
@@ -104,7 +104,6 @@ useDraggable(headerRef, (offset) => {
         </UITooltip>
       </header>
       <div ref="bodyRef" class="body">
-        <!-- <MarkdownView :value="testContent"></MarkdownView> -->
         <template v-if="isSignedIn()">
           <ul v-if="rounds != null" class="messages">
             <CopilotRound

--- a/spx-gui/src/components/copilot/MarkdownView.vue
+++ b/spx-gui/src/components/copilot/MarkdownView.vue
@@ -1,12 +1,19 @@
 <script lang="ts">
 function getComponents(copilot: Copilot): Components {
-  const customComponents = copilot.getCustomElements().reduce<Record<string, Component>>((acc, tool) => {
-    acc[tool.tagName] = tool.component
-    return acc
-  }, {})
+  const customComponents: Record<string, Component> = {}
+  const customRawComponents: Record<string, Component> = {}
+
+  copilot.getCustomElements().forEach((tool) => {
+    if (tool.isRaw) {
+      customRawComponents[tool.tagName] = tool.component
+      return
+    }
+    customComponents[tool.tagName] = tool.component
+  })
   return {
     codeBlock: CodeBlock,
-    custom: customComponents
+    custom: customComponents,
+    customRaw: customRawComponents
   }
 }
 

--- a/spx-gui/src/components/copilot/copilot.ts
+++ b/spx-gui/src/components/copilot/copilot.ts
@@ -313,6 +313,11 @@ export type CustomElementDefinition = {
   description: string
   /** Attributes definition for the tool (Element). */
   attributes: ZodObject<any>
+  /**
+   * Whether the component is raw, that can include lines without exiting, just like `pre`/`textarea` tags.
+   * See details in https://github.com/micromark/micromark/blob/774a70c6bae6dd94486d3385dbd9a0f14550b709/packages/micromark-util-html-tag-name/readme.md#htmlrawnames
+   */
+  isRaw: boolean
   /** Component to render the tool in the UI. */
   component: Component
 }
@@ -375,9 +380,10 @@ ${stringifyZodSchema(customElement.attributes)}
     if (customElements.length === 0) return ''
     return `# Available custom elements
 
-You can use custom elements in your messages to render specific UI content or invoke additional functionality. \
-For example: \`<pre is="foo-bar" a="1" b='"Hello"'></pre>\` creates a custom element with tag name \`foo-bar\` \
-and attributes \`{ a: "1", b: '"Hello"' }\`.
+You can use custom elements in your messages to render specific UI content or invoke additional functionality. For example:
+
+* \`<foo a="1" b='"Hello"' />\` creates a custom element with tag name \`foo\` and attributes \`{ a: "1", b: '"Hello"' }\`.
+* \`<bar a="1">Hello</bar>\` creates a custom element with tag name \`bar\` and attributes \`{ a: "1" }\` and content \`Hello\`.
 
 Each custom element has a tag name, a description, and an attributes schema that defines what values are accepted for each attribute.
 

--- a/spx-gui/src/components/copilot/custom-elements/CodeChange.vue
+++ b/spx-gui/src/components/copilot/custom-elements/CodeChange.vue
@@ -3,15 +3,19 @@ import { z } from 'zod'
 
 export const tagName = 'code-change'
 
-export const description = 'Display a modification based on the existing code. The user can decide if apply the change.'
+export const isRaw = true
+
+export const description = 'Display a modification based on the existing code.'
 
 export const detailedDescription = `Display a modification based on the existing code. For example,
-<pre is="code-change" file="file:///NiuXiaoQi.spx" line="10" remove-line-count="2">
+
+<code-change file="file:///NiuXiaoQi.spx" line="10" remove-line-count="2">
 onStart => {
 	say "Hello, world!"
 }
-</pre>
-will display a code change that removes 2 lines starting from line 10, and adds the code block.`
+</code-change>
+
+will display a code change that removes line 10 & 11, then adds the new code content. The user can then apply the change by clicking the "Apply" button.`
 
 export const attributes = z.object({
   file: z.string().describe('Text document URI, e.g., `file:///NiuXiaoQi.spx`'),

--- a/spx-gui/src/components/copilot/custom-elements/CodeLink.ts
+++ b/spx-gui/src/components/copilot/custom-elements/CodeLink.ts
@@ -5,18 +5,22 @@ import RawCodeLink from '@/components/editor/code-editor/CodeLink.vue'
 
 export const tagName = 'code-link'
 
+export const isRaw = false
+
 export const description = 'Display a link to a code location in the project.'
 
 export const detailedDescription = `Display a link to a code location in the project. By clicking on the link, \
 the user will be navigated to the code location. A location can be a position or a range. For example, \
-<pre is="code-link" file="file:///NiuXiaoQi.spx" position="10,20" text="L10,C20"></pre> will create a link to \
+<code-link file="file:///NiuXiaoQi.spx" position="10,20" text="L10,C20" /> will create a link to \
 line 10, column 20 in the file "NiuXiaoQi.spx" with text "L10,C20".`
 
 export const attributes = z.object({
   file: z.string().describe('Text document URI, e.g., `file:///NiuXiaoQi.spx`'),
-  position: z.string().describe('Position in the document, `${line},${column}`, e.g., `10,20`'),
+  text: z.string().optional().describe('Link text, if not provided, the file name will be used as the link text'),
+  position: z.string().optional().describe('Position in the document, `${line},${column}`, e.g., `10,20`'),
   range: z
     .string()
+    .optional()
     .describe('Range in the document, `${startLine},${startColumn}-${endLine},${endColumn}`, e.g., `10,20-12,10`')
 })
 

--- a/spx-gui/src/components/copilot/custom-elements/HighlightLink.vue
+++ b/spx-gui/src/components/copilot/custom-elements/HighlightLink.vue
@@ -3,12 +3,14 @@ import { z } from 'zod'
 
 export const tagName = 'highlight-link'
 
+export const isRaw = false
+
 export const description = 'Create a link that reveals & highlights a specific node in the UI when clicked.'
 
 export const detailedDescription = `Create a link that reveals & highlights a specific node in the UI when clicked. \
 Use the node ID provided in the UI information to specify the target node. \
 Use this element in your output to help users to find the relevant UI element quickly. \
-For example, <pre is="highlight-link" target-id="xxxyyy" tip="Click this button to submit" text="Submit button"></pre> \
+For example, <highlight-link target-id="xxxyyy" tip="Click this button to submit" text="Submit button" /> \
 will create a link with text "Submit button", when clicked, reveals the node with ID "xxxyyy" and shows the tip "Click this button to submit".`
 
 export const attributes = z.object({

--- a/spx-gui/src/components/copilot/custom-elements/ToolUse.vue
+++ b/spx-gui/src/components/copilot/custom-elements/ToolUse.vue
@@ -3,11 +3,13 @@ import { z } from 'zod'
 
 export const tagName = 'tool-use'
 
+export const isRaw = false
+
 export const description = 'Use a tool and get the result.'
 
 export const detailedDescription = `Use a tool and get the result. \
 The client provides various tools with specific capabilities and input schemas that define their required and optional parameters. \
-For example, <tool-use id="hmztvy" tool="example-tool" parameters='{"foo":"bar"}'></tool-use> invokes the tool named "example-tool" with parameters \`{"foo":"bar"}\`. \
+For example, <tool-use id="hmztvy" tool="example-tool" parameters='{"foo":"bar"}' /> invokes the tool named "example-tool" with parameters \`{"foo":"bar"}\`. \
 DO NOT output any content after this element, as you should wait for the client to execute the tool and provide you the result in later messages. Then you can continue.`
 
 export const attributes = z.object({

--- a/spx-gui/src/components/tutorials/TutorialCourseSuccess.vue
+++ b/spx-gui/src/components/tutorials/TutorialCourseSuccess.vue
@@ -4,10 +4,12 @@ import TutorialCourseSuccessModal from './TutorialCourseSuccessModal.vue'
 
 export const tagName = 'tutorial-course-success'
 
+export const isRaw = false
+
 export const detailedDescription = `
 Please add tags to the reply message according to the following rules:
-1. Only when the user completes the course, you must add the tag at the end of the reply message: <pre is="tutorial-course-success"></pre>
-2. Within the entire conversation context, the <pre is="tutorial-course-success"></pre> tag can only appear once
+1. Only when the user completes the course, you must add the tag at the end of the reply message: <tutorial-course-success />
+2. Within the entire conversation context, the <tutorial-course-success /> tag can only appear once
 3. Do not add this tag if the user has not completed the course or is still studying
 4. If this tag has been added before, do not repeat it in subsequent replies
 5. The tag must be complete and accurate, with no spelling errors or formatting deviations

--- a/spx-gui/src/components/tutorials/TutorialRoot.vue
+++ b/spx-gui/src/components/tutorials/TutorialRoot.vue
@@ -17,6 +17,7 @@ onUnmounted(
     tagName: tutorialCourseSuccess.tagName,
     description: tutorialCourseSuccess.detailedDescription,
     attributes: tutorialCourseSuccess.attributes,
+    isRaw: tutorialCourseSuccess.isRaw,
     component: tutorialCourseSuccess.default
   })
 )


### PR DESCRIPTION
close #1913.

> * Custom element with raw (including blank line) content
>   See details in [Fix code-change in markdown with blank-line content #1193](https://github.com/goplus/builder/pull/1193)

We introduce `components.customRaw`, which ensures given custom components rendered like ["HTML raw tag names"](https://github.com/micromark/micromark/blob/774a70c6bae6dd94486d3385dbd9a0f14550b709/packages/micromark-util-html-tag-name/readme.md#htmlrawnames). So `<pre is="...">` is not needed any more.

> * Ignore incomplete html tag content when streaming

We discard incomplete HTML tag content before rendering.

> * Support self-closing

Self-closing for custom components are always supported now.

