### PR TITLE
Remove entry for Tutorials from Navbar temporarily

### DIFF
--- a/spx-gui/src/components/navbar/NavbarWrapper.vue
+++ b/spx-gui/src/components/navbar/NavbarWrapper.vue
@@ -5,7 +5,6 @@
         <NavbarLogo />
         <slot name="left"></slot>
         <NavbarLang />
-        <NavbarTutorials />
       </div>
       <div class="center">
         <slot name="center"></slot>
@@ -22,7 +21,6 @@
 import NavbarLogo from './NavbarLogo.vue'
 import NavbarLang from './NavbarLang.vue'
 import NavbarProfile from './NavbarProfile.vue'
-import NavbarTutorials from './NavbarTutorials.vue'
 
 withDefaults(
   defineProps<{


### PR DESCRIPTION
We will add the entry back when https://github.com/goplus/builder/issues/1829 is ready.