### PR TITLE
feat(spx-backend): add Redis cluster support

### DIFF
--- a/spx-backend/internal/config/config.go
+++ b/spx-backend/internal/config/config.go
@@ -1,5 +1,10 @@
 package config
 
+import (
+	"slices"
+	"strings"
+)
+
 // Config holds all configuration for the application.
 type Config struct {
 	Server   ServerConfig
@@ -44,12 +49,26 @@ type RedisConfig struct {
 	PoolSize int
 }
 
-// GetAddr returns the Redis address, defaulting to "127.0.0.1:6379" if not set.
-func (c *RedisConfig) GetAddr() string {
-	if c.Addr != "" {
-		return c.Addr
+// GetAddr returns the Redis address(es) as a slice. It supports both single
+// address and comma-separated multiple addresses. It defaults to
+// ["127.0.0.1:6379"] if not set.
+func (c *RedisConfig) GetAddr() []string {
+	if c.Addr == "" {
+		return []string{"127.0.0.1:6379"}
 	}
-	return "127.0.0.1:6379"
+
+	addresses := strings.Split(c.Addr, ",")
+	for i, addr := range addresses {
+		addresses[i] = strings.TrimSpace(addr)
+	}
+	return slices.DeleteFunc(addresses, func(addr string) bool {
+		return addr == ""
+	})
+}
+
+// IsClusterMode returns true if multiple Redis addresses are configured.
+func (c *RedisConfig) IsClusterMode() bool {
+	return len(c.GetAddr()) > 1
 }
 
 // GetPoolSize returns the Redis pool size, defaulting to 10 if not set.

--- a/spx-backend/internal/config/loader_test.go
+++ b/spx-backend/internal/config/loader_test.go
@@ -43,78 +43,97 @@ func setTestEnv(t *testing.T) {
 }
 
 func TestLoad(t *testing.T) {
-	setTestEnv(t)
+	t.Run("BasicConfig", func(t *testing.T) {
+		setTestEnv(t)
 
-	logger := log.GetLogger()
-	config, err := Load(logger)
-	require.NoError(t, err)
-	require.NotNil(t, config)
+		logger := log.GetLogger()
+		config, err := Load(logger)
+		require.NoError(t, err)
+		require.NotNil(t, config)
 
-	// Server
-	assert.Empty(t, config.Server.Port)
-	assert.Equal(t, ":8080", config.Server.GetPort())
+		// Server
+		assert.Empty(t, config.Server.Port)
+		assert.Equal(t, ":8080", config.Server.GetPort())
 
-	// Database
-	assert.Equal(t, "root:root@tcp(mysql.example.com:3306)/builder?charset=utf8&parseTime=True", config.Database.DSN)
+		// Database
+		assert.Equal(t, "root:root@tcp(mysql.example.com:3306)/builder?charset=utf8&parseTime=True", config.Database.DSN)
 
-	// Redis
-	assert.Equal(t, "redis.example.com:6379", config.Redis.Addr)
-	assert.Equal(t, "redis.example.com:6379", config.Redis.GetAddr())
-	assert.Equal(t, "test-redis-password", config.Redis.Password)
-	assert.Equal(t, 1, config.Redis.DB)
-	assert.Equal(t, 15, config.Redis.PoolSize)
-	assert.Equal(t, config.Redis.PoolSize, config.Redis.GetPoolSize())
+		// Redis
+		assert.Equal(t, "redis.example.com:6379", config.Redis.Addr)
+		assert.Equal(t, []string{"redis.example.com:6379"}, config.Redis.GetAddr())
+		assert.False(t, config.Redis.IsClusterMode())
+		assert.Equal(t, "test-redis-password", config.Redis.Password)
+		assert.Equal(t, 1, config.Redis.DB)
+		assert.Equal(t, 15, config.Redis.PoolSize)
+		assert.Equal(t, config.Redis.PoolSize, config.Redis.GetPoolSize())
 
-	// Kodo
-	assert.Equal(t, "test-kodo-ak", config.Kodo.AccessKey)
-	assert.Equal(t, "test-kodo-sk", config.Kodo.SecretKey)
-	assert.Equal(t, "builder", config.Kodo.Bucket)
-	assert.Equal(t, "earth", config.Kodo.BucketRegion)
-	assert.Equal(t, "https://kodo.example.com", config.Kodo.BaseURL)
+		// Kodo
+		assert.Equal(t, "test-kodo-ak", config.Kodo.AccessKey)
+		assert.Equal(t, "test-kodo-sk", config.Kodo.SecretKey)
+		assert.Equal(t, "builder", config.Kodo.Bucket)
+		assert.Equal(t, "earth", config.Kodo.BucketRegion)
+		assert.Equal(t, "https://kodo.example.com", config.Kodo.BaseURL)
 
-	// Casdoor
-	assert.Equal(t, "https://casdoor.example.com", config.Casdoor.Endpoint)
-	assert.Equal(t, "test-client-id", config.Casdoor.ClientID)
-	assert.Equal(t, "test-client-secret", config.Casdoor.ClientSecret)
-	assert.Equal(t, "test-certificate", config.Casdoor.Certificate)
-	assert.Equal(t, "test-org", config.Casdoor.OrganizationName)
-	assert.Equal(t, "test-app", config.Casdoor.ApplicationName)
+		// Casdoor
+		assert.Equal(t, "https://casdoor.example.com", config.Casdoor.Endpoint)
+		assert.Equal(t, "test-client-id", config.Casdoor.ClientID)
+		assert.Equal(t, "test-client-secret", config.Casdoor.ClientSecret)
+		assert.Equal(t, "test-certificate", config.Casdoor.Certificate)
+		assert.Equal(t, "test-org", config.Casdoor.OrganizationName)
+		assert.Equal(t, "test-app", config.Casdoor.ApplicationName)
 
-	// OpenAI
-	assert.Equal(t, "test-openai-key", config.OpenAI.APIKey)
-	assert.Equal(t, "https://api.openai.com/v1", config.OpenAI.APIEndpoint)
-	assert.Equal(t, "gpt-3.5-turbo", config.OpenAI.ModelID)
-	assert.Empty(t, config.OpenAI.PremiumAPIKey)
-	assert.Empty(t, config.OpenAI.PremiumAPIEndpoint)
-	assert.Empty(t, config.OpenAI.PremiumModelID)
+		// OpenAI
+		assert.Equal(t, "test-openai-key", config.OpenAI.APIKey)
+		assert.Equal(t, "https://api.openai.com/v1", config.OpenAI.APIEndpoint)
+		assert.Equal(t, "gpt-3.5-turbo", config.OpenAI.ModelID)
+		assert.Empty(t, config.OpenAI.PremiumAPIKey)
+		assert.Empty(t, config.OpenAI.PremiumAPIEndpoint)
+		assert.Empty(t, config.OpenAI.PremiumModelID)
 
-	// AIGC
-	assert.Equal(t, "https://aigc.example.com", config.AIGC.Endpoint)
-}
+		// AIGC
+		assert.Equal(t, "https://aigc.example.com", config.AIGC.Endpoint)
+	})
 
-func TestLoadWithPremiumConfig(t *testing.T) {
-	setTestEnv(t)
-	t.Setenv("PORT", ":9090")
-	t.Setenv("OPENAI_PREMIUM_API_KEY", "premium-key")
-	t.Setenv("OPENAI_PREMIUM_API_ENDPOINT", "https://premium.openai.com/v1")
-	t.Setenv("OPENAI_PREMIUM_MODEL_ID", "gpt-4")
+	t.Run("RedisCluster", func(t *testing.T) {
+		setTestEnv(t)
+		t.Setenv("REDIS_ADDR", "node1:6379,node2:6379,node3:6379")
 
-	logger := log.GetLogger()
-	config, err := Load(logger)
-	require.NoError(t, err)
-	require.NotNil(t, config)
+		logger := log.GetLogger()
+		config, err := Load(logger)
+		require.NoError(t, err)
+		require.NotNil(t, config)
 
-	// Server
-	assert.Equal(t, ":9090", config.Server.Port)
-	assert.Equal(t, config.Server.Port, config.Server.GetPort())
+		// Redis cluster configuration
+		assert.Equal(t, "node1:6379,node2:6379,node3:6379", config.Redis.Addr)
+		assert.True(t, config.Redis.IsClusterMode())
+		expected := []string{"node1:6379", "node2:6379", "node3:6379"}
+		assert.Equal(t, expected, config.Redis.GetAddr())
+	})
 
-	// OpenAI
-	assert.Equal(t, "premium-key", config.OpenAI.PremiumAPIKey)
-	assert.Equal(t, config.OpenAI.PremiumAPIKey, config.OpenAI.GetPremiumAPIKey())
-	assert.Equal(t, "https://premium.openai.com/v1", config.OpenAI.PremiumAPIEndpoint)
-	assert.Equal(t, config.OpenAI.PremiumAPIEndpoint, config.OpenAI.GetPremiumAPIEndpoint())
-	assert.Equal(t, "gpt-4", config.OpenAI.PremiumModelID)
-	assert.Equal(t, config.OpenAI.PremiumModelID, config.OpenAI.GetPremiumModelID())
+	t.Run("PremiumConfig", func(t *testing.T) {
+		setTestEnv(t)
+		t.Setenv("PORT", ":9090")
+		t.Setenv("OPENAI_PREMIUM_API_KEY", "premium-key")
+		t.Setenv("OPENAI_PREMIUM_API_ENDPOINT", "https://premium.openai.com/v1")
+		t.Setenv("OPENAI_PREMIUM_MODEL_ID", "gpt-4")
+
+		logger := log.GetLogger()
+		config, err := Load(logger)
+		require.NoError(t, err)
+		require.NotNil(t, config)
+
+		// Server
+		assert.Equal(t, ":9090", config.Server.Port)
+		assert.Equal(t, config.Server.Port, config.Server.GetPort())
+
+		// OpenAI
+		assert.Equal(t, "premium-key", config.OpenAI.PremiumAPIKey)
+		assert.Equal(t, config.OpenAI.PremiumAPIKey, config.OpenAI.GetPremiumAPIKey())
+		assert.Equal(t, "https://premium.openai.com/v1", config.OpenAI.PremiumAPIEndpoint)
+		assert.Equal(t, config.OpenAI.PremiumAPIEndpoint, config.OpenAI.GetPremiumAPIEndpoint())
+		assert.Equal(t, "gpt-4", config.OpenAI.PremiumModelID)
+		assert.Equal(t, config.OpenAI.PremiumModelID, config.OpenAI.GetPremiumModelID())
+	})
 }
 
 func TestGetIntEnv(t *testing.T) {


### PR DESCRIPTION
- Modify `config.RedisConfig.GetAddr()` to return `[]string` for multiple addresses
- Add `config.RedisConfig.IsClusterMode()` to detect cluster configuration
- Update `authz/quota.NewRedisQuotaTracker` to choose between single/cluster client
- Change quota tracker client type to `redis.Cmdable` interface

Fixes #1944