### PR TITLE
feat(spx-backend): enforce rates on AI endpoints

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -908,11 +908,13 @@ paths:
       description: |
         Generate a message by sending a list of input messages.
 
-        #### Quota limits
+        #### Quota & rate limits
 
         - Each message consumes 1 quota from the authenticated user's allowance.
-        - Quota limits vary based on the authenticated user's plan.
-        - When the limit is reached, the 403 response includes a `Retry-After` header with the wait time in seconds.
+        - Per-user short-window rate limits also apply to prevent bursts. Hitting them returns 429 with `Retry-After`.
+        - Long-window quota limits vary based on the authenticated user's plan.
+        - When the long-window quota limit is reached, the 403 response includes a `Retry-After` header with the wait
+          time in seconds.
       requestBody:
         required: true
         content:
@@ -960,7 +962,14 @@ paths:
           description: Insufficient permissions or quota to perform this operation.
           headers:
             Retry-After:
-              description: Seconds to wait before retrying after hitting the limit.
+              description: Seconds to wait before retrying after hitting the long-window quota limit.
+              schema:
+                type: integer
+        "429":
+          description: Too many requests to perform this operation.
+          headers:
+            Retry-After:
+              description: Seconds to wait before retrying after hitting the short-window rate limit.
               schema:
                 type: integer
 
@@ -972,11 +981,13 @@ paths:
       description: |
         Generate a stream message by sending a list of input messages.
 
-        #### Quota limits
+        #### Quota & rate limits
 
         - Each message consumes 1 quota from the authenticated user's allowance.
-        - Quota limits vary based on the authenticated user's plan.
-        - When the limit is reached, the 403 response includes a `Retry-After` header with the wait time in seconds.
+        - Per-user short-window rate limits also apply to prevent bursts. Hitting them returns 429 with `Retry-After`.
+        - Long-window quota limits vary based on the authenticated user's plan.
+        - When the long-window quota limit is reached, the 403 response includes a `Retry-After` header with the wait
+          time in seconds.
       requestBody:
         required: true
         content:
@@ -1016,7 +1027,14 @@ paths:
           description: Insufficient permissions or quota to perform this operation.
           headers:
             Retry-After:
-              description: Seconds to wait before retrying after hitting the limit.
+              description: Seconds to wait before retrying after hitting the long-window quota limit.
+              schema:
+                type: integer
+        "429":
+          description: Too many requests to perform this operation.
+          headers:
+            Retry-After:
+              description: Seconds to wait before retrying after hitting the short-window rate limit.
               schema:
                 type: integer
 
@@ -1028,11 +1046,13 @@ paths:
       description: |
         Generate a stream message by sending a list of input messages.
 
-        #### Quota limits
+        #### Quota & rate limits
 
         - Each workflow execution may consume multiple quotas from the authenticated user's allowance.
-        - Quota limits vary based on the authenticated user's plan.
-        - When the limit is reached, the 403 response includes a `Retry-After` header with the wait time in seconds.
+        - Per-user short-window rate limits also apply to prevent bursts. Hitting them returns 429 with `Retry-After`.
+        - Long-window quota limits vary based on the authenticated user's plan.
+        - When the long-window quota limit is reached, the 403 response includes a `Retry-After` header with the wait
+          time in seconds.
       requestBody:
         required: true
         content:
@@ -1075,7 +1095,14 @@ paths:
           description: Insufficient permissions or quota to perform this operation.
           headers:
             Retry-After:
-              description: Seconds to wait before retrying after hitting the limit.
+              description: Seconds to wait before retrying after hitting the long-window quota limit.
+              schema:
+                type: integer
+        "429":
+          description: Too many requests to perform this operation.
+          headers:
+            Retry-After:
+              description: Seconds to wait before retrying after hitting the short-window rate limit.
               schema:
                 type: integer
 
@@ -1088,11 +1115,13 @@ paths:
         Generate an AI-powered descriptive summary of a game from the player's perspective based on provided game
         content (such as spx source code and project structure).
 
-        #### Quota limits
+        #### Quota & rate limits
 
         - Each request consumes 1 quota from the authenticated user's AI description allowance.
+        - Per-user short-window rate limits also apply to prevent bursts. Hitting them returns 429 with `Retry-After`.
         - Quota limits vary based on the authenticated user's plan.
-        - When the limit is reached, the 403 response includes a `Retry-After` header with the wait time in seconds.
+        - When the long-window quota limit is reached, the 403 response includes a `Retry-After` header with the wait
+          time in seconds.
       requestBody:
         required: true
         content:
@@ -1110,7 +1139,14 @@ paths:
           description: Insufficient permissions or quota to perform this operation.
           headers:
             Retry-After:
-              description: Seconds to wait before retrying after hitting the limit.
+              description: Seconds to wait before retrying after hitting the long-window quota limit.
+              schema:
+                type: integer
+        "429":
+          description: Too many requests to perform this operation.
+          headers:
+            Retry-After:
+              description: Seconds to wait before retrying after hitting the short-window rate limit.
               schema:
                 type: integer
 
@@ -1122,11 +1158,13 @@ paths:
       description: |
         Send a message and context to the AI, receive a response including text and an optional command.
 
-        #### Quota limits
+        #### Quota & rate limits
 
         - Each turn consumes 1 quota from the authenticated user's AI interaction turn allowance.
-        - Quota limits vary based on the authenticated user's plan.
-        - When the limit is reached, the 403 response includes a `Retry-After` header with the wait time in seconds.
+        - Per-user short-window rate limits also apply to prevent bursts. Hitting them returns 429 with `Retry-After`.
+        - Long-window quota limits vary based on the authenticated user's plan.
+        - When the long-window quota limit is reached, the 403 response includes a `Retry-After` header with the wait
+          time in seconds.
       requestBody:
         required: true
         content:
@@ -1144,7 +1182,14 @@ paths:
           description: Insufficient permissions or quota to perform this operation.
           headers:
             Retry-After:
-              description: Seconds to wait before retrying after hitting the limit.
+              description: Seconds to wait before retrying after hitting the long-window quota limit.
+              schema:
+                type: integer
+        "429":
+          description: Too many requests to perform this operation.
+          headers:
+            Retry-After:
+              description: Seconds to wait before retrying after hitting the short-window rate limit.
               schema:
                 type: integer
 
@@ -1156,11 +1201,13 @@ paths:
       description: |
         Archive a batch of interaction turns into a condensed summary for future context.
 
-        #### Quota limits
+        #### Quota & rate limits
 
         - Each archive request consumes 1 quota from the authenticated user's AI interaction archive allowance.
-        - Quota limits vary based on the authenticated user's plan.
-        - When the limit is reached, the 403 response includes a `Retry-After` header with the wait time in seconds.
+        - Per-user short-window rate limits also apply to prevent bursts. Hitting them returns 429 with `Retry-After`.
+        - Long-window quota limits vary based on the authenticated user's plan.
+        - When the long-window quota limit is reached, the 403 response includes a `Retry-After` header with the wait
+          time in seconds.
       requestBody:
         required: true
         content:
@@ -1178,7 +1225,14 @@ paths:
           description: Insufficient permissions or quota to perform this operation.
           headers:
             Retry-After:
-              description: Seconds to wait before retrying after hitting the limit.
+              description: Seconds to wait before retrying after hitting the long-window quota limit.
+              schema:
+                type: integer
+        "429":
+          description: Too many requests to perform this operation.
+          headers:
+            Retry-After:
+              description: Seconds to wait before retrying after hitting the short-window rate limit.
               schema:
                 type: integer
 

--- a/spx-gui/src/apis/common/exception.ts
+++ b/spx-gui/src/apis/common/exception.ts
@@ -24,6 +24,8 @@ export enum ApiExceptionCode {
   errorForbidden = 40300,
   errorQuotaExceeded = 40301,
   errorNotFound = 40400,
+  errorTooManyRequests = 42900,
+  errorRateLimitExceeded = 42901,
   errorUnknown = 50000
 }
 
@@ -43,6 +45,14 @@ const codeMessages: Record<ApiExceptionCode, LocaleMessage> = {
   [ApiExceptionCode.errorQuotaExceeded]: {
     en: 'quota exceeded',
     zh: '超出配额'
+  },
+  [ApiExceptionCode.errorTooManyRequests]: {
+    en: 'too many requests',
+    zh: '请求太频繁了'
+  },
+  [ApiExceptionCode.errorRateLimitExceeded]: {
+    en: 'rate limit exceeded, please retry later',
+    zh: '触发频率限制，请稍后重试'
   },
   [ApiExceptionCode.errorNotFound]: {
     en: 'resource not exist',

--- a/tools/ai/httptrans/httptrans.go
+++ b/tools/ai/httptrans/httptrans.go
@@ -147,6 +147,13 @@ func handleResponse(resp *http.Response, target any) error {
 	}
 
 	if resp.StatusCode != http.StatusOK {
+		if resp.StatusCode == http.StatusTooManyRequests {
+			retryAfter := ai.RetryAfterFromHeader(resp.Header.Get("Retry-After"))
+			return &ai.TooManyRequestsError{
+				RetryAfter: retryAfter,
+				Err:        fmt.Errorf("failed to fetch with status: %s: %s", resp.Status, body),
+			}
+		}
 		return fmt.Errorf("failed to fetch with status: %s: %s", resp.Status, body)
 	}
 

--- a/tools/ai/transport_test.go
+++ b/tools/ai/transport_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"reflect"
 	"testing"
+	"time"
 )
 
 type mockTransport struct {
@@ -75,4 +76,122 @@ func TestNotSetTransportArchive(t *testing.T) {
 	if got, want := archived, (ArchivedHistory{}); !reflect.DeepEqual(got, want) {
 		t.Errorf("got %#v, want %#v", got, want)
 	}
+}
+
+func TestTooManyRequestsError(t *testing.T) {
+	baseErr := errors.New("too many requests")
+	var err error = &TooManyRequestsError{
+		RetryAfter: 5 * time.Second,
+		Err:        baseErr,
+	}
+
+	var tmrErr *TooManyRequestsError
+	if got, want := errors.As(err, &tmrErr), true; got != want {
+		t.Fatalf("got %t, want %t", got, want)
+	}
+	if got, want := tmrErr.RetryAfter, 5*time.Second; got != want {
+		t.Errorf("got %v, want %v", got, want)
+	}
+	if got, want := errors.Is(tmrErr, baseErr), true; got != want {
+		t.Errorf("got %t, want %t", got, want)
+	}
+}
+
+func TestRetryAfterFromHeader(t *testing.T) {
+	t.Run("SecondsValue", func(t *testing.T) {
+		got := RetryAfterFromHeader("42")
+		want := 42 * time.Second
+		if got != want {
+			t.Errorf("got %v, want %v", got, want)
+		}
+	})
+
+	t.Run("HTTPDateValue", func(t *testing.T) {
+		future := time.Now().Add(90 * time.Second)
+		header := future.UTC().Format(httpTimeFormat)
+		got := RetryAfterFromHeader(header)
+		expected := 90 * time.Second
+		tolerance := 2 * time.Second
+		if got < expected-tolerance || got > expected+tolerance {
+			t.Errorf("got %v, want %v±%v", got, expected, tolerance)
+		}
+	})
+
+	t.Run("PastHTTPDateValue", func(t *testing.T) {
+		past := time.Now().Add(-time.Minute)
+		header := past.UTC().Format(httpTimeFormat)
+		if got := RetryAfterFromHeader(header); got != 0 {
+			t.Errorf("got %v, want 0", got)
+		}
+	})
+
+	t.Run("InvalidValue", func(t *testing.T) {
+		got := RetryAfterFromHeader("abc")
+		if got != 0 {
+			t.Errorf("got %v, want 0", got)
+		}
+	})
+}
+
+func TestRateLimitGate(t *testing.T) {
+	t.Run("ObserveSetsNextAllowed", func(t *testing.T) {
+		var rateGate rateLimitGate
+		start := time.Now()
+		rateGate.Observe(&TooManyRequestsError{RetryAfter: 25 * time.Millisecond})
+
+		expectedMin := start.Add(25 * time.Millisecond)
+		if rateGate.nextAllowed.Before(expectedMin) {
+			t.Errorf("nextAllowed %v before expected minimum %v", rateGate.nextAllowed, expectedMin)
+		}
+	})
+
+	t.Run("ObserveKeepsLaterDeadline", func(t *testing.T) {
+		initial := time.Now().Add(200 * time.Millisecond)
+		rateGate := rateLimitGate{nextAllowed: initial}
+
+		rateGate.Observe(&TooManyRequestsError{RetryAfter: 10 * time.Millisecond})
+		if rateGate.nextAllowed != initial {
+			t.Errorf("nextAllowed %v changed from %v", rateGate.nextAllowed, initial)
+		}
+	})
+
+	t.Run("ObserveIgnoresNonRateErrors", func(t *testing.T) {
+		var rateGate rateLimitGate
+		rateGate.Observe(errors.New("other"))
+		if !rateGate.nextAllowed.IsZero() {
+			t.Errorf("nextAllowed %v, want zero time", rateGate.nextAllowed)
+		}
+	})
+
+	t.Run("WaitBlocksUntilAllowed", func(t *testing.T) {
+		delay := 30 * time.Millisecond
+		rateGate := rateLimitGate{nextAllowed: time.Now().Add(delay)}
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		t.Cleanup(cancel)
+		start := time.Now()
+
+		if err := rateGate.Wait(ctx); err != nil {
+			t.Fatalf("wait returned error: %v", err)
+		}
+		if elapsed := time.Since(start); elapsed < delay {
+			t.Fatalf("wait returned too early: elapsed %v, want at least %v", elapsed, delay)
+		}
+	})
+
+	t.Run("WaitReturnsImmediatelyWhenAllowed", func(t *testing.T) {
+		var rateGate rateLimitGate
+		if err := rateGate.Wait(context.Background()); err != nil {
+			t.Fatalf("wait returned error: %v", err)
+		}
+	})
+
+	t.Run("WaitRespectsContextTimeout", func(t *testing.T) {
+		rateGate := rateLimitGate{nextAllowed: time.Now().Add(time.Second)}
+		ctx, cancel := context.WithTimeout(context.Background(), 25*time.Millisecond)
+		t.Cleanup(cancel)
+
+		if err := rateGate.Wait(ctx); !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("expected deadline exceeded, got %v", err)
+		}
+	})
 }


### PR DESCRIPTION
- Add plan-aware rate limit specs in the embedded PDP
- Ensure `ConsumeQuota` updates both kinds with limit-only and rate-limit-only tests
- Surface 429 vs 403 semantics via `ensureQuotaRemaining` and OpenAPI
- Improve AI transports in tools/ai to honor `Retry-After` through `TooManyRequestsError` and the `rateLimitGate` waiting logic