### PR TITLE
feat: add file size limit for inline files

### DIFF
--- a/spx-gui/src/models/common/cloud.ts
+++ b/spx-gui/src/models/common/cloud.ts
@@ -207,12 +207,17 @@ export async function saveFile(file: File, signal?: AbortSignal) {
   const savedUrl = getUniversalUrl(file)
   if (savedUrl != null) return savedUrl
 
-  const url = await (isInlineable(file) ? inlineFile(file) : uploadToKodo(file, signal))
+  const url = await ((await isInlineable(file)) ? inlineFile(file) : uploadToKodo(file, signal))
   setUniversalUrl(file, url)
   return url
 }
 
-const isInlineable = isText
+async function isInlineable(file: File) {
+  const maxInlineSize = 10 * 1024 // 10 KB threshold
+  if (!isText(file)) return false
+  const arrayBuffer = await file.arrayBuffer()
+  return arrayBuffer.byteLength <= maxInlineSize
+}
 
 async function inlineFile(file: File): Promise<UniversalUrl> {
   let mimeType, content


### PR DESCRIPTION
Add 10 KB threshold to `isInlineable` function to prevent large text files from being stored as inline data URLs in database. Large files now use cloud storage instead, reducing database pressure and avoiding MySQL JSON field size limits.

Fixes #1922