### PR TITLE
fix(spx-backend): handle system errors properly in AuthN and AuthZ middleware

### DIFF
--- a/spx-backend/internal/authn/middleware.go
+++ b/spx-backend/internal/authn/middleware.go
@@ -1,6 +1,7 @@
 package authn
 
 import (
+	"errors"
 	"net/http"
 	"strings"
 
@@ -9,8 +10,8 @@ import (
 
 // Middleware returns a middleware function that authenticates requests using
 // the provided [Authenticator] and injects user information into the request
-// context. It follows a soft fail strategy where authentication errors are
-// logged but do not prevent the request from proceeding.
+// context. It follows a soft fail strategy where authentication failures do not
+// prevent the request from proceeding, except for system errors.
 func Middleware(a Authenticator) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -21,7 +22,12 @@ func Middleware(a Authenticator) func(http.Handler) http.Handler {
 				token := strings.TrimPrefix(authorization, "Bearer ")
 				mUser, err := a.Authenticate(ctx, token)
 				if err != nil {
-					logger.Printf("failed to get user from token: %v", err)
+					if !errors.Is(err, ErrUnauthorized) {
+						logger.Printf("authentication system error: %v", err)
+						http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+						return
+					}
+					logger.Printf("failed to authenticate user: %v", err)
 				} else if mUser == nil {
 					logger.Printf("no user info")
 				} else {

--- a/spx-backend/internal/authz/authz_test.go
+++ b/spx-backend/internal/authz/authz_test.go
@@ -126,7 +126,7 @@ func TestAuthorizerMiddleware(t *testing.T) {
 
 		handler.ServeHTTP(recorder, req)
 
-		assert.Equal(t, http.StatusOK, recorder.Code)
-		assert.Equal(t, "no capabilities", recorder.Body.String())
+		assert.Equal(t, http.StatusInternalServerError, recorder.Code)
+		assert.Equal(t, "Internal Server Error\n", recorder.Body.String())
 	})
 }


### PR DESCRIPTION
- Distinguish between authentication failures and system errors in AuthN middleware
- Return HTTP 500 for system errors instead of soft fail behavior
- Remove soft fail strategy from AuthZ middleware for capability computation errors