### PR TITLE
fix(spx-gui): Wrong undo/redo logic

### DIFF
--- a/spx-gui/src/components/editor/common/painter/paintBoard.vue
+++ b/spx-gui/src/components/editor/common/painter/paintBoard.vue
@@ -399,16 +399,18 @@ const initPaper = (): void => {
 
 //painter提供allPath接口给直线组件
 const getAllPathsValue = (): paper.Path[] => {
-  return allPaths.value
+  return allPaths.value.map(p => p.clone({insert:false}))
 }
 const setAllPathsValue = (paths: paper.Path[]): void => {
   //历史记录保存
   if (!historyManager.value || !importExportManager) return
 
+  //这里保存的是修改后的值
   const svgContent = importExportManager.exportSvg()
   if (svgContent) {
     historyManager.value.addState(svgContent)
   }
+
   allPaths.value = paths
 }
 
@@ -480,11 +482,6 @@ const importSvgFromPicgcToCanvas = async (svgContent: string): Promise<void> => 
 const clearCanvas = (): void => {
   if (!historyManager.value || !importExportManager) return
 
-  // 先保存清空前的状态（用于撤销）
-  const svgContentBeforeClear = importExportManager.exportSvg()
-  if (svgContentBeforeClear) {
-    historyManager.value.addState(svgContentBeforeClear, 'Before Clear')
-  }
 
   clearCanvasFunction({
     canvasWidth,
@@ -508,7 +505,7 @@ const clearCanvas = (): void => {
     drawBrushRef.value.resetDrawing()
   }
 
-  // 保存清空后的状态（用于重做）
+  // 保存清空后的状态
   const svgContentAfterClear = importExportManager.exportSvg()
   if (svgContentAfterClear) {
     historyManager.value.addState(svgContentAfterClear, 'Clear')

--- a/spx-gui/src/components/editor/common/painter/paintBoard.vue
+++ b/spx-gui/src/components/editor/common/painter/paintBoard.vue
@@ -399,7 +399,7 @@ const initPaper = (): void => {
 
 //painter提供allPath接口给直线组件
 const getAllPathsValue = (): paper.Path[] => {
-  return allPaths.value.map(p => p.clone({insert:false}))
+  return allPaths.value.map((p) => p.clone({ insert: false }))
 }
 const setAllPathsValue = (paths: paper.Path[]): void => {
   //历史记录保存
@@ -481,7 +481,6 @@ const importSvgFromPicgcToCanvas = async (svgContent: string): Promise<void> => 
 // 清空画布
 const clearCanvas = (): void => {
   if (!historyManager.value || !importExportManager) return
-
 
   clearCanvasFunction({
     canvasWidth,


### PR DESCRIPTION
The logical error in the undo/redo feature has now been fixed. The 'clear' operation and all painter operations now  save the modified painter data, achieving logical consistency. At the same time, the logical issues in the code have also been corrected, and the code now more clearly reflects the data-saving logic.
现在，撤消重做功能的逻辑性错误已经得到了修复。清空操作和所有的画板操作全都统一保存修改后的画板数据，从而实现了逻辑的一致性。同时，代码中的逻辑问题也到了修改，现在代码更清晰的体现了数据保存的逻辑