### PR TITLE
fix: keep project runner state consistent after crashes

### DIFF
--- a/spx-gui/src/components/editor/runtime.ts
+++ b/spx-gui/src/components/editor/runtime.ts
@@ -12,14 +12,10 @@ export type RunningState =
       mode: 'none'
     }
   | {
-      /** Debugging, run in place */
+      /** Debugging */
       mode: 'debug'
       /** Initializing for debug */
       initializing: boolean
-    }
-  | {
-      /** Running full screen */
-      mode: 'run'
     }
 
 export enum RuntimeOutputKind {
@@ -42,9 +38,10 @@ export class Runtime extends Emitter<{
 
   setRunning(running: RunningState, filesHash?: string) {
     this.running = running
-    if (running.mode === 'debug' && running.initializing === false) {
-      if (filesHash == null) throw new Error('filesHash is required when running in debug mode')
-      this.filesHash = filesHash
+    if (running.mode === 'debug' && !running.initializing) {
+      const nextHash = filesHash ?? this.filesHash
+      if (nextHash == null) throw new Error('filesHash is required when running in debug mode')
+      this.filesHash = nextHash
     }
   }
 

--- a/spx-gui/src/components/project/runner/ProjectRunnerSurface.vue
+++ b/spx-gui/src/components/project/runner/ProjectRunnerSurface.vue
@@ -13,22 +13,22 @@ const props = withDefaults(
     project: Project
     fullscreen?: boolean
     inlineAnchor?: () => HTMLElement | null
-    run?: () => void | Promise<void>
+    onRun?: () => void | Promise<void>
     runLoading?: boolean
-    rerun?: () => void | Promise<void>
+    onRerun?: () => void | Promise<void>
     rerunLoading?: boolean
-    stop?: () => void | Promise<void>
+    onStop?: () => void | Promise<void>
     stopLoading?: boolean
     runnerState?: RunnerState
   }>(),
   {
     fullscreen: false,
     inlineAnchor: undefined,
-    run: undefined,
+    onRun: undefined,
     runLoading: false,
-    rerun: undefined,
+    onRerun: undefined,
     rerunLoading: false,
-    stop: undefined,
+    onStop: undefined,
     stopLoading: false,
     runnerState: 'running' as RunnerState
   }
@@ -343,16 +343,18 @@ const handleInternalStop = useMessageHandle(() => runnerRef.value?.stop(), {
   zh: '停止项目失败'
 })
 
-const runHandler = computed(() => props.run ?? handleInternalRun.fn)
-const runButtonLoading = computed(() => (props.run != null ? props.runLoading : handleInternalRun.isLoading.value))
+const runHandler = computed(() => props.onRun ?? handleInternalRun.fn)
+const runButtonLoading = computed(() => (props.onRun != null ? props.runLoading : handleInternalRun.isLoading.value))
 
-const rerunHandler = computed(() => props.rerun ?? handleInternalRerun.fn)
+const rerunHandler = computed(() => props.onRerun ?? handleInternalRerun.fn)
 const rerunButtonLoading = computed(() =>
-  props.rerun != null ? props.rerunLoading : handleInternalRerun.isLoading.value
+  props.onRerun != null ? props.rerunLoading : handleInternalRerun.isLoading.value
 )
 
-const stopHandler = computed(() => props.stop ?? handleInternalStop.fn)
-const stopButtonLoading = computed(() => (props.stop != null ? props.stopLoading : handleInternalStop.isLoading.value))
+const stopHandler = computed(() => props.onStop ?? handleInternalStop.fn)
+const stopButtonLoading = computed(() =>
+  props.onStop != null ? props.stopLoading : handleInternalStop.isLoading.value
+)
 
 function handleRunClick() {
   const fn = runHandler.value

--- a/spx-gui/src/components/project/runner/v2/ProjectRunnerV2.vue
+++ b/spx-gui/src/components/project/runner/v2/ProjectRunnerV2.vue
@@ -273,6 +273,7 @@ defineExpose({
     runCtrl?.abort(new Cancelled('stop'))
     if (promise != null) await promise.catch(() => {})
     loading.value = false
+    failed.value = false
 
     const iframeWindow = iframeWindowRef.value
     if (iframeWindow == null) return

--- a/spx-gui/src/pages/community/project.vue
+++ b/spx-gui/src/pages/community/project.vue
@@ -325,11 +325,11 @@ const remixesRet = useQuery(
               v-model:fullscreen="isFullScreenRunning"
               :project="project"
               :runner-state="runnerState"
-              :run="handleRun.fn"
+              :on-run="handleRun.fn"
               :run-loading="handleRun.isLoading.value"
-              :rerun="handleRerun.fn"
+              :on-rerun="handleRerun.fn"
               :rerun-loading="handleRerun.isLoading.value"
-              :stop="handleStop.fn"
+              :on-stop="handleStop.fn"
               :stop-loading="handleStop.isLoading.value"
             >
               <template #inline-overlay>


### PR DESCRIPTION
- Reset `ProjectRunnerV2` failure overlay on stop so manual exit works after a crash
- Restore debug runtime with the last files hash and unify fullscreen exit handling