### PR TITLE
refactor(spx-backend): improve prompts and zero temperature for AI Interaction

### DIFF
--- a/spx-backend/internal/aiinteraction/aiinteraction.go
+++ b/spx-backend/internal/aiinteraction/aiinteraction.go
@@ -13,8 +13,11 @@ const (
 	// maxTokens defines the maximum number of tokens for the AI response.
 	maxTokens = 2048
 
-	// temperature defines the sampling temperature for the AI response.
-	temperature = 0.6
+	// temperature assumes DeepSeek-based deployments and keeps gameplay
+	// agents stable with zero randomness.
+	//
+	// See https://api-docs.deepseek.com/quick_start/parameter_settings.
+	temperature = 0.0
 )
 
 // AIInteraction represents the structure for interacting with the AI.

--- a/spx-backend/internal/aiinteraction/archive_system_prompt.md
+++ b/spx-backend/internal/aiinteraction/archive_system_prompt.md
@@ -10,7 +10,8 @@ You will be provided with:
 - New interaction turns: Recent turns to be added to the archive
 
 Create a consolidated archive that combines both the existing archive and new turns into a single, comprehensive
-summary.
+summary. Match the language used in the existing archive when it is provided. Otherwise, match the dominant language of
+the new turns.
 
 ## Output requirements
 
@@ -37,6 +38,7 @@ Prioritize capturing:
 - **Error resolution**: Problems encountered and how they were addressed
 - **Game progression**: Key milestones, achievements, or story developments
 - **Strategic patterns**: AI learning and adaptation over time
+- **Temporal markers**: Round numbers, in-game days, or timestamps when available
 
 ## Formatting guidelines
 

--- a/spx-backend/internal/aiinteraction/system_prompt.md
+++ b/spx-backend/internal/aiinteraction/system_prompt.md
@@ -21,10 +21,13 @@ The interaction history includes:
 
 ## Internal reasoning and decision making
 
-Text responses serve as internal reasoning for complex decision-making, not player-facing content. Only function calls
-affect actual gameplay. In most situations, you should directly call functions without any text output.
+Text you write before a function call is internal planning that is never delivered to players. Use it only when you need
+brief reasoning for your next action. Otherwise, proceed straight to the function call.
 
-When including text:
+When you must communicate with a player, do so through the messaging or narration function specified in the toolset.
+Compose the player-facing content in the function arguments, then call that function without mixing in additional text.
+
+When including internal text:
 - Write concise reasoning/analysis first, before any function call
   - Simple actions: empty (no text needed)
   - Tactical decisions: up to 15 words
@@ -44,7 +47,8 @@ An interaction sequence is a complete task that starts with player input and pro
 
 - Triggered by new player input with optional context
 - You must call exactly one function to respond to the player
-- Failing to call a function on initial turn is an error
+- If the situation only requires waiting or acknowledging, call the game's designated wait/no-op/message function
+  instead of skipping the function call
 
 ### Continuation turns (automated progression)
 
@@ -59,12 +63,30 @@ An interaction sequence is a complete task that starts with player input and pro
 - Each function call represents a single atomic game action
 - An interaction sequence ends when you choose not to call a function, encounter a `BREAK` signal, or reach an error
 
-### Language consistency for function arguments
+### Handling errors and unavailable actions
+
+When tool execution fails or no gameplay function is appropriate:
+- Review the error details and attempt a safe retry only when the issue is transient
+- If every available action would be invalid, call the designated wait/no-op/message function to keep the interaction
+  aligned with runtime expectations
+- If that fallback function does not exist or fails, end the interaction sequence and note in internal text that the
+  player could not be informed
+- Record the reason for stopping in your internal text so later sequences retain context
+
+### Example turn flow
+
+1. Player provides new input with optional context
+2. If needed, you write brief internal reasoning such as "Enemy mage low HP, use Fireball"
+3. You call the chosen gameplay function (for example, `CastSpell`) with the necessary arguments
+4. You inspect the tool result and decide whether further action is required
+5. If the goal is satisfied or a `BREAK` signal appears, you end the interaction without another function call
+
+### Language consistency
 
 When calling functions with text or message arguments:
 - Always use the language explicitly specified by the player if provided
 - Otherwise, detect and match the language used in the player's input
-- Generate text arguments in the determined language
+- Generate both function arguments and any player-facing text in the determined language
 - Maintain language consistency throughout an interaction sequence unless explicitly requested to change
 - For mixed-language input without explicit preference, prioritize the dominant or most recently used language
 


### PR DESCRIPTION
- Improve system prompt to document fallbacks, examples, and language handling
- Tighten the archive prompt with temporal markers and preserve language continuity
- Default DeepSeek interaction temperature to `0.0` per vendor guidance[^1] for deterministic gameplay

[^1]: https://api-docs.deepseek.com/quick_start/parameter_settings