### PR TITLE
refactor(recording): improve code consistency and remove redundancy

### DIFF
--- a/spx-backend/cmd/spx-backend/get_recording_#id_liking.yap
+++ b/spx-backend/cmd/spx-backend/get_recording_#id_liking.yap
@@ -4,6 +4,9 @@
 //   GET /recording/:id/liking
 
 ctx := &Context
+if _, ok := ensureAuthenticatedUser(ctx); !ok {
+    return
+}
 
 isLiking, err := ctrl.HasLikedRecording(ctx.Context(), ${id})
 if err != nil {

--- a/spx-backend/cmd/spx-backend/get_recordings_list.yap
+++ b/spx-backend/cmd/spx-backend/get_recordings_list.yap
@@ -11,7 +11,6 @@ ctx := &Context
 
 params := controller.NewListRecordingsParams()
 
-// Handle owner parameter
 switch owner := ${owner}; owner {
 case "":
 	mUser, ok := ensureAuthenticatedUser(ctx)
@@ -25,7 +24,6 @@ default:
 	params.Owner = &owner
 }
 
-// Handle projectFullName filter
 if projectFullName := ${projectFullName}; projectFullName != "" {
 	pfn, err := controller.ParseProjectFullName(projectFullName)
 	if err != nil {
@@ -35,42 +33,33 @@ if projectFullName := ${projectFullName}; projectFullName != "" {
 	params.ProjectFullName = &pfn
 }
 
-// Handle keyword filter
 if keyword := ${keyword}; keyword != "" {
 	params.Keyword = &keyword
 }
 
-// Handle liker filter
 if liker := ${liker}; liker != "" {
 	params.Liker = &liker
 }
 
-// Handle orderBy parameter
 if orderBy := ${orderBy}; orderBy != "" {
 	params.OrderBy = controller.ListRecordingsOrderBy(orderBy)
 }
 
-// Handle sortOrder parameter
 if sortOrder := ${sortOrder}; sortOrder != "" {
 	params.SortOrder = controller.SortOrder(sortOrder)
 }
 
-// Handle pagination
 params.Pagination.Index = paramInt("pageIndex", firstPageIndex)
 params.Pagination.Size = paramInt("pageSize", defaultPageSize)
 
-// Validate parameters
 if ok, msg := params.Validate(); !ok {
 	replyWithCodeMsg(ctx, errorInvalidArgs, msg)
 	return
 }
 
-// Call controller method
 recordings, err := ctrl.ListRecordings(ctx.Context(), params)
 if err != nil {
 	replyWithInnerError(ctx, err)
 	return
 }
-
-// Return JSON response
 json recordings

--- a/spx-backend/cmd/spx-backend/post_recording.yap
+++ b/spx-backend/cmd/spx-backend/post_recording.yap
@@ -1,7 +1,7 @@
 // Create a recording.
 //
 // Request:
-//   POST /recordings
+//   POST /recording
 
 import (
 	"github.com/goplus/builder/spx-backend/internal/controller"

--- a/spx-backend/internal/model/recording.go
+++ b/spx-backend/internal/model/recording.go
@@ -4,9 +4,9 @@ package model
 type Recording struct {
 	Model
 
-	// UserID is the ID of the user who created the recording.
-	UserID int64 `gorm:"column:user_id;index"`
-	User   User  `gorm:"foreignKey:UserID"`
+	// OwnerID is the ID of the user who created the recording.
+	OwnerID int64 `gorm:"column:owner_id;index"`
+	Owner   User  `gorm:"foreignKey:OwnerID"`
 
 	// ProjectID is the ID of the project that the recording is associated with.
 	ProjectID int64   `gorm:"column:project_id;index"`

--- a/spx-gui/src/apis/recording.ts
+++ b/spx-gui/src/apis/recording.ts
@@ -43,7 +43,7 @@ export type CreateRecordingParams = {
 }
 
 export async function createRecording(params: CreateRecordingParams, signal?: AbortSignal) {
-  return client.post('/recordings', params, { signal }) as Promise<RecordingData>
+  return client.post('/recording', params, { signal }) as Promise<RecordingData>
 }
 
 export type UpdateRecordingParams = Partial<Pick<RecordingData, 'title' | 'description'>>


### PR DESCRIPTION
- Rename Recording model fields from UserID/User to OwnerID/Owner for consistency with other models
- Change CreateRecordingParams.ProjectFullName from string to ProjectFullName type to reuse existing validation logic
- Remove redundant parameter validation in the controller layer (already handled in the YAP layer)
- Remove duplicate ownership checks in DeleteRecording and UpdateRecording (already handled by ensureRecording with ownedOnly=true)
- Remove unnecessary private project access validation in CreateRecording (already handled by ensureProject)

Addresses code review feedback from nighca regarding:
1. Field naming consistency across models
2. Code reuse for ProjectFullName validation  
3. Elimination of redundant validation and authorization checks