### PR TITLE
refactor(spx-backend): make quota enforcement window-aware and reset-aware

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -908,10 +908,11 @@ paths:
       description: |
         Generate a message by sending a list of input messages.
 
-        #### Quota requirements
+        #### Quota limits
 
         - Each message consumes 1 quota from the authenticated user's allowance.
         - Quota limits vary based on the authenticated user's plan.
+        - When the limit is reached, the 403 response includes a `Retry-After` header with the wait time in seconds.
       requestBody:
         required: true
         content:
@@ -955,8 +956,13 @@ paths:
                     content:
                       type: text
                       text: Hello!
-        "429":
-          description: Insufficient quota to perform this operation.
+        "403":
+          description: Insufficient permissions or quota to perform this operation.
+          headers:
+            Retry-After:
+              description: Seconds to wait before retrying after hitting the limit.
+              schema:
+                type: integer
 
   /copilot/stream/message:
     post:
@@ -966,10 +972,11 @@ paths:
       description: |
         Generate a stream message by sending a list of input messages.
 
-        #### Quota requirements
+        #### Quota limits
 
         - Each message consumes 1 quota from the authenticated user's allowance.
         - Quota limits vary based on the authenticated user's plan.
+        - When the limit is reached, the 403 response includes a `Retry-After` header with the wait time in seconds.
       requestBody:
         required: true
         content:
@@ -1005,8 +1012,13 @@ paths:
           description: Stream Message successfully generated.
           content:
             application/stream:
-        "429":
-          description: Insufficient quota to perform this operation.
+        "403":
+          description: Insufficient permissions or quota to perform this operation.
+          headers:
+            Retry-After:
+              description: Seconds to wait before retrying after hitting the limit.
+              schema:
+                type: integer
 
   /workflow/stream/message:
     post:
@@ -1016,10 +1028,11 @@ paths:
       description: |
         Generate a stream message by sending a list of input messages.
 
-        #### Quota requirements
+        #### Quota limits
 
         - Each workflow execution may consume multiple quotas from the authenticated user's allowance.
         - Quota limits vary based on the authenticated user's plan.
+        - When the limit is reached, the 403 response includes a `Retry-After` header with the wait time in seconds.
       requestBody:
         required: true
         content:
@@ -1058,8 +1071,13 @@ paths:
           description: Stream Message successfully generated.
           content:
             application/stream:
-        "429":
-          description: Insufficient quota to perform this operation.
+        "403":
+          description: Insufficient permissions or quota to perform this operation.
+          headers:
+            Retry-After:
+              description: Seconds to wait before retrying after hitting the limit.
+              schema:
+                type: integer
 
   /ai/description:
     post:
@@ -1070,10 +1088,11 @@ paths:
         Generate an AI-powered descriptive summary of a game from the player's perspective based on provided game
         content (such as spx source code and project structure).
 
-        #### Quota requirements
+        #### Quota limits
 
         - Each request consumes 1 quota from the authenticated user's AI description allowance.
         - Quota limits vary based on the authenticated user's plan.
+        - When the limit is reached, the 403 response includes a `Retry-After` header with the wait time in seconds.
       requestBody:
         required: true
         content:
@@ -1087,8 +1106,13 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/AIDescriptionResponse"
-        "429":
-          description: Insufficient quota to perform this operation.
+        "403":
+          description: Insufficient permissions or quota to perform this operation.
+          headers:
+            Retry-After:
+              description: Seconds to wait before retrying after hitting the limit.
+              schema:
+                type: integer
 
   /ai/interaction/turn:
     post:
@@ -1098,10 +1122,11 @@ paths:
       description: |
         Send a message and context to the AI, receive a response including text and an optional command.
 
-        #### Quota requirements
+        #### Quota limits
 
         - Each turn consumes 1 quota from the authenticated user's AI interaction turn allowance.
         - Quota limits vary based on the authenticated user's plan.
+        - When the limit is reached, the 403 response includes a `Retry-After` header with the wait time in seconds.
       requestBody:
         required: true
         content:
@@ -1115,8 +1140,13 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/AIInteractionResponse"
-        "429":
-          description: Insufficient quota to perform this operation.
+        "403":
+          description: Insufficient permissions or quota to perform this operation.
+          headers:
+            Retry-After:
+              description: Seconds to wait before retrying after hitting the limit.
+              schema:
+                type: integer
 
   /ai/interaction/archive:
     post:
@@ -1126,10 +1156,11 @@ paths:
       description: |
         Archive a batch of interaction turns into a condensed summary for future context.
 
-        #### Quota requirements
+        #### Quota limits
 
         - Each archive request consumes 1 quota from the authenticated user's AI interaction archive allowance.
         - Quota limits vary based on the authenticated user's plan.
+        - When the limit is reached, the 403 response includes a `Retry-After` header with the wait time in seconds.
       requestBody:
         required: true
         content:
@@ -1143,8 +1174,13 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/AIInteractionArchiveResponse"
-        "429":
-          description: Insufficient quota to perform this operation.
+        "403":
+          description: Insufficient permissions or quota to perform this operation.
+          headers:
+            Retry-After:
+              description: Seconds to wait before retrying after hitting the limit.
+              schema:
+                type: integer
 
   /course:
     post:
@@ -1682,7 +1718,7 @@ components:
           $ref: "#/components/schemas/UserCapabilities"
           nullable: true
           description: |
-            Capabilities and quotas of the user.
+            Capabilities of the user.
 
             **This field is only present for the authenticated user's own profile.**
 
@@ -1704,62 +1740,6 @@ components:
           description: Whether user can access premium LLM models.
           examples:
             - true
-        copilotMessageQuota:
-          type: integer
-          format: int64
-          minimum: 0
-          description: Total quota for Copilot messages.
-          examples:
-            - 1000
-        copilotMessageQuotaLeft:
-          type: integer
-          format: int64
-          minimum: 0
-          description: Remaining quota for Copilot messages.
-          examples:
-            - 789
-        aiDescriptionQuota:
-          type: integer
-          format: int64
-          minimum: 0
-          description: Total quota for AI description generations.
-          examples:
-            - 300
-        aiDescriptionQuotaLeft:
-          type: integer
-          format: int64
-          minimum: 0
-          description: Remaining quota for AI description generations.
-          examples:
-            - 295
-        aiInteractionTurnQuota:
-          type: integer
-          format: int64
-          minimum: 0
-          description: Total quota for AI interaction turns.
-          examples:
-            - 12000
-        aiInteractionTurnQuotaLeft:
-          type: integer
-          format: int64
-          minimum: 0
-          description: Remaining quota for AI interaction turns.
-          examples:
-            - 11900
-        aiInteractionArchiveQuota:
-          type: integer
-          format: int64
-          minimum: 0
-          description: Total quota for AI interaction archive requests.
-          examples:
-            - 8000
-        aiInteractionArchiveQuotaLeft:
-          type: integer
-          format: int64
-          minimum: 0
-          description: Remaining quota for AI interaction archive requests.
-          examples:
-            - 7980
 
     Project:
       type: object

--- a/spx-backend/cmd/spx-backend/post_ai_description.yap
+++ b/spx-backend/cmd/spx-backend/post_ai_description.yap
@@ -13,7 +13,11 @@ if _, ok := ensureAuthenticatedUser(ctx); !ok {
 	return
 }
 
-if !ensureQuotaLeft(ctx, authz.ResourceAIDescription) {
+const (
+	quotaResource = authz.ResourceAIDescription
+	quotaAmount   = 1
+)
+if !ensureQuotaRemaining(ctx, quotaResource, quotaAmount) {
 	return
 }
 
@@ -32,5 +36,6 @@ if err != nil {
 	return
 }
 
-consumeQuota(ctx, authz.ResourceAIDescription, 1)
+consumeQuota(ctx, quotaResource, quotaAmount)
+
 json result

--- a/spx-backend/cmd/spx-backend/post_ai_interaction_archive.yap
+++ b/spx-backend/cmd/spx-backend/post_ai_interaction_archive.yap
@@ -13,7 +13,11 @@ if _, ok := ensureAuthenticatedUser(ctx); !ok {
 	return
 }
 
-if !ensureQuotaLeft(ctx, authz.ResourceAIInteractionArchive) {
+const (
+	quotaResource = authz.ResourceAIInteractionArchive
+	quotaAmount   = 1
+)
+if !ensureQuotaRemaining(ctx, quotaResource, quotaAmount) {
 	return
 }
 
@@ -32,5 +36,6 @@ if err != nil {
 	return
 }
 
-consumeQuota(ctx, authz.ResourceAIInteractionArchive, 1)
+consumeQuota(ctx, quotaResource, quotaAmount)
+
 json result

--- a/spx-backend/cmd/spx-backend/post_ai_interaction_turn.yap
+++ b/spx-backend/cmd/spx-backend/post_ai_interaction_turn.yap
@@ -13,7 +13,11 @@ if _, ok := ensureAuthenticatedUser(ctx); !ok {
 	return
 }
 
-if !ensureQuotaLeft(ctx, authz.ResourceAIInteractionTurn) {
+const (
+	quotaResource = authz.ResourceAIInteractionTurn
+	quotaAmount   = 1
+)
+if !ensureQuotaRemaining(ctx, quotaResource, quotaAmount) {
 	return
 }
 
@@ -32,5 +36,6 @@ if err != nil {
 	return
 }
 
-consumeQuota(ctx, authz.ResourceAIInteractionTurn, 1)
+consumeQuota(ctx, quotaResource, quotaAmount)
+
 json result

--- a/spx-backend/cmd/spx-backend/post_copilot_message.yap
+++ b/spx-backend/cmd/spx-backend/post_copilot_message.yap
@@ -13,8 +13,11 @@ if _, ok := ensureAuthenticatedUser(ctx); !ok {
 	return
 }
 
-// Check remaining quota.
-if !ensureQuotaLeft(ctx, authz.ResourceCopilotMessage) {
+const (
+	quotaResource = authz.ResourceCopilotMessage
+	quotaAmount   = 1
+)
+if !ensureQuotaRemaining(ctx, quotaResource, quotaAmount) {
 	return
 }
 
@@ -34,7 +37,6 @@ if err != nil {
 	return
 }
 
-// Consume quota after successful generation.
-consumeQuota(ctx, authz.ResourceCopilotMessage, 1)
+consumeQuota(ctx, quotaResource, quotaAmount)
 
 json result

--- a/spx-backend/cmd/spx-backend/post_copilot_stream_message.yap
+++ b/spx-backend/cmd/spx-backend/post_copilot_stream_message.yap
@@ -13,8 +13,11 @@ if _, ok := ensureAuthenticatedUser(ctx); !ok {
 	return
 }
 
-// Check remaining quota.
-if !ensureQuotaLeft(ctx, authz.ResourceCopilotMessage) {
+const (
+	quotaResource = authz.ResourceCopilotMessage
+	quotaAmount   = 1
+)
+if !ensureQuotaRemaining(ctx, quotaResource, quotaAmount) {
 	return
 }
 
@@ -33,11 +36,9 @@ if err != nil {
 	replyWithInnerError(ctx, err)
 	return
 }
-
-// Consume quota after successful stream initiation.
-consumeQuota(ctx, authz.ResourceCopilotMessage, 1)
-
 defer read.Close()
+
+consumeQuota(ctx, quotaResource, quotaAmount)
 
 buf := make([]byte, 4096)
 stream read, buf

--- a/spx-backend/cmd/spx-backend/post_workflow_stream_message.yap
+++ b/spx-backend/cmd/spx-backend/post_workflow_stream_message.yap
@@ -13,8 +13,11 @@ if _, ok := ensureAuthenticatedUser(ctx); !ok {
 	return
 }
 
-// Check remaining quota (workflow uses copilot quota).
-if !ensureQuotaLeft(ctx, authz.ResourceCopilotMessage) {
+const (
+	quotaResource = authz.ResourceCopilotMessage
+	quotaAmount   = 1
+)
+if !ensureQuotaRemaining(ctx, quotaResource, quotaAmount) {
 	return
 }
 
@@ -33,11 +36,9 @@ if err != nil {
 	replyWithInnerError(ctx, err)
 	return
 }
-
-// Consume quota after successful workflow initiation.
-consumeQuota(ctx, authz.ResourceCopilotMessage, 1)
-
 defer read.Close()
+
+consumeQuota(ctx, quotaResource, quotaAmount)
 
 buf := make([]byte, 4096)
 stream read, buf

--- a/spx-backend/cmd/spx-backend/util.go
+++ b/spx-backend/cmd/spx-backend/util.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"strconv"
 
 	"github.com/goplus/builder/spx-backend/internal/authn"
 	"github.com/goplus/builder/spx-backend/internal/authz"
@@ -80,28 +81,23 @@ func replyWithInnerError(ctx *yap.Context, err error) {
 	}
 }
 
-// ensureQuotaLeft checks the remaining quota and replies with a 429 error if exhausted.
-func ensureQuotaLeft(ctx *yap.Context, resource authz.Resource) bool {
+// ensureQuotaRemaining checks the remaining quota for the given amount and
+// replies with a 403 error if exceeded.
+func ensureQuotaRemaining(ctx *yap.Context, resource authz.Resource, amount int64) bool {
 	caps, ok := authz.UserCapabilitiesFromContext(ctx.Context())
 	if !ok {
 		return true
 	}
 
-	var quotaLeft int64
-	switch resource {
-	case authz.ResourceCopilotMessage:
-		quotaLeft = caps.CopilotMessageQuotaLeft
-	case authz.ResourceAIDescription:
-		quotaLeft = caps.AIDescriptionQuotaLeft
-	case authz.ResourceAIInteractionTurn:
-		quotaLeft = caps.AIInteractionTurnQuotaLeft
-	case authz.ResourceAIInteractionArchive:
-		quotaLeft = caps.AIInteractionArchiveQuotaLeft
-	default:
+	quota, ok := caps.Quota(resource)
+	if !ok {
 		return true
 	}
-	if quotaLeft <= 0 {
-		replyWithCodeMsg(ctx, errorTooManyRequests, fmt.Sprintf("%s quota exceeded", resource))
+	if quota.Remaining < amount {
+		if reset := quota.Reset(); reset > 0 {
+			ctx.ResponseWriter.Header().Set("Retry-After", strconv.FormatInt(reset, 10))
+		}
+		replyWithCodeMsg(ctx, errorQuotaExceeded, fmt.Sprintf("%s quota exceeded", resource))
 		return false
 	}
 	return true
@@ -131,6 +127,7 @@ const (
 	errorInvalidArgs     errorCode = 40001
 	errorUnauthorized    errorCode = 40100
 	errorForbidden       errorCode = 40300
+	errorQuotaExceeded   errorCode = 40301
 	errorNotFound        errorCode = 40400
 	errorTooManyRequests errorCode = 42900
 	errorUnknown         errorCode = 50000
@@ -141,6 +138,7 @@ var errorMsgs = map[errorCode]string{
 	errorInvalidArgs:     "Invalid args",
 	errorUnauthorized:    "Unauthorized",
 	errorForbidden:       "Forbidden",
+	errorQuotaExceeded:   "Quota exceeded",
 	errorNotFound:        "Not found",
 	errorTooManyRequests: "Too many requests",
 	errorUnknown:         "Internal error",

--- a/spx-backend/cmd/spx-backend/xgo_autogen.go
+++ b/spx-backend/cmd/spx-backend/xgo_autogen.go
@@ -1491,38 +1491,43 @@ func (this *post_ai_description) Main(_xgo_arg0 *yap.Context) {
 		return
 	}
 //line cmd/spx-backend/post_ai_description.yap:16:1
-	if !ensureQuotaLeft(ctx, authz.ResourceAIDescription) {
-//line cmd/spx-backend/post_ai_description.yap:17:1
-		return
-	}
+	const (
+		quotaResource = authz.ResourceAIDescription
+		quotaAmount   = 1
+	)
 //line cmd/spx-backend/post_ai_description.yap:20:1
-	params := &controller.AIDescriptionParams{}
+	if !ensureQuotaRemaining(ctx, quotaResource, quotaAmount) {
 //line cmd/spx-backend/post_ai_description.yap:21:1
-	if !parseJSON(ctx, params) {
-//line cmd/spx-backend/post_ai_description.yap:22:1
 		return
 	}
 //line cmd/spx-backend/post_ai_description.yap:24:1
-	if
-//line cmd/spx-backend/post_ai_description.yap:24:1
-	ok, msg := params.Validate(); !ok {
+	params := &controller.AIDescriptionParams{}
 //line cmd/spx-backend/post_ai_description.yap:25:1
-		replyWithCodeMsg(ctx, errorInvalidArgs, msg)
+	if !parseJSON(ctx, params) {
 //line cmd/spx-backend/post_ai_description.yap:26:1
 		return
 	}
+//line cmd/spx-backend/post_ai_description.yap:28:1
+	if
+//line cmd/spx-backend/post_ai_description.yap:28:1
+	ok, msg := params.Validate(); !ok {
 //line cmd/spx-backend/post_ai_description.yap:29:1
-	result, err := this.ctrl.GenerateAIDescription(ctx.Context(), params)
+		replyWithCodeMsg(ctx, errorInvalidArgs, msg)
 //line cmd/spx-backend/post_ai_description.yap:30:1
-	if err != nil {
-//line cmd/spx-backend/post_ai_description.yap:31:1
-		replyWithInnerError(ctx, err)
-//line cmd/spx-backend/post_ai_description.yap:32:1
 		return
 	}
+//line cmd/spx-backend/post_ai_description.yap:33:1
+	result, err := this.ctrl.GenerateAIDescription(ctx.Context(), params)
+//line cmd/spx-backend/post_ai_description.yap:34:1
+	if err != nil {
 //line cmd/spx-backend/post_ai_description.yap:35:1
-	consumeQuota(ctx, authz.ResourceAIDescription, 1)
+		replyWithInnerError(ctx, err)
 //line cmd/spx-backend/post_ai_description.yap:36:1
+		return
+	}
+//line cmd/spx-backend/post_ai_description.yap:39:1
+	consumeQuota(ctx, quotaResource, quotaAmount)
+//line cmd/spx-backend/post_ai_description.yap:41:1
 	this.Json__1(result)
 }
 func (this *post_ai_description) Classfname() string {
@@ -1545,38 +1550,43 @@ func (this *post_ai_interaction_archive) Main(_xgo_arg0 *yap.Context) {
 		return
 	}
 //line cmd/spx-backend/post_ai_interaction_archive.yap:16:1
-	if !ensureQuotaLeft(ctx, authz.ResourceAIInteractionArchive) {
-//line cmd/spx-backend/post_ai_interaction_archive.yap:17:1
-		return
-	}
+	const (
+		quotaResource = authz.ResourceAIInteractionArchive
+		quotaAmount   = 1
+	)
 //line cmd/spx-backend/post_ai_interaction_archive.yap:20:1
-	params := &controller.AIInteractionArchiveParams{}
+	if !ensureQuotaRemaining(ctx, quotaResource, quotaAmount) {
 //line cmd/spx-backend/post_ai_interaction_archive.yap:21:1
-	if !parseJSON(ctx, params) {
-//line cmd/spx-backend/post_ai_interaction_archive.yap:22:1
 		return
 	}
 //line cmd/spx-backend/post_ai_interaction_archive.yap:24:1
-	if
-//line cmd/spx-backend/post_ai_interaction_archive.yap:24:1
-	ok, msg := params.Validate(); !ok {
+	params := &controller.AIInteractionArchiveParams{}
 //line cmd/spx-backend/post_ai_interaction_archive.yap:25:1
-		replyWithCodeMsg(ctx, errorInvalidArgs, msg)
+	if !parseJSON(ctx, params) {
 //line cmd/spx-backend/post_ai_interaction_archive.yap:26:1
 		return
 	}
+//line cmd/spx-backend/post_ai_interaction_archive.yap:28:1
+	if
+//line cmd/spx-backend/post_ai_interaction_archive.yap:28:1
+	ok, msg := params.Validate(); !ok {
 //line cmd/spx-backend/post_ai_interaction_archive.yap:29:1
-	result, err := this.ctrl.PerformAIInteractionArchive(ctx.Context(), params)
+		replyWithCodeMsg(ctx, errorInvalidArgs, msg)
 //line cmd/spx-backend/post_ai_interaction_archive.yap:30:1
-	if err != nil {
-//line cmd/spx-backend/post_ai_interaction_archive.yap:31:1
-		replyWithInnerError(ctx, err)
-//line cmd/spx-backend/post_ai_interaction_archive.yap:32:1
 		return
 	}
+//line cmd/spx-backend/post_ai_interaction_archive.yap:33:1
+	result, err := this.ctrl.PerformAIInteractionArchive(ctx.Context(), params)
+//line cmd/spx-backend/post_ai_interaction_archive.yap:34:1
+	if err != nil {
 //line cmd/spx-backend/post_ai_interaction_archive.yap:35:1
-	consumeQuota(ctx, authz.ResourceAIInteractionArchive, 1)
+		replyWithInnerError(ctx, err)
 //line cmd/spx-backend/post_ai_interaction_archive.yap:36:1
+		return
+	}
+//line cmd/spx-backend/post_ai_interaction_archive.yap:39:1
+	consumeQuota(ctx, quotaResource, quotaAmount)
+//line cmd/spx-backend/post_ai_interaction_archive.yap:41:1
 	this.Json__1(result)
 }
 func (this *post_ai_interaction_archive) Classfname() string {
@@ -1599,38 +1609,43 @@ func (this *post_ai_interaction_turn) Main(_xgo_arg0 *yap.Context) {
 		return
 	}
 //line cmd/spx-backend/post_ai_interaction_turn.yap:16:1
-	if !ensureQuotaLeft(ctx, authz.ResourceAIInteractionTurn) {
-//line cmd/spx-backend/post_ai_interaction_turn.yap:17:1
-		return
-	}
+	const (
+		quotaResource = authz.ResourceAIInteractionTurn
+		quotaAmount   = 1
+	)
 //line cmd/spx-backend/post_ai_interaction_turn.yap:20:1
-	params := &controller.AIInteractionTurnParams{}
+	if !ensureQuotaRemaining(ctx, quotaResource, quotaAmount) {
 //line cmd/spx-backend/post_ai_interaction_turn.yap:21:1
-	if !parseJSON(ctx, params) {
-//line cmd/spx-backend/post_ai_interaction_turn.yap:22:1
 		return
 	}
 //line cmd/spx-backend/post_ai_interaction_turn.yap:24:1
-	if
-//line cmd/spx-backend/post_ai_interaction_turn.yap:24:1
-	ok, msg := params.Validate(); !ok {
+	params := &controller.AIInteractionTurnParams{}
 //line cmd/spx-backend/post_ai_interaction_turn.yap:25:1
-		replyWithCodeMsg(ctx, errorInvalidArgs, msg)
+	if !parseJSON(ctx, params) {
 //line cmd/spx-backend/post_ai_interaction_turn.yap:26:1
 		return
 	}
+//line cmd/spx-backend/post_ai_interaction_turn.yap:28:1
+	if
+//line cmd/spx-backend/post_ai_interaction_turn.yap:28:1
+	ok, msg := params.Validate(); !ok {
 //line cmd/spx-backend/post_ai_interaction_turn.yap:29:1
-	result, err := this.ctrl.PerformAIInteractionTurn(ctx.Context(), params)
+		replyWithCodeMsg(ctx, errorInvalidArgs, msg)
 //line cmd/spx-backend/post_ai_interaction_turn.yap:30:1
-	if err != nil {
-//line cmd/spx-backend/post_ai_interaction_turn.yap:31:1
-		replyWithInnerError(ctx, err)
-//line cmd/spx-backend/post_ai_interaction_turn.yap:32:1
 		return
 	}
+//line cmd/spx-backend/post_ai_interaction_turn.yap:33:1
+	result, err := this.ctrl.PerformAIInteractionTurn(ctx.Context(), params)
+//line cmd/spx-backend/post_ai_interaction_turn.yap:34:1
+	if err != nil {
 //line cmd/spx-backend/post_ai_interaction_turn.yap:35:1
-	consumeQuota(ctx, authz.ResourceAIInteractionTurn, 1)
+		replyWithInnerError(ctx, err)
 //line cmd/spx-backend/post_ai_interaction_turn.yap:36:1
+		return
+	}
+//line cmd/spx-backend/post_ai_interaction_turn.yap:39:1
+	consumeQuota(ctx, quotaResource, quotaAmount)
+//line cmd/spx-backend/post_ai_interaction_turn.yap:41:1
 	this.Json__1(result)
 }
 func (this *post_ai_interaction_turn) Classfname() string {
@@ -1756,41 +1771,46 @@ func (this *post_copilot_message) Main(_xgo_arg0 *yap.Context) {
 //line cmd/spx-backend/post_copilot_message.yap:13:1
 		return
 	}
-//line cmd/spx-backend/post_copilot_message.yap:17:1
-	if !ensureQuotaLeft(ctx, authz.ResourceCopilotMessage) {
-//line cmd/spx-backend/post_copilot_message.yap:18:1
-		return
-	}
+//line cmd/spx-backend/post_copilot_message.yap:16:1
+	const (
+		quotaResource = authz.ResourceCopilotMessage
+		quotaAmount   = 1
+	)
+//line cmd/spx-backend/post_copilot_message.yap:20:1
+	if !ensureQuotaRemaining(ctx, quotaResource, quotaAmount) {
 //line cmd/spx-backend/post_copilot_message.yap:21:1
+		return
+	}
+//line cmd/spx-backend/post_copilot_message.yap:24:1
 	params := &controller.GenerateMessageParams{}
-//line cmd/spx-backend/post_copilot_message.yap:22:1
+//line cmd/spx-backend/post_copilot_message.yap:25:1
 	if !parseJSON(ctx, params) {
-//line cmd/spx-backend/post_copilot_message.yap:23:1
-		return
-	}
-//line cmd/spx-backend/post_copilot_message.yap:25:1
-	if
-//line cmd/spx-backend/post_copilot_message.yap:25:1
-	ok, msg := params.Validate(); !ok {
 //line cmd/spx-backend/post_copilot_message.yap:26:1
+		return
+	}
+//line cmd/spx-backend/post_copilot_message.yap:28:1
+	if
+//line cmd/spx-backend/post_copilot_message.yap:28:1
+	ok, msg := params.Validate(); !ok {
+//line cmd/spx-backend/post_copilot_message.yap:29:1
 		replyWithCodeMsg(ctx, errorInvalidArgs, msg)
-//line cmd/spx-backend/post_copilot_message.yap:27:1
-		return
-	}
 //line cmd/spx-backend/post_copilot_message.yap:30:1
-	canUsePremium := authz.CanUsePremiumLLM(ctx.Context())
-//line cmd/spx-backend/post_copilot_message.yap:31:1
-	result, err := this.ctrl.GenerateMessage(ctx.Context(), params, canUsePremium)
-//line cmd/spx-backend/post_copilot_message.yap:32:1
-	if err != nil {
-//line cmd/spx-backend/post_copilot_message.yap:33:1
-		replyWithInnerError(ctx, err)
-//line cmd/spx-backend/post_copilot_message.yap:34:1
 		return
 	}
-//line cmd/spx-backend/post_copilot_message.yap:38:1
-	consumeQuota(ctx, authz.ResourceCopilotMessage, 1)
+//line cmd/spx-backend/post_copilot_message.yap:33:1
+	canUsePremium := authz.CanUsePremiumLLM(ctx.Context())
+//line cmd/spx-backend/post_copilot_message.yap:34:1
+	result, err := this.ctrl.GenerateMessage(ctx.Context(), params, canUsePremium)
+//line cmd/spx-backend/post_copilot_message.yap:35:1
+	if err != nil {
+//line cmd/spx-backend/post_copilot_message.yap:36:1
+		replyWithInnerError(ctx, err)
+//line cmd/spx-backend/post_copilot_message.yap:37:1
+		return
+	}
 //line cmd/spx-backend/post_copilot_message.yap:40:1
+	consumeQuota(ctx, quotaResource, quotaAmount)
+//line cmd/spx-backend/post_copilot_message.yap:42:1
 	this.Json__1(result)
 }
 func (this *post_copilot_message) Classfname() string {
@@ -1812,45 +1832,50 @@ func (this *post_copilot_stream_message) Main(_xgo_arg0 *yap.Context) {
 //line cmd/spx-backend/post_copilot_stream_message.yap:13:1
 		return
 	}
-//line cmd/spx-backend/post_copilot_stream_message.yap:17:1
-	if !ensureQuotaLeft(ctx, authz.ResourceCopilotMessage) {
-//line cmd/spx-backend/post_copilot_stream_message.yap:18:1
-		return
-	}
+//line cmd/spx-backend/post_copilot_stream_message.yap:16:1
+	const (
+		quotaResource = authz.ResourceCopilotMessage
+		quotaAmount   = 1
+	)
+//line cmd/spx-backend/post_copilot_stream_message.yap:20:1
+	if !ensureQuotaRemaining(ctx, quotaResource, quotaAmount) {
 //line cmd/spx-backend/post_copilot_stream_message.yap:21:1
+		return
+	}
+//line cmd/spx-backend/post_copilot_stream_message.yap:24:1
 	params := &controller.GenerateMessageParams{}
-//line cmd/spx-backend/post_copilot_stream_message.yap:22:1
+//line cmd/spx-backend/post_copilot_stream_message.yap:25:1
 	if !parseJSON(ctx, params) {
-//line cmd/spx-backend/post_copilot_stream_message.yap:23:1
-		return
-	}
-//line cmd/spx-backend/post_copilot_stream_message.yap:25:1
-	if
-//line cmd/spx-backend/post_copilot_stream_message.yap:25:1
-	ok, msg := params.Validate(); !ok {
 //line cmd/spx-backend/post_copilot_stream_message.yap:26:1
+		return
+	}
+//line cmd/spx-backend/post_copilot_stream_message.yap:28:1
+	if
+//line cmd/spx-backend/post_copilot_stream_message.yap:28:1
+	ok, msg := params.Validate(); !ok {
+//line cmd/spx-backend/post_copilot_stream_message.yap:29:1
 		replyWithCodeMsg(ctx, errorInvalidArgs, msg)
-//line cmd/spx-backend/post_copilot_stream_message.yap:27:1
-		return
-	}
 //line cmd/spx-backend/post_copilot_stream_message.yap:30:1
-	canUsePremium := authz.CanUsePremiumLLM(ctx.Context())
-//line cmd/spx-backend/post_copilot_stream_message.yap:31:1
-	read, err := this.ctrl.GenerateMessageStream(ctx.Context(), params, canUsePremium)
-//line cmd/spx-backend/post_copilot_stream_message.yap:32:1
-	if err != nil {
-//line cmd/spx-backend/post_copilot_stream_message.yap:33:1
-		replyWithInnerError(ctx, err)
-//line cmd/spx-backend/post_copilot_stream_message.yap:34:1
 		return
 	}
-//line cmd/spx-backend/post_copilot_stream_message.yap:38:1
-	consumeQuota(ctx, authz.ResourceCopilotMessage, 1)
-//line cmd/spx-backend/post_copilot_stream_message.yap:40:1
+//line cmd/spx-backend/post_copilot_stream_message.yap:33:1
+	canUsePremium := authz.CanUsePremiumLLM(ctx.Context())
+//line cmd/spx-backend/post_copilot_stream_message.yap:34:1
+	read, err := this.ctrl.GenerateMessageStream(ctx.Context(), params, canUsePremium)
+//line cmd/spx-backend/post_copilot_stream_message.yap:35:1
+	if err != nil {
+//line cmd/spx-backend/post_copilot_stream_message.yap:36:1
+		replyWithInnerError(ctx, err)
+//line cmd/spx-backend/post_copilot_stream_message.yap:37:1
+		return
+	}
+//line cmd/spx-backend/post_copilot_stream_message.yap:39:1
 	defer read.Close()
-//line cmd/spx-backend/post_copilot_stream_message.yap:42:1
-	buf := make([]byte, 4096)
+//line cmd/spx-backend/post_copilot_stream_message.yap:41:1
+	consumeQuota(ctx, quotaResource, quotaAmount)
 //line cmd/spx-backend/post_copilot_stream_message.yap:43:1
+	buf := make([]byte, 4096)
+//line cmd/spx-backend/post_copilot_stream_message.yap:44:1
 	this.Stream__2(read, buf)
 }
 func (this *post_copilot_stream_message) Classfname() string {
@@ -2211,45 +2236,50 @@ func (this *post_workflow_stream_message) Main(_xgo_arg0 *yap.Context) {
 //line cmd/spx-backend/post_workflow_stream_message.yap:13:1
 		return
 	}
-//line cmd/spx-backend/post_workflow_stream_message.yap:17:1
-	if !ensureQuotaLeft(ctx, authz.ResourceCopilotMessage) {
-//line cmd/spx-backend/post_workflow_stream_message.yap:18:1
-		return
-	}
+//line cmd/spx-backend/post_workflow_stream_message.yap:16:1
+	const (
+		quotaResource = authz.ResourceCopilotMessage
+		quotaAmount   = 1
+	)
+//line cmd/spx-backend/post_workflow_stream_message.yap:20:1
+	if !ensureQuotaRemaining(ctx, quotaResource, quotaAmount) {
 //line cmd/spx-backend/post_workflow_stream_message.yap:21:1
+		return
+	}
+//line cmd/spx-backend/post_workflow_stream_message.yap:24:1
 	params := &controller.WorkflowMessageParams{}
-//line cmd/spx-backend/post_workflow_stream_message.yap:22:1
+//line cmd/spx-backend/post_workflow_stream_message.yap:25:1
 	if !parseJSON(ctx, params) {
-//line cmd/spx-backend/post_workflow_stream_message.yap:23:1
-		return
-	}
-//line cmd/spx-backend/post_workflow_stream_message.yap:25:1
-	if
-//line cmd/spx-backend/post_workflow_stream_message.yap:25:1
-	ok, msg := params.Validate(); !ok {
 //line cmd/spx-backend/post_workflow_stream_message.yap:26:1
+		return
+	}
+//line cmd/spx-backend/post_workflow_stream_message.yap:28:1
+	if
+//line cmd/spx-backend/post_workflow_stream_message.yap:28:1
+	ok, msg := params.Validate(); !ok {
+//line cmd/spx-backend/post_workflow_stream_message.yap:29:1
 		replyWithCodeMsg(ctx, errorInvalidArgs, msg)
-//line cmd/spx-backend/post_workflow_stream_message.yap:27:1
-		return
-	}
 //line cmd/spx-backend/post_workflow_stream_message.yap:30:1
-	canUsePremium := authz.CanUsePremiumLLM(ctx.Context())
-//line cmd/spx-backend/post_workflow_stream_message.yap:31:1
-	read, err := this.ctrl.WorkflowMessageStream(ctx.Context(), params, canUsePremium)
-//line cmd/spx-backend/post_workflow_stream_message.yap:32:1
-	if err != nil {
-//line cmd/spx-backend/post_workflow_stream_message.yap:33:1
-		replyWithInnerError(ctx, err)
-//line cmd/spx-backend/post_workflow_stream_message.yap:34:1
 		return
 	}
-//line cmd/spx-backend/post_workflow_stream_message.yap:38:1
-	consumeQuota(ctx, authz.ResourceCopilotMessage, 1)
-//line cmd/spx-backend/post_workflow_stream_message.yap:40:1
+//line cmd/spx-backend/post_workflow_stream_message.yap:33:1
+	canUsePremium := authz.CanUsePremiumLLM(ctx.Context())
+//line cmd/spx-backend/post_workflow_stream_message.yap:34:1
+	read, err := this.ctrl.WorkflowMessageStream(ctx.Context(), params, canUsePremium)
+//line cmd/spx-backend/post_workflow_stream_message.yap:35:1
+	if err != nil {
+//line cmd/spx-backend/post_workflow_stream_message.yap:36:1
+		replyWithInnerError(ctx, err)
+//line cmd/spx-backend/post_workflow_stream_message.yap:37:1
+		return
+	}
+//line cmd/spx-backend/post_workflow_stream_message.yap:39:1
 	defer read.Close()
-//line cmd/spx-backend/post_workflow_stream_message.yap:42:1
-	buf := make([]byte, 4096)
+//line cmd/spx-backend/post_workflow_stream_message.yap:41:1
+	consumeQuota(ctx, quotaResource, quotaAmount)
 //line cmd/spx-backend/post_workflow_stream_message.yap:43:1
+	buf := make([]byte, 4096)
+//line cmd/spx-backend/post_workflow_stream_message.yap:44:1
 	this.Stream__2(read, buf)
 }
 func (this *post_workflow_stream_message) Classfname() string {

--- a/spx-backend/internal/authz/authz_test.go
+++ b/spx-backend/internal/authz/authz_test.go
@@ -74,17 +74,30 @@ func TestAuthorizerMiddleware(t *testing.T) {
 	})
 
 	t.Run("ValidUser", func(t *testing.T) {
+		const quotaWindow = 24 * 60 * 60
 		wantCaps := UserCapabilities{
-			CanManageAssets:               true,
-			CanUsePremiumLLM:              true,
-			CopilotMessageQuota:           1000,
-			CopilotMessageQuotaLeft:       900,
-			AIDescriptionQuota:            1000,
-			AIDescriptionQuotaLeft:        850,
-			AIInteractionTurnQuota:        24000,
-			AIInteractionTurnQuotaLeft:    23500,
-			AIInteractionArchiveQuota:     16000,
-			AIInteractionArchiveQuotaLeft: 15500,
+			CanManageAssets:  true,
+			CanUsePremiumLLM: true,
+			CopilotMessageQuota: Quota{
+				Limit:     1000,
+				Remaining: 900,
+				Window:    quotaWindow,
+			},
+			AIDescriptionQuota: Quota{
+				Limit:     1000,
+				Remaining: 850,
+				Window:    quotaWindow,
+			},
+			AIInteractionTurnQuota: Quota{
+				Limit:     24000,
+				Remaining: 23500,
+				Window:    quotaWindow,
+			},
+			AIInteractionArchiveQuota: Quota{
+				Limit:     16000,
+				Remaining: 15500,
+				Window:    quotaWindow,
+			},
 		}
 
 		pdp := &mockPolicyDecisionPoint{}

--- a/spx-backend/internal/authz/context_test.go
+++ b/spx-backend/internal/authz/context_test.go
@@ -16,17 +16,30 @@ func newTestAuthorizer() *Authorizer {
 }
 
 func newTestUserCapabilities() UserCapabilities {
+	const quotaWindow = 24 * 60 * 60
 	return UserCapabilities{
-		CanManageAssets:               true,
-		CanUsePremiumLLM:              false,
-		CopilotMessageQuota:           100,
-		CopilotMessageQuotaLeft:       85,
-		AIDescriptionQuota:            300,
-		AIDescriptionQuotaLeft:        290,
-		AIInteractionTurnQuota:        12000,
-		AIInteractionTurnQuotaLeft:    11700,
-		AIInteractionArchiveQuota:     8000,
-		AIInteractionArchiveQuotaLeft: 7600,
+		CanManageAssets:  true,
+		CanUsePremiumLLM: false,
+		CopilotMessageQuota: Quota{
+			Limit:     100,
+			Remaining: 85,
+			Window:    quotaWindow,
+		},
+		AIDescriptionQuota: Quota{
+			Limit:     300,
+			Remaining: 290,
+			Window:    quotaWindow,
+		},
+		AIInteractionTurnQuota: Quota{
+			Limit:     12000,
+			Remaining: 11700,
+			Window:    quotaWindow,
+		},
+		AIInteractionArchiveQuota: Quota{
+			Limit:     8000,
+			Remaining: 7600,
+			Window:    quotaWindow,
+		},
 	}
 }
 

--- a/spx-backend/internal/authz/embpdp/embpdp_test.go
+++ b/spx-backend/internal/authz/embpdp/embpdp_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/goplus/builder/spx-backend/internal/authz"
 	"github.com/goplus/builder/spx-backend/internal/model"
@@ -12,27 +13,32 @@ import (
 )
 
 type mockQuotaTracker struct {
-	usage map[string]int64
+	usage map[string]authz.QuotaUsage
 }
 
 func newMockQuotaTracker() *mockQuotaTracker {
-	return &mockQuotaTracker{usage: make(map[string]int64)}
+	return &mockQuotaTracker{usage: make(map[string]authz.QuotaUsage)}
 }
 
-func (m *mockQuotaTracker) Usage(ctx context.Context, userID int64, resource authz.Resource) (int64, error) {
+func (m *mockQuotaTracker) Usage(ctx context.Context, userID int64, resource authz.Resource) (authz.QuotaUsage, error) {
 	key := fmt.Sprintf("%d:%s", userID, resource)
 	return m.usage[key], nil
 }
 
-func (m *mockQuotaTracker) IncrementUsage(ctx context.Context, userID int64, resource authz.Resource, amount int64) error {
+func (m *mockQuotaTracker) IncrementUsage(ctx context.Context, userID int64, resource authz.Resource, amount int64, policy authz.QuotaPolicy) error {
 	key := fmt.Sprintf("%d:%s", userID, resource)
-	m.usage[key] += amount
+	entry := m.usage[key]
+	entry.Used += amount
+	if policy.Window > 0 {
+		entry.ResetTime = time.Now().Add(policy.Window)
+	}
+	m.usage[key] = entry
 	return nil
 }
 
 func (m *mockQuotaTracker) ResetUsage(ctx context.Context, userID int64, resource authz.Resource) error {
 	key := fmt.Sprintf("%d:%s", userID, resource)
-	m.usage[key] = 0
+	m.usage[key] = authz.QuotaUsage{}
 	return nil
 }
 
@@ -46,15 +52,19 @@ func TestNew(t *testing.T) {
 func TestEmbeddedPDPComputeUserCapabilities(t *testing.T) {
 	t.Run("Basic", func(t *testing.T) {
 		for _, tt := range []struct {
-			name                          string
-			mUser                         *model.User
-			wantCanManageAssets           bool
-			wantCanManageCourses          bool
-			wantCanUsePremiumLLM          bool
-			wantCopilotMessageQuota       int64
-			wantAIDescriptionQuota        int64
-			wantAIInteractionTurnQuota    int64
-			wantAIInteractionArchiveQuota int64
+			name                                string
+			mUser                               *model.User
+			wantCanManageAssets                 bool
+			wantCanManageCourses                bool
+			wantCanUsePremiumLLM                bool
+			wantCopilotMessageQuotaLimit        int64
+			wantCopilotMessageQuotaWindow       int64
+			wantAIDescriptionQuotaLimit         int64
+			wantAIDescriptionQuotaWindow        int64
+			wantAIInteractionTurnQuotaLimit     int64
+			wantAIInteractionTurnQuotaWindow    int64
+			wantAIInteractionArchiveQuotaLimit  int64
+			wantAIInteractionArchiveQuotaWindow int64
 		}{
 			{
 				name: "AssetAdminWithPlusPlan",
@@ -64,13 +74,17 @@ func TestEmbeddedPDPComputeUserCapabilities(t *testing.T) {
 					Roles:    model.UserRoles{"assetAdmin"},
 					Plan:     model.UserPlanPlus,
 				},
-				wantCanManageAssets:           true,
-				wantCanManageCourses:          false,
-				wantCanUsePremiumLLM:          true,
-				wantCopilotMessageQuota:       copilotQuotaPlus,
-				wantAIDescriptionQuota:        aiDescriptionQuotaPlus,
-				wantAIInteractionTurnQuota:    aiInteractionTurnQuotaPlus,
-				wantAIInteractionArchiveQuota: aiInteractionArchiveQuotaPlus,
+				wantCanManageAssets:                 true,
+				wantCanManageCourses:                false,
+				wantCanUsePremiumLLM:                true,
+				wantCopilotMessageQuotaLimit:        copilotQuotaLimitPlus,
+				wantCopilotMessageQuotaWindow:       quotaWindow,
+				wantAIDescriptionQuotaLimit:         aiDescriptionQuotaLimitPlus,
+				wantAIDescriptionQuotaWindow:        quotaWindow,
+				wantAIInteractionTurnQuotaLimit:     aiInteractionTurnQuotaLimitPlus,
+				wantAIInteractionTurnQuotaWindow:    quotaWindow,
+				wantAIInteractionArchiveQuotaLimit:  aiInteractionArchiveQuotaLimitPlus,
+				wantAIInteractionArchiveQuotaWindow: quotaWindow,
 			},
 			{
 				name: "RegularPlusUser",
@@ -80,13 +94,17 @@ func TestEmbeddedPDPComputeUserCapabilities(t *testing.T) {
 					Roles:    nil,
 					Plan:     model.UserPlanPlus,
 				},
-				wantCanManageAssets:           false,
-				wantCanManageCourses:          false,
-				wantCanUsePremiumLLM:          true,
-				wantCopilotMessageQuota:       copilotQuotaPlus,
-				wantAIDescriptionQuota:        aiDescriptionQuotaPlus,
-				wantAIInteractionTurnQuota:    aiInteractionTurnQuotaPlus,
-				wantAIInteractionArchiveQuota: aiInteractionArchiveQuotaPlus,
+				wantCanManageAssets:                 false,
+				wantCanManageCourses:                false,
+				wantCanUsePremiumLLM:                true,
+				wantCopilotMessageQuotaLimit:        copilotQuotaLimitPlus,
+				wantCopilotMessageQuotaWindow:       quotaWindow,
+				wantAIDescriptionQuotaLimit:         aiDescriptionQuotaLimitPlus,
+				wantAIDescriptionQuotaWindow:        quotaWindow,
+				wantAIInteractionTurnQuotaLimit:     aiInteractionTurnQuotaLimitPlus,
+				wantAIInteractionTurnQuotaWindow:    quotaWindow,
+				wantAIInteractionArchiveQuotaLimit:  aiInteractionArchiveQuotaLimitPlus,
+				wantAIInteractionArchiveQuotaWindow: quotaWindow,
 			},
 			{
 				name: "RegularFreeUser",
@@ -96,13 +114,17 @@ func TestEmbeddedPDPComputeUserCapabilities(t *testing.T) {
 					Roles:    nil,
 					Plan:     model.UserPlanFree,
 				},
-				wantCanManageAssets:           false,
-				wantCanManageCourses:          false,
-				wantCanUsePremiumLLM:          false,
-				wantCopilotMessageQuota:       copilotQuotaFree,
-				wantAIDescriptionQuota:        aiDescriptionQuotaFree,
-				wantAIInteractionTurnQuota:    aiInteractionTurnQuotaFree,
-				wantAIInteractionArchiveQuota: aiInteractionArchiveQuotaFree,
+				wantCanManageAssets:                 false,
+				wantCanManageCourses:                false,
+				wantCanUsePremiumLLM:                false,
+				wantCopilotMessageQuotaLimit:        copilotQuotaLimitFree,
+				wantCopilotMessageQuotaWindow:       quotaWindow,
+				wantAIDescriptionQuotaLimit:         aiDescriptionQuotaLimitFree,
+				wantAIDescriptionQuotaWindow:        quotaWindow,
+				wantAIInteractionTurnQuotaLimit:     aiInteractionTurnQuotaLimitFree,
+				wantAIInteractionTurnQuotaWindow:    quotaWindow,
+				wantAIInteractionArchiveQuotaLimit:  aiInteractionArchiveQuotaLimitFree,
+				wantAIInteractionArchiveQuotaWindow: quotaWindow,
 			},
 			{
 				name: "AdminWithFreePlan",
@@ -112,13 +134,17 @@ func TestEmbeddedPDPComputeUserCapabilities(t *testing.T) {
 					Roles:    model.UserRoles{"admin"},
 					Plan:     model.UserPlanFree,
 				},
-				wantCanManageAssets:           false,
-				wantCanManageCourses:          false,
-				wantCanUsePremiumLLM:          false,
-				wantCopilotMessageQuota:       copilotQuotaFree,
-				wantAIDescriptionQuota:        aiDescriptionQuotaFree,
-				wantAIInteractionTurnQuota:    aiInteractionTurnQuotaFree,
-				wantAIInteractionArchiveQuota: aiInteractionArchiveQuotaFree,
+				wantCanManageAssets:                 false,
+				wantCanManageCourses:                false,
+				wantCanUsePremiumLLM:                false,
+				wantCopilotMessageQuotaLimit:        copilotQuotaLimitFree,
+				wantCopilotMessageQuotaWindow:       quotaWindow,
+				wantAIDescriptionQuotaLimit:         aiDescriptionQuotaLimitFree,
+				wantAIDescriptionQuotaWindow:        quotaWindow,
+				wantAIInteractionTurnQuotaLimit:     aiInteractionTurnQuotaLimitFree,
+				wantAIInteractionTurnQuotaWindow:    quotaWindow,
+				wantAIInteractionArchiveQuotaLimit:  aiInteractionArchiveQuotaLimitFree,
+				wantAIInteractionArchiveQuotaWindow: quotaWindow,
 			},
 			{
 				name: "UserWithMultipleRoles",
@@ -128,13 +154,17 @@ func TestEmbeddedPDPComputeUserCapabilities(t *testing.T) {
 					Roles:    model.UserRoles{"user", "assetAdmin"},
 					Plan:     model.UserPlanFree,
 				},
-				wantCanManageAssets:           true,
-				wantCanManageCourses:          false,
-				wantCanUsePremiumLLM:          false,
-				wantCopilotMessageQuota:       copilotQuotaFree,
-				wantAIDescriptionQuota:        aiDescriptionQuotaFree,
-				wantAIInteractionTurnQuota:    aiInteractionTurnQuotaFree,
-				wantAIInteractionArchiveQuota: aiInteractionArchiveQuotaFree,
+				wantCanManageAssets:                 true,
+				wantCanManageCourses:                false,
+				wantCanUsePremiumLLM:                false,
+				wantCopilotMessageQuotaLimit:        copilotQuotaLimitFree,
+				wantCopilotMessageQuotaWindow:       quotaWindow,
+				wantAIDescriptionQuotaLimit:         aiDescriptionQuotaLimitFree,
+				wantAIDescriptionQuotaWindow:        quotaWindow,
+				wantAIInteractionTurnQuotaLimit:     aiInteractionTurnQuotaLimitFree,
+				wantAIInteractionTurnQuotaWindow:    quotaWindow,
+				wantAIInteractionArchiveQuotaLimit:  aiInteractionArchiveQuotaLimitFree,
+				wantAIInteractionArchiveQuotaWindow: quotaWindow,
 			},
 			{
 				name: "CourseAdminUser",
@@ -144,13 +174,17 @@ func TestEmbeddedPDPComputeUserCapabilities(t *testing.T) {
 					Roles:    model.UserRoles{"courseAdmin"},
 					Plan:     model.UserPlanFree,
 				},
-				wantCanManageAssets:           false,
-				wantCanManageCourses:          true,
-				wantCanUsePremiumLLM:          false,
-				wantCopilotMessageQuota:       copilotQuotaFree,
-				wantAIDescriptionQuota:        aiDescriptionQuotaFree,
-				wantAIInteractionTurnQuota:    aiInteractionTurnQuotaFree,
-				wantAIInteractionArchiveQuota: aiInteractionArchiveQuotaFree,
+				wantCanManageAssets:                 false,
+				wantCanManageCourses:                true,
+				wantCanUsePremiumLLM:                false,
+				wantCopilotMessageQuotaLimit:        copilotQuotaLimitFree,
+				wantCopilotMessageQuotaWindow:       quotaWindow,
+				wantAIDescriptionQuotaLimit:         aiDescriptionQuotaLimitFree,
+				wantAIDescriptionQuotaWindow:        quotaWindow,
+				wantAIInteractionTurnQuotaLimit:     aiInteractionTurnQuotaLimitFree,
+				wantAIInteractionTurnQuotaWindow:    quotaWindow,
+				wantAIInteractionArchiveQuotaLimit:  aiInteractionArchiveQuotaLimitFree,
+				wantAIInteractionArchiveQuotaWindow: quotaWindow,
 			},
 			{
 				name: "UserWithMultipleAdminRoles",
@@ -160,13 +194,17 @@ func TestEmbeddedPDPComputeUserCapabilities(t *testing.T) {
 					Roles:    model.UserRoles{"assetAdmin", "courseAdmin"},
 					Plan:     model.UserPlanPlus,
 				},
-				wantCanManageAssets:           true,
-				wantCanManageCourses:          true,
-				wantCanUsePremiumLLM:          true,
-				wantCopilotMessageQuota:       copilotQuotaPlus,
-				wantAIDescriptionQuota:        aiDescriptionQuotaPlus,
-				wantAIInteractionTurnQuota:    aiInteractionTurnQuotaPlus,
-				wantAIInteractionArchiveQuota: aiInteractionArchiveQuotaPlus,
+				wantCanManageAssets:                 true,
+				wantCanManageCourses:                true,
+				wantCanUsePremiumLLM:                true,
+				wantCopilotMessageQuotaLimit:        copilotQuotaLimitPlus,
+				wantCopilotMessageQuotaWindow:       quotaWindow,
+				wantAIDescriptionQuotaLimit:         aiDescriptionQuotaLimitPlus,
+				wantAIDescriptionQuotaWindow:        quotaWindow,
+				wantAIInteractionTurnQuotaLimit:     aiInteractionTurnQuotaLimitPlus,
+				wantAIInteractionTurnQuotaWindow:    quotaWindow,
+				wantAIInteractionArchiveQuotaLimit:  aiInteractionArchiveQuotaLimitPlus,
+				wantAIInteractionArchiveQuotaWindow: quotaWindow,
 			},
 		} {
 			t.Run(tt.name, func(t *testing.T) {
@@ -178,14 +216,22 @@ func TestEmbeddedPDPComputeUserCapabilities(t *testing.T) {
 				assert.Equal(t, tt.wantCanManageAssets, caps.CanManageAssets)
 				assert.Equal(t, tt.wantCanManageCourses, caps.CanManageCourses)
 				assert.Equal(t, tt.wantCanUsePremiumLLM, caps.CanUsePremiumLLM)
-				assert.Equal(t, tt.wantCopilotMessageQuota, caps.CopilotMessageQuota)
-				assert.Equal(t, caps.CopilotMessageQuota, caps.CopilotMessageQuotaLeft)
-				assert.Equal(t, tt.wantAIDescriptionQuota, caps.AIDescriptionQuota)
-				assert.Equal(t, caps.AIDescriptionQuota, caps.AIDescriptionQuotaLeft)
-				assert.Equal(t, tt.wantAIInteractionTurnQuota, caps.AIInteractionTurnQuota)
-				assert.Equal(t, caps.AIInteractionTurnQuota, caps.AIInteractionTurnQuotaLeft)
-				assert.Equal(t, tt.wantAIInteractionArchiveQuota, caps.AIInteractionArchiveQuota)
-				assert.Equal(t, caps.AIInteractionArchiveQuota, caps.AIInteractionArchiveQuotaLeft)
+				assert.Equal(t, tt.wantCopilotMessageQuotaLimit, caps.CopilotMessageQuota.Limit)
+				assert.Equal(t, tt.wantCopilotMessageQuotaWindow, caps.CopilotMessageQuota.Window)
+				assert.Equal(t, caps.CopilotMessageQuota.Limit, caps.CopilotMessageQuota.Remaining)
+				assert.Equal(t, caps.CopilotMessageQuota.Window, caps.CopilotMessageQuota.Reset())
+				assert.Equal(t, tt.wantAIDescriptionQuotaLimit, caps.AIDescriptionQuota.Limit)
+				assert.Equal(t, tt.wantAIDescriptionQuotaWindow, caps.AIDescriptionQuota.Window)
+				assert.Equal(t, caps.AIDescriptionQuota.Limit, caps.AIDescriptionQuota.Remaining)
+				assert.Equal(t, caps.AIDescriptionQuota.Window, caps.AIDescriptionQuota.Reset())
+				assert.Equal(t, tt.wantAIInteractionTurnQuotaLimit, caps.AIInteractionTurnQuota.Limit)
+				assert.Equal(t, tt.wantAIInteractionTurnQuotaWindow, caps.AIInteractionTurnQuota.Window)
+				assert.Equal(t, caps.AIInteractionTurnQuota.Limit, caps.AIInteractionTurnQuota.Remaining)
+				assert.Equal(t, caps.AIInteractionTurnQuota.Window, caps.AIInteractionTurnQuota.Reset())
+				assert.Equal(t, tt.wantAIInteractionArchiveQuotaLimit, caps.AIInteractionArchiveQuota.Limit)
+				assert.Equal(t, tt.wantAIInteractionArchiveQuotaWindow, caps.AIInteractionArchiveQuota.Window)
+				assert.Equal(t, caps.AIInteractionArchiveQuota.Limit, caps.AIInteractionArchiveQuota.Remaining)
+				assert.Equal(t, caps.AIInteractionArchiveQuota.Window, caps.AIInteractionArchiveQuota.Reset())
 			})
 		}
 	})
@@ -201,13 +247,39 @@ func TestEmbeddedPDPComputeUserCapabilities(t *testing.T) {
 			Plan:     model.UserPlanFree,
 		}
 
-		err := quotaTracker.IncrementUsage(context.Background(), mUser.ID, authz.ResourceCopilotMessage, 30)
+		window := quotaWindow * time.Second
+
+		err := quotaTracker.IncrementUsage(
+			context.Background(),
+			mUser.ID,
+			authz.ResourceCopilotMessage,
+			30,
+			authz.QuotaPolicy{Limit: copilotQuotaLimitFree, Window: window},
+		)
 		require.NoError(t, err)
-		err = quotaTracker.IncrementUsage(context.Background(), mUser.ID, authz.ResourceAIDescription, 5)
+		err = quotaTracker.IncrementUsage(
+			context.Background(),
+			mUser.ID,
+			authz.ResourceAIDescription,
+			5,
+			authz.QuotaPolicy{Limit: aiDescriptionQuotaLimitFree, Window: window},
+		)
 		require.NoError(t, err)
-		err = quotaTracker.IncrementUsage(context.Background(), mUser.ID, authz.ResourceAIInteractionTurn, 120)
+		err = quotaTracker.IncrementUsage(
+			context.Background(),
+			mUser.ID,
+			authz.ResourceAIInteractionTurn,
+			120,
+			authz.QuotaPolicy{Limit: aiInteractionTurnQuotaLimitFree, Window: window},
+		)
 		require.NoError(t, err)
-		err = quotaTracker.IncrementUsage(context.Background(), mUser.ID, authz.ResourceAIInteractionArchive, 10)
+		err = quotaTracker.IncrementUsage(
+			context.Background(),
+			mUser.ID,
+			authz.ResourceAIInteractionArchive,
+			10,
+			authz.QuotaPolicy{Limit: aiInteractionArchiveQuotaLimitFree, Window: window},
+		)
 		require.NoError(t, err)
 
 		caps, err := pdp.ComputeUserCapabilities(context.Background(), mUser)
@@ -215,17 +287,25 @@ func TestEmbeddedPDPComputeUserCapabilities(t *testing.T) {
 		assert.Equal(t, false, caps.CanManageAssets)
 		assert.Equal(t, false, caps.CanManageCourses)
 		assert.Equal(t, false, caps.CanUsePremiumLLM)
-		assert.Equal(t, int64(copilotQuotaFree), caps.CopilotMessageQuota)
-		assert.Equal(t, int64(copilotQuotaFree-30), caps.CopilotMessageQuotaLeft)
-		assert.Equal(t, int64(aiDescriptionQuotaFree), caps.AIDescriptionQuota)
-		assert.Equal(t, int64(aiDescriptionQuotaFree-5), caps.AIDescriptionQuotaLeft)
-		assert.Equal(t, int64(aiInteractionTurnQuotaFree), caps.AIInteractionTurnQuota)
-		assert.Equal(t, int64(aiInteractionTurnQuotaFree-120), caps.AIInteractionTurnQuotaLeft)
-		assert.Equal(t, int64(aiInteractionArchiveQuotaFree), caps.AIInteractionArchiveQuota)
-		assert.Equal(t, int64(aiInteractionArchiveQuotaFree-10), caps.AIInteractionArchiveQuotaLeft)
+		assert.Equal(t, int64(copilotQuotaLimitFree), caps.CopilotMessageQuota.Limit)
+		assert.Equal(t, int64(quotaWindow), caps.CopilotMessageQuota.Window)
+		assert.Equal(t, int64(copilotQuotaLimitFree-30), caps.CopilotMessageQuota.Remaining)
+		assert.Equal(t, int64(quotaWindow), caps.CopilotMessageQuota.Reset())
+		assert.Equal(t, int64(aiDescriptionQuotaLimitFree), caps.AIDescriptionQuota.Limit)
+		assert.Equal(t, int64(quotaWindow), caps.AIDescriptionQuota.Window)
+		assert.Equal(t, int64(aiDescriptionQuotaLimitFree-5), caps.AIDescriptionQuota.Remaining)
+		assert.Equal(t, int64(quotaWindow), caps.AIDescriptionQuota.Reset())
+		assert.Equal(t, int64(aiInteractionTurnQuotaLimitFree), caps.AIInteractionTurnQuota.Limit)
+		assert.Equal(t, int64(quotaWindow), caps.AIInteractionTurnQuota.Window)
+		assert.Equal(t, int64(aiInteractionTurnQuotaLimitFree-120), caps.AIInteractionTurnQuota.Remaining)
+		assert.Equal(t, int64(quotaWindow), caps.AIInteractionTurnQuota.Reset())
+		assert.Equal(t, int64(aiInteractionArchiveQuotaLimitFree), caps.AIInteractionArchiveQuota.Limit)
+		assert.Equal(t, int64(quotaWindow), caps.AIInteractionArchiveQuota.Window)
+		assert.Equal(t, int64(aiInteractionArchiveQuotaLimitFree-10), caps.AIInteractionArchiveQuota.Remaining)
+		assert.Equal(t, int64(quotaWindow), caps.AIInteractionArchiveQuota.Reset())
 	})
 
-	t.Run("QuotaExhausted", func(t *testing.T) {
+	t.Run("QuotaExceeded", func(t *testing.T) {
 		quotaTracker := newMockQuotaTracker()
 		pdp := New(quotaTracker)
 
@@ -236,24 +316,122 @@ func TestEmbeddedPDPComputeUserCapabilities(t *testing.T) {
 			Plan:     model.UserPlanFree,
 		}
 
-		err := quotaTracker.IncrementUsage(context.Background(), mUser.ID, authz.ResourceCopilotMessage, copilotQuotaFree+50)
+		window := quotaWindow * time.Second
+
+		err := quotaTracker.IncrementUsage(
+			context.Background(),
+			mUser.ID,
+			authz.ResourceCopilotMessage,
+			copilotQuotaLimitFree+50,
+			authz.QuotaPolicy{Limit: copilotQuotaLimitFree, Window: window},
+		)
 		require.NoError(t, err)
-		err = quotaTracker.IncrementUsage(context.Background(), mUser.ID, authz.ResourceAIDescription, aiDescriptionQuotaFree+100)
+		err = quotaTracker.IncrementUsage(
+			context.Background(),
+			mUser.ID,
+			authz.ResourceAIDescription,
+			aiDescriptionQuotaLimitFree+100,
+			authz.QuotaPolicy{Limit: aiDescriptionQuotaLimitFree, Window: window},
+		)
 		require.NoError(t, err)
-		err = quotaTracker.IncrementUsage(context.Background(), mUser.ID, authz.ResourceAIInteractionTurn, aiInteractionTurnQuotaFree+5000)
+		err = quotaTracker.IncrementUsage(
+			context.Background(),
+			mUser.ID,
+			authz.ResourceAIInteractionTurn,
+			aiInteractionTurnQuotaLimitFree+5000,
+			authz.QuotaPolicy{Limit: aiInteractionTurnQuotaLimitFree, Window: window},
+		)
 		require.NoError(t, err)
-		err = quotaTracker.IncrementUsage(context.Background(), mUser.ID, authz.ResourceAIInteractionArchive, aiInteractionArchiveQuotaFree+3000)
+		err = quotaTracker.IncrementUsage(
+			context.Background(),
+			mUser.ID,
+			authz.ResourceAIInteractionArchive,
+			aiInteractionArchiveQuotaLimitFree+3000,
+			authz.QuotaPolicy{Limit: aiInteractionArchiveQuotaLimitFree, Window: window},
+		)
 		require.NoError(t, err)
 
 		caps, err := pdp.ComputeUserCapabilities(context.Background(), mUser)
 		require.NoError(t, err)
-		assert.Equal(t, int64(copilotQuotaFree), caps.CopilotMessageQuota)
-		assert.Equal(t, int64(0), caps.CopilotMessageQuotaLeft)
-		assert.Equal(t, int64(aiDescriptionQuotaFree), caps.AIDescriptionQuota)
-		assert.Equal(t, int64(0), caps.AIDescriptionQuotaLeft)
-		assert.Equal(t, int64(aiInteractionTurnQuotaFree), caps.AIInteractionTurnQuota)
-		assert.Equal(t, int64(0), caps.AIInteractionTurnQuotaLeft)
-		assert.Equal(t, int64(aiInteractionArchiveQuotaFree), caps.AIInteractionArchiveQuota)
-		assert.Equal(t, int64(0), caps.AIInteractionArchiveQuotaLeft)
+		assert.Equal(t, int64(copilotQuotaLimitFree), caps.CopilotMessageQuota.Limit)
+		assert.Equal(t, int64(quotaWindow), caps.CopilotMessageQuota.Window)
+		assert.Equal(t, int64(0), caps.CopilotMessageQuota.Remaining)
+		assert.Equal(t, int64(quotaWindow), caps.CopilotMessageQuota.Reset())
+		assert.Equal(t, int64(aiDescriptionQuotaLimitFree), caps.AIDescriptionQuota.Limit)
+		assert.Equal(t, int64(quotaWindow), caps.AIDescriptionQuota.Window)
+		assert.Equal(t, int64(0), caps.AIDescriptionQuota.Remaining)
+		assert.Equal(t, int64(quotaWindow), caps.AIDescriptionQuota.Reset())
+		assert.Equal(t, int64(aiInteractionTurnQuotaLimitFree), caps.AIInteractionTurnQuota.Limit)
+		assert.Equal(t, int64(quotaWindow), caps.AIInteractionTurnQuota.Window)
+		assert.Equal(t, int64(0), caps.AIInteractionTurnQuota.Remaining)
+		assert.Equal(t, int64(quotaWindow), caps.AIInteractionTurnQuota.Reset())
+		assert.Equal(t, int64(aiInteractionArchiveQuotaLimitFree), caps.AIInteractionArchiveQuota.Limit)
+		assert.Equal(t, int64(quotaWindow), caps.AIInteractionArchiveQuota.Window)
+		assert.Equal(t, int64(0), caps.AIInteractionArchiveQuota.Remaining)
+		assert.Equal(t, int64(quotaWindow), caps.AIInteractionArchiveQuota.Reset())
+	})
+}
+
+func TestQuotaRemaining(t *testing.T) {
+	for _, tt := range []struct {
+		name  string
+		limit int64
+		usage authz.QuotaUsage
+		want  int64
+	}{
+		{
+			name:  "WithinLimit",
+			limit: 100,
+			usage: authz.QuotaUsage{Used: 20},
+			want:  80,
+		},
+		{
+			name:  "ExceedsLimit",
+			limit: 50,
+			usage: authz.QuotaUsage{Used: 80},
+			want:  0,
+		},
+		{
+			name:  "Unlimited",
+			limit: 0,
+			usage: authz.QuotaUsage{Used: 0},
+			want:  0,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			got := quotaRemaining(tt.limit, tt.usage)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestQuotaResetTime(t *testing.T) {
+	t.Run("TrackerProvidesReset", func(t *testing.T) {
+		resetAt := time.Now().Add(120 * time.Second)
+		usage := authz.QuotaUsage{
+			Used:      10,
+			ResetTime: resetAt,
+		}
+		got := quotaResetTime(86400, usage)
+		require.True(t, got.Equal(resetAt))
+	})
+
+	t.Run("FreshWindowDefaultsToWindow", func(t *testing.T) {
+		const window = int64(3600)
+		usage := authz.QuotaUsage{Used: 0}
+		got := quotaResetTime(window, usage)
+		require.False(t, got.IsZero())
+
+		remaining := time.Until(got)
+		require.Greater(t, remaining, 0*time.Second)
+
+		expected := time.Duration(window) * time.Second
+		assert.InDelta(t, float64(expected), float64(remaining), float64(time.Second))
+	})
+
+	t.Run("NoResetInfo", func(t *testing.T) {
+		usage := authz.QuotaUsage{Used: 100}
+		got := quotaResetTime(3600, usage)
+		assert.True(t, got.IsZero())
 	})
 }

--- a/spx-backend/internal/authz/helper_test.go
+++ b/spx-backend/internal/authz/helper_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/goplus/builder/spx-backend/internal/authn"
 	"github.com/stretchr/testify/assert"
@@ -14,10 +15,12 @@ import (
 func TestCanManageAssets(t *testing.T) {
 	t.Run("HasPermission", func(t *testing.T) {
 		ctx := NewContextWithUserCapabilities(context.Background(), UserCapabilities{
-			CanManageAssets:         true,
-			CanUsePremiumLLM:        false,
-			CopilotMessageQuota:     100,
-			CopilotMessageQuotaLeft: 50,
+			CanManageAssets:  true,
+			CanUsePremiumLLM: false,
+			CopilotMessageQuota: Quota{
+				Limit:     100,
+				Remaining: 50,
+			},
 		})
 
 		result := CanManageAssets(ctx)
@@ -26,10 +29,12 @@ func TestCanManageAssets(t *testing.T) {
 
 	t.Run("NoPermission", func(t *testing.T) {
 		ctx := NewContextWithUserCapabilities(context.Background(), UserCapabilities{
-			CanManageAssets:         false,
-			CanUsePremiumLLM:        true,
-			CopilotMessageQuota:     100,
-			CopilotMessageQuotaLeft: 50,
+			CanManageAssets:  false,
+			CanUsePremiumLLM: true,
+			CopilotMessageQuota: Quota{
+				Limit:     100,
+				Remaining: 50,
+			},
 		})
 
 		result := CanManageAssets(ctx)
@@ -61,11 +66,13 @@ func TestCanManageAssets(t *testing.T) {
 func TestCanManageCourses(t *testing.T) {
 	t.Run("HasPermission", func(t *testing.T) {
 		ctx := NewContextWithUserCapabilities(context.Background(), UserCapabilities{
-			CanManageAssets:         false,
-			CanManageCourses:        true,
-			CanUsePremiumLLM:        false,
-			CopilotMessageQuota:     100,
-			CopilotMessageQuotaLeft: 50,
+			CanManageAssets:  false,
+			CanManageCourses: true,
+			CanUsePremiumLLM: false,
+			CopilotMessageQuota: Quota{
+				Limit:     100,
+				Remaining: 50,
+			},
 		})
 
 		result := CanManageCourses(ctx)
@@ -74,11 +81,13 @@ func TestCanManageCourses(t *testing.T) {
 
 	t.Run("NoPermission", func(t *testing.T) {
 		ctx := NewContextWithUserCapabilities(context.Background(), UserCapabilities{
-			CanManageAssets:         true,
-			CanManageCourses:        false,
-			CanUsePremiumLLM:        true,
-			CopilotMessageQuota:     100,
-			CopilotMessageQuotaLeft: 50,
+			CanManageAssets:  true,
+			CanManageCourses: false,
+			CanUsePremiumLLM: true,
+			CopilotMessageQuota: Quota{
+				Limit:     100,
+				Remaining: 50,
+			},
 		})
 
 		result := CanManageCourses(ctx)
@@ -110,10 +119,12 @@ func TestCanManageCourses(t *testing.T) {
 func TestCanUsePremiumLLM(t *testing.T) {
 	t.Run("HasPermission", func(t *testing.T) {
 		ctx := NewContextWithUserCapabilities(context.Background(), UserCapabilities{
-			CanManageAssets:         false,
-			CanUsePremiumLLM:        true,
-			CopilotMessageQuota:     1000,
-			CopilotMessageQuotaLeft: 800,
+			CanManageAssets:  false,
+			CanUsePremiumLLM: true,
+			CopilotMessageQuota: Quota{
+				Limit:     1000,
+				Remaining: 800,
+			},
 		})
 
 		result := CanUsePremiumLLM(ctx)
@@ -122,10 +133,12 @@ func TestCanUsePremiumLLM(t *testing.T) {
 
 	t.Run("NoPermission", func(t *testing.T) {
 		ctx := NewContextWithUserCapabilities(context.Background(), UserCapabilities{
-			CanManageAssets:         true,
-			CanUsePremiumLLM:        false,
-			CopilotMessageQuota:     100,
-			CopilotMessageQuotaLeft: 30,
+			CanManageAssets:  true,
+			CanUsePremiumLLM: false,
+			CopilotMessageQuota: Quota{
+				Limit:     100,
+				Remaining: 30,
+			},
 		})
 
 		result := CanUsePremiumLLM(ctx)
@@ -157,10 +170,12 @@ func TestCanUsePremiumLLM(t *testing.T) {
 func TestConsumeQuota(t *testing.T) {
 	t.Run("Normal", func(t *testing.T) {
 		quotaTracker := &mockQuotaTracker{}
-		quotaTracker.incrementUsageFunc = func(ctx context.Context, userID int64, resource Resource, amount int64) error {
+		quotaTracker.incrementUsageFunc = func(ctx context.Context, userID int64, resource Resource, amount int64, policy QuotaPolicy) error {
 			assert.Equal(t, int64(123), userID)
 			assert.Equal(t, ResourceCopilotMessage, resource)
 			assert.Equal(t, int64(2), amount)
+			assert.Equal(t, int64(100), policy.Limit)
+			assert.Equal(t, 24*time.Hour, policy.Window)
 			return nil
 		}
 
@@ -171,6 +186,21 @@ func TestConsumeQuota(t *testing.T) {
 		ctx := context.Background()
 		ctx = authn.NewContextWithUser(ctx, testUser)
 		ctx = newContextWithAuthorizer(ctx, authorizer)
+		ctx = NewContextWithUserCapabilities(ctx, UserCapabilities{
+			CopilotMessageQuota: Quota{
+				Limit:  100,
+				Window: int64(24 * 60 * 60),
+			},
+			AIDescriptionQuota: Quota{
+				Window: int64(24 * 60 * 60),
+			},
+			AIInteractionTurnQuota: Quota{
+				Window: int64(24 * 60 * 60),
+			},
+			AIInteractionArchiveQuota: Quota{
+				Window: int64(24 * 60 * 60),
+			},
+		})
 
 		err := ConsumeQuota(ctx, ResourceCopilotMessage, 2)
 		assert.NoError(t, err)
@@ -201,7 +231,7 @@ func TestConsumeQuota(t *testing.T) {
 
 	t.Run("QuotaTrackerError", func(t *testing.T) {
 		quotaTracker := &mockQuotaTracker{}
-		quotaTracker.incrementUsageFunc = func(ctx context.Context, userID int64, resource Resource, amount int64) error {
+		quotaTracker.incrementUsageFunc = func(ctx context.Context, userID int64, resource Resource, amount int64, policy QuotaPolicy) error {
 			return errors.New("quota exceeded")
 		}
 
@@ -212,10 +242,40 @@ func TestConsumeQuota(t *testing.T) {
 		ctx := context.Background()
 		ctx = authn.NewContextWithUser(ctx, testUser)
 		ctx = newContextWithAuthorizer(ctx, authorizer)
+		ctx = NewContextWithUserCapabilities(ctx, UserCapabilities{
+			CopilotMessageQuota: Quota{
+				Limit:  100,
+				Window: int64(24 * 60 * 60),
+			},
+			AIDescriptionQuota: Quota{
+				Window: int64(24 * 60 * 60),
+			},
+			AIInteractionTurnQuota: Quota{
+				Window: int64(24 * 60 * 60),
+			},
+			AIInteractionArchiveQuota: Quota{
+				Window: int64(24 * 60 * 60),
+			},
+		})
 
 		err := ConsumeQuota(ctx, ResourceCopilotMessage, 1)
 		require.Error(t, err)
 		assert.EqualError(t, err, "quota exceeded")
+	})
+
+	t.Run("NoCapabilities", func(t *testing.T) {
+		quotaTracker := &mockQuotaTracker{}
+		pdp := &mockPolicyDecisionPoint{}
+		authorizer := New(&gorm.DB{}, pdp, quotaTracker)
+
+		testUser := newTestUser()
+		ctx := context.Background()
+		ctx = authn.NewContextWithUser(ctx, testUser)
+		ctx = newContextWithAuthorizer(ctx, authorizer)
+
+		err := ConsumeQuota(ctx, ResourceCopilotMessage, 1)
+		require.Error(t, err)
+		assert.EqualError(t, err, "missing user capabilities in context")
 	})
 
 	t.Run("WrongAuthorizerContextValue", func(t *testing.T) {
@@ -227,5 +287,66 @@ func TestConsumeQuota(t *testing.T) {
 		err := ConsumeQuota(ctx, ResourceCopilotMessage, 1)
 		require.Error(t, err)
 		assert.EqualError(t, err, "missing authorizer in context")
+	})
+}
+
+func TestQuotaPolicyFromUserCapabilities(t *testing.T) {
+	const windowSeconds = int64(24 * 60 * 60)
+	caps := UserCapabilities{
+		CopilotMessageQuota: Quota{
+			Limit:  100,
+			Window: windowSeconds,
+		},
+		AIDescriptionQuota: Quota{
+			Limit:  300,
+			Window: windowSeconds,
+		},
+		AIInteractionTurnQuota: Quota{
+			Limit:  12000,
+			Window: windowSeconds,
+		},
+		AIInteractionArchiveQuota: Quota{
+			Limit:  8000,
+			Window: windowSeconds,
+		},
+	}
+
+	for _, tt := range []struct {
+		name     string
+		resource Resource
+		want     QuotaPolicy
+	}{
+		{
+			name:     "Copilot",
+			resource: ResourceCopilotMessage,
+			want:     QuotaPolicy{Limit: 100, Window: 24 * time.Hour},
+		},
+		{
+			name:     "AIDescription",
+			resource: ResourceAIDescription,
+			want:     QuotaPolicy{Limit: 300, Window: 24 * time.Hour},
+		},
+		{
+			name:     "AIInteractionTurn",
+			resource: ResourceAIInteractionTurn,
+			want:     QuotaPolicy{Limit: 12000, Window: 24 * time.Hour},
+		},
+		{
+			name:     "AIInteractionArchive",
+			resource: ResourceAIInteractionArchive,
+			want:     QuotaPolicy{Limit: 8000, Window: 24 * time.Hour},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := quotaPolicyFromUserCapabilities(tt.resource, caps)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+
+	t.Run("UnsupportedResource", func(t *testing.T) {
+		_, err := quotaPolicyFromUserCapabilities(Resource("unknown"), caps)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unsupported quota resource")
 	})
 }

--- a/spx-backend/internal/authz/pdp.go
+++ b/spx-backend/internal/authz/pdp.go
@@ -24,27 +24,31 @@ type UserCapabilities struct {
 	// CanUsePremiumLLM indicates if user can access premium LLM models.
 	CanUsePremiumLLM bool `json:"canUsePremiumLLM"`
 
-	// CopilotMessageQuota is the total quota for copilot messages.
-	CopilotMessageQuota int64 `json:"copilotMessageQuota"`
+	// CopilotMessageQuota represents quotas for copilot messages.
+	CopilotMessageQuota Quota `json:"-"`
 
-	// CopilotMessageQuotaLeft is the remaining quota for copilot messages.
-	CopilotMessageQuotaLeft int64 `json:"copilotMessageQuotaLeft"`
+	// AIDescriptionQuota represents quotas for AI description generations.
+	AIDescriptionQuota Quota `json:"-"`
 
-	// AIDescriptionQuota is the total quota for AI description generations.
-	AIDescriptionQuota int64 `json:"aiDescriptionQuota"`
+	// AIInteractionTurnQuota represents quotas for AI interaction turns.
+	AIInteractionTurnQuota Quota `json:"-"`
 
-	// AIDescriptionQuotaLeft is the remaining quota for AI description generations.
-	AIDescriptionQuotaLeft int64 `json:"aiDescriptionQuotaLeft"`
+	// AIInteractionArchiveQuota represents quotas for AI interaction archive requests.
+	AIInteractionArchiveQuota Quota `json:"-"`
+}
 
-	// AIInteractionTurnQuota is the total quota for AI interaction turns.
-	AIInteractionTurnQuota int64 `json:"aiInteractionTurnQuota"`
-
-	// AIInteractionTurnQuotaLeft is the remaining quota for AI interaction turns.
-	AIInteractionTurnQuotaLeft int64 `json:"aiInteractionTurnQuotaLeft"`
-
-	// AIInteractionArchiveQuota is the total quota for AI interaction archive requests.
-	AIInteractionArchiveQuota int64 `json:"aiInteractionArchiveQuota"`
-
-	// AIInteractionArchiveQuotaLeft is the remaining quota for AI interaction archive requests.
-	AIInteractionArchiveQuotaLeft int64 `json:"aiInteractionArchiveQuotaLeft"`
+// Quota returns the quota for the given resource.
+func (uc UserCapabilities) Quota(resource Resource) (Quota, bool) {
+	switch resource {
+	case ResourceCopilotMessage:
+		return uc.CopilotMessageQuota, true
+	case ResourceAIDescription:
+		return uc.AIDescriptionQuota, true
+	case ResourceAIInteractionTurn:
+		return uc.AIInteractionTurnQuota, true
+	case ResourceAIInteractionArchive:
+		return uc.AIInteractionArchiveQuota, true
+	default:
+		return Quota{}, false
+	}
 }

--- a/spx-backend/internal/authz/pdp_test.go
+++ b/spx-backend/internal/authz/pdp_test.go
@@ -15,15 +15,27 @@ func (m *mockPolicyDecisionPoint) ComputeUserCapabilities(ctx context.Context, m
 		return m.computeUserCapabilitiesFunc(ctx, mUser)
 	}
 	return UserCapabilities{
-		CanManageAssets:               true,
-		CanUsePremiumLLM:              false,
-		CopilotMessageQuota:           100,
-		CopilotMessageQuotaLeft:       80,
-		AIDescriptionQuota:            300,
-		AIDescriptionQuotaLeft:        280,
-		AIInteractionTurnQuota:        12000,
-		AIInteractionTurnQuotaLeft:    11600,
-		AIInteractionArchiveQuota:     8000,
-		AIInteractionArchiveQuotaLeft: 7620,
+		CanManageAssets:  true,
+		CanUsePremiumLLM: false,
+		CopilotMessageQuota: Quota{
+			Limit:     100,
+			Remaining: 80,
+			Window:    24 * 60 * 60,
+		},
+		AIDescriptionQuota: Quota{
+			Limit:     300,
+			Remaining: 280,
+			Window:    24 * 60 * 60,
+		},
+		AIInteractionTurnQuota: Quota{
+			Limit:     12000,
+			Remaining: 11600,
+			Window:    24 * 60 * 60,
+		},
+		AIInteractionArchiveQuota: Quota{
+			Limit:     8000,
+			Remaining: 7620,
+			Window:    24 * 60 * 60,
+		},
 	}, nil
 }

--- a/spx-backend/internal/authz/quota.go
+++ b/spx-backend/internal/authz/quota.go
@@ -1,17 +1,69 @@
 package authz
 
-import "context"
+import (
+	"context"
+	"time"
+)
 
 // QuotaTracker defines the interface for tracking resource usage quotas.
 type QuotaTracker interface {
 	// Usage returns the current usage for a user and resource.
-	Usage(ctx context.Context, userID int64, resource Resource) (int64, error)
+	Usage(ctx context.Context, userID int64, resource Resource) (QuotaUsage, error)
 
 	// IncrementUsage increments the usage counter for a user and resource.
-	IncrementUsage(ctx context.Context, userID int64, resource Resource, amount int64) error
+	IncrementUsage(ctx context.Context, userID int64, resource Resource, amount int64, policy QuotaPolicy) error
 
 	// ResetUsage resets the usage counter for a user and resource.
 	ResetUsage(ctx context.Context, userID int64, resource Resource) error
+}
+
+// QuotaPolicy defines the quota configuration for a usage update.
+type QuotaPolicy struct {
+	// Limit is the maximum allowed usage within the quota window.
+	Limit int64
+
+	// Window is the duration of the quota window.
+	Window time.Duration
+}
+
+// QuotaUsage captures consumption and reset information reported by trackers.
+type QuotaUsage struct {
+	// Used is the amount of quota consumed within the current window.
+	Used int64
+
+	// ResetTime is the time when the current quota window resets.
+	ResetTime time.Time
+}
+
+// Quota represents quota limits and usage counters for a resource.
+type Quota struct {
+	// Limit is the total quota available for the resource.
+	Limit int64
+
+	// Remaining is the remaining quota for the resource.
+	Remaining int64
+
+	// ResetTime is the time when the quota resets.
+	ResetTime time.Time
+
+	// Window is the quota window in seconds.
+	Window int64
+}
+
+// Reset returns the remaining time in seconds before the window resets.
+func (q Quota) Reset() int64 {
+	if q.ResetTime.IsZero() {
+		if q.Window > 0 && q.Remaining == q.Limit {
+			return q.Window
+		}
+		return 0
+	}
+
+	remaining := time.Until(q.ResetTime)
+	if remaining <= 0 {
+		return 0
+	}
+	return int64((remaining + time.Second - 1) / time.Second)
 }
 
 // Resource represents different types of resources that can be metered and tracked.

--- a/spx-backend/internal/authz/quota/nop.go
+++ b/spx-backend/internal/authz/quota/nop.go
@@ -15,12 +15,12 @@ func NewNopQuotaTracker() authz.QuotaTracker {
 }
 
 // Usage implements [authz.QuotaTracker].
-func (*nopQuotaTracker) Usage(context.Context, int64, authz.Resource) (int64, error) {
-	return 0, nil
+func (*nopQuotaTracker) Usage(context.Context, int64, authz.Resource) (authz.QuotaUsage, error) {
+	return authz.QuotaUsage{}, nil
 }
 
 // IncrementUsage implements [authz.QuotaTracker].
-func (*nopQuotaTracker) IncrementUsage(context.Context, int64, authz.Resource, int64) error {
+func (*nopQuotaTracker) IncrementUsage(context.Context, int64, authz.Resource, int64, authz.QuotaPolicy) error {
 	return nil
 }
 

--- a/spx-backend/internal/authz/quota/nop_test.go
+++ b/spx-backend/internal/authz/quota/nop_test.go
@@ -16,7 +16,8 @@ func TestNopQuotaTrackerUsage(t *testing.T) {
 
 		usage, err := tracker.Usage(ctx, 123, authz.ResourceCopilotMessage)
 		require.NoError(t, err)
-		assert.Equal(t, int64(0), usage)
+		assert.Equal(t, int64(0), usage.Used)
+		assert.True(t, usage.ResetTime.IsZero())
 	})
 
 	t.Run("DifferentUsersReturnZero", func(t *testing.T) {
@@ -25,11 +26,13 @@ func TestNopQuotaTrackerUsage(t *testing.T) {
 
 		usage1, err := tracker.Usage(ctx, 123, authz.ResourceCopilotMessage)
 		require.NoError(t, err)
-		assert.Equal(t, int64(0), usage1)
+		assert.Equal(t, int64(0), usage1.Used)
+		assert.True(t, usage1.ResetTime.IsZero())
 
 		usage2, err := tracker.Usage(ctx, 456, authz.ResourceCopilotMessage)
 		require.NoError(t, err)
-		assert.Equal(t, int64(0), usage2)
+		assert.Equal(t, int64(0), usage2.Used)
+		assert.True(t, usage2.ResetTime.IsZero())
 	})
 }
 
@@ -38,7 +41,7 @@ func TestNopQuotaTrackerIncrementUsage(t *testing.T) {
 		ctx := context.Background()
 		tracker := NewNopQuotaTracker()
 
-		err := tracker.IncrementUsage(ctx, 123, authz.ResourceCopilotMessage, 10)
+		err := tracker.IncrementUsage(ctx, 123, authz.ResourceCopilotMessage, 10, authz.QuotaPolicy{})
 		require.NoError(t, err)
 	})
 
@@ -46,34 +49,36 @@ func TestNopQuotaTrackerIncrementUsage(t *testing.T) {
 		ctx := context.Background()
 		tracker := NewNopQuotaTracker()
 
-		err := tracker.IncrementUsage(ctx, 123, authz.ResourceCopilotMessage, 10)
+		err := tracker.IncrementUsage(ctx, 123, authz.ResourceCopilotMessage, 10, authz.QuotaPolicy{})
 		require.NoError(t, err)
 
 		usage, err := tracker.Usage(ctx, 123, authz.ResourceCopilotMessage)
 		require.NoError(t, err)
-		assert.Equal(t, int64(0), usage)
+		assert.Equal(t, int64(0), usage.Used)
+		assert.True(t, usage.ResetTime.IsZero())
 	})
 
 	t.Run("MultipleIncrementsHaveNoEffect", func(t *testing.T) {
 		ctx := context.Background()
 		tracker := NewNopQuotaTracker()
 
-		err := tracker.IncrementUsage(ctx, 123, authz.ResourceCopilotMessage, 5)
+		err := tracker.IncrementUsage(ctx, 123, authz.ResourceCopilotMessage, 5, authz.QuotaPolicy{})
 		require.NoError(t, err)
 
-		err = tracker.IncrementUsage(ctx, 123, authz.ResourceCopilotMessage, 15)
+		err = tracker.IncrementUsage(ctx, 123, authz.ResourceCopilotMessage, 15, authz.QuotaPolicy{})
 		require.NoError(t, err)
 
 		usage, err := tracker.Usage(ctx, 123, authz.ResourceCopilotMessage)
 		require.NoError(t, err)
-		assert.Equal(t, int64(0), usage)
+		assert.Equal(t, int64(0), usage.Used)
+		assert.True(t, usage.ResetTime.IsZero())
 	})
 
 	t.Run("ZeroIncrement", func(t *testing.T) {
 		ctx := context.Background()
 		tracker := NewNopQuotaTracker()
 
-		err := tracker.IncrementUsage(ctx, 123, authz.ResourceCopilotMessage, 0)
+		err := tracker.IncrementUsage(ctx, 123, authz.ResourceCopilotMessage, 0, authz.QuotaPolicy{})
 		require.NoError(t, err)
 	})
 
@@ -81,7 +86,7 @@ func TestNopQuotaTrackerIncrementUsage(t *testing.T) {
 		ctx := context.Background()
 		tracker := NewNopQuotaTracker()
 
-		err := tracker.IncrementUsage(ctx, 123, authz.ResourceCopilotMessage, -5)
+		err := tracker.IncrementUsage(ctx, 123, authz.ResourceCopilotMessage, -5, authz.QuotaPolicy{})
 		require.NoError(t, err)
 	})
 }
@@ -104,14 +109,15 @@ func TestNopQuotaTrackerResetUsage(t *testing.T) {
 
 		usage, err := tracker.Usage(ctx, 123, authz.ResourceCopilotMessage)
 		require.NoError(t, err)
-		assert.Equal(t, int64(0), usage)
+		assert.Equal(t, int64(0), usage.Used)
+		assert.True(t, usage.ResetTime.IsZero())
 	})
 
 	t.Run("ResetAfterIncrementHasNoEffect", func(t *testing.T) {
 		ctx := context.Background()
 		tracker := NewNopQuotaTracker()
 
-		err := tracker.IncrementUsage(ctx, 123, authz.ResourceCopilotMessage, 100)
+		err := tracker.IncrementUsage(ctx, 123, authz.ResourceCopilotMessage, 100, authz.QuotaPolicy{})
 		require.NoError(t, err)
 
 		err = tracker.ResetUsage(ctx, 123, authz.ResourceCopilotMessage)
@@ -119,6 +125,7 @@ func TestNopQuotaTrackerResetUsage(t *testing.T) {
 
 		usage, err := tracker.Usage(ctx, 123, authz.ResourceCopilotMessage)
 		require.NoError(t, err)
-		assert.Equal(t, int64(0), usage)
+		assert.Equal(t, int64(0), usage.Used)
+		assert.True(t, usage.ResetTime.IsZero())
 	})
 }

--- a/spx-backend/internal/authz/quota_test.go
+++ b/spx-backend/internal/authz/quota_test.go
@@ -1,23 +1,30 @@
 package authz
 
-import "context"
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
 
 type mockQuotaTracker struct {
-	usageFunc          func(ctx context.Context, userID int64, resource Resource) (int64, error)
-	incrementUsageFunc func(ctx context.Context, userID int64, resource Resource, amount int64) error
+	usageFunc          func(ctx context.Context, userID int64, resource Resource) (QuotaUsage, error)
+	incrementUsageFunc func(ctx context.Context, userID int64, resource Resource, amount int64, policy QuotaPolicy) error
 	resetUsageFunc     func(ctx context.Context, userID int64, resource Resource) error
 }
 
-func (m *mockQuotaTracker) Usage(ctx context.Context, userID int64, resource Resource) (int64, error) {
+func (m *mockQuotaTracker) Usage(ctx context.Context, userID int64, resource Resource) (QuotaUsage, error) {
 	if m.usageFunc != nil {
 		return m.usageFunc(ctx, userID, resource)
 	}
-	return 20, nil
+	return QuotaUsage{Used: 20}, nil
 }
 
-func (m *mockQuotaTracker) IncrementUsage(ctx context.Context, userID int64, resource Resource, amount int64) error {
+func (m *mockQuotaTracker) IncrementUsage(ctx context.Context, userID int64, resource Resource, amount int64, policy QuotaPolicy) error {
 	if m.incrementUsageFunc != nil {
-		return m.incrementUsageFunc(ctx, userID, resource, amount)
+		return m.incrementUsageFunc(ctx, userID, resource, amount, policy)
 	}
 	return nil
 }
@@ -27,4 +34,45 @@ func (m *mockQuotaTracker) ResetUsage(ctx context.Context, userID int64, resourc
 		return m.resetUsageFunc(ctx, userID, resource)
 	}
 	return nil
+}
+
+func TestQuotaReset(t *testing.T) {
+	t.Run("FreshWindowFullRemaining", func(t *testing.T) {
+		quota := Quota{
+			Limit:     100,
+			Remaining: 100,
+			Window:    3600,
+		}
+		assert.Equal(t, int64(3600), quota.Reset())
+	})
+
+	t.Run("FreshWindowPartiallyConsumed", func(t *testing.T) {
+		quota := Quota{
+			Limit:     100,
+			Remaining: 80,
+			Window:    3600,
+		}
+		assert.Equal(t, int64(0), quota.Reset())
+	})
+
+	t.Run("WithFutureResetTime", func(t *testing.T) {
+		quota := Quota{
+			ResetTime: time.Now().Add(5 * time.Second),
+		}
+		got := quota.Reset()
+		require.GreaterOrEqual(t, got, int64(4))
+		require.LessOrEqual(t, got, int64(5))
+	})
+
+	t.Run("WithPastResetTime", func(t *testing.T) {
+		quota := Quota{
+			ResetTime: time.Now().Add(-1 * time.Second),
+		}
+		assert.Equal(t, int64(0), quota.Reset())
+	})
+
+	t.Run("ZeroWindow", func(t *testing.T) {
+		var quota Quota
+		assert.Equal(t, int64(0), quota.Reset())
+	})
 }

--- a/spx-backend/internal/controller/user_test.go
+++ b/spx-backend/internal/controller/user_test.go
@@ -35,16 +35,28 @@ func newContextWithTestUser(ctx context.Context) context.Context {
 	testUser := newTestUser()
 	ctx = authn.NewContextWithUser(ctx, testUser)
 	ctx = authz.NewContextWithUserCapabilities(ctx, authz.UserCapabilities{
-		CanManageAssets:               false,
-		CanUsePremiumLLM:              false,
-		CopilotMessageQuota:           100,
-		CopilotMessageQuotaLeft:       100,
-		AIDescriptionQuota:            300,
-		AIDescriptionQuotaLeft:        295,
-		AIInteractionTurnQuota:        12000,
-		AIInteractionTurnQuotaLeft:    11900,
-		AIInteractionArchiveQuota:     8000,
-		AIInteractionArchiveQuotaLeft: 7980,
+		CanManageAssets:  false,
+		CanUsePremiumLLM: false,
+		CopilotMessageQuota: authz.Quota{
+			Limit:     100,
+			Remaining: 100,
+			Window:    24 * 60 * 60,
+		},
+		AIDescriptionQuota: authz.Quota{
+			Limit:     300,
+			Remaining: 295,
+			Window:    24 * 60 * 60,
+		},
+		AIInteractionTurnQuota: authz.Quota{
+			Limit:     12000,
+			Remaining: 11900,
+			Window:    24 * 60 * 60,
+		},
+		AIInteractionArchiveQuota: authz.Quota{
+			Limit:     8000,
+			Remaining: 7980,
+			Window:    24 * 60 * 60,
+		},
 	})
 	return ctx
 }
@@ -469,14 +481,6 @@ func TestControllerGetAuthenticatedUser(t *testing.T) {
 		assert.NotNil(t, result.Capabilities)
 		assert.False(t, result.Capabilities.CanManageAssets)
 		assert.False(t, result.Capabilities.CanUsePremiumLLM)
-		assert.Equal(t, int64(100), result.Capabilities.CopilotMessageQuota)
-		assert.Equal(t, int64(100), result.Capabilities.CopilotMessageQuotaLeft)
-		assert.Equal(t, int64(300), result.Capabilities.AIDescriptionQuota)
-		assert.Equal(t, int64(295), result.Capabilities.AIDescriptionQuotaLeft)
-		assert.Equal(t, int64(12000), result.Capabilities.AIInteractionTurnQuota)
-		assert.Equal(t, int64(11900), result.Capabilities.AIInteractionTurnQuotaLeft)
-		assert.Equal(t, int64(8000), result.Capabilities.AIInteractionArchiveQuota)
-		assert.Equal(t, int64(7980), result.Capabilities.AIInteractionArchiveQuotaLeft)
 	})
 
 	t.Run("Unauthorized", func(t *testing.T) {
@@ -550,14 +554,6 @@ func TestControllerUpdateAuthenticatedUser(t *testing.T) {
 		assert.NotNil(t, result.Capabilities)
 		assert.False(t, result.Capabilities.CanManageAssets)
 		assert.False(t, result.Capabilities.CanUsePremiumLLM)
-		assert.Equal(t, int64(100), result.Capabilities.CopilotMessageQuota)
-		assert.Equal(t, int64(100), result.Capabilities.CopilotMessageQuotaLeft)
-		assert.Equal(t, int64(300), result.Capabilities.AIDescriptionQuota)
-		assert.Equal(t, int64(295), result.Capabilities.AIDescriptionQuotaLeft)
-		assert.Equal(t, int64(12000), result.Capabilities.AIInteractionTurnQuota)
-		assert.Equal(t, int64(11900), result.Capabilities.AIInteractionTurnQuotaLeft)
-		assert.Equal(t, int64(8000), result.Capabilities.AIInteractionArchiveQuota)
-		assert.Equal(t, int64(7980), result.Capabilities.AIInteractionArchiveQuotaLeft)
 
 		require.NoError(t, dbMock.ExpectationsWereMet())
 	})

--- a/spx-gui/src/apis/common/exception.ts
+++ b/spx-gui/src/apis/common/exception.ts
@@ -22,8 +22,8 @@ export enum ApiExceptionCode {
   errorInvalidArgs = 40001,
   errorUnauthorized = 40100,
   errorForbidden = 40300,
+  errorQuotaExceeded = 40301,
   errorNotFound = 40400,
-  errorQuotaExceeded = 42900,
   errorUnknown = 50000
 }
 
@@ -40,13 +40,13 @@ const codeMessages: Record<ApiExceptionCode, LocaleMessage> = {
     en: 'permission denied',
     zh: '没有权限'
   },
-  [ApiExceptionCode.errorNotFound]: {
-    en: 'resource not exist',
-    zh: '资源不存在'
-  },
   [ApiExceptionCode.errorQuotaExceeded]: {
     en: 'quota exceeded',
     zh: '超出配额'
+  },
+  [ApiExceptionCode.errorNotFound]: {
+    en: 'resource not exist',
+    zh: '资源不存在'
   },
   [ApiExceptionCode.errorUnknown]: {
     en: 'something wrong with the server',

--- a/spx-gui/src/apis/user.ts
+++ b/spx-gui/src/apis/user.ts
@@ -21,7 +21,7 @@ export type User = {
 }
 
 export type SignedInUser = User & {
-  /** Capabilities and quotas of the user */
+  /** Capabilities of the user */
   capabilities: UserCapabilities
 }
 
@@ -32,22 +32,6 @@ export type UserCapabilities = {
   canManageCourses: boolean
   /** Whether user can access premium LLM models */
   canUsePremiumLLM: boolean
-  /** Total quota for Copilot messages */
-  copilotMessageQuota: number
-  /** Remaining quota for Copilot messages */
-  copilotMessageQuotaLeft: number
-  /** Total quota for AI description generations */
-  aiDescriptionQuota: number
-  /** Remaining quota for AI description generations */
-  aiDescriptionQuotaLeft: number
-  /** Total quota for AI interaction turns */
-  aiInteractionTurnQuota: number
-  /** Remaining quota for AI interaction turns */
-  aiInteractionTurnQuotaLeft: number
-  /** Total quota for AI interaction archives */
-  aiInteractionArchiveQuota: number
-  /** Remaining quota for AI interaction archives */
-  aiInteractionArchiveQuotaLeft: number
 }
 
 export async function getUser(name: string): Promise<User> {


### PR DESCRIPTION
- Group per-resource quota fields inside `UserCapabilities` into a dedicated `Quota` struct
- Stop serializing quota fields in `UserCapabilities` while keeping internal bookkeeping
- Require callers to pass explicit quota amounts and derive `QuotaPolicy` (limit + window) from `UserCapabilities` before updating usage
- Persist Redis counters with `ExpireNX` so TTLs stay fixed per window while noop tracker stays compatible
- Return `QuotaUsage` with reset hints from trackers and propagate them through PDP `UserCapabilities`
- Emit `errorQuotaExceeded` (403) with `Retry-After` headers when clients exhaust their quota