### PR TITLE
feat: enforce AI Description payload budgets

### DIFF
--- a/spx-backend/internal/controller/aidescription.go
+++ b/spx-backend/internal/controller/aidescription.go
@@ -12,7 +12,7 @@ type AIDescriptionParams struct {
 
 // Validate validates the parameters.
 func (p *AIDescriptionParams) Validate() (ok bool, msg string) {
-	const maxContentLength = 100000 // Allow larger content from frontend
+	const maxContentLength = 150_000 // Allow larger content from frontend
 	if p.Content == "" {
 		return false, "content is required"
 	}

--- a/spx-backend/internal/controller/aidescription_test.go
+++ b/spx-backend/internal/controller/aidescription_test.go
@@ -28,16 +28,16 @@ func TestAIDescriptionParamsValidate(t *testing.T) {
 
 	t.Run("ContentTooLong", func(t *testing.T) {
 		params := &AIDescriptionParams{
-			Content: strings.Repeat("a", 100001),
+			Content: strings.Repeat("a", 150001),
 		}
 		ok, msg := params.Validate()
 		assert.False(t, ok)
-		assert.Equal(t, "content length exceeds 100000 characters", msg)
+		assert.Equal(t, "content length exceeds 150000 characters", msg)
 	})
 
 	t.Run("MaxLengthContent", func(t *testing.T) {
 		params := &AIDescriptionParams{
-			Content: strings.Repeat("a", 100000),
+			Content: strings.Repeat("a", 150000),
 		}
 		ok, msg := params.Validate()
 		assert.True(t, ok)


### PR DESCRIPTION
Increase backend `maxContentLength` limit to 150k for AI Description and add sophisticated truncation logic in frontend to ensure content stays within budget constraints and avoid validation errors.