### PR TITLE
fix: disable ambiguous character highlighting in `MonacoEditor`

### DIFF
--- a/spx-gui/src/components/editor/code-editor/ui/MonacoEditor.vue
+++ b/spx-gui/src/components/editor/code-editor/ui/MonacoEditor.vue
@@ -70,6 +70,9 @@ watchEffect(async (onClenaup) => {
     stickyScroll: {
       enabled: false
     },
+    unicodeHighlight: {
+      ambiguousCharacters: false // Disable highlighting of ambiguous characters (like Chinese punctuation)
+    },
     ...props.options
   })
 


### PR DESCRIPTION
<img width="318" height="211" alt="Screenshot 2025-08-15 at 14 17 14" src="https://github.com/user-attachments/assets/ad6ffa73-dd6a-4fe4-99a0-be755989f1cf" />
