### PR TITLE
Fix `waitUntil` in API References

### DIFF
--- a/spx-gui/src/components/editor/code-editor/code-editor.ts
+++ b/spx-gui/src/components/editor/code-editor/code-editor.ts
@@ -102,7 +102,7 @@ const apiReferenceItems = [
   'xgo:?if_else_statement',
 
   `xgo:${packageSpx}?Game.wait`,
-  `xgo:${packageSpx}?Game.waitUntil`,
+  `xgo:${packageSpx}?waitUntil`, // TODO: Consider updating spx to define `waitUntil` on `Game` to keep consistent with `Game.wait`
   `xgo:${packageSpx}?Game.timer`,
   `xgo:${packageSpx}?Game.resetTimer`,
 


### PR DESCRIPTION
This PR corrects an ID mismatch that caused `waitUntil` to be missing from the API references.