### PR TITLE
chore: configure Dependabot multi-ecosystem groups for streamlined updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,29 +1,24 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
-
 version: 2
+
+multi-ecosystem-groups:
+  infrastructure:
+    schedule:
+      interval: weekly
+  go-modules:
+    schedule:
+      interval: weekly
+
 updates:
   - package-ecosystem: github-actions
     directory: /
-    labels:
-      - dependabot
-      - actions
-    schedule:
-      interval: daily
-
-  - package-ecosystem: "gomod" # See documentation for possible values
-    directory: "/spx-backend" # Location of package manifests
-    schedule:
-      interval: "daily"
-
-  - package-ecosystem: "gomod" # See documentation for possible values
-    directory: "/tools/spxls" # Location of package manifests
-    schedule:
-      interval: "daily"
-
-  - package-ecosystem: "gomod" # See documentation for possible values
-    directory: "/tools/ispx" # Location of package manifests
-    schedule:
-      interval: "daily"
+    patterns:
+      - "*"
+    multi-ecosystem-group: infrastructure
+  - package-ecosystem: gomod
+    directories:
+      - /spx-backend
+      - /tools/spxls
+      - /tools/ai
+    patterns:
+      - "*"
+    multi-ecosystem-group: go-modules


### PR DESCRIPTION
Migrate from individual ecosystem updates to multi-ecosystem groups [^1][^2] to reduce PR volume and improve dependency management workflow:
- Add `infrastructure` group for GitHub Actions with weekly scheduling
- Add `go-modules` group consolidating `spx-backend`, `tools/spxls`, and `tools/ai`
- Use `directories` field to manage multiple Go module paths under single ecosystem

[^1]: https://github.blog/changelog/2025-07-01-single-pull-request-for-dependabot-multi-ecosystem-support/
[^2]: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/configuring-multi-ecosystem-updates