### PR TITLE
feat(spx-gui): improve course link UX and switch tutorial to sessionStorage

### DIFF
--- a/spx-gui/src/components/copilot/copilot.ts
+++ b/spx-gui/src/components/copilot/copilot.ts
@@ -633,6 +633,7 @@ ${parts.filter((p) => p.trim() !== '').join('\n\n')}
     this.currentSessionRef.value = null
   }
 
+  /** Open copilot, checks idle timeout and may end the current session if conditions are met */
   open() {
     this.checkIdleTimeout()
     this.activeRef.value = true

--- a/spx-gui/src/components/tutorials/tutorial.ts
+++ b/spx-gui/src/components/tutorials/tutorial.ts
@@ -3,7 +3,7 @@ import type { InjectionKey, Ref } from 'vue'
 import type { Router } from 'vue-router'
 
 import { timeout, until } from '@/utils/utils'
-import { userLocalStorageRef } from '@/utils/user-storage'
+import { userSessionStorageRef } from '@/utils/user-storage'
 import type { Copilot, Topic } from '@/components/copilot/copilot'
 import { tagName as highlightLinkTagName } from '@/components/copilot/custom-elements/HighlightLink.vue'
 import type { Course } from '@/apis/course'
@@ -45,8 +45,8 @@ export function isTutorialTopic(topic: Topic): topic is TutorialTopic {
 }
 
 export class Tutorial {
-  private course = userLocalStorageRef<Course | null>('spx-gui-tutorial-course', null)
-  private series = userLocalStorageRef<CourseSeriesWithCourses | null>('spx-gui-tutorial-series', null)
+  private course = userSessionStorageRef<Course | null>('spx-gui-tutorial-course', null)
+  private series = userSessionStorageRef<CourseSeriesWithCourses | null>('spx-gui-tutorial-series', null)
 
   constructor(
     private copilot: Copilot,

--- a/spx-gui/src/pages/tutorials/index.vue
+++ b/spx-gui/src/pages/tutorials/index.vue
@@ -25,7 +25,7 @@
                 v-for="course in courseList"
                 :key="course.id"
                 :href="`/course/${courseSeries.id}/${course.id}/start`"
-                @click.prevent="handleCourseClick(course, courseSeries, courseList)"
+                @click="handleCourseClick($event, course, courseSeries, courseList)"
               >
                 <CourseItem :course="course" />
               </a>
@@ -73,7 +73,12 @@ const courseSeriesQuery = useQuery(
   { en: 'Failed to load course series', zh: '加载课程系列失败' }
 )
 
-function handleCourseClick(course: Course, courseSeries: CourseSeries, courseList: Course[]) {
+function handleCourseClick(event: MouseEvent, course: Course, courseSeries: CourseSeries, courseList: Course[]) {
+  if (event.button !== 0 || event.ctrlKey || event.metaKey || event.shiftKey) {
+    return
+  }
+
+  event.preventDefault()
   tutorial.startCourse(course, {
     ...courseSeries,
     courses: courseList


### PR DESCRIPTION
Revise PRs #2414,  #2346

1. support course link `Ctrl/Cmd + click` to open in new tab
2. tutorial course `localStorage` to `seesionStorage`
3. add copilt `open` func comment 