### PR TITLE
refactor(tools/ai): optimize timeout and backoff parameters for improved reliability

### DIFF
--- a/tools/ai/ai.go
+++ b/tools/ai/ai.go
@@ -107,11 +107,11 @@ func (p *Player) Think__1(msg string) {
 }
 func (p *Player) think(owner any, msg string, context map[string]any) {
 	const (
-		transportTimeout    = 15 * time.Second      // Timeout for each transport call.
-		maxTransportRetries = 3                     // Maximum number of retries for each AI transport call.
-		maxTurns            = 20                    // Maximum number of turns in a single call to prevent infinite loops.
-		backoffBase         = 50 * time.Millisecond // Base time for exponential backoff calculation.
-		backoffCap          = time.Second           // Maximum backoff time cap.
+		transportTimeout    = 45 * time.Second       // Timeout for each transport call.
+		maxTransportRetries = 3                      // Maximum number of retries for each AI transport call.
+		maxTurns            = 20                     // Maximum number of turns in a single call to prevent infinite loops.
+		backoffBase         = 100 * time.Millisecond // Base time for exponential backoff calculation.
+		backoffCap          = 2 * time.Second        // Maximum backoff time cap.
 	)
 
 	var (

--- a/tools/ai/go.mod
+++ b/tools/ai/go.mod
@@ -2,11 +2,11 @@ module github.com/goplus/builder/tools/ai
 
 go 1.23.0
 
-require github.com/goplus/spx/v2 v2.0.0-pre.4
+require github.com/goplus/spx/v2 v2.0.0-pre.10
 
 require (
+	github.com/goplus/spbase v0.1.0 // indirect
 	github.com/h2non/filetype v1.1.3 // indirect
 	github.com/petermattis/goid v0.0.0-20250721140440-ea1c0173183e // indirect
-	github.com/realdream-ai/mathf v0.0.0-20250513071532-e55e1277a8c5 // indirect
 	golang.org/x/image v0.23.0 // indirect
 )

--- a/tools/ai/go.sum
+++ b/tools/ai/go.sum
@@ -1,10 +1,10 @@
-github.com/goplus/spx/v2 v2.0.0-pre.4 h1:zUW/4D/i7DsXHLYva/zkpjCp7Gy7ssSQJUJMmFzCMPY=
-github.com/goplus/spx/v2 v2.0.0-pre.4/go.mod h1:pJw+stGi0Uah1czCfnviaXsRhjgPFo31XovTP/YB/Mo=
+github.com/goplus/spbase v0.1.0 h1:JNZ0D/65DerYyv9/9IfrXHZZbd0WNK0jHiVvgCtZhwY=
+github.com/goplus/spbase v0.1.0/go.mod h1:brnD3OJnHtipqob2IsJ3/QzGBf+eOnqXNnHGKpv1irQ=
+github.com/goplus/spx/v2 v2.0.0-pre.10 h1:utkon95kKQtQ0nloQqC2OsTZ2HkagFlk/jyKGMGvxUE=
+github.com/goplus/spx/v2 v2.0.0-pre.10/go.mod h1:nmCMvPSNMw1BuN7a1GRBHW+YPthstZpwSrn5UqQ4r1M=
 github.com/h2non/filetype v1.1.3 h1:FKkx9QbD7HR/zjK1Ia5XiBsq9zdLi5Kf3zGyFTAFkGg=
 github.com/h2non/filetype v1.1.3/go.mod h1:319b3zT68BvV+WRj7cwy856M2ehB3HqNOt6sy1HndBY=
 github.com/petermattis/goid v0.0.0-20250721140440-ea1c0173183e h1:D0bJD+4O3G4izvrQUmzCL80zazlN7EwJ0PPDhpJWC/I=
 github.com/petermattis/goid v0.0.0-20250721140440-ea1c0173183e/go.mod h1:pxMtw7cyUw6B2bRH0ZBANSPg+AoSud1I1iyJHI69jH4=
-github.com/realdream-ai/mathf v0.0.0-20250513071532-e55e1277a8c5 h1:KuC3mEHh8NPOaOR0acOW+6ISKL4S9iY3n102KE/tst0=
-github.com/realdream-ai/mathf v0.0.0-20250513071532-e55e1277a8c5/go.mod h1:zCbLmeT7a+pH1sknxgdFLiha6xA3gezTtwbTuuNRJWE=
 golang.org/x/image v0.23.0 h1:HseQ7c2OpPKTPVzNjG5fwJsOTCiiwS4QdsYi5XU6H68=
 golang.org/x/image v0.23.0/go.mod h1:wJJBTdLfCCf3tiHa1fNxpZmUI4mmoZvwMCPP0ddoNKY=


### PR DESCRIPTION
Increase timeout values to provide sufficient time for complex AI operations:
- transportTimeout: 15s -> 45s (for complex operations like history archiving)
- backoffBase: 50ms -> 100ms (improved retry intervals)
- backoffCap: 1s -> 2s (allow longer backoff periods for stability)