### PR TITLE
feat: integrate avatar management with Kodo

### DIFF
--- a/spx-backend/cmd/spx-backend/main.yap
+++ b/spx-backend/cmd/spx-backend/main.yap
@@ -14,6 +14,7 @@ import (
 	"github.com/goplus/builder/spx-backend/internal/authz"
 	"github.com/goplus/builder/spx-backend/internal/authz/embpdp"
 	"github.com/goplus/builder/spx-backend/internal/authz/quota"
+	"github.com/goplus/builder/spx-backend/internal/avatar"
 	"github.com/goplus/builder/spx-backend/internal/config"
 	"github.com/goplus/builder/spx-backend/internal/controller"
 	"github.com/goplus/builder/spx-backend/internal/log"
@@ -64,8 +65,17 @@ if err != nil {
 }
 // TODO: Configure connection pool and timeouts.
 
+// Initialize avatar manager.
+avatarManager, err := avatar.NewKodoManager(cfg.Kodo)
+if err != nil {
+	logger.Fatalln("failed to create avatar manager:", err)
+}
+
 // Initialize authenticator.
-authenticator := casdoor.New(db, cfg.Casdoor)
+authenticator, err := casdoor.New(db, cfg.Casdoor, avatarManager)
+if err != nil {
+	logger.Fatalln("failed to create authenticator:", err)
+}
 
 // Initialize authorizer.
 var quotaTracker authz.QuotaTracker

--- a/spx-backend/go.mod
+++ b/spx-backend/go.mod
@@ -4,6 +4,7 @@ go 1.23.0
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2
+	github.com/aofei/cameron v1.3.2
 	github.com/casdoor/casdoor-go-sdk v1.20.0
 	github.com/getsentry/sentry-go v0.35.3
 	github.com/go-redis/redismock/v9 v9.2.0

--- a/spx-backend/go.sum
+++ b/spx-backend/go.sum
@@ -25,6 +25,8 @@ github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERo
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/alex-ant/gomath v0.0.0-20160516115720-89013a210a82 h1:7dONQ3WNZ1zy960TmkxJPuwoolZwL7xKtpcM04MBnt4=
 github.com/alex-ant/gomath v0.0.0-20160516115720-89013a210a82/go.mod h1:nLnM0KdK1CmygvjpDUO6m1TjSsiQtL61juhNsvV/JVI=
+github.com/aofei/cameron v1.3.2 h1:aj703iafH4tLTcOgy37zhc9gcqtF80CX3dIjLrYHEfI=
+github.com/aofei/cameron v1.3.2/go.mod h1://m6rSwkxNLUWUj2N+1VKTU/hYMWBeoHjM7UJfXDPgo=
 github.com/aws/aws-sdk-go v1.49.6 h1:yNldzF5kzLBRvKlKz1S0bkvc2+04R1kt13KfBWQBfFA=
 github.com/aws/aws-sdk-go v1.49.6/go.mod h1:LF8svs817+Nz+DmiMQKTO3ubZ/6IaTpq3TjupRn3Eqk=
 github.com/aws/aws-sdk-go-v2 v1.30.3 h1:jUeBtG0Ih+ZIFH0F4UkmL9w3cSpaMv9tYYDbzILP8dY=

--- a/spx-backend/internal/avatar/manager.go
+++ b/spx-backend/internal/avatar/manager.go
@@ -1,0 +1,228 @@
+package avatar
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"image/png"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/aofei/cameron"
+	qiniuAuth "github.com/qiniu/go-sdk/v7/auth"
+	"github.com/qiniu/go-sdk/v7/storage"
+
+	"github.com/goplus/builder/spx-backend/internal/config"
+)
+
+const (
+	defaultAvatarMaxBytes = 5 << 20 // 5 MiB
+	defaultHTTPTimeout    = 10 * time.Second
+	uploadTokenTTL        = 1800 // 30 minutes in seconds
+	defaultIdenticonCell  = 70
+)
+
+// Manager handles avatar uploads and generation.
+type Manager interface {
+	UploadFromURL(ctx context.Context, sourceURL string) (string, error)
+	UploadDefault(ctx context.Context, seed []byte) (string, error)
+}
+
+// Option customizes the behavior of a Kodo-backed avatar manager during construction.
+type Option func(*kodoManager)
+
+// kodoManager implements [Manager] using Qiniu Kodo as the backing store.
+type kodoManager struct {
+	httpClient    *http.Client
+	bucket        string
+	credentials   *qiniuAuth.Credentials
+	uploader      *storage.FormUploader
+	putPolicy     storage.PutPolicy
+	maxBytes      int64
+	identiconCell int
+}
+
+// WithHTTPClient overrides the HTTP client used to fetch avatars from remote URLs.
+func WithHTTPClient(client *http.Client) Option {
+	return func(m *kodoManager) {
+		if client != nil {
+			m.httpClient = client
+		}
+	}
+}
+
+// WithMaxBytes overrides the maximum avatar size that can be downloaded or generated.
+func WithMaxBytes(limit int64) Option {
+	return func(m *kodoManager) {
+		if limit > 0 {
+			m.maxBytes = limit
+		}
+	}
+}
+
+// WithIdenticonCell overrides the identicon cell size used for generated identicons.
+func WithIdenticonCell(cell int) Option {
+	return func(m *kodoManager) {
+		if cell > 0 {
+			m.identiconCell = cell
+		}
+	}
+}
+
+// NewKodoManager creates a new [Manager] backed by Qiniu Kodo storage.
+func NewKodoManager(cfg config.KodoConfig, opts ...Option) (Manager, error) {
+	if cfg.AccessKey == "" {
+		return nil, errors.New("missing kodo access key")
+	}
+	if cfg.SecretKey == "" {
+		return nil, errors.New("missing kodo secret key")
+	}
+	if cfg.Bucket == "" {
+		return nil, errors.New("missing kodo bucket")
+	}
+
+	mgr := &kodoManager{
+		bucket:      cfg.Bucket,
+		httpClient:  &http.Client{Timeout: defaultHTTPTimeout},
+		credentials: qiniuAuth.New(cfg.AccessKey, cfg.SecretKey),
+		uploader: storage.NewFormUploader(&storage.Config{
+			UseHTTPS:      true,
+			UseCdnDomains: true,
+		}),
+		putPolicy: storage.PutPolicy{
+			Scope:        cfg.Bucket,
+			ForceSaveKey: true,
+			SaveKey:      "files/$(etag)-$(fsize)",
+			Expires:      uploadTokenTTL,
+		},
+		maxBytes:      defaultAvatarMaxBytes,
+		identiconCell: defaultIdenticonCell,
+	}
+	for _, opt := range opts {
+		opt(mgr)
+	}
+	return mgr, nil
+}
+
+// UploadFromURL downloads avatar data from the given URL and reuploads it to Kodo.
+func (m *kodoManager) UploadFromURL(ctx context.Context, sourceURL string) (string, error) {
+	sourceURL = strings.TrimSpace(sourceURL)
+	if sourceURL == "" {
+		return "", nil
+	}
+
+	parsed, err := url.Parse(sourceURL)
+	if err != nil {
+		return "", fmt.Errorf("parse avatar source url: %w", err)
+	}
+	if strings.EqualFold(parsed.Scheme, "kodo") {
+		return sourceURL, nil
+	}
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return "", fmt.Errorf("unsupported avatar url scheme %q", parsed.Scheme)
+	}
+
+	data, contentType, err := m.download(ctx, sourceURL)
+	if err != nil {
+		return "", err
+	}
+	return m.upload(ctx, data, contentType)
+}
+
+// UploadDefault generates an identicon avatar for the provided seed and uploads
+// it to Kodo.
+func (m *kodoManager) UploadDefault(ctx context.Context, seed []byte) (string, error) {
+	seed = bytes.TrimSpace(seed)
+	if len(seed) == 0 {
+		return "", errors.New("missing avatar seed")
+	}
+	img := cameron.Identicon(seed, m.identiconCell)
+
+	var buf bytes.Buffer
+	if err := png.Encode(&buf, img); err != nil {
+		return "", fmt.Errorf("encode default avatar: %w", err)
+	}
+	return m.upload(ctx, buf.Bytes(), "image/png")
+}
+
+// download downloads the remote avatar data and returns its bytes and MIME type.
+func (m *kodoManager) download(ctx context.Context, url string) ([]byte, string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, "", fmt.Errorf("create avatar request: %w", err)
+	}
+
+	resp, err := m.httpClient.Do(req)
+	if err != nil {
+		return nil, "", fmt.Errorf("download avatar: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, "", fmt.Errorf("unexpected avatar response status %d", resp.StatusCode)
+	}
+	if resp.ContentLength > 0 && resp.ContentLength > m.maxBytes {
+		return nil, "", fmt.Errorf("avatar payload exceeds %d bytes", m.maxBytes)
+	}
+
+	limited := io.LimitReader(resp.Body, m.maxBytes+1)
+	payload, err := io.ReadAll(limited)
+	if err != nil {
+		return nil, "", fmt.Errorf("read avatar response: %w", err)
+	}
+	if int64(len(payload)) > m.maxBytes {
+		return nil, "", fmt.Errorf("avatar payload exceeds %d bytes", m.maxBytes)
+	}
+
+	mimeType := normalizeContentType(resp.Header.Get("Content-Type"), payload)
+	if !strings.HasPrefix(mimeType, "image/") {
+		return nil, "", fmt.Errorf("unsupported avatar content type %q", mimeType)
+	}
+
+	return payload, mimeType, nil
+}
+
+// upload uploads avatar data to Kodo and returns the resulting kodo:// URL.
+func (m *kodoManager) upload(ctx context.Context, data []byte, contentType string) (string, error) {
+	if len(data) == 0 {
+		return "", errors.New("empty avatar payload")
+	}
+
+	token := m.putPolicy.UploadToken(m.credentials)
+	reader := bytes.NewReader(data)
+	extra := &storage.PutExtra{MimeType: contentType}
+	var ret storage.PutRet
+
+	if err := m.uploader.Put(ctx, &ret, token, "", reader, int64(len(data)), extra); err != nil {
+		return "", fmt.Errorf("upload avatar to kodo: %w", err)
+	}
+
+	if ret.Key == "" {
+		return "", errors.New("empty key returned by kodo")
+	}
+
+	return fmt.Sprintf("kodo://%s/%s", m.bucket, ret.Key), nil
+}
+
+// normalizeContentType resolves a reliable MIME type from response headers and payload bytes.
+func normalizeContentType(header string, payload []byte) string {
+	header = strings.TrimSpace(header)
+	if header != "" {
+		if idx := strings.IndexByte(header, ';'); idx >= 0 {
+			header = strings.TrimSpace(header[:idx])
+		}
+		if header != "" && header != "application/octet-stream" {
+			return strings.ToLower(header)
+		}
+	}
+
+	if len(payload) > 512 {
+		payload = payload[:512]
+	}
+	detected := http.DetectContentType(payload)
+	return strings.ToLower(detected)
+}

--- a/spx-gui/src/components/agent-copilot/UserMessage.vue
+++ b/spx-gui/src/components/agent-copilot/UserMessage.vue
@@ -1,17 +1,19 @@
 <script setup lang="ts">
 import MarkdownView from './markdown/MarkdownView.vue'
 import { useSignedInUser } from '@/stores/user'
+import { useAvatarUrl } from '@/stores/user/avatar'
 
 const props = defineProps<{
   content: string
 }>()
 
 const { data: signedInUser } = useSignedInUser()
+const avatarUrl = useAvatarUrl(() => signedInUser.value?.avatar)
 </script>
 
 <template>
   <section class="user-message">
-    <img class="avatar" :src="signedInUser?.avatar || ''" />
+    <img class="avatar" :src="avatarUrl ?? undefined" />
     <MarkdownView class="content" :value="props.content" />
   </section>
 </template>

--- a/spx-gui/src/components/community/project/OwnerInfo.vue
+++ b/spx-gui/src/components/community/project/OwnerInfo.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import { useExternalUrl } from '@/utils/utils'
 import { useUser } from '@/stores/user'
+import { useAvatarUrl } from '@/stores/user/avatar'
 import UserLink from '../user/UserLink.vue'
 
 const props = defineProps<{
@@ -8,7 +8,7 @@ const props = defineProps<{
 }>()
 
 const { data: user } = useUser(() => props.owner)
-const avatarUrl = useExternalUrl(() => user.value?.avatar)
+const avatarUrl = useAvatarUrl(() => user.value?.avatar)
 </script>
 
 <template>

--- a/spx-gui/src/components/community/user/EditProfileModal.vue
+++ b/spx-gui/src/components/community/user/EditProfileModal.vue
@@ -1,7 +1,7 @@
 <script lang="ts" setup>
 import { computed } from 'vue'
 import { useMessageHandle } from '@/utils/exception'
-import { useExternalUrl } from '@/utils/utils'
+import { useAvatarUrl } from '@/stores/user/avatar'
 import { useI18n } from '@/utils/i18n'
 import { type User } from '@/apis/user'
 import { UIImg, UIFormModal, UIForm, UIFormItem, UITextInput, UIButton, useForm } from '@/components/ui'
@@ -21,7 +21,7 @@ const emit = defineEmits<{
 const { t } = useI18n()
 
 const coverImgUrl = computed(() => getCoverImgUrl(props.user.username))
-const avatarUrl = useExternalUrl(() => props.user.avatar)
+const avatarUrl = useAvatarUrl(() => props.user.avatar)
 
 const form = useForm({
   description: [props.user.description, validateDescription]

--- a/spx-gui/src/components/community/user/UserAvatar.vue
+++ b/spx-gui/src/components/community/user/UserAvatar.vue
@@ -8,8 +8,8 @@
 </template>
 
 <script setup lang="ts">
-import { useExternalUrl } from '@/utils/utils'
 import { useUser } from '@/stores/user'
+import { useAvatarUrl } from '@/stores/user/avatar'
 import UserLink from './UserLink.vue'
 
 export type Size = 'small' | 'medium'
@@ -25,7 +25,7 @@ const props = withDefaults(
 )
 
 const { data: userInfo } = useUser(() => props.user)
-const avatarUrl = useExternalUrl(() => userInfo.value?.avatar)
+const avatarUrl = useAvatarUrl(() => userInfo.value?.avatar)
 </script>
 
 <style lang="scss" scoped>

--- a/spx-gui/src/components/community/user/UserHeader.vue
+++ b/spx-gui/src/components/community/user/UserHeader.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import { type User } from '@/apis/user'
-import { useExternalUrl } from '@/utils/utils'
+import { useAvatarUrl } from '@/stores/user/avatar'
 import { useMessageHandle } from '@/utils/exception'
 import { getSignedInUsername } from '@/stores/user'
 import { UIButton, UIImg, useModal } from '@/components/ui'
@@ -17,7 +17,7 @@ const props = defineProps<{
 }>()
 
 const isSignedInUser = computed(() => props.user.username === getSignedInUsername())
-const avatarUrl = useExternalUrl(() => props.user.avatar)
+const avatarUrl = useAvatarUrl(() => props.user.avatar)
 const coverImgUrl = computed(() => getCoverImgUrl(props.user.username))
 
 const invokeEditProfileModal = useModal(EditProfileModal)

--- a/spx-gui/src/components/copilot/UserMessage.vue
+++ b/spx-gui/src/components/copilot/UserMessage.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import { useExternalUrl } from '@/utils/utils'
 import { useSignedInUser } from '@/stores/user'
+import { useAvatarUrl } from '@/stores/user/avatar'
 import type { UserMessage } from './copilot'
 import MarkdownView from './MarkdownView.vue'
 
@@ -9,7 +9,7 @@ defineProps<{
 }>()
 
 const signedInUser = useSignedInUser()
-const avatarUrl = useExternalUrl(() => signedInUser.data.value?.avatar)
+const avatarUrl = useAvatarUrl(() => signedInUser.data.value?.avatar)
 </script>
 
 <template>

--- a/spx-gui/src/components/navbar/NavbarProfile.vue
+++ b/spx-gui/src/components/navbar/NavbarProfile.vue
@@ -65,11 +65,11 @@
 <script setup lang="ts">
 import { useRouter } from 'vue-router'
 import { useNetwork } from '@/utils/network'
-import { useExternalUrl } from '@/utils/utils'
 import { useMessageHandle } from '@/utils/exception'
 import { getUserPageRoute } from '@/router'
 import { AssetType } from '@/apis/asset'
 import { initiateSignIn, signOut, useSignedInUser } from '@/stores/user'
+import { useAvatarUrl } from '@/stores/user/avatar'
 import { UIButton, UIDropdown, UIMenu, UIMenuGroup, UIMenuItem } from '@/components/ui'
 import { useAssetLibraryManagement } from '@/components/asset'
 import { useCourseManagement, useCourseSeriesManagement } from '@/components/course'
@@ -81,7 +81,7 @@ const router = useRouter()
 const { controls } = useAgentCopilotCtx()
 
 const { data: signedInUser } = useSignedInUser()
-const avatarUrl = useExternalUrl(() => signedInUser.value?.avatar)
+const avatarUrl = useAvatarUrl(() => signedInUser.value?.avatar)
 
 const handleAskCopilotAgent = useMessageHandle(
   async () => {

--- a/spx-gui/src/stores/user/avatar.ts
+++ b/spx-gui/src/stores/user/avatar.ts
@@ -1,0 +1,31 @@
+import { shallowRef, watch, type WatchSource } from 'vue'
+import { useAsyncComputedFixed, useExternalUrl } from '@/utils/utils'
+import { universalUrlToWebUrl } from '@/models/common/cloud'
+
+export function useAvatarUrl(urlSource: WatchSource<string | null | undefined>) {
+  const latestRawRef = shallowRef<string | null>(null)
+
+  watch(
+    urlSource,
+    (raw) => {
+      const normalized = raw == null || raw === '' ? null : raw
+      if (normalized === latestRawRef.value) return
+      latestRawRef.value = normalized
+    },
+    { immediate: true }
+  )
+
+  const resolvedUrl = useAsyncComputedFixed(async () => {
+    const raw = latestRawRef.value
+    if (raw == null) return null
+
+    try {
+      return await universalUrlToWebUrl(raw)
+    } catch (err) {
+      console.warn('Failed to resolve avatar url', raw, err)
+      return null
+    }
+  })
+
+  return useExternalUrl(() => resolvedUrl.value)
+}


### PR DESCRIPTION
- Add `avatar.Manager` interface with Kodo implementation
- Integrate avatar manager into Casdoor authenticator
- Generate default avatars using `github.com/aofei/cameron` for users without avatar
- Migrate legacy HTTP avatar URLs to Kodo

Fixes #2159