### PR TITLE
Fix component with children in `MarkdowView`

### DIFF
--- a/spx-gui/src/components/common/markdown-vue/MarkdownView.ts
+++ b/spx-gui/src/components/common/markdown-vue/MarkdownView.ts
@@ -276,6 +276,10 @@ function renderHastElement(element: hast.Element, components: Components, key?: 
     props = hastProps2VueProps(element.properties)
     children = element.children.map((c, i) => renderHastNode(c, components, i))
   }
+  // There's issue when children of custom component (for exmaple `DefinitionOverviewWrapper`) updated: the component will not be notified,
+  // here we use random key to force re-render the component as a workaround.
+  // TODO: check https://github.com/goplus/builder/pull/2433 and remove this workaround.
+  key = key + '' + Math.random()
   return h(type, { ...props, key }, children)
 }
 


### PR DESCRIPTION
<img width="364" height="407" alt="WeChatWorkScreenshot_51a56f76-0cfb-4646-a16b-ec89ce30436f" src="https://github.com/user-attachments/assets/30353c55-e1ee-4fed-891a-65bac5873766" />
