### PR TITLE
refactor: migrate history management from backend to client-side

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1103,6 +1103,26 @@ paths:
               schema:
                 $ref: "#/components/schemas/AIInteractionResponse"
 
+  /ai/interaction/archive:
+    post:
+      tags:
+        - AI
+      summary: Archive AI interaction history
+      description: Archive a batch of interaction turns into a condensed summary for future context.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AIInteractionArchiveRequest"
+      responses:
+        "200":
+          description: Successfully archived interaction history.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AIInteractionArchiveResponse"
+
   /course:
     post:
       tags:
@@ -2017,10 +2037,6 @@ components:
           items:
             $ref: "#/components/schemas/AIInteractionCommandSpec"
           description: Commands the AI is allowed to call.
-        previousCommandResult:
-          $ref: "#/components/schemas/AIInteractionCommandResult"
-          nullable: true
-          description: Outcome of the command executed in the previous turn.
         history:
           type: array
           items:
@@ -2037,10 +2053,11 @@ components:
           minimum: 0
           default: 0
           description: |
-            Current turn number in a multi-turn interaction.
+            Current turn number in a multi-turn interaction sequence.
 
             A value of 0 means this is the initial turn from user input. Values > 0 indicate continuation turns where
-            the AI should decide next steps based on previous command results.
+            the AI continues the current interaction sequence based on the outcomes of commands executed within this
+            sequence.
           examples:
             - 0
 
@@ -2065,10 +2082,6 @@ components:
             - Row: 1
               Col: 1
               Result: ""
-        archivedHistory:
-          $ref: "#/components/schemas/AIInteractionArchivedHistory"
-          nullable: true
-          description: Archived history information when history management occurs.
 
     AIInteractionTurn:
       type: object
@@ -2170,21 +2183,31 @@ components:
           examples:
             - false
 
-    AIInteractionArchivedHistory:
+    AIInteractionArchiveRequest:
+      type: object
+      required:
+        - turns
+      properties:
+        turns:
+          type: array
+          items:
+            $ref: "#/components/schemas/AIInteractionTurn"
+          description: Interaction turns to be archived.
+        existingArchive:
+          type: string
+          nullable: true
+          description: Existing archived content to be merged with new turns.
+          examples:
+            - "Previous conversation summary..."
+
+    AIInteractionArchiveResponse:
       type: object
       properties:
         content:
           type: string
-          description: Archived content of historical interactions.
+          description: The consolidated archive content.
           examples:
-            - Previous conversation summary...
-        turnCount:
-          type: integer
-          format: int32
-          minimum: 0
-          description: Number of turns that were archived.
-          examples:
-            - 5
+            - "Complete conversation summary including new turns..."
 
     UpInfo:
       type: object

--- a/spx-backend/cmd/spx-backend/post_ai_interaction_archive.yap
+++ b/spx-backend/cmd/spx-backend/post_ai_interaction_archive.yap
@@ -1,0 +1,32 @@
+// Archive a batch of interaction turns into a condensed summary for future context.
+//
+// Request:
+//   POST /ai/interaction/archive
+
+import (
+	"github.com/goplus/builder/spx-backend/internal/controller"
+)
+
+ctx := &Context
+
+// FIXME: Uncomment the following line to ensure the user is authenticated once
+// https://github.com/goplus/builder/issues/1673 is fixed.
+// if _, ok := ensureAuthenticatedUser(ctx); !ok {
+// 	return
+// }
+
+params := &controller.AIInteractionArchiveParams{}
+if !parseJSON(ctx, params) {
+	return
+}
+if ok, msg := params.Validate(); !ok {
+	replyWithCodeMsg(ctx, errorInvalidArgs, msg)
+	return
+}
+
+result, err := ctrl.PerformAIInteractionArchive(ctx.Context(), params)
+if err != nil {
+	replyWithInnerError(ctx, err)
+	return
+}
+json result

--- a/spx-backend/cmd/spx-backend/xgo_autogen.go
+++ b/spx-backend/cmd/spx-backend/xgo_autogen.go
@@ -126,6 +126,10 @@ type post_ai_description struct {
 	yap.Handler
 	*AppV2
 }
+type post_ai_interaction_archive struct {
+	yap.Handler
+	*AppV2
+}
 type post_ai_interaction_turn struct {
 	yap.Handler
 	*AppV2
@@ -333,26 +337,27 @@ func (this *AppV2) Main() {
 	_xgo_obj20 := &get_users_list{AppV2: this}
 	_xgo_obj21 := &get_util_upinfo{AppV2: this}
 	_xgo_obj22 := &post_ai_description{AppV2: this}
-	_xgo_obj23 := &post_ai_interaction_turn{AppV2: this}
-	_xgo_obj24 := &post_aigc_matting{AppV2: this}
-	_xgo_obj25 := &post_asset{AppV2: this}
-	_xgo_obj26 := &post_copilot_message{AppV2: this}
-	_xgo_obj27 := &post_copilot_stream_message{AppV2: this}
-	_xgo_obj28 := &post_course_series{AppV2: this}
-	_xgo_obj29 := &post_course{AppV2: this}
-	_xgo_obj30 := &post_project_release{AppV2: this}
-	_xgo_obj31 := &post_project{AppV2: this}
-	_xgo_obj32 := &post_project_owner_name_liking{AppV2: this}
-	_xgo_obj33 := &post_project_owner_name_view{AppV2: this}
-	_xgo_obj34 := &post_user_username_following{AppV2: this}
-	_xgo_obj35 := &post_util_fileurls{AppV2: this}
-	_xgo_obj36 := &post_workflow_stream_message{AppV2: this}
-	_xgo_obj37 := &put_asset_id{AppV2: this}
-	_xgo_obj38 := &put_course_series_id{AppV2: this}
-	_xgo_obj39 := &put_course_id{AppV2: this}
-	_xgo_obj40 := &put_project_owner_name{AppV2: this}
-	_xgo_obj41 := &put_user{AppV2: this}
-	yap.Gopt_AppV2_Main(this, _xgo_obj0, _xgo_obj1, _xgo_obj2, _xgo_obj3, _xgo_obj4, _xgo_obj5, _xgo_obj6, _xgo_obj7, _xgo_obj8, _xgo_obj9, _xgo_obj10, _xgo_obj11, _xgo_obj12, _xgo_obj13, _xgo_obj14, _xgo_obj15, _xgo_obj16, _xgo_obj17, _xgo_obj18, _xgo_obj19, _xgo_obj20, _xgo_obj21, _xgo_obj22, _xgo_obj23, _xgo_obj24, _xgo_obj25, _xgo_obj26, _xgo_obj27, _xgo_obj28, _xgo_obj29, _xgo_obj30, _xgo_obj31, _xgo_obj32, _xgo_obj33, _xgo_obj34, _xgo_obj35, _xgo_obj36, _xgo_obj37, _xgo_obj38, _xgo_obj39, _xgo_obj40, _xgo_obj41)
+	_xgo_obj23 := &post_ai_interaction_archive{AppV2: this}
+	_xgo_obj24 := &post_ai_interaction_turn{AppV2: this}
+	_xgo_obj25 := &post_aigc_matting{AppV2: this}
+	_xgo_obj26 := &post_asset{AppV2: this}
+	_xgo_obj27 := &post_copilot_message{AppV2: this}
+	_xgo_obj28 := &post_copilot_stream_message{AppV2: this}
+	_xgo_obj29 := &post_course_series{AppV2: this}
+	_xgo_obj30 := &post_course{AppV2: this}
+	_xgo_obj31 := &post_project_release{AppV2: this}
+	_xgo_obj32 := &post_project{AppV2: this}
+	_xgo_obj33 := &post_project_owner_name_liking{AppV2: this}
+	_xgo_obj34 := &post_project_owner_name_view{AppV2: this}
+	_xgo_obj35 := &post_user_username_following{AppV2: this}
+	_xgo_obj36 := &post_util_fileurls{AppV2: this}
+	_xgo_obj37 := &post_workflow_stream_message{AppV2: this}
+	_xgo_obj38 := &put_asset_id{AppV2: this}
+	_xgo_obj39 := &put_course_series_id{AppV2: this}
+	_xgo_obj40 := &put_course_id{AppV2: this}
+	_xgo_obj41 := &put_project_owner_name{AppV2: this}
+	_xgo_obj42 := &put_user{AppV2: this}
+	yap.Gopt_AppV2_Main(this, _xgo_obj0, _xgo_obj1, _xgo_obj2, _xgo_obj3, _xgo_obj4, _xgo_obj5, _xgo_obj6, _xgo_obj7, _xgo_obj8, _xgo_obj9, _xgo_obj10, _xgo_obj11, _xgo_obj12, _xgo_obj13, _xgo_obj14, _xgo_obj15, _xgo_obj16, _xgo_obj17, _xgo_obj18, _xgo_obj19, _xgo_obj20, _xgo_obj21, _xgo_obj22, _xgo_obj23, _xgo_obj24, _xgo_obj25, _xgo_obj26, _xgo_obj27, _xgo_obj28, _xgo_obj29, _xgo_obj30, _xgo_obj31, _xgo_obj32, _xgo_obj33, _xgo_obj34, _xgo_obj35, _xgo_obj36, _xgo_obj37, _xgo_obj38, _xgo_obj39, _xgo_obj40, _xgo_obj41, _xgo_obj42)
 }
 //line cmd/spx-backend/delete_asset_#id.yap:6
 func (this *delete_asset_id) Main(_xgo_arg0 *yap.Context) {
@@ -1497,6 +1502,46 @@ func (this *post_ai_description) Classfname() string {
 	return "post_ai_description"
 }
 func (this *post_ai_description) Classclone() yap.HandlerProto {
+	_xgo_ret := *this
+	return &_xgo_ret
+}
+//line cmd/spx-backend/post_ai_interaction_archive.yap:10
+func (this *post_ai_interaction_archive) Main(_xgo_arg0 *yap.Context) {
+	this.Handler.Main(_xgo_arg0)
+//line cmd/spx-backend/post_ai_interaction_archive.yap:10:1
+	ctx := &this.Context
+//line cmd/spx-backend/post_ai_interaction_archive.yap:18:1
+	params := &controller.AIInteractionArchiveParams{}
+//line cmd/spx-backend/post_ai_interaction_archive.yap:19:1
+	if !parseJSON(ctx, params) {
+//line cmd/spx-backend/post_ai_interaction_archive.yap:20:1
+		return
+	}
+//line cmd/spx-backend/post_ai_interaction_archive.yap:22:1
+	if
+//line cmd/spx-backend/post_ai_interaction_archive.yap:22:1
+	ok, msg := params.Validate(); !ok {
+//line cmd/spx-backend/post_ai_interaction_archive.yap:23:1
+		replyWithCodeMsg(ctx, errorInvalidArgs, msg)
+//line cmd/spx-backend/post_ai_interaction_archive.yap:24:1
+		return
+	}
+//line cmd/spx-backend/post_ai_interaction_archive.yap:27:1
+	result, err := this.ctrl.PerformAIInteractionArchive(ctx.Context(), params)
+//line cmd/spx-backend/post_ai_interaction_archive.yap:28:1
+	if err != nil {
+//line cmd/spx-backend/post_ai_interaction_archive.yap:29:1
+		replyWithInnerError(ctx, err)
+//line cmd/spx-backend/post_ai_interaction_archive.yap:30:1
+		return
+	}
+//line cmd/spx-backend/post_ai_interaction_archive.yap:32:1
+	this.Json__1(result)
+}
+func (this *post_ai_interaction_archive) Classfname() string {
+	return "post_ai_interaction_archive"
+}
+func (this *post_ai_interaction_archive) Classclone() yap.HandlerProto {
 	_xgo_ret := *this
 	return &_xgo_ret
 }

--- a/spx-backend/go.mod
+++ b/spx-backend/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/golang-migrate/migrate/v4 v4.19.0
 	github.com/goplus/yap v0.8.4 //xgo:class
 	github.com/joho/godotenv v1.5.1
-	github.com/openai/openai-go/v2 v2.3.1
+	github.com/openai/openai-go/v2 v2.4.1
 	github.com/qiniu/go-cdk-driver v0.1.1
 	github.com/qiniu/go-sdk/v7 v7.25.4
 	github.com/qiniu/x v1.15.1

--- a/spx-backend/go.sum
+++ b/spx-backend/go.sum
@@ -218,8 +218,8 @@ github.com/onsi/ginkgo/v2 v2.14.0 h1:vSmGj2Z5YPb9JwCWT6z6ihcUvDhuXLc3sJiqd3jMKAY
 github.com/onsi/ginkgo/v2 v2.14.0/go.mod h1:JkUdW7JkN0V6rFvsHcJ478egV3XH9NxpD27Hal/PhZw=
 github.com/onsi/gomega v1.30.0 h1:hvMK7xYz4D3HapigLTeGdId/NcfQx1VHMJc60ew99+8=
 github.com/onsi/gomega v1.30.0/go.mod h1:9sxs+SwGrKI0+PWe4Fxa9tFQQBG5xSsSbMXOI8PPpoQ=
-github.com/openai/openai-go/v2 v2.3.1 h1:ETbQy/21NaUeGmWD/ykOPX4q/Xin6eVi3J+cXwAbeKI=
-github.com/openai/openai-go/v2 v2.3.1/go.mod h1:sIUkR+Cu/PMUVkSKhkk742PRURkQOCFhiwJ7eRSBqmk=
+github.com/openai/openai-go/v2 v2.4.1 h1:18RB0Qo21nzXfuFaMXy828Jlyho6cqNg1RLGWYBoXsk=
+github.com/openai/openai-go/v2 v2.4.1/go.mod h1:sIUkR+Cu/PMUVkSKhkk742PRURkQOCFhiwJ7eRSBqmk=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.0 h1:8SG7/vwALn54lVB/0yZ/MMwhFrPYtpEHQb2IpWsCzug=

--- a/spx-backend/internal/aiinteraction/system_prompt.md
+++ b/spx-backend/internal/aiinteraction/system_prompt.md
@@ -8,40 +8,61 @@ understand game situations, and make appropriate decisions based on the context 
 You will receive structured information to help you make informed decisions:
 - Role and context: Your assigned role in the game (if any) and additional role-specific context
 - Knowledge base: Background information about the game world, rules, and current state
-- Session history: Summarized interactions from earlier in the session (for long conversations)
-- Recent history: Detailed conversation history showing recent player actions and your responses
+- Archived history: Summarized interactions from previous interaction sequences
+- Recent history: Detailed interaction history showing recent player actions and your responses
 
-## Conversation history format
+## Interaction history format
 
-The conversation history alternates between user and assistant messages:
-- User messages: Either player input (with optional context) or function execution results
-- Assistant messages: Your text responses and function calls
-- Function calls appear as: `Function call: <function_name>` or `Function call: <function_name> with arguments <JSON>`
-- Execution results appear as: `Function call <function_name> succeeded.` or
-  `Function call <function_name> failed: <error_message>` (with `[Interaction terminated]` appended when the interaction
-  ends)
+The interaction history includes:
+- User messages: Either player input (with optional context) or continuation prompts
+- Assistant messages: Your text responses and/or function calls made through the tools provided
+- Tool messages: Function execution results showing success, failure, or `BREAK` signals that mark interaction sequence
+  endpoints
 
-## Text response format
+## Internal reasoning and decision making
 
-Keep your text responses extremely brief—ideally one sentence around 140 characters (maximum 280). Since your primary
-communication is through function calls, use text only for minimal acknowledgments or essential explanations.
+Text responses serve as internal reasoning (for debugging and improved decision-making), not player-facing content. Only
+function calls affect actual gameplay.
 
-## Function calling rules
+When including text:
+- Write concise reasoning/analysis first, before any function call
+  - Simple actions: empty (no text needed)
+  - Tactical decisions: up to 20 words
+  - Complex strategy: up to 50 words
+- Use abbreviated style: keywords, coordinates, and essential facts only
+  - Good: "Enemy mage (10,20), low HP. Flank right, use ranged."
+  - Bad: "I can see that there is an enemy mage located at position 10,20 who appears to have low health points. I
+    think the best strategy would be to flank from the right side and use ranged attacks."
+- After text (if any), immediately make your function call
+- Never output text after a function call
 
-You operate in a turn-based system with these rules:
-- In initial turns, you MUST call exactly one function because the player expects an action
-- In continuation turns, you may call one function or no function based on the situation
-- Call a function when further action is needed
-- Do not call any function when the task is complete, the game has reached a conclusion, or no further action is
-  possible
-- Never call multiple functions in a single turn, as each function represents one atomic game action
+## Interaction sequences and function calling
+
+An interaction sequence is a complete task that starts with player input and progresses through function calls.
+
+### Initial turn (player input)
+- Triggered by new player input with optional context
+- You must call exactly one function to respond to the player
+- Failing to call a function on initial turn is an error
+
+### Continuation turns (automated progression)
+- Triggered after each function execution to continue the task
+- You receive the execution result and decide the next step
+- You may call one function to continue, or call none to end the interaction sequence
+- Base your decision on the command results and whether the task is complete
+
+### Key constraints
+- Each turn allows at most one function call (never multiple)
+- Each function call represents a single atomic game action
+- An interaction sequence ends when you choose not to call a function, encounter a `BREAK` signal, or reach an error
 
 ## Decision guidelines
 
 As an AI player in this game, you should:
-- Make intelligent decisions using ALL provided context (role, knowledge base, history)
+- Make intelligent decisions using all provided context (role, knowledge base, history)
 - Follow game rules and constraints strictly
 - Provide appropriate challenge or assistance based on your assigned role
-- React logically to player actions and previous function call results
-- Maintain consistent behavior throughout the interaction based on session history
-- Consider the outcomes of your previous function calls when planning next steps
+- React logically to player actions and function call results
+- Pay special attention to command results within the current interaction sequence
+- Maintain consistent behavior based on historical context from previous interaction sequences
+- Use the outcomes of function calls in the current interaction sequence to determine your next action

--- a/spx-backend/internal/aiinteraction/types.go
+++ b/spx-backend/internal/aiinteraction/types.go
@@ -20,9 +20,6 @@ type Request struct {
 	// CommandSpecs defines the commands the AI is allowed to call.
 	CommandSpecs []CommandSpec `json:"commandSpecs,omitempty"`
 
-	// PreviousCommandResult contains the outcome of the command executed in the previous turn.
-	PreviousCommandResult *CommandResult `json:"previousCommandResult,omitempty"`
-
 	// History contains the record of previous interactions in this session.
 	History []Turn `json:"history,omitempty"`
 
@@ -48,18 +45,6 @@ type Response struct {
 
 	// CommandArgs contains the arguments for the command to be executed.
 	CommandArgs map[string]any `json:"commandArgs,omitempty"`
-
-	// ArchivedHistory contains archived history information when history management occurs.
-	ArchivedHistory *ArchivedHistory `json:"archivedHistory,omitempty"`
-}
-
-// ArchivedHistory contains information about archived historical interactions.
-type ArchivedHistory struct {
-	// Content is the archived content of historical interactions.
-	Content string `json:"content"`
-
-	// TurnCount indicates how many turns were archived.
-	TurnCount int `json:"turnCount"`
 }
 
 // Turn represents a single turn in the AI interaction.
@@ -121,4 +106,10 @@ type CommandResult struct {
 
 	// IsBreak indicates if the interaction should be terminated.
 	IsBreak bool `json:"isBreak,omitempty"`
+}
+
+// ArchivedHistory contains information about archived historical interactions.
+type ArchivedHistory struct {
+	// Content is the archived content of historical interactions.
+	Content string `json:"content"`
 }

--- a/spx-backend/internal/controller/aiinteraction.go
+++ b/spx-backend/internal/controller/aiinteraction.go
@@ -43,3 +43,43 @@ func (ctrl *Controller) PerformAIInteractionTurn(ctx context.Context, params *AI
 	result := (*AIInteractionTurnResult)(response)
 	return result, nil
 }
+
+// AIInteractionArchiveParams represents the parameters for archiving AI interaction history.
+type AIInteractionArchiveParams struct {
+	Turns           []aiinteraction.Turn `json:"turns"`
+	ExistingArchive string               `json:"existingArchive,omitempty"`
+}
+
+// Validate validates the parameters.
+func (p *AIInteractionArchiveParams) Validate() (ok bool, msg string) {
+	const maxTurns = 50
+	if len(p.Turns) == 0 {
+		return false, "no turns to archive"
+	}
+	if len(p.Turns) > maxTurns {
+		return false, fmt.Sprintf("too many turns to archive (max %d)", maxTurns)
+	}
+	return true, ""
+}
+
+// AIInteractionArchiveResult represents the result of archiving AI interaction history.
+type AIInteractionArchiveResult struct {
+	Content string `json:"content"`
+}
+
+// PerformAIInteractionArchive archives AI interaction history.
+func (ctrl *Controller) PerformAIInteractionArchive(ctx context.Context, params *AIInteractionArchiveParams) (*AIInteractionArchiveResult, error) {
+	if ctrl.aiInteraction == nil {
+		return nil, errors.New("ai interaction service not initialized")
+	}
+
+	archivedHistory, err := ctrl.aiInteraction.Archive(ctx, params.Turns, params.ExistingArchive)
+	if err != nil {
+		return nil, fmt.Errorf("failed to archive interaction history: %w", err)
+	}
+
+	result := &AIInteractionArchiveResult{
+		Content: archivedHistory.Content,
+	}
+	return result, nil
+}

--- a/spx-backend/internal/controller/aiinteraction_test.go
+++ b/spx-backend/internal/controller/aiinteraction_test.go
@@ -61,3 +61,60 @@ func TestAIInteractionTurnParamsValidate(t *testing.T) {
 		assert.Equal(t, "missing content", msg)
 	})
 }
+
+func TestAIInteractionArchiveParamsValidate(t *testing.T) {
+	t.Run("Valid", func(t *testing.T) {
+		params := &AIInteractionArchiveParams{
+			Turns: []aiinteraction.Turn{
+				{
+					RequestContent: "Test",
+					ResponseText:   "Response",
+				},
+			},
+		}
+		ok, msg := params.Validate()
+		assert.True(t, ok)
+		assert.Empty(t, msg)
+	})
+
+	t.Run("NoTurns", func(t *testing.T) {
+		params := &AIInteractionArchiveParams{
+			Turns: []aiinteraction.Turn{},
+		}
+		ok, msg := params.Validate()
+		assert.False(t, ok)
+		assert.Equal(t, "no turns to archive", msg)
+	})
+
+	t.Run("TooManyTurns", func(t *testing.T) {
+		turns := make([]aiinteraction.Turn, 51)
+		for i := range turns {
+			turns[i] = aiinteraction.Turn{
+				RequestContent: "Test",
+				ResponseText:   "Response",
+			}
+		}
+		params := &AIInteractionArchiveParams{
+			Turns: turns,
+		}
+		ok, msg := params.Validate()
+		assert.False(t, ok)
+		assert.Contains(t, msg, "too many turns to archive")
+	})
+
+	t.Run("MaxTurnsAllowed", func(t *testing.T) {
+		turns := make([]aiinteraction.Turn, 50)
+		for i := range turns {
+			turns[i] = aiinteraction.Turn{
+				RequestContent: "Test",
+				ResponseText:   "Response",
+			}
+		}
+		params := &AIInteractionArchiveParams{
+			Turns: turns,
+		}
+		ok, msg := params.Validate()
+		assert.True(t, ok)
+		assert.Empty(t, msg)
+	})
+}

--- a/tools/ai/ai_test.go
+++ b/tools/ai/ai_test.go
@@ -1,0 +1,457 @@
+package ai
+
+import (
+	"reflect"
+	"sync"
+	"testing"
+)
+
+func TestPlayerAppendHistory(t *testing.T) {
+	for _, tt := range []struct {
+		name           string
+		initialHistory []Turn
+		turnToAppend   Turn
+		wantLength     int
+	}{
+		{
+			name:           "EmptyHistory",
+			initialHistory: nil,
+			turnToAppend: Turn{
+				RequestContent: "hello",
+				ResponseText:   "world",
+				IsInitial:      true,
+			},
+			wantLength: 1,
+		},
+		{
+			name: "ExistingHistory",
+			initialHistory: []Turn{
+				{RequestContent: "first", IsInitial: true},
+				{RequestContent: "second"},
+			},
+			turnToAppend: Turn{
+				RequestContent: "third",
+			},
+			wantLength: 3,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &Player{
+				history: tt.initialHistory,
+			}
+
+			p.appendHistory(tt.turnToAppend)
+
+			if got, want := len(p.history), tt.wantLength; got != want {
+				t.Errorf("got %d, want %d", got, want)
+			}
+
+			lastTurn := p.history[len(p.history)-1]
+			if got, want := lastTurn.RequestContent, tt.turnToAppend.RequestContent; got != want {
+				t.Errorf("got %q, want %q", got, want)
+			}
+		})
+	}
+
+	t.Run("ConcurrentAppend", func(t *testing.T) {
+		p := &Player{}
+		const numGoroutines = 100
+
+		var wg sync.WaitGroup
+		wg.Add(numGoroutines)
+		for i := 0; i < numGoroutines; i++ {
+			go func(idx int) {
+				defer wg.Done()
+				p.appendHistory(Turn{
+					RequestContent: string(rune('a' + idx%26)),
+				})
+			}(i)
+		}
+		wg.Wait()
+
+		if got, want := len(p.history), numGoroutines; got != want {
+			t.Errorf("got %d, want %d", got, want)
+		}
+	})
+}
+
+func TestPlayerPrepareArchive(t *testing.T) {
+	makeHistory := func(count int, initialPattern []int) []Turn {
+		history := make([]Turn, count)
+		for i := 0; i < count; i++ {
+			history[i] = Turn{
+				RequestContent: string(rune('a' + i%26)),
+			}
+			for _, pos := range initialPattern {
+				if i == pos {
+					history[i].IsInitial = true
+					break
+				}
+			}
+		}
+		return history
+	}
+
+	for _, tt := range []struct {
+		name                  string
+		history               []Turn
+		archivedHistory       string
+		archiveInProgress     bool
+		wantTurnsCount        int
+		wantExistingArchive   string
+		wantArchiveInProgress bool
+	}{
+		{
+			name:                  "BelowThreshold",
+			history:               makeHistory(20, []int{0, 10}),
+			archivedHistory:       "previous",
+			wantTurnsCount:        0,
+			wantExistingArchive:   "",
+			wantArchiveInProgress: false,
+		},
+		{
+			name:                  "AlreadyInProgress",
+			history:               makeHistory(35, []int{0, 10, 20, 30}),
+			archiveInProgress:     true,
+			wantTurnsCount:        0,
+			wantExistingArchive:   "",
+			wantArchiveInProgress: true,
+		},
+		{
+			name:                  "NotEnoughToRetain",
+			history:               makeHistory(15, []int{0}),
+			wantTurnsCount:        0,
+			wantExistingArchive:   "",
+			wantArchiveInProgress: false,
+		},
+		{
+			name:                  "NoSequenceBoundary",
+			history:               makeHistory(35, []int{0}),
+			wantTurnsCount:        0,
+			wantExistingArchive:   "",
+			wantArchiveInProgress: false,
+		},
+		{
+			name:                  "SingleBoundary",
+			history:               makeHistory(35, []int{0, 10}),
+			archivedHistory:       "existing",
+			wantTurnsCount:        10,
+			wantExistingArchive:   "existing",
+			wantArchiveInProgress: true,
+		},
+		{
+			name:                  "MultipleBoundaries",
+			history:               makeHistory(40, []int{0, 5, 15, 25, 35}),
+			archivedHistory:       "old",
+			wantTurnsCount:        15,
+			wantExistingArchive:   "old",
+			wantArchiveInProgress: true,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &Player{
+				history:           tt.history,
+				archivedHistory:   tt.archivedHistory,
+				archiveInProgress: tt.archiveInProgress,
+			}
+
+			turns, existingArchive := p.prepareArchive()
+
+			if got, want := len(turns), tt.wantTurnsCount; got != want {
+				t.Errorf("got %d, want %d", got, want)
+			}
+
+			if got, want := existingArchive, tt.wantExistingArchive; got != want {
+				t.Errorf("got %q, want %q", got, want)
+			}
+
+			if got, want := p.archiveInProgress, tt.wantArchiveInProgress; got != want {
+				t.Errorf("got %v, want %v", got, want)
+			}
+
+			// Verify turns are correctly cloned (not sharing underlying array).
+			if len(turns) > 0 {
+				// Modify the returned slice.
+				turns[0].RequestContent = "modified"
+				// Original should be unchanged.
+				if p.history[0].RequestContent == "modified" {
+					t.Error("returned turns share underlying array with history")
+				}
+			}
+		})
+	}
+
+	t.Run("CompleteWorkflow", func(t *testing.T) {
+		p := &Player{}
+
+		// Build history with clear boundaries.
+		for i := 0; i < 35; i++ {
+			p.appendHistory(Turn{
+				RequestContent: string(rune('a' + i%26)),
+				IsInitial:      i%10 == 0,
+			})
+		}
+
+		// Phase 1: Prepare.
+		turns, existingArchive := p.prepareArchive()
+		if turns == nil {
+			t.Fatal("expected successful prepare")
+		}
+		if existingArchive != "" {
+			t.Errorf("expected empty existingArchive, got %q", existingArchive)
+		}
+		if !p.archiveInProgress {
+			t.Error("expected archiveInProgress to be true after prepare")
+		}
+
+		originalTurnCount := len(turns)
+
+		// Phase 2: Apply.
+		p.applyArchive("archived_content", originalTurnCount)
+
+		if got, want := p.archivedHistory, "archived_content"; got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+		if got, want := len(p.history), 35-originalTurnCount; got != want {
+			t.Errorf("got %d, want %d", got, want)
+		}
+		if p.archiveInProgress {
+			t.Error("expected archiveInProgress to be false after apply")
+		}
+
+		// Phase 3: Second prepare should fail (not enough turns).
+		turns2, _ := p.prepareArchive()
+		if turns2 != nil {
+			t.Error("second prepare should return nil (not enough turns)")
+		}
+	})
+
+	t.Run("ConcurrentOperations", func(t *testing.T) {
+		p := &Player{}
+
+		// Build history.
+		for i := 0; i < 40; i++ {
+			p.history = append(p.history, Turn{
+				RequestContent: string(rune('a' + i%26)),
+				IsInitial:      i%10 == 0,
+			})
+		}
+
+		var wg sync.WaitGroup
+		wg.Add(3)
+
+		// Concurrent operations.
+		go func() {
+			defer wg.Done()
+			p.appendHistory(Turn{RequestContent: "concurrent1"})
+		}()
+
+		go func() {
+			defer wg.Done()
+			turns, _ := p.prepareArchive()
+			if turns != nil {
+				p.applyArchive("concurrent_archive", len(turns))
+			}
+		}()
+
+		go func() {
+			defer wg.Done()
+			p.appendHistory(Turn{RequestContent: "concurrent2"})
+		}()
+
+		wg.Wait()
+
+		// Verify consistency - no panics and valid state.
+		if p.archiveInProgress {
+			// If still in progress, cancel should work.
+			p.cancelArchive()
+			if p.archiveInProgress {
+				t.Error("cancelArchive failed to reset flag")
+			}
+		}
+
+		// History should be valid (no nil entries).
+		for i, turn := range p.history {
+			if turn.RequestContent == "" && !turn.IsInitial && turn.ResponseText == "" {
+				t.Errorf("invalid turn at index %d", i)
+			}
+		}
+	})
+}
+
+func TestPlayerApplyArchive(t *testing.T) {
+	for _, tt := range []struct {
+		name                  string
+		initialHistory        []Turn
+		initialArchived       string
+		initialInProgress     bool
+		newArchived           string
+		turnCount             int
+		wantRemainingCount    int
+		wantArchived          string
+		wantArchiveInProgress bool
+	}{
+		{
+			name: "Basic",
+			initialHistory: []Turn{
+				{RequestContent: "a"},
+				{RequestContent: "b"},
+				{RequestContent: "c"},
+				{RequestContent: "d"},
+				{RequestContent: "e"},
+			},
+			initialArchived:       "old",
+			initialInProgress:     true,
+			newArchived:           "new",
+			turnCount:             3,
+			wantRemainingCount:    2,
+			wantArchived:          "new",
+			wantArchiveInProgress: false,
+		},
+		{
+			name: "ArchiveAll",
+			initialHistory: []Turn{
+				{RequestContent: "x"},
+				{RequestContent: "y"},
+			},
+			initialInProgress:     true,
+			newArchived:           "all",
+			turnCount:             2,
+			wantRemainingCount:    0,
+			wantArchived:          "all",
+			wantArchiveInProgress: false,
+		},
+		{
+			name: "ArchiveNone",
+			initialHistory: []Turn{
+				{RequestContent: "keep1"},
+				{RequestContent: "keep2"},
+			},
+			initialArchived:       "unchanged",
+			initialInProgress:     true,
+			newArchived:           "empty",
+			turnCount:             0,
+			wantRemainingCount:    2,
+			wantArchived:          "empty",
+			wantArchiveInProgress: false,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &Player{
+				history:           tt.initialHistory,
+				archivedHistory:   tt.initialArchived,
+				archiveInProgress: tt.initialInProgress,
+			}
+
+			p.applyArchive(tt.newArchived, tt.turnCount)
+
+			if got, want := len(p.history), tt.wantRemainingCount; got != want {
+				t.Errorf("got %d, want %d", got, want)
+			}
+
+			if got, want := p.archivedHistory, tt.wantArchived; got != want {
+				t.Errorf("got %q, want %q", got, want)
+			}
+
+			if got, want := p.archiveInProgress, tt.wantArchiveInProgress; got != want {
+				t.Errorf("got %v, want %v", got, want)
+			}
+
+			// Verify correct turns remain.
+			if tt.turnCount > 0 && len(p.history) > 0 {
+				firstRemaining := p.history[0].RequestContent
+				expectedFirst := tt.initialHistory[tt.turnCount].RequestContent
+				if got, want := firstRemaining, expectedFirst; got != want {
+					t.Errorf("got %q, want %q", got, want)
+				}
+			}
+		})
+	}
+}
+
+func TestPlayerCancelArchive(t *testing.T) {
+	for _, tt := range []struct {
+		name                  string
+		initialInProgress     bool
+		initialArchived       string
+		initialHistory        []Turn
+		wantArchiveInProgress bool
+	}{
+		{
+			name:                  "CancelInProgress",
+			initialInProgress:     true,
+			initialArchived:       "keep",
+			initialHistory:        []Turn{{RequestContent: "a"}},
+			wantArchiveInProgress: false,
+		},
+		{
+			name:                  "CancelNotInProgress",
+			initialInProgress:     false,
+			initialArchived:       "unchanged",
+			initialHistory:        []Turn{{RequestContent: "b"}},
+			wantArchiveInProgress: false,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &Player{
+				archiveInProgress: tt.initialInProgress,
+				archivedHistory:   tt.initialArchived,
+				history:           tt.initialHistory,
+			}
+
+			originalHistory := make([]Turn, len(p.history))
+			copy(originalHistory, p.history)
+
+			p.cancelArchive()
+
+			if got, want := p.archiveInProgress, tt.wantArchiveInProgress; got != want {
+				t.Errorf("got %v, want %v", got, want)
+			}
+
+			// Verify other fields unchanged.
+			if got, want := p.archivedHistory, tt.initialArchived; got != want {
+				t.Errorf("archivedHistory changed: got %q, want %q", got, want)
+			}
+
+			if got, want := p.history, originalHistory; !reflect.DeepEqual(got, want) {
+				t.Errorf("history changed: got %v, want %v", got, want)
+			}
+		})
+	}
+
+	t.Run("CancelWorkflow", func(t *testing.T) {
+		p := &Player{}
+
+		// Build history.
+		for i := 0; i < 35; i++ {
+			p.appendHistory(Turn{
+				RequestContent: string(rune('a' + i%26)),
+				IsInitial:      i%10 == 0,
+			})
+		}
+
+		// Prepare.
+		turns, _ := p.prepareArchive()
+		if turns == nil {
+			t.Fatal("expected successful prepare")
+		}
+
+		originalHistoryLen := len(p.history)
+
+		// Cancel instead of apply.
+		p.cancelArchive()
+
+		if p.archiveInProgress {
+			t.Error("expected archiveInProgress to be false after cancel")
+		}
+		if got, want := len(p.history), originalHistoryLen; got != want {
+			t.Errorf("history length changed after cancel: got %d, want %d", got, want)
+		}
+
+		// Should be able to prepare again.
+		turns2, _ := p.prepareArchive()
+		if turns2 == nil {
+			t.Error("should be able to prepare again after cancel")
+		}
+	})
+}


### PR DESCRIPTION
Previously, the backend automatically managed conversation history by archiving old turns when reaching a threshold. This approach had several issues:
- Could cause API response delays or timeouts during archiving operations
- Made performance issues opaque to frontend clients
- Coupled history management with interaction logic
- Made it difficult for clients to control archiving behavior

This commit moves history management responsibility to the client:
- Remove automatic history archiving from the backend
- Add explicit `/ai/interaction/archive` endpoint for client-controlled archiving
- Implement async history management in the client with configurable thresholds