### PR TITLE
fix(tools/ai): serialize `Player.think` sequence and keep commands consistent

### DIFF
--- a/tools/ai/ai_test.go
+++ b/tools/ai/ai_test.go
@@ -2,6 +2,7 @@ package ai
 
 import (
 	"reflect"
+	"slices"
 	"sync"
 	"testing"
 )
@@ -59,7 +60,7 @@ func TestPlayerAppendHistory(t *testing.T) {
 
 		var wg sync.WaitGroup
 		wg.Add(numGoroutines)
-		for i := 0; i < numGoroutines; i++ {
+		for i := range numGoroutines {
 			go func(idx int) {
 				defer wg.Done()
 				p.appendHistory(Turn{
@@ -78,15 +79,12 @@ func TestPlayerAppendHistory(t *testing.T) {
 func TestPlayerPrepareArchive(t *testing.T) {
 	makeHistory := func(count int, initialPattern []int) []Turn {
 		history := make([]Turn, count)
-		for i := 0; i < count; i++ {
+		for i := range count {
 			history[i] = Turn{
 				RequestContent: string(rune('a' + i%26)),
 			}
-			for _, pos := range initialPattern {
-				if i == pos {
-					history[i].IsInitial = true
-					break
-				}
+			if slices.Contains(initialPattern, i) {
+				history[i].IsInitial = true
 			}
 		}
 		return history
@@ -185,7 +183,7 @@ func TestPlayerPrepareArchive(t *testing.T) {
 		p := &Player{}
 
 		// Build history with clear boundaries.
-		for i := 0; i < 35; i++ {
+		for i := range 35 {
 			p.appendHistory(Turn{
 				RequestContent: string(rune('a' + i%26)),
 				IsInitial:      i%10 == 0,
@@ -230,7 +228,7 @@ func TestPlayerPrepareArchive(t *testing.T) {
 		p := &Player{}
 
 		// Build history.
-		for i := 0; i < 40; i++ {
+		for i := range 40 {
 			p.history = append(p.history, Turn{
 				RequestContent: string(rune('a' + i%26)),
 				IsInitial:      i%10 == 0,
@@ -423,7 +421,7 @@ func TestPlayerCancelArchive(t *testing.T) {
 		p := &Player{}
 
 		// Build history.
-		for i := 0; i < 35; i++ {
+		for i := range 35 {
 			p.appendHistory(Turn{
 				RequestContent: string(rune('a' + i%26)),
 				IsInitial:      i%10 == 0,


### PR DESCRIPTION
We decided to gate each `ai.Player.think` sequence so concurrent calls queue and run one at a time, because the so-called "think" is effectively "think and do", and the LLM may call any registered command. Letting multiple sequences overlap on one `ai.Player` lets those commands collide on game state (movement, win checks, etc.), even if history snapshots stay isolated. Running each sequence serially keeps the state coherent.

If true parallelism is needed, games can spawn multiple `ai.Player` instances. That keeps state isolated and still supports richer behavior without asking the LLM to juggle overlapping sequences.