### PR TITLE
Details improvement for tutorial course experience

### DIFF
--- a/spx-gui/src/components/asset/preprocessing/PreprocessModal.vue
+++ b/spx-gui/src/components/asset/preprocessing/PreprocessModal.vue
@@ -1,6 +1,9 @@
 <template>
   <UIFormModal
-    :radar="{ name: 'Preprocess modal', desc: 'Modal for preprocessing image for costumes' }"
+    :radar="{
+      name: 'Preprocess modal',
+      desc: 'Modal for preprocessing image for costumes. This modal allows users to apply various preprocessing methods to images before creating costumes with them.'
+    }"
     style="width: 780px"
     :visible="props.visible && ready"
     :title="$t(title)"

--- a/spx-gui/src/components/copilot/copilot.ts
+++ b/spx-gui/src/components/copilot/copilot.ts
@@ -484,6 +484,7 @@ ${tools.map((tool) => this.getToolPrompt(tool)).join('\n\n')}`
   private getTopicPrompt() {
     if (this.currentSession == null) return ''
     const topic = this.currentSession.topic
+    if (topic.description.trim() === '') return ''
     return `# Current topic between you and user
 
 ${topic.description}`

--- a/spx-gui/src/components/copilot/custom-elements/HighlightLink.vue
+++ b/spx-gui/src/components/copilot/custom-elements/HighlightLink.vue
@@ -1,5 +1,6 @@
 <script lang="ts">
 import { z } from 'zod'
+import { useSlotText } from '@/utils/vnode'
 
 export const tagName = 'highlight-link'
 
@@ -10,11 +11,10 @@ export const description = 'Create a link that reveals & highlights a specific n
 export const detailedDescription = `Create a link that reveals & highlights a specific node in the UI when clicked. \
 Use the node ID provided in the UI information to specify the target node. \
 Use this element in your output to help users to find the relevant UI element quickly. \
-For example, <highlight-link target-id="xxxyyy" tip="Click this button to submit" text="Submit button" /> \
+For example, <highlight-link target-id="xxxyyy" tip="Click this button to submit">Submit button</highlight-link> \
 will create a link with text "Submit button", when clicked, reveals the node with ID "xxxyyy" and shows the tip "Click this button to submit".`
 
 export const attributes = z.object({
-  text: z.string().describe('Link text'),
   'target-id': z.string().describe('ID for the linked node'),
   tip: z
     .string()
@@ -29,8 +29,6 @@ import { useSpotlight } from '@/utils/spotlight'
 import { useMessageHandle } from '@/utils/exception'
 
 const props = defineProps<{
-  /** Link text */
-  text: string
   /** ID for the linked node (from module `Radar`) */
   targetId: string
   /** Tip to show when node revealed */
@@ -39,6 +37,7 @@ const props = defineProps<{
 
 const radar = useRadar()
 const spotlight = useSpotlight()
+const text = useSlotText()
 
 const { fn: handleClick } = useMessageHandle(
   () => {
@@ -50,7 +49,7 @@ const { fn: handleClick } = useMessageHandle(
     const { visible } = nodeInfo
     const element = nodeInfo.getElement()
     if (visible) {
-      spotlight.reveal(element, props.tip ?? props.text)
+      spotlight.reveal(element, props.tip ?? text.value)
     } else {
       spotlight.conceal()
     }
@@ -61,7 +60,7 @@ const { fn: handleClick } = useMessageHandle(
 
 <template>
   <button type="button" class="highlight-link" @click="handleClick">
-    {{ text }}
+    <slot></slot>
   </button>
 </template>
 

--- a/spx-gui/src/components/editor/code-editor/ui/resource/ResourceItem.vue
+++ b/spx-gui/src/components/editor/code-editor/ui/resource/ResourceItem.vue
@@ -34,7 +34,12 @@ withDefaults(
     color="primary"
     :autoplay="autoplay"
   />
-  <BackdropItem v-else-if="resource instanceof Backdrop" :backdrop="resource" :selectable="selectable" />
+  <BackdropItem
+    v-else-if="resource instanceof Backdrop"
+    :backdrop="resource"
+    :selectable="selectable"
+    color="primary"
+  />
   <CostumeItem v-else-if="resource instanceof Costume" :costume="resource" :selectable="selectable" color="primary" />
   <SoundItem v-else-if="resource instanceof Sound" :sound="resource" :selectable="selectable" color="primary" />
   <SpriteItem

--- a/spx-gui/src/components/editor/common/EditorList.vue
+++ b/spx-gui/src/components/editor/common/EditorList.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="editor-list" :style="cssVars">
     <div class="sider">
-      <div ref="itemsWrapper" v-radar="{ name: 'Items', desc }" class="items">
+      <div ref="itemsWrapper" v-radar="listRadarInfo" class="items">
         <slot></slot>
       </div>
       <UIDropdownWithTooltip>
@@ -9,10 +9,10 @@
           <slot name="add-options"></slot>
         </template>
         <template #tooltip-content>
-          {{ addText }}
+          {{ $t(addText) }}
         </template>
         <template #trigger>
-          <button v-radar="{ name: 'Add item', desc: 'Button for adding new items to the list' }" class="add">
+          <button v-radar="addButtonRadarInfo" class="add">
             <UIIcon class="icon" type="plus" />
           </button>
         </template>
@@ -25,12 +25,14 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue'
 import { useDragSortable } from '@/utils/drag-and-drop'
+import type { RadarNodeMeta } from '@/utils/radar'
+import { humanizeResourceType, type ResourceModelType } from '@/models/common/resource-model'
 import { UIIcon, type Color, useUIVariables, getCssVars, UIDropdownWithTooltip } from '@/components/ui'
 
 const props = withDefaults(
   defineProps<{
     color: Color
-    addText: string
+    resourceType: ResourceModelType
     sortable?: { list: unknown[] } | false
   }>(),
   {
@@ -42,12 +44,25 @@ const emit = defineEmits<{
   sorted: [oldIdx: number, newIdx: number]
 }>()
 
-const desc = computed(() => {
-  if (props.sortable && props.sortable.list.length > 0) {
-    return 'Drag to reorder items'
+const resourceTypeName = computed(() => humanizeResourceType(props.resourceType))
+
+const listRadarInfo = computed<RadarNodeMeta>(() => {
+  const draggable = props.sortable && props.sortable.list.length > 0
+  return {
+    name: `List of ${resourceTypeName.value.en}`,
+    desc: draggable ? 'Drag to reorder' : ''
   }
-  return ''
 })
+
+const addText = computed(() => ({
+  en: `Add ${resourceTypeName.value.en}`,
+  zh: `添加${resourceTypeName.value.zh}`
+}))
+
+const addButtonRadarInfo = computed<RadarNodeMeta>(() => ({
+  name: `Add ${resourceTypeName.value.en}`,
+  desc: `Button for adding new ${resourceTypeName.value.en} to the list`
+}))
 
 const uiVariables = useUIVariables()
 const cssVars = computed(() => getCssVars('--editor-list-color-', uiVariables.color[props.color]))

--- a/spx-gui/src/components/editor/navbar/EditorNavbar.vue
+++ b/spx-gui/src/components/editor/navbar/EditorNavbar.vue
@@ -49,8 +49,8 @@
               {{ $t({ en: 'Open project page', zh: '打开项目主页' }) }}
             </UIMenuItem>
           </UIMenuGroup>
-          <UIMenuGroup :disabled="project == null">
-            <UIMenuItem v-if="canManageProject" @click="handleRemoveProject">
+          <UIMenuGroup v-if="canManageProject" :disabled="project == null">
+            <UIMenuItem @click="handleRemoveProject">
               <template #icon><img :src="removeProjectSvg" /></template>
               {{ $t({ en: 'Remove project', zh: '删除项目' }) }}
             </UIMenuItem>

--- a/spx-gui/src/components/editor/panels/sound/SoundsPanel.vue
+++ b/spx-gui/src/components/editor/panels/sound/SoundsPanel.vue
@@ -34,7 +34,7 @@
           :key="sound.id"
           :sound="sound"
           :selectable="{ selected: isSelected(sound) }"
-          removable
+          operable
           @click="handleSoundClick(sound)"
         />
       </PanelList>

--- a/spx-gui/src/components/editor/sound/SoundItem.vue
+++ b/spx-gui/src/components/editor/sound/SoundItem.vue
@@ -9,7 +9,13 @@
     <template #player>
       <SoundPlayer :color="color" :src="audioSrc" />
     </template>
-    <CornerMenu v-if="removable" :color="color" removable :item="sound" @remove="handleRemove" />
+    <CornerMenu
+      v-if="operable && selectable && selectable.selected"
+      :color="color"
+      :item="sound"
+      removable
+      @remove="handleRemove"
+    />
   </UIEditorSoundItem>
 </template>
 
@@ -28,20 +34,19 @@ const props = withDefaults(
     sound: Sound
     color?: 'sound' | 'primary'
     selectable?: false | { selected: boolean }
-    removable?: boolean
+    /** `operable: true` means the backdrop can be published & removed */
+    operable?: boolean
   }>(),
   {
     color: 'sound',
     selectable: false,
-    removable: false
+    operable: false
   }
 )
 
 const [audioSrc] = useFileUrl(() => props.sound.file)
 
 const editorCtx = useEditorCtx()
-
-const removable = computed(() => props.removable && props.selectable && props.selectable.selected)
 
 const radarNodeMeta = computed(() => {
   const name = `Sound item "${props.sound.name}"`

--- a/spx-gui/src/components/editor/sprite/AnimationEditor.vue
+++ b/spx-gui/src/components/editor/sprite/AnimationEditor.vue
@@ -19,7 +19,7 @@
     v-else
     v-radar="{ name: 'Animations management', desc: 'Managing animations of current sprite' }"
     color="sprite"
-    :add-text="$t({ en: 'Add animation', zh: '添加动画' })"
+    resource-type="animation"
     :sortable="{ list: sprite.animations }"
     @sorted="handleSorted"
   >

--- a/spx-gui/src/components/editor/sprite/CostumesEditor.vue
+++ b/spx-gui/src/components/editor/sprite/CostumesEditor.vue
@@ -2,7 +2,7 @@
   <EditorList
     v-radar="{ name: 'Costumes management', desc: 'Managing costumes of current sprite' }"
     color="sprite"
-    :add-text="$t({ en: 'Add costume', zh: '添加造型' })"
+    resource-type="costume"
     :sortable="{ list: sprite.costumes }"
     @sorted="handleSorted"
   >

--- a/spx-gui/src/components/editor/sprite/animation/SoundEditor.vue
+++ b/spx-gui/src/components/editor/sprite/animation/SoundEditor.vue
@@ -13,7 +13,6 @@
         :sound="sound"
         :selectable="{ selected: sound.id === selected }"
         color="primary"
-        removable
         @click="handleSoundClick(sound.id)"
       />
       <UIDropdown trigger="click" placement="top">

--- a/spx-gui/src/components/editor/stage/backdrop/BackdropItem.vue
+++ b/spx-gui/src/components/editor/stage/backdrop/BackdropItem.vue
@@ -5,9 +5,10 @@
     :img-loading="imgLoading"
     :name="backdrop.name"
     :selectable="selectable"
+    :color="color"
   >
     <CornerMenu
-      v-if="selectable && selectable.selected"
+      v-if="operable && selectable && selectable.selected"
       color="stage"
       :removable="removable"
       :item="backdrop"
@@ -28,12 +29,15 @@ import { useMessageHandle } from '@/utils/exception'
 const props = withDefaults(
   defineProps<{
     backdrop: Backdrop
+    color?: 'stage' | 'primary'
     selectable?: false | { selected: boolean }
-    removable?: boolean
+    /** `operable: true` means the backdrop can be published & removed */
+    operable?: boolean
   }>(),
   {
+    color: 'stage',
     selectable: false,
-    removable: false
+    operable: false
   }
 )
 
@@ -51,7 +55,7 @@ const stageRef = computed(() => {
   if (stage == null) throw new Error('stage expected')
   return stage
 })
-const removable = computed(() => props.removable && stageRef.value.backdrops.length > 1)
+const removable = computed(() => stageRef.value.backdrops.length > 1)
 
 const handleRemove = useMessageHandle(
   async () => {

--- a/spx-gui/src/components/editor/stage/backdrop/BackdropsEditor.vue
+++ b/spx-gui/src/components/editor/stage/backdrop/BackdropsEditor.vue
@@ -2,7 +2,7 @@
   <EditorList
     v-radar="{ name: 'Backdrops management', desc: 'Managing backdrops of stage' }"
     color="stage"
-    :add-text="$t({ en: 'Add backdrop', zh: '添加背景' })"
+    resource-type="backdrop"
     :sortable="{ list: stage.backdrops }"
     @sorted="handleSorted"
   >
@@ -11,7 +11,7 @@
       :key="backdrop.id"
       :backdrop="backdrop"
       :selectable="{ selected: state.selected?.id === backdrop.id }"
-      removable
+      operable
       @click="handleSelect(backdrop)"
     />
     <template #add-options>

--- a/spx-gui/src/components/editor/stage/widget/WidgetsEditor.vue
+++ b/spx-gui/src/components/editor/stage/widget/WidgetsEditor.vue
@@ -19,7 +19,7 @@
     v-else
     v-radar="{ name: 'Widgets management', desc: 'Managing widgets' }"
     color="stage"
-    :add-text="$t({ en: 'Add widget', zh: '添加控件' })"
+    resource-type="widget"
     :sortable="{ list: stage.widgets }"
     @sorted="handleSorted"
   >

--- a/spx-gui/src/components/tutorials/TutorialCourseSuccess.vue
+++ b/spx-gui/src/components/tutorials/TutorialCourseSuccess.vue
@@ -1,5 +1,6 @@
 <script lang="ts">
 import { z } from 'zod'
+import { timeout } from '@/utils/utils'
 import TutorialCourseSuccessModal from './TutorialCourseSuccessModal.vue'
 
 export const tagName = 'tutorial-course-success'
@@ -29,10 +30,11 @@ const tutorial = useTutorial()
 const copilot = useCopilot()
 const open = useModal(TutorialCourseSuccessModal)
 
-onMounted(() => {
+onMounted(async () => {
   if (!tutorial.currentCourse || !tutorial.currentSeries) {
     throw new Error('No course or series in progress')
   }
+  await timeout(500)
   open({ tutorial, course: tutorial.currentCourse, series: tutorial.currentSeries })
   copilot.close()
   tutorial.endCurrentCourse()

--- a/spx-gui/src/components/ui/block-items/UIEditorBackdropItem.vue
+++ b/spx-gui/src/components/ui/block-items/UIEditorBackdropItem.vue
@@ -1,5 +1,5 @@
 <template>
-  <UIBlockItem color="stage" :active="selectable && selectable.selected" :interactive="!!selectable">
+  <UIBlockItem :color="color" :active="selectable && selectable.selected" :interactive="!!selectable">
     <div class="img-container">
       <UIImg class="img" :src="imgSrc" :loading="imgLoading" />
     </div>
@@ -20,9 +20,11 @@ withDefaults(
     imgLoading: boolean
     name: string
     selectable?: false | { selected: boolean }
+    color?: 'stage' | 'primary'
   }>(),
   {
-    selectable: false
+    selectable: false,
+    color: 'stage'
   }
 )
 </script>

--- a/spx-gui/src/pages/tutorials/index.vue
+++ b/spx-gui/src/pages/tutorials/index.vue
@@ -42,6 +42,7 @@
 <script setup lang="ts">
 import { sortBy } from 'lodash'
 import { useQuery } from '@/utils/query'
+import { usePageTitle } from '@/utils/utils'
 
 import { listCourseSeries, type CourseSeries } from '@/apis/course-series'
 import { ownerAll } from '@/apis/common'
@@ -55,6 +56,11 @@ import ListResultWrapper from '@/components/common/ListResultWrapper.vue'
 import CourseItem from '@/components/tutorials/CourseItem.vue'
 import CommunityFooter from '@/components/community/footer/CommunityFooter.vue'
 import { useTutorial } from '@/components/tutorials/tutorial'
+
+usePageTitle({
+  en: 'Tutorials',
+  zh: '教程'
+})
 
 const tutorial = useTutorial()
 


### PR DESCRIPTION
Update #1961.

* Optimize radar info for some nodes
* Update API for `highlight-link`
* Provide `GetProjectContentTool` instead of `GetProjectSpritesTool`
* Provide `GetSpriteContentTool`
* Add `ProjectContextProvider`
* Fix detail behaviors for `ResourceItem`
* Add title for page tutorials