### PR TITLE
fix: optimize AI Description generation to prevent publish timeouts

### DIFF
--- a/spx-backend/internal/aidescription/aidescription.go
+++ b/spx-backend/internal/aidescription/aidescription.go
@@ -10,7 +10,7 @@ import (
 
 const (
 	// maxTokens defines the maximum number of tokens for the AI response.
-	maxTokens = 8192
+	maxTokens = 2048
 
 	// temperature defines the sampling temperature for the AI response.
 	temperature = 0.7

--- a/spx-gui/src/apis/ai-description.ts
+++ b/spx-gui/src/apis/ai-description.ts
@@ -5,7 +5,7 @@
 import { client } from './common'
 
 export async function generateAIDescription(content: string, signal?: AbortSignal) {
-  const result = (await client.post('/ai/description', { content }, { signal, timeout: 20 * 1000 })) as {
+  const result = (await client.post('/ai/description', { content }, { signal, timeout: 60 * 1000 })) as {
     description: string
   }
   return result.description


### PR DESCRIPTION
- Increase frontend API timeout from `20s` to `60s` to handle network latency
- Reduce backend `maxTokens` from `8192` to `2048` for faster generation