### PR TITLE
Rename `useAsyncComputed` related utils

### DIFF
--- a/spx-gui/src/components/agent-copilot/markdown/CodeView.vue
+++ b/spx-gui/src/components/agent-copilot/markdown/CodeView.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import { getHighlighter, theme, tabSize } from '@/utils/spx/highlighter'
-import { useAsyncComputed } from '@/utils/utils'
+import { useAsyncComputedLegacy } from '@/utils/utils'
 import { useSlotText } from '@/utils/vnode'
 
 const props = withDefaults(
@@ -26,7 +26,7 @@ const props = withDefaults(
 
 const childrenText = useSlotText()
 const codeToDisplay = computed(() => childrenText.value.replace(/\n$/, '')) // omit last line break when displaying
-const highlighter = useAsyncComputed(getHighlighter)
+const highlighter = useAsyncComputedLegacy(getHighlighter)
 
 const hasLineNumbers = computed(() => {
   return props.lineNumbers && props.mode === 'block' && codeToDisplay.value.split('\n').length > 1

--- a/spx-gui/src/components/asset/library/BackdropItem.vue
+++ b/spx-gui/src/components/asset/library/BackdropItem.vue
@@ -14,13 +14,13 @@ import { UIBackdropItem, UICornerIcon } from '@/components/ui'
 import { useFileUrl } from '@/utils/file'
 import type { AssetData } from '@/apis/asset'
 import { asset2Backdrop } from '@/models/common/asset'
-import { useAsyncComputed } from '@/utils/utils'
+import { useAsyncComputedLegacy } from '@/utils/utils'
 
 const props = defineProps<{
   asset: AssetData
   selected: boolean
 }>()
 
-const backdrop = useAsyncComputed(() => asset2Backdrop(props.asset))
+const backdrop = useAsyncComputedLegacy(() => asset2Backdrop(props.asset))
 const [imgSrc, imgLoading] = useFileUrl(() => backdrop.value?.img)
 </script>

--- a/spx-gui/src/components/asset/library/BackdropPreview.vue
+++ b/spx-gui/src/components/asset/library/BackdropPreview.vue
@@ -3,7 +3,7 @@
 </template>
 
 <script setup lang="ts">
-import { useAsyncComputed } from '@/utils/utils'
+import { useAsyncComputedLegacy } from '@/utils/utils'
 import { useFileUrl } from '@/utils/file'
 import type { AssetData } from '@/apis/asset'
 import { asset2Backdrop } from '@/models/common/asset'
@@ -14,7 +14,7 @@ const props = defineProps<{
   backdrop: Backdrop | AssetData
 }>()
 
-const backdrop = useAsyncComputed(async () => {
+const backdrop = useAsyncComputedLegacy(async () => {
   if (props.backdrop instanceof Backdrop) return props.backdrop
   return asset2Backdrop(props.backdrop)
 })

--- a/spx-gui/src/components/asset/library/SoundItem.vue
+++ b/spx-gui/src/components/asset/library/SoundItem.vue
@@ -12,7 +12,7 @@ import { useFileUrl } from '@/utils/file'
 import type { AssetData } from '@/apis/asset'
 import SoundPlayer from '@/components/editor/sound/SoundPlayer.vue'
 import { asset2Sound } from '@/models/common/asset'
-import { useAsyncComputed } from '@/utils/utils'
+import { useAsyncComputedLegacy } from '@/utils/utils'
 import { useAudioDuration } from '@/utils/audio'
 import { UISoundItem, UICornerIcon } from '@/components/ui'
 
@@ -21,7 +21,7 @@ const props = defineProps<{
   selected: boolean
 }>()
 
-const sound = useAsyncComputed(() => asset2Sound(props.asset))
+const sound = useAsyncComputedLegacy(() => asset2Sound(props.asset))
 const [audioSrc] = useFileUrl(() => sound.value?.file)
 const { formattedDuration } = useAudioDuration(() => {
   return audioSrc.value

--- a/spx-gui/src/components/asset/library/SoundPreview.vue
+++ b/spx-gui/src/components/asset/library/SoundPreview.vue
@@ -5,7 +5,7 @@
 </template>
 
 <script setup lang="ts">
-import { useAsyncComputed } from '@/utils/utils'
+import { useAsyncComputedLegacy } from '@/utils/utils'
 import { useFileUrl } from '@/utils/file'
 import { asset2Sound } from '@/models/common/asset'
 import type { AssetData } from '@/apis/asset'
@@ -16,7 +16,7 @@ const props = defineProps<{
   sound: Sound | AssetData
 }>()
 
-const sound = useAsyncComputed(async () => {
+const sound = useAsyncComputedLegacy(async () => {
   if (props.sound instanceof Sound) return props.sound
   return asset2Sound(props.sound)
 })

--- a/spx-gui/src/components/asset/library/SpriteItem.vue
+++ b/spx-gui/src/components/asset/library/SpriteItem.vue
@@ -20,7 +20,7 @@ import { UIImg, UISpriteItem, UICornerIcon } from '@/components/ui'
 import { useFileUrl } from '@/utils/file'
 import type { AssetData } from '@/apis/asset'
 import { asset2Sprite } from '@/models/common/asset'
-import { useAsyncComputed } from '@/utils/utils'
+import { useAsyncComputedLegacy } from '@/utils/utils'
 import { useHovered } from '@/utils/dom'
 import CostumesAutoPlayer from '@/components/common/CostumesAutoPlayer.vue'
 
@@ -29,7 +29,7 @@ const props = defineProps<{
   selected: boolean
 }>()
 
-const sprite = useAsyncComputed(() => asset2Sprite(props.asset))
+const sprite = useAsyncComputedLegacy(() => asset2Sprite(props.asset))
 const [imgSrc, imgLoading] = useFileUrl(() => sprite.value?.defaultCostume?.img)
 const wrapperRef = ref<InstanceType<typeof UISpriteItem>>()
 const hovered = useHovered(() => wrapperRef.value?.$el ?? null)

--- a/spx-gui/src/components/asset/library/SpritePreview.vue
+++ b/spx-gui/src/components/asset/library/SpritePreview.vue
@@ -3,7 +3,7 @@
 </template>
 
 <script setup lang="ts">
-import { useAsyncComputed } from '@/utils/utils'
+import { useAsyncComputedLegacy } from '@/utils/utils'
 import { useFileUrl } from '@/utils/file'
 import type { AssetData } from '@/apis/asset'
 import { asset2Sprite } from '@/models/common/asset'
@@ -14,7 +14,7 @@ const props = defineProps<{
   sprite: Sprite | AssetData
 }>()
 
-const sprite = useAsyncComputed(async () => {
+const sprite = useAsyncComputedLegacy(async () => {
   if (props.sprite instanceof Sprite) return props.sprite
   return asset2Sprite(props.sprite)
 })

--- a/spx-gui/src/components/asset/library/management/BackdropItem.vue
+++ b/spx-gui/src/components/asset/library/management/BackdropItem.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed } from 'vue'
-import { useAsyncComputed } from '@/utils/utils'
+import { useAsyncComputedLegacy } from '@/utils/utils'
 import { useFileUrl } from '@/utils/file'
 import type { AssetData } from '@/apis/asset'
 import { asset2Backdrop } from '@/models/common/asset'
@@ -11,7 +11,7 @@ const props = defineProps<{
   selected: boolean
 }>()
 
-const backdrop = useAsyncComputed(() => asset2Backdrop(props.asset))
+const backdrop = useAsyncComputedLegacy(() => asset2Backdrop(props.asset))
 const [imgSrc, imgLoading] = useFileUrl(() => backdrop.value?.img)
 const name = computed(() => props.asset.displayName)
 </script>

--- a/spx-gui/src/components/asset/library/management/SoundItem.vue
+++ b/spx-gui/src/components/asset/library/management/SoundItem.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import { useFileUrl } from '@/utils/file'
-import { useAsyncComputed } from '@/utils/utils'
+import { useAsyncComputedLegacy } from '@/utils/utils'
 import { useAudioDuration } from '@/utils/audio'
 import type { AssetData } from '@/apis/asset'
 import { asset2Sound } from '@/models/common/asset'
@@ -13,7 +13,7 @@ const props = defineProps<{
   selected: boolean
 }>()
 
-const sound = useAsyncComputed(() => asset2Sound(props.asset))
+const sound = useAsyncComputedLegacy(() => asset2Sound(props.asset))
 const [audioSrc] = useFileUrl(() => sound.value?.file)
 const name = computed(() => props.asset.displayName)
 const { formattedDuration } = useAudioDuration(() => {

--- a/spx-gui/src/components/asset/library/management/SpriteItem.vue
+++ b/spx-gui/src/components/asset/library/management/SpriteItem.vue
@@ -2,7 +2,7 @@
 import { computed, ref } from 'vue'
 import { useHovered } from '@/utils/dom'
 import { useFileUrl } from '@/utils/file'
-import { useAsyncComputed } from '@/utils/utils'
+import { useAsyncComputedLegacy } from '@/utils/utils'
 import type { AssetData } from '@/apis/asset'
 import { asset2Sprite } from '@/models/common/asset'
 import { UIImg, UISpriteItem } from '@/components/ui'
@@ -13,7 +13,7 @@ const props = defineProps<{
   selected: boolean
 }>()
 
-const sprite = useAsyncComputed(() => asset2Sprite(props.asset))
+const sprite = useAsyncComputedLegacy(() => asset2Sprite(props.asset))
 const [imgSrc, imgLoading] = useFileUrl(() => sprite.value?.defaultCostume?.img)
 const name = computed(() => props.asset.displayName)
 const wrapperRef = ref<InstanceType<typeof UISpriteItem>>()

--- a/spx-gui/src/components/common/CodeView.vue
+++ b/spx-gui/src/components/common/CodeView.vue
@@ -4,7 +4,7 @@ import type { ElementContent, RootContent } from 'hast'
 import { splitTokens, type ShikiTransformer } from 'shiki/core'
 import * as lsp from 'vscode-languageserver-protocol'
 import { getHighlighter, theme, tabSize } from '@/utils/spx/highlighter'
-import { useAsyncComputed } from '@/utils/utils'
+import { useAsyncComputedLegacy } from '@/utils/utils'
 import { useSlotText } from '@/utils/vnode'
 
 export type InlayHints = Array<lsp.InlayHint>
@@ -34,7 +34,7 @@ const props = withDefaults(
 
 const childrenText = useSlotText()
 const codeToDisplay = computed(() => childrenText.value.replace(/\n$/, '')) // omit last line break when displaying
-const highlighter = useAsyncComputed(getHighlighter)
+const highlighter = useAsyncComputedLegacy(getHighlighter)
 const inlayHintsComputed = computed(() => {
   if (props.inlayHints == null) return []
   try {

--- a/spx-gui/src/components/course/management/CourseItem.vue
+++ b/spx-gui/src/components/course/management/CourseItem.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
 import type { Course } from '@/apis/course'
-import { useAsyncComputed } from '@/utils/utils'
+import { useAsyncComputedLegacy } from '@/utils/utils'
 import { createFileWithWebUrl } from '@/models/common/cloud'
 import { UIImg } from '@/components/ui'
 
@@ -8,7 +8,7 @@ const props = defineProps<{
   course: Course
 }>()
 
-const thumbnailUrl = useAsyncComputed(async (onCleanup) => {
+const thumbnailUrl = useAsyncComputedLegacy(async (onCleanup) => {
   if (props.course.thumbnail == null) return null
   const file = createFileWithWebUrl(props.course.thumbnail)
   return file.url(onCleanup)

--- a/spx-gui/src/components/course/management/CourseItemMini.vue
+++ b/spx-gui/src/components/course/management/CourseItemMini.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
 import type { Course } from '@/apis/course'
-import { useAsyncComputed } from '@/utils/utils'
+import { useAsyncComputedLegacy } from '@/utils/utils'
 import { createFileWithWebUrl } from '@/models/common/cloud'
 import { UIImg } from '@/components/ui'
 
@@ -11,7 +11,7 @@ const props = defineProps<{
   dimmed?: boolean
 }>()
 
-const thumbnailUrl = useAsyncComputed(async (onCleanup) => {
+const thumbnailUrl = useAsyncComputedLegacy(async (onCleanup) => {
   if (props.course.thumbnail == null) return null
   const file = createFileWithWebUrl(props.course.thumbnail)
   return file.url(onCleanup)

--- a/spx-gui/src/components/course/management/ThumbnailUploader.vue
+++ b/spx-gui/src/components/course/management/ThumbnailUploader.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
 import { useMessageHandle } from '@/utils/exception'
-import { useAsyncComputed } from '@/utils/utils'
+import { useAsyncComputedLegacy } from '@/utils/utils'
 import { createFileWithWebUrl, saveFileForWebUrl, selectFileWithUploadLimit } from '@/models/common/cloud'
 import { fromNativeFile } from '@/models/common/file'
 import { UIIcon, UIImg, UILoading } from '@/components/ui'
@@ -26,7 +26,7 @@ const handleUpload = useMessageHandle(
   }
 )
 
-const thumbnailUrl = useAsyncComputed(async (onCleanup) => {
+const thumbnailUrl = useAsyncComputedLegacy(async (onCleanup) => {
   if (props.thumbnail === '') return null
   const file = createFileWithWebUrl(props.thumbnail)
   return file.url(onCleanup)

--- a/spx-gui/src/components/editor/code-editor/ui/definition/DefinitionDetail.vue
+++ b/spx-gui/src/components/editor/code-editor/ui/definition/DefinitionDetail.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed } from 'vue'
-import { useAsyncComputed } from '@/utils/utils'
+import { useAsyncComputedLegacy } from '@/utils/utils'
 import { useSlotText } from '@/utils/vnode'
 import { parseDefinitionId, type DefinitionDocumentationItem } from '../../common'
 import { useCodeEditorUICtx } from '../CodeEditorUI.vue'
@@ -13,7 +13,7 @@ const props = defineProps<{
 
 const codeEditorCtx = useCodeEditorUICtx()
 
-const documentation = useAsyncComputed<DefinitionDocumentationItem | null>(async () => {
+const documentation = useAsyncComputedLegacy<DefinitionDocumentationItem | null>(async () => {
   const defId = parseDefinitionId(props.defId)
   const documentBase = codeEditorCtx.ui.documentBase
   if (documentBase == null) return null

--- a/spx-gui/src/components/editor/common/viewer/SpriteNode.vue
+++ b/spx-gui/src/components/editor/common/viewer/SpriteNode.vue
@@ -5,7 +5,7 @@ import type { Image, ImageConfig } from 'konva/lib/shapes/Image'
 import type { Action, Project } from '@/models/project'
 import { LeftRight, RotationStyle, headingToLeftRight, leftRightToHeading, type Sprite } from '@/models/sprite'
 import type { Size } from '@/models/common'
-import { nomalizeDegree, round, useAsyncComputed } from '@/utils/utils'
+import { nomalizeDegree, round, useAsyncComputedLegacy } from '@/utils/utils'
 import { useFileImg } from '@/utils/file'
 import { cancelBubble, getNodeId } from './common'
 
@@ -32,7 +32,7 @@ const nodeRef = ref<KonvaNodeInstance<Image>>()
 const costume = computed(() => props.sprite.defaultCostume)
 const bitmapResolution = computed(() => costume.value?.bitmapResolution ?? 1)
 const [image] = useFileImg(() => costume.value?.img)
-const rawSize = useAsyncComputed(async () => costume.value?.getRawSize() ?? null)
+const rawSize = useAsyncComputedLegacy(async () => costume.value?.getRawSize() ?? null)
 
 const nodeId = computed(() => getNodeId(props.sprite))
 

--- a/spx-gui/src/components/editor/sound/waveform/WaveformPlayer.vue
+++ b/spx-gui/src/components/editor/sound/waveform/WaveformPlayer.vue
@@ -15,7 +15,7 @@
 import { ref, watch } from 'vue'
 import WaveformWithControls from './WaveformWithControls.vue'
 import { getAudioContext, trimAndApplyGainToWavBlob } from '@/utils/audio'
-import { useAsyncComputed } from '@/utils/utils'
+import { useAsyncComputedLegacy } from '@/utils/utils'
 import { registerPlayer } from '@/utils/player-registry'
 
 const props = defineProps<{
@@ -145,7 +145,7 @@ watch(
   { immediate: true }
 )
 
-const waveformDataFromSrc = useAsyncComputed(async () => {
+const waveformDataFromSrc = useAsyncComputedLegacy(async () => {
   if (!props.audioSrc) return null
   const scale = 5
   const audioContext = getAudioContext()

--- a/spx-gui/src/components/editor/sprite/SpriteCollisionEditor.vue
+++ b/spx-gui/src/components/editor/sprite/SpriteCollisionEditor.vue
@@ -8,7 +8,7 @@ import type { GroupConfig } from 'konva/lib/Group'
 import type { LayerConfig } from 'konva/lib/Layer'
 import type { Rect, RectConfig } from 'konva/lib/shapes/Rect'
 import type { CircleConfig } from 'konva/lib/shapes/Circle'
-import { useAsyncComputedFixed } from '@/utils/utils'
+import { useAsyncComputed } from '@/utils/utils'
 import { useI18n } from '@/utils/i18n'
 import { useFileImg } from '@/utils/file'
 import { useContentSize } from '@/utils/dom'
@@ -41,7 +41,7 @@ const defaultCostume = computed(() => {
   return c
 })
 const [image] = useFileImg(() => defaultCostume.value.img)
-const costumeSize = useAsyncComputedFixed(() => defaultCostume.value.getSize())
+const costumeSize = useAsyncComputed(() => defaultCostume.value.getSize())
 const canvasSize = computed(() => {
   if (costumeSize.value == null) return null
   return {

--- a/spx-gui/src/components/project/ProjectItem.vue
+++ b/spx-gui/src/components/project/ProjectItem.vue
@@ -114,7 +114,13 @@
 import { computed } from 'vue'
 import { useRouter } from 'vue-router'
 import { useMessageHandle } from '@/utils/exception'
-import { humanizeCount, humanizeExactCount, humanizeTime, humanizeExactTime, useAsyncComputed } from '@/utils/utils'
+import {
+  humanizeCount,
+  humanizeExactCount,
+  humanizeTime,
+  humanizeExactTime,
+  useAsyncComputedLegacy
+} from '@/utils/utils'
 import { getProjectEditorRoute, getProjectPageRoute } from '@/router'
 import { Visibility, type ProjectData } from '@/apis/project'
 import { createFileWithUniversalUrl, getPublishedContent } from '@/models/common/cloud'
@@ -158,7 +164,7 @@ const to = computed(() => {
   return props.context === 'edit' ? getProjectEditorRoute(owner, name) : getProjectPageRoute(owner, name)
 })
 
-const thumbnailUrl = useAsyncComputed(async (onCleanup) => {
+const thumbnailUrl = useAsyncComputedLegacy(async (onCleanup) => {
   const thumbnailUniversalUrl = getPublishedContent(props.project)?.thumbnail ?? props.project.thumbnail
   if (thumbnailUniversalUrl === '') return null
   const thumbnail = createFileWithUniversalUrl(thumbnailUniversalUrl)

--- a/spx-gui/src/components/tutorials/CourseItem.vue
+++ b/spx-gui/src/components/tutorials/CourseItem.vue
@@ -1,14 +1,14 @@
 <script lang="ts" setup>
 import { type Course } from '@/apis/course'
 import { createFileWithUniversalUrl } from '@/models/common/cloud'
-import { useAsyncComputed } from '@/utils/utils'
+import { useAsyncComputedLegacy } from '@/utils/utils'
 import { UIImg } from '@/components/ui'
 
 const props = defineProps<{
   course: Course
 }>()
 
-const thumbnailUrl = useAsyncComputed(async (onCleanup) => {
+const thumbnailUrl = useAsyncComputedLegacy(async (onCleanup) => {
   const thumbnailUniversalUrl = props.course.thumbnail
   if (thumbnailUniversalUrl === '') return null
   const thumbnail = createFileWithUniversalUrl(thumbnailUniversalUrl)

--- a/spx-gui/src/stores/user/avatar.ts
+++ b/spx-gui/src/stores/user/avatar.ts
@@ -1,5 +1,5 @@
 import { shallowRef, watch, type WatchSource } from 'vue'
-import { useAsyncComputedFixed, useExternalUrl } from '@/utils/utils'
+import { useAsyncComputed, useExternalUrl } from '@/utils/utils'
 import { universalUrlToWebUrl } from '@/models/common/cloud'
 
 export function useAvatarUrl(urlSource: WatchSource<string | null | undefined>) {
@@ -15,7 +15,7 @@ export function useAvatarUrl(urlSource: WatchSource<string | null | undefined>) 
     { immediate: true }
   )
 
-  const resolvedUrl = useAsyncComputedFixed(async () => {
+  const resolvedUrl = useAsyncComputed(async () => {
     const raw = latestRawRef.value
     if (raw == null) return null
 

--- a/spx-gui/src/utils/utils.ts
+++ b/spx-gui/src/utils/utils.ts
@@ -29,7 +29,11 @@ export const isSound = (url: string): boolean => {
   return ['wav', 'mp3', 'ogg'].includes(extension)
 }
 
-export function useAsyncComputed<T>(getter: (onCleanup: OnCleanup) => Promise<T>) {
+/**
+ * @deprecated Use `useAsyncComputed` instead if possible.
+ * Like `useAsyncComputed`, but keep the previous value when re-evaluating.
+ */
+export function useAsyncComputedLegacy<T>(getter: (onCleanup: OnCleanup) => Promise<T>) {
   const r = shallowRef<T | null>(null)
   watchEffect(async (onCleanup) => {
     let cancelled = false
@@ -43,10 +47,10 @@ export function useAsyncComputed<T>(getter: (onCleanup: OnCleanup) => Promise<T>
 }
 
 /**
- * Like `useAsyncComputed`, but reset value to `null` when re-evaluating.
- * TODO: Migrate usages of `useAsyncComputed` to this if possible.
+ * Like `useAsyncComputedLegacy`, but reset value to `null` when re-evaluating.
+ * TODO: Migrate usages of `useAsyncComputedLegacy` to this if possible.
  */
-export function useAsyncComputedFixed<T>(getter: (onCleanup: OnCleanup) => Promise<T>) {
+export function useAsyncComputed<T>(getter: (onCleanup: OnCleanup) => Promise<T>) {
   const r = shallowRef<T | null>(null)
   watchEffect(async (onCleanup) => {
     let cancelled = false


### PR DESCRIPTION
To prevent misuse of the legacy `useAsyncComputed`.

Related: https://github.com/goplus/builder/pull/2239#discussion_r2366499852