### PR TITLE
fix(tools/ai): correct Full-Jitter retry backoff

### DIFF
--- a/tools/ai/backoff_test.go
+++ b/tools/ai/backoff_test.go
@@ -1,6 +1,8 @@
 package ai
 
 import (
+	"context"
+	"slices"
 	"testing"
 	"time"
 )
@@ -21,4 +23,68 @@ func TestBackoffSleep(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestBackoffAttempts(t *testing.T) {
+	t.Run("IteratesUpToMaxAttempts", func(t *testing.T) {
+		ctx := t.Context()
+		maxAttempts := 3
+
+		got := slices.Collect(backoffAttempts(ctx, maxAttempts, 1, 1))
+		if want := []int{0, 1, 2}; !slices.Equal(got, want) {
+			t.Errorf("got %v, want %v", got, want)
+		}
+	})
+
+	t.Run("StopsWhenConsumerBreaks", func(t *testing.T) {
+		ctx := t.Context()
+		maxAttempts := 3
+
+		var got []int
+		for attempt := range backoffAttempts(ctx, maxAttempts, 1, 1) {
+			got = append(got, attempt)
+			if attempt == 1 {
+				break
+			}
+		}
+		if want := []int{0, 1}; !slices.Equal(got, want) {
+			t.Errorf("got %v, want %v", got, want)
+		}
+	})
+
+	t.Run("StopsWhenContextCanceledAfterFirstAttempt", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
+		maxAttempts := 3
+
+		var got []int
+		for attempt := range backoffAttempts(ctx, maxAttempts, time.Second, time.Second) {
+			got = append(got, attempt)
+			cancel()
+		}
+		if want := []int{0}; !slices.Equal(got, want) {
+			t.Errorf("got %v, want %v", got, want)
+		}
+	})
+
+	t.Run("NoAttemptsWhenContextCanceled", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel()
+		maxAttempts := 1
+
+		got := slices.Collect(backoffAttempts(ctx, maxAttempts, 1, 1))
+		if len(got) != 0 {
+			t.Errorf("got %v, want 0", got)
+		}
+	})
+
+	t.Run("ZeroMaxAttempts", func(t *testing.T) {
+		ctx := t.Context()
+		maxAttempts := 0
+
+		got := slices.Collect(backoffAttempts(ctx, maxAttempts, 1, 1))
+		if len(got) != 0 {
+			t.Errorf("got %v, want 0", got)
+		}
+	})
 }

--- a/tools/ai/transport_test.go
+++ b/tools/ai/transport_test.go
@@ -52,7 +52,7 @@ func TestDefaultTransport(t *testing.T) {
 func TestNotSetTransportInteract(t *testing.T) {
 	transport := &notSetTransport{}
 	req := Request{Content: "test"}
-	ctx := context.Background()
+	ctx := t.Context()
 
 	resp, err := transport.Interact(ctx, req)
 	if got, want := err, ErrTransportNotSet; !errors.Is(got, want) {
@@ -66,7 +66,7 @@ func TestNotSetTransportInteract(t *testing.T) {
 func TestNotSetTransportArchive(t *testing.T) {
 	transport := &notSetTransport{}
 	turns := []Turn{{RequestContent: "test"}}
-	ctx := context.Background()
+	ctx := t.Context()
 
 	archived, err := transport.Archive(ctx, turns, "")
 	if got, want := err, ErrTransportNotSet; !errors.Is(got, want) {


### PR DESCRIPTION
- Keep transport and archive retries on Full Jitter timing by starting the attempt counter at zero
- Reuse a shared backoff iterator so exponential delays stay aligned across call sites
- Rename the `max*Retries` constants to `max*Attempts` to reflect the updated semantics inspired by https://github.com/goplus/builder/pull/2381#discussion_r2450171411