### PR TITLE
fix: keep project runner `Rerun` button responsive during loading transitions

### DIFF
--- a/spx-gui/src/components/editor/preview/EditorPreview.vue
+++ b/spx-gui/src/components/editor/preview/EditorPreview.vue
@@ -20,12 +20,12 @@
       </UIButton>
       <template v-else>
         <UIButton
-          v-if="runnerState === 'running' && !handleStop.isLoading.value"
           v-radar="{ name: 'Rerun button', desc: 'Click to rerun the project' }"
           class="button"
           type="primary"
           icon="rotate"
-          :loading="handleRerun.isLoading.value"
+          :disabled="runnerState !== 'running' || handleStop.isLoading.value"
+          :loading="handleRerun.isLoading.value && !handleStop.isLoading.value"
           @click="handleRerun.fn"
         >
           {{ $t({ en: 'Rerun', zh: '重新运行' }) }}

--- a/spx-gui/src/components/project/runner/ProjectRunnerSurface.vue
+++ b/spx-gui/src/components/project/runner/ProjectRunnerSurface.vue
@@ -431,11 +431,12 @@ defineExpose({
             {{ $t({ en: 'Run', zh: '运行' }) }}
           </UIButton>
           <UIButton
-            v-else-if="runnerState === 'running' && !stopButtonLoading"
+            v-else
             v-radar="{ name: 'Rerun button', desc: 'Click to rerun the project in overlay' }"
             class="button"
             icon="rotate"
-            :loading="rerunButtonLoading"
+            :disabled="runnerState !== 'running' || stopButtonLoading"
+            :loading="rerunButtonLoading && !stopButtonLoading"
             @click="handleRerunClick"
           >
             {{ $t({ en: 'Rerun', zh: '重新运行' }) }}

--- a/spx-gui/src/pages/community/project.vue
+++ b/spx-gui/src/pages/community/project.vue
@@ -381,12 +381,12 @@ const remixesRet = useQuery(
         </div>
         <div class="ops">
           <UIButton
-            v-if="runnerState === 'running' && !handleStop.isLoading.value"
+            v-if="runnerState !== 'initial'"
             v-radar="{ name: 'Rerun button', desc: 'Click to rerun the project' }"
             type="primary"
             icon="rotate"
-            :disabled="projectRunnerRef == null || handleStop.isLoading.value"
-            :loading="handleRerun.isLoading.value"
+            :disabled="runnerState !== 'running' || projectRunnerRef == null || handleStop.isLoading.value"
+            :loading="handleRerun.isLoading.value && !handleStop.isLoading.value"
             @click="handleRerun.fn"
           >
             {{ $t({ en: 'Rerun', zh: '重新运行' }) }}


### PR DESCRIPTION
- Keep `Rerun` button visible once the runner leaves the initial state while disabling them until it reports running again
- Clear `Rerun` loading spinners when stop begins so only one button shows progress at a time

---

https://www.figma.com/design/cdVeI1qEpKJkw7PJhewhiU/Camera?node-id=804-57418&m=dev