### PR TITLE
feat(spx-backend): enforce quotas for AI endpoints

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1069,6 +1069,11 @@ paths:
       description: |
         Generate an AI-powered descriptive summary of a game from the player's perspective based on provided game
         content (such as spx source code and project structure).
+
+        #### Quota requirements
+
+        - Each request consumes 1 quota from the authenticated user's AI description allowance.
+        - Quota limits vary based on the authenticated user's plan.
       requestBody:
         required: true
         content:
@@ -1082,13 +1087,21 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/AIDescriptionResponse"
+        "429":
+          description: Insufficient quota to perform this operation.
 
   /ai/interaction/turn:
     post:
       tags:
         - AI
       summary: Perform an AI interaction turn
-      description: Send a message and context to the AI, receive a response including text and an optional command.
+      description: |
+        Send a message and context to the AI, receive a response including text and an optional command.
+
+        #### Quota requirements
+
+        - Each turn consumes 1 quota from the authenticated user's AI interaction turn allowance.
+        - Quota limits vary based on the authenticated user's plan.
       requestBody:
         required: true
         content:
@@ -1102,13 +1115,21 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/AIInteractionResponse"
+        "429":
+          description: Insufficient quota to perform this operation.
 
   /ai/interaction/archive:
     post:
       tags:
         - AI
       summary: Archive AI interaction history
-      description: Archive a batch of interaction turns into a condensed summary for future context.
+      description: |
+        Archive a batch of interaction turns into a condensed summary for future context.
+
+        #### Quota requirements
+
+        - Each archive request consumes 1 quota from the authenticated user's AI interaction archive allowance.
+        - Quota limits vary based on the authenticated user's plan.
       requestBody:
         required: true
         content:
@@ -1122,6 +1143,8 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/AIInteractionArchiveResponse"
+        "429":
+          description: Insufficient quota to perform this operation.
 
   /course:
     post:
@@ -1695,6 +1718,48 @@ components:
           description: Remaining quota for Copilot messages.
           examples:
             - 789
+        aiDescriptionQuota:
+          type: integer
+          format: int64
+          minimum: 0
+          description: Total quota for AI description generations.
+          examples:
+            - 300
+        aiDescriptionQuotaLeft:
+          type: integer
+          format: int64
+          minimum: 0
+          description: Remaining quota for AI description generations.
+          examples:
+            - 295
+        aiInteractionTurnQuota:
+          type: integer
+          format: int64
+          minimum: 0
+          description: Total quota for AI interaction turns.
+          examples:
+            - 12000
+        aiInteractionTurnQuotaLeft:
+          type: integer
+          format: int64
+          minimum: 0
+          description: Remaining quota for AI interaction turns.
+          examples:
+            - 11900
+        aiInteractionArchiveQuota:
+          type: integer
+          format: int64
+          minimum: 0
+          description: Total quota for AI interaction archive requests.
+          examples:
+            - 8000
+        aiInteractionArchiveQuotaLeft:
+          type: integer
+          format: int64
+          minimum: 0
+          description: Remaining quota for AI interaction archive requests.
+          examples:
+            - 7980
 
     Project:
       type: object

--- a/spx-backend/cmd/spx-backend/post_ai_description.yap
+++ b/spx-backend/cmd/spx-backend/post_ai_description.yap
@@ -4,11 +4,16 @@
 //   POST /ai/description
 
 import (
+	"github.com/goplus/builder/spx-backend/internal/authz"
 	"github.com/goplus/builder/spx-backend/internal/controller"
 )
 
 ctx := &Context
 if _, ok := ensureAuthenticatedUser(ctx); !ok {
+	return
+}
+
+if !ensureQuotaLeft(ctx, authz.ResourceAIDescription) {
 	return
 }
 
@@ -26,4 +31,6 @@ if err != nil {
 	replyWithInnerError(ctx, err)
 	return
 }
+
+consumeQuota(ctx, authz.ResourceAIDescription, 1)
 json result

--- a/spx-backend/cmd/spx-backend/post_ai_interaction_archive.yap
+++ b/spx-backend/cmd/spx-backend/post_ai_interaction_archive.yap
@@ -4,11 +4,16 @@
 //   POST /ai/interaction/archive
 
 import (
+	"github.com/goplus/builder/spx-backend/internal/authz"
 	"github.com/goplus/builder/spx-backend/internal/controller"
 )
 
 ctx := &Context
 if _, ok := ensureAuthenticatedUser(ctx); !ok {
+	return
+}
+
+if !ensureQuotaLeft(ctx, authz.ResourceAIInteractionArchive) {
 	return
 }
 
@@ -26,4 +31,6 @@ if err != nil {
 	replyWithInnerError(ctx, err)
 	return
 }
+
+consumeQuota(ctx, authz.ResourceAIInteractionArchive, 1)
 json result

--- a/spx-backend/cmd/spx-backend/post_ai_interaction_turn.yap
+++ b/spx-backend/cmd/spx-backend/post_ai_interaction_turn.yap
@@ -4,11 +4,16 @@
 //   POST /ai/interaction/turn
 
 import (
+	"github.com/goplus/builder/spx-backend/internal/authz"
 	"github.com/goplus/builder/spx-backend/internal/controller"
 )
 
 ctx := &Context
 if _, ok := ensureAuthenticatedUser(ctx); !ok {
+	return
+}
+
+if !ensureQuotaLeft(ctx, authz.ResourceAIInteractionTurn) {
 	return
 }
 
@@ -26,4 +31,6 @@ if err != nil {
 	replyWithInnerError(ctx, err)
 	return
 }
+
+consumeQuota(ctx, authz.ResourceAIInteractionTurn, 1)
 json result

--- a/spx-backend/cmd/spx-backend/post_copilot_stream_message.yap
+++ b/spx-backend/cmd/spx-backend/post_copilot_stream_message.yap
@@ -6,7 +6,6 @@
 import (
 	"github.com/goplus/builder/spx-backend/internal/authz"
 	"github.com/goplus/builder/spx-backend/internal/controller"
-	"github.com/goplus/builder/spx-backend/internal/log"
 )
 
 ctx := &Context
@@ -15,11 +14,8 @@ if _, ok := ensureAuthenticatedUser(ctx); !ok {
 }
 
 // Check remaining quota.
-if caps, ok := authz.UserCapabilitiesFromContext(ctx.Context()); ok {
-	if caps.CopilotMessageQuotaLeft <= 0 {
-		replyWithCodeMsg(ctx, errorTooManyRequests, "Copilot message quota exceeded")
-		return
-	}
+if !ensureQuotaLeft(ctx, authz.ResourceCopilotMessage) {
+	return
 }
 
 params := &controller.GenerateMessageParams{}
@@ -39,10 +35,7 @@ if err != nil {
 }
 
 // Consume quota after successful stream initiation.
-if err := authz.ConsumeQuota(ctx.Context(), authz.ResourceCopilotMessage, 1); err != nil {
-	logger := log.GetReqLogger(ctx.Context())
-	logger.Printf("failed to consume copilot quota: %v", err)
-}
+consumeQuota(ctx, authz.ResourceCopilotMessage, 1)
 
 defer read.Close()
 

--- a/spx-backend/cmd/spx-backend/post_workflow_stream_message.yap
+++ b/spx-backend/cmd/spx-backend/post_workflow_stream_message.yap
@@ -6,7 +6,6 @@
 import (
 	"github.com/goplus/builder/spx-backend/internal/authz"
 	"github.com/goplus/builder/spx-backend/internal/controller"
-	"github.com/goplus/builder/spx-backend/internal/log"
 )
 
 ctx := &Context
@@ -15,11 +14,8 @@ if _, ok := ensureAuthenticatedUser(ctx); !ok {
 }
 
 // Check remaining quota (workflow uses copilot quota).
-if caps, ok := authz.UserCapabilitiesFromContext(ctx.Context()); ok {
-	if caps.CopilotMessageQuotaLeft <= 0 {
-		replyWithCodeMsg(ctx, errorTooManyRequests, "Copilot message quota exceeded")
-		return
-	}
+if !ensureQuotaLeft(ctx, authz.ResourceCopilotMessage) {
+	return
 }
 
 params := &controller.WorkflowMessageParams{}
@@ -39,10 +35,7 @@ if err != nil {
 }
 
 // Consume quota after successful workflow initiation.
-if err := authz.ConsumeQuota(ctx.Context(), authz.ResourceCopilotMessage, 1); err != nil {
-	logger := log.GetReqLogger(ctx.Context())
-	logger.Printf("failed to consume copilot quota: %v", err)
-}
+consumeQuota(ctx, authz.ResourceCopilotMessage, 1)
 
 defer read.Close()
 

--- a/spx-backend/cmd/spx-backend/xgo_autogen.go
+++ b/spx-backend/cmd/spx-backend/xgo_autogen.go
@@ -1478,44 +1478,51 @@ func (this *get_util_upinfo) Classclone() yap.HandlerProto {
 	_xgo_ret := *this
 	return &_xgo_ret
 }
-//line cmd/spx-backend/post_ai_description.yap:10
+//line cmd/spx-backend/post_ai_description.yap:11
 func (this *post_ai_description) Main(_xgo_arg0 *yap.Context) {
 	this.Handler.Main(_xgo_arg0)
-//line cmd/spx-backend/post_ai_description.yap:10:1
+//line cmd/spx-backend/post_ai_description.yap:11:1
 	ctx := &this.Context
-//line cmd/spx-backend/post_ai_description.yap:11:1
-	if
-//line cmd/spx-backend/post_ai_description.yap:11:1
-	_, ok := ensureAuthenticatedUser(ctx); !ok {
 //line cmd/spx-backend/post_ai_description.yap:12:1
+	if
+//line cmd/spx-backend/post_ai_description.yap:12:1
+	_, ok := ensureAuthenticatedUser(ctx); !ok {
+//line cmd/spx-backend/post_ai_description.yap:13:1
 		return
 	}
-//line cmd/spx-backend/post_ai_description.yap:15:1
-	params := &controller.AIDescriptionParams{}
 //line cmd/spx-backend/post_ai_description.yap:16:1
-	if !parseJSON(ctx, params) {
+	if !ensureQuotaLeft(ctx, authz.ResourceAIDescription) {
 //line cmd/spx-backend/post_ai_description.yap:17:1
 		return
 	}
-//line cmd/spx-backend/post_ai_description.yap:19:1
-	if
-//line cmd/spx-backend/post_ai_description.yap:19:1
-	ok, msg := params.Validate(); !ok {
 //line cmd/spx-backend/post_ai_description.yap:20:1
-		replyWithCodeMsg(ctx, errorInvalidArgs, msg)
+	params := &controller.AIDescriptionParams{}
 //line cmd/spx-backend/post_ai_description.yap:21:1
+	if !parseJSON(ctx, params) {
+//line cmd/spx-backend/post_ai_description.yap:22:1
 		return
 	}
 //line cmd/spx-backend/post_ai_description.yap:24:1
-	result, err := this.ctrl.GenerateAIDescription(ctx.Context(), params)
+	if
+//line cmd/spx-backend/post_ai_description.yap:24:1
+	ok, msg := params.Validate(); !ok {
 //line cmd/spx-backend/post_ai_description.yap:25:1
-	if err != nil {
+		replyWithCodeMsg(ctx, errorInvalidArgs, msg)
 //line cmd/spx-backend/post_ai_description.yap:26:1
-		replyWithInnerError(ctx, err)
-//line cmd/spx-backend/post_ai_description.yap:27:1
 		return
 	}
 //line cmd/spx-backend/post_ai_description.yap:29:1
+	result, err := this.ctrl.GenerateAIDescription(ctx.Context(), params)
+//line cmd/spx-backend/post_ai_description.yap:30:1
+	if err != nil {
+//line cmd/spx-backend/post_ai_description.yap:31:1
+		replyWithInnerError(ctx, err)
+//line cmd/spx-backend/post_ai_description.yap:32:1
+		return
+	}
+//line cmd/spx-backend/post_ai_description.yap:35:1
+	consumeQuota(ctx, authz.ResourceAIDescription, 1)
+//line cmd/spx-backend/post_ai_description.yap:36:1
 	this.Json__1(result)
 }
 func (this *post_ai_description) Classfname() string {
@@ -1525,44 +1532,51 @@ func (this *post_ai_description) Classclone() yap.HandlerProto {
 	_xgo_ret := *this
 	return &_xgo_ret
 }
-//line cmd/spx-backend/post_ai_interaction_archive.yap:10
+//line cmd/spx-backend/post_ai_interaction_archive.yap:11
 func (this *post_ai_interaction_archive) Main(_xgo_arg0 *yap.Context) {
 	this.Handler.Main(_xgo_arg0)
-//line cmd/spx-backend/post_ai_interaction_archive.yap:10:1
+//line cmd/spx-backend/post_ai_interaction_archive.yap:11:1
 	ctx := &this.Context
-//line cmd/spx-backend/post_ai_interaction_archive.yap:11:1
-	if
-//line cmd/spx-backend/post_ai_interaction_archive.yap:11:1
-	_, ok := ensureAuthenticatedUser(ctx); !ok {
 //line cmd/spx-backend/post_ai_interaction_archive.yap:12:1
+	if
+//line cmd/spx-backend/post_ai_interaction_archive.yap:12:1
+	_, ok := ensureAuthenticatedUser(ctx); !ok {
+//line cmd/spx-backend/post_ai_interaction_archive.yap:13:1
 		return
 	}
-//line cmd/spx-backend/post_ai_interaction_archive.yap:15:1
-	params := &controller.AIInteractionArchiveParams{}
 //line cmd/spx-backend/post_ai_interaction_archive.yap:16:1
-	if !parseJSON(ctx, params) {
+	if !ensureQuotaLeft(ctx, authz.ResourceAIInteractionArchive) {
 //line cmd/spx-backend/post_ai_interaction_archive.yap:17:1
 		return
 	}
-//line cmd/spx-backend/post_ai_interaction_archive.yap:19:1
-	if
-//line cmd/spx-backend/post_ai_interaction_archive.yap:19:1
-	ok, msg := params.Validate(); !ok {
 //line cmd/spx-backend/post_ai_interaction_archive.yap:20:1
-		replyWithCodeMsg(ctx, errorInvalidArgs, msg)
+	params := &controller.AIInteractionArchiveParams{}
 //line cmd/spx-backend/post_ai_interaction_archive.yap:21:1
+	if !parseJSON(ctx, params) {
+//line cmd/spx-backend/post_ai_interaction_archive.yap:22:1
 		return
 	}
 //line cmd/spx-backend/post_ai_interaction_archive.yap:24:1
-	result, err := this.ctrl.PerformAIInteractionArchive(ctx.Context(), params)
+	if
+//line cmd/spx-backend/post_ai_interaction_archive.yap:24:1
+	ok, msg := params.Validate(); !ok {
 //line cmd/spx-backend/post_ai_interaction_archive.yap:25:1
-	if err != nil {
+		replyWithCodeMsg(ctx, errorInvalidArgs, msg)
 //line cmd/spx-backend/post_ai_interaction_archive.yap:26:1
-		replyWithInnerError(ctx, err)
-//line cmd/spx-backend/post_ai_interaction_archive.yap:27:1
 		return
 	}
 //line cmd/spx-backend/post_ai_interaction_archive.yap:29:1
+	result, err := this.ctrl.PerformAIInteractionArchive(ctx.Context(), params)
+//line cmd/spx-backend/post_ai_interaction_archive.yap:30:1
+	if err != nil {
+//line cmd/spx-backend/post_ai_interaction_archive.yap:31:1
+		replyWithInnerError(ctx, err)
+//line cmd/spx-backend/post_ai_interaction_archive.yap:32:1
+		return
+	}
+//line cmd/spx-backend/post_ai_interaction_archive.yap:35:1
+	consumeQuota(ctx, authz.ResourceAIInteractionArchive, 1)
+//line cmd/spx-backend/post_ai_interaction_archive.yap:36:1
 	this.Json__1(result)
 }
 func (this *post_ai_interaction_archive) Classfname() string {
@@ -1572,44 +1586,51 @@ func (this *post_ai_interaction_archive) Classclone() yap.HandlerProto {
 	_xgo_ret := *this
 	return &_xgo_ret
 }
-//line cmd/spx-backend/post_ai_interaction_turn.yap:10
+//line cmd/spx-backend/post_ai_interaction_turn.yap:11
 func (this *post_ai_interaction_turn) Main(_xgo_arg0 *yap.Context) {
 	this.Handler.Main(_xgo_arg0)
-//line cmd/spx-backend/post_ai_interaction_turn.yap:10:1
+//line cmd/spx-backend/post_ai_interaction_turn.yap:11:1
 	ctx := &this.Context
-//line cmd/spx-backend/post_ai_interaction_turn.yap:11:1
-	if
-//line cmd/spx-backend/post_ai_interaction_turn.yap:11:1
-	_, ok := ensureAuthenticatedUser(ctx); !ok {
 //line cmd/spx-backend/post_ai_interaction_turn.yap:12:1
+	if
+//line cmd/spx-backend/post_ai_interaction_turn.yap:12:1
+	_, ok := ensureAuthenticatedUser(ctx); !ok {
+//line cmd/spx-backend/post_ai_interaction_turn.yap:13:1
 		return
 	}
-//line cmd/spx-backend/post_ai_interaction_turn.yap:15:1
-	params := &controller.AIInteractionTurnParams{}
 //line cmd/spx-backend/post_ai_interaction_turn.yap:16:1
-	if !parseJSON(ctx, params) {
+	if !ensureQuotaLeft(ctx, authz.ResourceAIInteractionTurn) {
 //line cmd/spx-backend/post_ai_interaction_turn.yap:17:1
 		return
 	}
-//line cmd/spx-backend/post_ai_interaction_turn.yap:19:1
-	if
-//line cmd/spx-backend/post_ai_interaction_turn.yap:19:1
-	ok, msg := params.Validate(); !ok {
 //line cmd/spx-backend/post_ai_interaction_turn.yap:20:1
-		replyWithCodeMsg(ctx, errorInvalidArgs, msg)
+	params := &controller.AIInteractionTurnParams{}
 //line cmd/spx-backend/post_ai_interaction_turn.yap:21:1
+	if !parseJSON(ctx, params) {
+//line cmd/spx-backend/post_ai_interaction_turn.yap:22:1
 		return
 	}
 //line cmd/spx-backend/post_ai_interaction_turn.yap:24:1
-	result, err := this.ctrl.PerformAIInteractionTurn(ctx.Context(), params)
+	if
+//line cmd/spx-backend/post_ai_interaction_turn.yap:24:1
+	ok, msg := params.Validate(); !ok {
 //line cmd/spx-backend/post_ai_interaction_turn.yap:25:1
-	if err != nil {
+		replyWithCodeMsg(ctx, errorInvalidArgs, msg)
 //line cmd/spx-backend/post_ai_interaction_turn.yap:26:1
-		replyWithInnerError(ctx, err)
-//line cmd/spx-backend/post_ai_interaction_turn.yap:27:1
 		return
 	}
 //line cmd/spx-backend/post_ai_interaction_turn.yap:29:1
+	result, err := this.ctrl.PerformAIInteractionTurn(ctx.Context(), params)
+//line cmd/spx-backend/post_ai_interaction_turn.yap:30:1
+	if err != nil {
+//line cmd/spx-backend/post_ai_interaction_turn.yap:31:1
+		replyWithInnerError(ctx, err)
+//line cmd/spx-backend/post_ai_interaction_turn.yap:32:1
+		return
+	}
+//line cmd/spx-backend/post_ai_interaction_turn.yap:35:1
+	consumeQuota(ctx, authz.ResourceAIInteractionTurn, 1)
+//line cmd/spx-backend/post_ai_interaction_turn.yap:36:1
 	this.Json__1(result)
 }
 func (this *post_ai_interaction_turn) Classfname() string {
@@ -1723,67 +1744,53 @@ func (this *post_asset) Classclone() yap.HandlerProto {
 	_xgo_ret := *this
 	return &_xgo_ret
 }
-//line cmd/spx-backend/post_copilot_message.yap:12
+//line cmd/spx-backend/post_copilot_message.yap:11
 func (this *post_copilot_message) Main(_xgo_arg0 *yap.Context) {
 	this.Handler.Main(_xgo_arg0)
-//line cmd/spx-backend/post_copilot_message.yap:12:1
+//line cmd/spx-backend/post_copilot_message.yap:11:1
 	ctx := &this.Context
-//line cmd/spx-backend/post_copilot_message.yap:13:1
+//line cmd/spx-backend/post_copilot_message.yap:12:1
 	if
-//line cmd/spx-backend/post_copilot_message.yap:13:1
+//line cmd/spx-backend/post_copilot_message.yap:12:1
 	_, ok := ensureAuthenticatedUser(ctx); !ok {
-//line cmd/spx-backend/post_copilot_message.yap:14:1
+//line cmd/spx-backend/post_copilot_message.yap:13:1
 		return
 	}
+//line cmd/spx-backend/post_copilot_message.yap:17:1
+	if !ensureQuotaLeft(ctx, authz.ResourceCopilotMessage) {
 //line cmd/spx-backend/post_copilot_message.yap:18:1
-	if
-//line cmd/spx-backend/post_copilot_message.yap:18:1
-	caps, ok := authz.UserCapabilitiesFromContext(ctx.Context()); ok {
-//line cmd/spx-backend/post_copilot_message.yap:19:1
-		if caps.CopilotMessageQuotaLeft <= 0 {
-//line cmd/spx-backend/post_copilot_message.yap:20:1
-			replyWithCodeMsg(ctx, errorTooManyRequests, "Copilot message quota exceeded")
+		return
+	}
 //line cmd/spx-backend/post_copilot_message.yap:21:1
-			return
-		}
+	params := &controller.GenerateMessageParams{}
+//line cmd/spx-backend/post_copilot_message.yap:22:1
+	if !parseJSON(ctx, params) {
+//line cmd/spx-backend/post_copilot_message.yap:23:1
+		return
 	}
 //line cmd/spx-backend/post_copilot_message.yap:25:1
-	params := &controller.GenerateMessageParams{}
+	if
+//line cmd/spx-backend/post_copilot_message.yap:25:1
+	ok, msg := params.Validate(); !ok {
 //line cmd/spx-backend/post_copilot_message.yap:26:1
-	if !parseJSON(ctx, params) {
+		replyWithCodeMsg(ctx, errorInvalidArgs, msg)
 //line cmd/spx-backend/post_copilot_message.yap:27:1
 		return
 	}
-//line cmd/spx-backend/post_copilot_message.yap:29:1
-	if
-//line cmd/spx-backend/post_copilot_message.yap:29:1
-	ok, msg := params.Validate(); !ok {
 //line cmd/spx-backend/post_copilot_message.yap:30:1
-		replyWithCodeMsg(ctx, errorInvalidArgs, msg)
-//line cmd/spx-backend/post_copilot_message.yap:31:1
-		return
-	}
-//line cmd/spx-backend/post_copilot_message.yap:34:1
 	canUsePremium := authz.CanUsePremiumLLM(ctx.Context())
-//line cmd/spx-backend/post_copilot_message.yap:35:1
+//line cmd/spx-backend/post_copilot_message.yap:31:1
 	result, err := this.ctrl.GenerateMessage(ctx.Context(), params, canUsePremium)
-//line cmd/spx-backend/post_copilot_message.yap:36:1
+//line cmd/spx-backend/post_copilot_message.yap:32:1
 	if err != nil {
-//line cmd/spx-backend/post_copilot_message.yap:37:1
+//line cmd/spx-backend/post_copilot_message.yap:33:1
 		replyWithInnerError(ctx, err)
-//line cmd/spx-backend/post_copilot_message.yap:38:1
+//line cmd/spx-backend/post_copilot_message.yap:34:1
 		return
 	}
-//line cmd/spx-backend/post_copilot_message.yap:42:1
-	if
-//line cmd/spx-backend/post_copilot_message.yap:42:1
-	err := authz.ConsumeQuota(ctx.Context(), authz.ResourceCopilotMessage, 1); err != nil {
-//line cmd/spx-backend/post_copilot_message.yap:43:1
-		logger := log.GetReqLogger(ctx.Context())
-//line cmd/spx-backend/post_copilot_message.yap:44:1
-		logger.Printf("failed to consume copilot quota: %v", err)
-	}
-//line cmd/spx-backend/post_copilot_message.yap:47:1
+//line cmd/spx-backend/post_copilot_message.yap:38:1
+	consumeQuota(ctx, authz.ResourceCopilotMessage, 1)
+//line cmd/spx-backend/post_copilot_message.yap:40:1
 	this.Json__1(result)
 }
 func (this *post_copilot_message) Classfname() string {
@@ -1793,71 +1800,57 @@ func (this *post_copilot_message) Classclone() yap.HandlerProto {
 	_xgo_ret := *this
 	return &_xgo_ret
 }
-//line cmd/spx-backend/post_copilot_stream_message.yap:12
+//line cmd/spx-backend/post_copilot_stream_message.yap:11
 func (this *post_copilot_stream_message) Main(_xgo_arg0 *yap.Context) {
 	this.Handler.Main(_xgo_arg0)
-//line cmd/spx-backend/post_copilot_stream_message.yap:12:1
+//line cmd/spx-backend/post_copilot_stream_message.yap:11:1
 	ctx := &this.Context
-//line cmd/spx-backend/post_copilot_stream_message.yap:13:1
+//line cmd/spx-backend/post_copilot_stream_message.yap:12:1
 	if
-//line cmd/spx-backend/post_copilot_stream_message.yap:13:1
+//line cmd/spx-backend/post_copilot_stream_message.yap:12:1
 	_, ok := ensureAuthenticatedUser(ctx); !ok {
-//line cmd/spx-backend/post_copilot_stream_message.yap:14:1
+//line cmd/spx-backend/post_copilot_stream_message.yap:13:1
 		return
 	}
+//line cmd/spx-backend/post_copilot_stream_message.yap:17:1
+	if !ensureQuotaLeft(ctx, authz.ResourceCopilotMessage) {
 //line cmd/spx-backend/post_copilot_stream_message.yap:18:1
-	if
-//line cmd/spx-backend/post_copilot_stream_message.yap:18:1
-	caps, ok := authz.UserCapabilitiesFromContext(ctx.Context()); ok {
-//line cmd/spx-backend/post_copilot_stream_message.yap:19:1
-		if caps.CopilotMessageQuotaLeft <= 0 {
-//line cmd/spx-backend/post_copilot_stream_message.yap:20:1
-			replyWithCodeMsg(ctx, errorTooManyRequests, "Copilot message quota exceeded")
+		return
+	}
 //line cmd/spx-backend/post_copilot_stream_message.yap:21:1
-			return
-		}
+	params := &controller.GenerateMessageParams{}
+//line cmd/spx-backend/post_copilot_stream_message.yap:22:1
+	if !parseJSON(ctx, params) {
+//line cmd/spx-backend/post_copilot_stream_message.yap:23:1
+		return
 	}
 //line cmd/spx-backend/post_copilot_stream_message.yap:25:1
-	params := &controller.GenerateMessageParams{}
+	if
+//line cmd/spx-backend/post_copilot_stream_message.yap:25:1
+	ok, msg := params.Validate(); !ok {
 //line cmd/spx-backend/post_copilot_stream_message.yap:26:1
-	if !parseJSON(ctx, params) {
+		replyWithCodeMsg(ctx, errorInvalidArgs, msg)
 //line cmd/spx-backend/post_copilot_stream_message.yap:27:1
 		return
 	}
-//line cmd/spx-backend/post_copilot_stream_message.yap:29:1
-	if
-//line cmd/spx-backend/post_copilot_stream_message.yap:29:1
-	ok, msg := params.Validate(); !ok {
 //line cmd/spx-backend/post_copilot_stream_message.yap:30:1
-		replyWithCodeMsg(ctx, errorInvalidArgs, msg)
-//line cmd/spx-backend/post_copilot_stream_message.yap:31:1
-		return
-	}
-//line cmd/spx-backend/post_copilot_stream_message.yap:34:1
 	canUsePremium := authz.CanUsePremiumLLM(ctx.Context())
-//line cmd/spx-backend/post_copilot_stream_message.yap:35:1
+//line cmd/spx-backend/post_copilot_stream_message.yap:31:1
 	read, err := this.ctrl.GenerateMessageStream(ctx.Context(), params, canUsePremium)
-//line cmd/spx-backend/post_copilot_stream_message.yap:36:1
+//line cmd/spx-backend/post_copilot_stream_message.yap:32:1
 	if err != nil {
-//line cmd/spx-backend/post_copilot_stream_message.yap:37:1
+//line cmd/spx-backend/post_copilot_stream_message.yap:33:1
 		replyWithInnerError(ctx, err)
-//line cmd/spx-backend/post_copilot_stream_message.yap:38:1
+//line cmd/spx-backend/post_copilot_stream_message.yap:34:1
 		return
 	}
-//line cmd/spx-backend/post_copilot_stream_message.yap:42:1
-	if
-//line cmd/spx-backend/post_copilot_stream_message.yap:42:1
-	err := authz.ConsumeQuota(ctx.Context(), authz.ResourceCopilotMessage, 1); err != nil {
-//line cmd/spx-backend/post_copilot_stream_message.yap:43:1
-		logger := log.GetReqLogger(ctx.Context())
-//line cmd/spx-backend/post_copilot_stream_message.yap:44:1
-		logger.Printf("failed to consume copilot quota: %v", err)
-	}
-//line cmd/spx-backend/post_copilot_stream_message.yap:47:1
+//line cmd/spx-backend/post_copilot_stream_message.yap:38:1
+	consumeQuota(ctx, authz.ResourceCopilotMessage, 1)
+//line cmd/spx-backend/post_copilot_stream_message.yap:40:1
 	defer read.Close()
-//line cmd/spx-backend/post_copilot_stream_message.yap:49:1
+//line cmd/spx-backend/post_copilot_stream_message.yap:42:1
 	buf := make([]byte, 4096)
-//line cmd/spx-backend/post_copilot_stream_message.yap:50:1
+//line cmd/spx-backend/post_copilot_stream_message.yap:43:1
 	this.Stream__2(read, buf)
 }
 func (this *post_copilot_stream_message) Classfname() string {
@@ -2206,71 +2199,57 @@ func (this *post_util_fileurls) Classclone() yap.HandlerProto {
 	_xgo_ret := *this
 	return &_xgo_ret
 }
-//line cmd/spx-backend/post_workflow_stream_message.yap:12
+//line cmd/spx-backend/post_workflow_stream_message.yap:11
 func (this *post_workflow_stream_message) Main(_xgo_arg0 *yap.Context) {
 	this.Handler.Main(_xgo_arg0)
-//line cmd/spx-backend/post_workflow_stream_message.yap:12:1
+//line cmd/spx-backend/post_workflow_stream_message.yap:11:1
 	ctx := &this.Context
-//line cmd/spx-backend/post_workflow_stream_message.yap:13:1
+//line cmd/spx-backend/post_workflow_stream_message.yap:12:1
 	if
-//line cmd/spx-backend/post_workflow_stream_message.yap:13:1
+//line cmd/spx-backend/post_workflow_stream_message.yap:12:1
 	_, ok := ensureAuthenticatedUser(ctx); !ok {
-//line cmd/spx-backend/post_workflow_stream_message.yap:14:1
+//line cmd/spx-backend/post_workflow_stream_message.yap:13:1
 		return
 	}
+//line cmd/spx-backend/post_workflow_stream_message.yap:17:1
+	if !ensureQuotaLeft(ctx, authz.ResourceCopilotMessage) {
 //line cmd/spx-backend/post_workflow_stream_message.yap:18:1
-	if
-//line cmd/spx-backend/post_workflow_stream_message.yap:18:1
-	caps, ok := authz.UserCapabilitiesFromContext(ctx.Context()); ok {
-//line cmd/spx-backend/post_workflow_stream_message.yap:19:1
-		if caps.CopilotMessageQuotaLeft <= 0 {
-//line cmd/spx-backend/post_workflow_stream_message.yap:20:1
-			replyWithCodeMsg(ctx, errorTooManyRequests, "Copilot message quota exceeded")
+		return
+	}
 //line cmd/spx-backend/post_workflow_stream_message.yap:21:1
-			return
-		}
+	params := &controller.WorkflowMessageParams{}
+//line cmd/spx-backend/post_workflow_stream_message.yap:22:1
+	if !parseJSON(ctx, params) {
+//line cmd/spx-backend/post_workflow_stream_message.yap:23:1
+		return
 	}
 //line cmd/spx-backend/post_workflow_stream_message.yap:25:1
-	params := &controller.WorkflowMessageParams{}
+	if
+//line cmd/spx-backend/post_workflow_stream_message.yap:25:1
+	ok, msg := params.Validate(); !ok {
 //line cmd/spx-backend/post_workflow_stream_message.yap:26:1
-	if !parseJSON(ctx, params) {
+		replyWithCodeMsg(ctx, errorInvalidArgs, msg)
 //line cmd/spx-backend/post_workflow_stream_message.yap:27:1
 		return
 	}
-//line cmd/spx-backend/post_workflow_stream_message.yap:29:1
-	if
-//line cmd/spx-backend/post_workflow_stream_message.yap:29:1
-	ok, msg := params.Validate(); !ok {
 //line cmd/spx-backend/post_workflow_stream_message.yap:30:1
-		replyWithCodeMsg(ctx, errorInvalidArgs, msg)
-//line cmd/spx-backend/post_workflow_stream_message.yap:31:1
-		return
-	}
-//line cmd/spx-backend/post_workflow_stream_message.yap:34:1
 	canUsePremium := authz.CanUsePremiumLLM(ctx.Context())
-//line cmd/spx-backend/post_workflow_stream_message.yap:35:1
+//line cmd/spx-backend/post_workflow_stream_message.yap:31:1
 	read, err := this.ctrl.WorkflowMessageStream(ctx.Context(), params, canUsePremium)
-//line cmd/spx-backend/post_workflow_stream_message.yap:36:1
+//line cmd/spx-backend/post_workflow_stream_message.yap:32:1
 	if err != nil {
-//line cmd/spx-backend/post_workflow_stream_message.yap:37:1
+//line cmd/spx-backend/post_workflow_stream_message.yap:33:1
 		replyWithInnerError(ctx, err)
-//line cmd/spx-backend/post_workflow_stream_message.yap:38:1
+//line cmd/spx-backend/post_workflow_stream_message.yap:34:1
 		return
 	}
-//line cmd/spx-backend/post_workflow_stream_message.yap:42:1
-	if
-//line cmd/spx-backend/post_workflow_stream_message.yap:42:1
-	err := authz.ConsumeQuota(ctx.Context(), authz.ResourceCopilotMessage, 1); err != nil {
-//line cmd/spx-backend/post_workflow_stream_message.yap:43:1
-		logger := log.GetReqLogger(ctx.Context())
-//line cmd/spx-backend/post_workflow_stream_message.yap:44:1
-		logger.Printf("failed to consume copilot quota: %v", err)
-	}
-//line cmd/spx-backend/post_workflow_stream_message.yap:47:1
+//line cmd/spx-backend/post_workflow_stream_message.yap:38:1
+	consumeQuota(ctx, authz.ResourceCopilotMessage, 1)
+//line cmd/spx-backend/post_workflow_stream_message.yap:40:1
 	defer read.Close()
-//line cmd/spx-backend/post_workflow_stream_message.yap:49:1
+//line cmd/spx-backend/post_workflow_stream_message.yap:42:1
 	buf := make([]byte, 4096)
-//line cmd/spx-backend/post_workflow_stream_message.yap:50:1
+//line cmd/spx-backend/post_workflow_stream_message.yap:43:1
 	this.Stream__2(read, buf)
 }
 func (this *post_workflow_stream_message) Classfname() string {

--- a/spx-backend/internal/authz/authz_test.go
+++ b/spx-backend/internal/authz/authz_test.go
@@ -75,10 +75,16 @@ func TestAuthorizerMiddleware(t *testing.T) {
 
 	t.Run("ValidUser", func(t *testing.T) {
 		wantCaps := UserCapabilities{
-			CanManageAssets:         true,
-			CanUsePremiumLLM:        true,
-			CopilotMessageQuota:     1000,
-			CopilotMessageQuotaLeft: 900,
+			CanManageAssets:               true,
+			CanUsePremiumLLM:              true,
+			CopilotMessageQuota:           1000,
+			CopilotMessageQuotaLeft:       900,
+			AIDescriptionQuota:            1000,
+			AIDescriptionQuotaLeft:        850,
+			AIInteractionTurnQuota:        24000,
+			AIInteractionTurnQuotaLeft:    23500,
+			AIInteractionArchiveQuota:     16000,
+			AIInteractionArchiveQuotaLeft: 15500,
 		}
 
 		pdp := &mockPolicyDecisionPoint{}

--- a/spx-backend/internal/authz/context_test.go
+++ b/spx-backend/internal/authz/context_test.go
@@ -17,10 +17,16 @@ func newTestAuthorizer() *Authorizer {
 
 func newTestUserCapabilities() UserCapabilities {
 	return UserCapabilities{
-		CanManageAssets:         true,
-		CanUsePremiumLLM:        false,
-		CopilotMessageQuota:     100,
-		CopilotMessageQuotaLeft: 85,
+		CanManageAssets:               true,
+		CanUsePremiumLLM:              false,
+		CopilotMessageQuota:           100,
+		CopilotMessageQuotaLeft:       85,
+		AIDescriptionQuota:            300,
+		AIDescriptionQuotaLeft:        290,
+		AIInteractionTurnQuota:        12000,
+		AIInteractionTurnQuotaLeft:    11700,
+		AIInteractionArchiveQuota:     8000,
+		AIInteractionArchiveQuotaLeft: 7600,
 	}
 }
 

--- a/spx-backend/internal/authz/embpdp/embpdp_test.go
+++ b/spx-backend/internal/authz/embpdp/embpdp_test.go
@@ -46,12 +46,15 @@ func TestNew(t *testing.T) {
 func TestEmbeddedPDPComputeUserCapabilities(t *testing.T) {
 	t.Run("Basic", func(t *testing.T) {
 		for _, tt := range []struct {
-			name                    string
-			mUser                   *model.User
-			wantCanManageAssets     bool
-			wantCanManageCourses    bool
-			wantCanUsePremiumLLM    bool
-			wantCopilotMessageQuota int64
+			name                          string
+			mUser                         *model.User
+			wantCanManageAssets           bool
+			wantCanManageCourses          bool
+			wantCanUsePremiumLLM          bool
+			wantCopilotMessageQuota       int64
+			wantAIDescriptionQuota        int64
+			wantAIInteractionTurnQuota    int64
+			wantAIInteractionArchiveQuota int64
 		}{
 			{
 				name: "AssetAdminWithPlusPlan",
@@ -61,10 +64,13 @@ func TestEmbeddedPDPComputeUserCapabilities(t *testing.T) {
 					Roles:    model.UserRoles{"assetAdmin"},
 					Plan:     model.UserPlanPlus,
 				},
-				wantCanManageAssets:     true,
-				wantCanManageCourses:    false,
-				wantCanUsePremiumLLM:    true,
-				wantCopilotMessageQuota: 1000,
+				wantCanManageAssets:           true,
+				wantCanManageCourses:          false,
+				wantCanUsePremiumLLM:          true,
+				wantCopilotMessageQuota:       copilotQuotaPlus,
+				wantAIDescriptionQuota:        aiDescriptionQuotaPlus,
+				wantAIInteractionTurnQuota:    aiInteractionTurnQuotaPlus,
+				wantAIInteractionArchiveQuota: aiInteractionArchiveQuotaPlus,
 			},
 			{
 				name: "RegularPlusUser",
@@ -74,10 +80,13 @@ func TestEmbeddedPDPComputeUserCapabilities(t *testing.T) {
 					Roles:    nil,
 					Plan:     model.UserPlanPlus,
 				},
-				wantCanManageAssets:     false,
-				wantCanManageCourses:    false,
-				wantCanUsePremiumLLM:    true,
-				wantCopilotMessageQuota: 1000,
+				wantCanManageAssets:           false,
+				wantCanManageCourses:          false,
+				wantCanUsePremiumLLM:          true,
+				wantCopilotMessageQuota:       copilotQuotaPlus,
+				wantAIDescriptionQuota:        aiDescriptionQuotaPlus,
+				wantAIInteractionTurnQuota:    aiInteractionTurnQuotaPlus,
+				wantAIInteractionArchiveQuota: aiInteractionArchiveQuotaPlus,
 			},
 			{
 				name: "RegularFreeUser",
@@ -87,10 +96,13 @@ func TestEmbeddedPDPComputeUserCapabilities(t *testing.T) {
 					Roles:    nil,
 					Plan:     model.UserPlanFree,
 				},
-				wantCanManageAssets:     false,
-				wantCanManageCourses:    false,
-				wantCanUsePremiumLLM:    false,
-				wantCopilotMessageQuota: 100,
+				wantCanManageAssets:           false,
+				wantCanManageCourses:          false,
+				wantCanUsePremiumLLM:          false,
+				wantCopilotMessageQuota:       copilotQuotaFree,
+				wantAIDescriptionQuota:        aiDescriptionQuotaFree,
+				wantAIInteractionTurnQuota:    aiInteractionTurnQuotaFree,
+				wantAIInteractionArchiveQuota: aiInteractionArchiveQuotaFree,
 			},
 			{
 				name: "AdminWithFreePlan",
@@ -100,10 +112,13 @@ func TestEmbeddedPDPComputeUserCapabilities(t *testing.T) {
 					Roles:    model.UserRoles{"admin"},
 					Plan:     model.UserPlanFree,
 				},
-				wantCanManageAssets:     false,
-				wantCanManageCourses:    false,
-				wantCanUsePremiumLLM:    false,
-				wantCopilotMessageQuota: 100,
+				wantCanManageAssets:           false,
+				wantCanManageCourses:          false,
+				wantCanUsePremiumLLM:          false,
+				wantCopilotMessageQuota:       copilotQuotaFree,
+				wantAIDescriptionQuota:        aiDescriptionQuotaFree,
+				wantAIInteractionTurnQuota:    aiInteractionTurnQuotaFree,
+				wantAIInteractionArchiveQuota: aiInteractionArchiveQuotaFree,
 			},
 			{
 				name: "UserWithMultipleRoles",
@@ -113,10 +128,13 @@ func TestEmbeddedPDPComputeUserCapabilities(t *testing.T) {
 					Roles:    model.UserRoles{"user", "assetAdmin"},
 					Plan:     model.UserPlanFree,
 				},
-				wantCanManageAssets:     true,
-				wantCanManageCourses:    false,
-				wantCanUsePremiumLLM:    false,
-				wantCopilotMessageQuota: 100,
+				wantCanManageAssets:           true,
+				wantCanManageCourses:          false,
+				wantCanUsePremiumLLM:          false,
+				wantCopilotMessageQuota:       copilotQuotaFree,
+				wantAIDescriptionQuota:        aiDescriptionQuotaFree,
+				wantAIInteractionTurnQuota:    aiInteractionTurnQuotaFree,
+				wantAIInteractionArchiveQuota: aiInteractionArchiveQuotaFree,
 			},
 			{
 				name: "CourseAdminUser",
@@ -126,10 +144,13 @@ func TestEmbeddedPDPComputeUserCapabilities(t *testing.T) {
 					Roles:    model.UserRoles{"courseAdmin"},
 					Plan:     model.UserPlanFree,
 				},
-				wantCanManageAssets:     false,
-				wantCanManageCourses:    true,
-				wantCanUsePremiumLLM:    false,
-				wantCopilotMessageQuota: 100,
+				wantCanManageAssets:           false,
+				wantCanManageCourses:          true,
+				wantCanUsePremiumLLM:          false,
+				wantCopilotMessageQuota:       copilotQuotaFree,
+				wantAIDescriptionQuota:        aiDescriptionQuotaFree,
+				wantAIInteractionTurnQuota:    aiInteractionTurnQuotaFree,
+				wantAIInteractionArchiveQuota: aiInteractionArchiveQuotaFree,
 			},
 			{
 				name: "UserWithMultipleAdminRoles",
@@ -139,10 +160,13 @@ func TestEmbeddedPDPComputeUserCapabilities(t *testing.T) {
 					Roles:    model.UserRoles{"assetAdmin", "courseAdmin"},
 					Plan:     model.UserPlanPlus,
 				},
-				wantCanManageAssets:     true,
-				wantCanManageCourses:    true,
-				wantCanUsePremiumLLM:    true,
-				wantCopilotMessageQuota: 1000,
+				wantCanManageAssets:           true,
+				wantCanManageCourses:          true,
+				wantCanUsePremiumLLM:          true,
+				wantCopilotMessageQuota:       copilotQuotaPlus,
+				wantAIDescriptionQuota:        aiDescriptionQuotaPlus,
+				wantAIInteractionTurnQuota:    aiInteractionTurnQuotaPlus,
+				wantAIInteractionArchiveQuota: aiInteractionArchiveQuotaPlus,
 			},
 		} {
 			t.Run(tt.name, func(t *testing.T) {
@@ -156,6 +180,12 @@ func TestEmbeddedPDPComputeUserCapabilities(t *testing.T) {
 				assert.Equal(t, tt.wantCanUsePremiumLLM, caps.CanUsePremiumLLM)
 				assert.Equal(t, tt.wantCopilotMessageQuota, caps.CopilotMessageQuota)
 				assert.Equal(t, caps.CopilotMessageQuota, caps.CopilotMessageQuotaLeft)
+				assert.Equal(t, tt.wantAIDescriptionQuota, caps.AIDescriptionQuota)
+				assert.Equal(t, caps.AIDescriptionQuota, caps.AIDescriptionQuotaLeft)
+				assert.Equal(t, tt.wantAIInteractionTurnQuota, caps.AIInteractionTurnQuota)
+				assert.Equal(t, caps.AIInteractionTurnQuota, caps.AIInteractionTurnQuotaLeft)
+				assert.Equal(t, tt.wantAIInteractionArchiveQuota, caps.AIInteractionArchiveQuota)
+				assert.Equal(t, caps.AIInteractionArchiveQuota, caps.AIInteractionArchiveQuotaLeft)
 			})
 		}
 	})
@@ -173,14 +203,26 @@ func TestEmbeddedPDPComputeUserCapabilities(t *testing.T) {
 
 		err := quotaTracker.IncrementUsage(context.Background(), mUser.ID, authz.ResourceCopilotMessage, 30)
 		require.NoError(t, err)
+		err = quotaTracker.IncrementUsage(context.Background(), mUser.ID, authz.ResourceAIDescription, 5)
+		require.NoError(t, err)
+		err = quotaTracker.IncrementUsage(context.Background(), mUser.ID, authz.ResourceAIInteractionTurn, 120)
+		require.NoError(t, err)
+		err = quotaTracker.IncrementUsage(context.Background(), mUser.ID, authz.ResourceAIInteractionArchive, 10)
+		require.NoError(t, err)
 
 		caps, err := pdp.ComputeUserCapabilities(context.Background(), mUser)
 		require.NoError(t, err)
 		assert.Equal(t, false, caps.CanManageAssets)
 		assert.Equal(t, false, caps.CanManageCourses)
 		assert.Equal(t, false, caps.CanUsePremiumLLM)
-		assert.Equal(t, int64(100), caps.CopilotMessageQuota)
-		assert.Equal(t, int64(70), caps.CopilotMessageQuotaLeft)
+		assert.Equal(t, int64(copilotQuotaFree), caps.CopilotMessageQuota)
+		assert.Equal(t, int64(copilotQuotaFree-30), caps.CopilotMessageQuotaLeft)
+		assert.Equal(t, int64(aiDescriptionQuotaFree), caps.AIDescriptionQuota)
+		assert.Equal(t, int64(aiDescriptionQuotaFree-5), caps.AIDescriptionQuotaLeft)
+		assert.Equal(t, int64(aiInteractionTurnQuotaFree), caps.AIInteractionTurnQuota)
+		assert.Equal(t, int64(aiInteractionTurnQuotaFree-120), caps.AIInteractionTurnQuotaLeft)
+		assert.Equal(t, int64(aiInteractionArchiveQuotaFree), caps.AIInteractionArchiveQuota)
+		assert.Equal(t, int64(aiInteractionArchiveQuotaFree-10), caps.AIInteractionArchiveQuotaLeft)
 	})
 
 	t.Run("QuotaExhausted", func(t *testing.T) {
@@ -194,12 +236,24 @@ func TestEmbeddedPDPComputeUserCapabilities(t *testing.T) {
 			Plan:     model.UserPlanFree,
 		}
 
-		err := quotaTracker.IncrementUsage(context.Background(), mUser.ID, authz.ResourceCopilotMessage, 150)
+		err := quotaTracker.IncrementUsage(context.Background(), mUser.ID, authz.ResourceCopilotMessage, copilotQuotaFree+50)
+		require.NoError(t, err)
+		err = quotaTracker.IncrementUsage(context.Background(), mUser.ID, authz.ResourceAIDescription, aiDescriptionQuotaFree+100)
+		require.NoError(t, err)
+		err = quotaTracker.IncrementUsage(context.Background(), mUser.ID, authz.ResourceAIInteractionTurn, aiInteractionTurnQuotaFree+5000)
+		require.NoError(t, err)
+		err = quotaTracker.IncrementUsage(context.Background(), mUser.ID, authz.ResourceAIInteractionArchive, aiInteractionArchiveQuotaFree+3000)
 		require.NoError(t, err)
 
 		caps, err := pdp.ComputeUserCapabilities(context.Background(), mUser)
 		require.NoError(t, err)
-		assert.Equal(t, int64(100), caps.CopilotMessageQuota)
+		assert.Equal(t, int64(copilotQuotaFree), caps.CopilotMessageQuota)
 		assert.Equal(t, int64(0), caps.CopilotMessageQuotaLeft)
+		assert.Equal(t, int64(aiDescriptionQuotaFree), caps.AIDescriptionQuota)
+		assert.Equal(t, int64(0), caps.AIDescriptionQuotaLeft)
+		assert.Equal(t, int64(aiInteractionTurnQuotaFree), caps.AIInteractionTurnQuota)
+		assert.Equal(t, int64(0), caps.AIInteractionTurnQuotaLeft)
+		assert.Equal(t, int64(aiInteractionArchiveQuotaFree), caps.AIInteractionArchiveQuota)
+		assert.Equal(t, int64(0), caps.AIInteractionArchiveQuotaLeft)
 	})
 }

--- a/spx-backend/internal/authz/pdp.go
+++ b/spx-backend/internal/authz/pdp.go
@@ -29,4 +29,22 @@ type UserCapabilities struct {
 
 	// CopilotMessageQuotaLeft is the remaining quota for copilot messages.
 	CopilotMessageQuotaLeft int64 `json:"copilotMessageQuotaLeft"`
+
+	// AIDescriptionQuota is the total quota for AI description generations.
+	AIDescriptionQuota int64 `json:"aiDescriptionQuota"`
+
+	// AIDescriptionQuotaLeft is the remaining quota for AI description generations.
+	AIDescriptionQuotaLeft int64 `json:"aiDescriptionQuotaLeft"`
+
+	// AIInteractionTurnQuota is the total quota for AI interaction turns.
+	AIInteractionTurnQuota int64 `json:"aiInteractionTurnQuota"`
+
+	// AIInteractionTurnQuotaLeft is the remaining quota for AI interaction turns.
+	AIInteractionTurnQuotaLeft int64 `json:"aiInteractionTurnQuotaLeft"`
+
+	// AIInteractionArchiveQuota is the total quota for AI interaction archive requests.
+	AIInteractionArchiveQuota int64 `json:"aiInteractionArchiveQuota"`
+
+	// AIInteractionArchiveQuotaLeft is the remaining quota for AI interaction archive requests.
+	AIInteractionArchiveQuotaLeft int64 `json:"aiInteractionArchiveQuotaLeft"`
 }

--- a/spx-backend/internal/authz/pdp_test.go
+++ b/spx-backend/internal/authz/pdp_test.go
@@ -15,9 +15,15 @@ func (m *mockPolicyDecisionPoint) ComputeUserCapabilities(ctx context.Context, m
 		return m.computeUserCapabilitiesFunc(ctx, mUser)
 	}
 	return UserCapabilities{
-		CanManageAssets:         true,
-		CanUsePremiumLLM:        false,
-		CopilotMessageQuota:     100,
-		CopilotMessageQuotaLeft: 80,
+		CanManageAssets:               true,
+		CanUsePremiumLLM:              false,
+		CopilotMessageQuota:           100,
+		CopilotMessageQuotaLeft:       80,
+		AIDescriptionQuota:            300,
+		AIDescriptionQuotaLeft:        280,
+		AIInteractionTurnQuota:        12000,
+		AIInteractionTurnQuotaLeft:    11600,
+		AIInteractionArchiveQuota:     8000,
+		AIInteractionArchiveQuotaLeft: 7620,
 	}, nil
 }

--- a/spx-backend/internal/authz/quota.go
+++ b/spx-backend/internal/authz/quota.go
@@ -18,5 +18,8 @@ type QuotaTracker interface {
 type Resource string
 
 const (
-	ResourceCopilotMessage Resource = "copilotMessage"
+	ResourceCopilotMessage       Resource = "copilotMessage"
+	ResourceAIDescription        Resource = "aiDescription"
+	ResourceAIInteractionTurn    Resource = "aiInteractionTurn"
+	ResourceAIInteractionArchive Resource = "aiInteractionArchive"
 )

--- a/spx-backend/internal/controller/user_test.go
+++ b/spx-backend/internal/controller/user_test.go
@@ -35,10 +35,16 @@ func newContextWithTestUser(ctx context.Context) context.Context {
 	testUser := newTestUser()
 	ctx = authn.NewContextWithUser(ctx, testUser)
 	ctx = authz.NewContextWithUserCapabilities(ctx, authz.UserCapabilities{
-		CanManageAssets:         false,
-		CanUsePremiumLLM:        false,
-		CopilotMessageQuota:     100,
-		CopilotMessageQuotaLeft: 100,
+		CanManageAssets:               false,
+		CanUsePremiumLLM:              false,
+		CopilotMessageQuota:           100,
+		CopilotMessageQuotaLeft:       100,
+		AIDescriptionQuota:            300,
+		AIDescriptionQuotaLeft:        295,
+		AIInteractionTurnQuota:        12000,
+		AIInteractionTurnQuotaLeft:    11900,
+		AIInteractionArchiveQuota:     8000,
+		AIInteractionArchiveQuotaLeft: 7980,
 	})
 	return ctx
 }
@@ -465,6 +471,12 @@ func TestControllerGetAuthenticatedUser(t *testing.T) {
 		assert.False(t, result.Capabilities.CanUsePremiumLLM)
 		assert.Equal(t, int64(100), result.Capabilities.CopilotMessageQuota)
 		assert.Equal(t, int64(100), result.Capabilities.CopilotMessageQuotaLeft)
+		assert.Equal(t, int64(300), result.Capabilities.AIDescriptionQuota)
+		assert.Equal(t, int64(295), result.Capabilities.AIDescriptionQuotaLeft)
+		assert.Equal(t, int64(12000), result.Capabilities.AIInteractionTurnQuota)
+		assert.Equal(t, int64(11900), result.Capabilities.AIInteractionTurnQuotaLeft)
+		assert.Equal(t, int64(8000), result.Capabilities.AIInteractionArchiveQuota)
+		assert.Equal(t, int64(7980), result.Capabilities.AIInteractionArchiveQuotaLeft)
 	})
 
 	t.Run("Unauthorized", func(t *testing.T) {
@@ -540,6 +552,12 @@ func TestControllerUpdateAuthenticatedUser(t *testing.T) {
 		assert.False(t, result.Capabilities.CanUsePremiumLLM)
 		assert.Equal(t, int64(100), result.Capabilities.CopilotMessageQuota)
 		assert.Equal(t, int64(100), result.Capabilities.CopilotMessageQuotaLeft)
+		assert.Equal(t, int64(300), result.Capabilities.AIDescriptionQuota)
+		assert.Equal(t, int64(295), result.Capabilities.AIDescriptionQuotaLeft)
+		assert.Equal(t, int64(12000), result.Capabilities.AIInteractionTurnQuota)
+		assert.Equal(t, int64(11900), result.Capabilities.AIInteractionTurnQuotaLeft)
+		assert.Equal(t, int64(8000), result.Capabilities.AIInteractionArchiveQuota)
+		assert.Equal(t, int64(7980), result.Capabilities.AIInteractionArchiveQuotaLeft)
 
 		require.NoError(t, dbMock.ExpectationsWereMet())
 	})

--- a/spx-gui/src/apis/user.ts
+++ b/spx-gui/src/apis/user.ts
@@ -36,6 +36,18 @@ export type UserCapabilities = {
   copilotMessageQuota: number
   /** Remaining quota for Copilot messages */
   copilotMessageQuotaLeft: number
+  /** Total quota for AI description generations */
+  aiDescriptionQuota: number
+  /** Remaining quota for AI description generations */
+  aiDescriptionQuotaLeft: number
+  /** Total quota for AI interaction turns */
+  aiInteractionTurnQuota: number
+  /** Remaining quota for AI interaction turns */
+  aiInteractionTurnQuotaLeft: number
+  /** Total quota for AI interaction archives */
+  aiInteractionArchiveQuota: number
+  /** Remaining quota for AI interaction archives */
+  aiInteractionArchiveQuotaLeft: number
 }
 
 export async function getUser(name: string): Promise<User> {


### PR DESCRIPTION
- Track `aiDescription`, `aiInteractionTurn`, and `aiInteractionArchive` usage via embedded PDP capabilities
- Gate AI Description and Interaction handlers with quota checks and quota consumption

Fixes #2299