### PR TITLE
refactor(spx-backend): decouple quota snapshots from user capabilities

### DIFF
--- a/spx-backend/cmd/spx-backend/util.go
+++ b/spx-backend/cmd/spx-backend/util.go
@@ -84,16 +84,16 @@ func replyWithInnerError(ctx *yap.Context, err error) {
 // ensureQuotaRemaining checks the remaining quota for the given amount and
 // replies with a 403 error if exceeded.
 func ensureQuotaRemaining(ctx *yap.Context, resource authz.Resource, amount int64) bool {
-	caps, ok := authz.UserCapabilitiesFromContext(ctx.Context())
+	quotas, ok := authz.UserQuotasFromContext(ctx.Context())
 	if !ok {
 		return true
 	}
 
-	quota, ok := caps.Quota(resource)
+	quota, ok := quotas.Limits[resource]
 	if !ok {
 		return true
 	}
-	if quota.Remaining < amount {
+	if quota.Remaining() < amount {
 		if reset := quota.Reset(); reset > 0 {
 			ctx.ResponseWriter.Header().Set("Retry-After", strconv.FormatInt(reset, 10))
 		}

--- a/spx-backend/internal/authz/authz.go
+++ b/spx-backend/internal/authz/authz.go
@@ -25,7 +25,7 @@ func New(db *gorm.DB, pdp PolicyDecisionPoint, quotaTracker QuotaTracker) *Autho
 }
 
 // Middleware returns a middleware function that computes user capabilities and
-// injects them into the request context.
+// quotas and injects them into the request context.
 func (a *Authorizer) Middleware() func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -35,8 +35,8 @@ func (a *Authorizer) Middleware() func(http.Handler) http.Handler {
 			// Inject the authorizer instance into the context.
 			ctx = newContextWithAuthorizer(ctx, a)
 
-			// Compute user capabilities for authenticated users and inject them into
-			// the context.
+			// Compute user capabilities and quotas for authenticated users
+			// and inject them into the context.
 			if mUser, ok := authn.UserFromContext(ctx); ok {
 				caps, err := a.pdp.ComputeUserCapabilities(ctx, mUser)
 				if err != nil {
@@ -45,6 +45,14 @@ func (a *Authorizer) Middleware() func(http.Handler) http.Handler {
 					return
 				}
 				ctx = NewContextWithUserCapabilities(ctx, caps)
+
+				quotas, err := a.pdp.ComputeUserQuotas(ctx, mUser)
+				if err != nil {
+					logger.Printf("authorization system error: %v", err)
+					http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+					return
+				}
+				ctx = NewContextWithUserQuotas(ctx, quotas)
 			}
 
 			next.ServeHTTP(w, r.WithContext(ctx))

--- a/spx-backend/internal/authz/authz_test.go
+++ b/spx-backend/internal/authz/authz_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/goplus/builder/spx-backend/internal/authn"
 	"github.com/goplus/builder/spx-backend/internal/model"
@@ -25,7 +26,7 @@ func newTestUser() *model.User {
 	}
 }
 
-func newTestHandler(t *testing.T, wantCaps *UserCapabilities) http.HandlerFunc {
+func newTestHandler(t *testing.T, wantCaps *UserCapabilities, wantQuotas *UserQuotas) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		caps, ok := UserCapabilitiesFromContext(r.Context())
 		if wantCaps != nil {
@@ -38,6 +39,15 @@ func newTestHandler(t *testing.T, wantCaps *UserCapabilities) http.HandlerFunc {
 			require.Zero(t, caps)
 			w.WriteHeader(http.StatusOK)
 			w.Write([]byte("no capabilities"))
+		}
+
+		quotas, ok := UserQuotasFromContext(r.Context())
+		if wantQuotas != nil {
+			require.True(t, ok)
+			assert.Equal(t, *wantQuotas, quotas)
+		} else {
+			require.False(t, ok)
+			require.Zero(t, quotas)
 		}
 	}
 }
@@ -62,7 +72,7 @@ func TestAuthorizerMiddleware(t *testing.T) {
 		authorizer := New(&gorm.DB{}, pdp, quotaTracker)
 
 		middleware := authorizer.Middleware()
-		handler := middleware(newTestHandler(t, nil))
+		handler := middleware(newTestHandler(t, nil, nil))
 
 		req := httptest.NewRequest("GET", "/test", nil)
 		recorder := httptest.NewRecorder()
@@ -74,29 +84,49 @@ func TestAuthorizerMiddleware(t *testing.T) {
 	})
 
 	t.Run("ValidUser", func(t *testing.T) {
-		const quotaWindow = 24 * 60 * 60
+		const quotaWindow = 24 * time.Hour
 		wantCaps := UserCapabilities{
 			CanManageAssets:  true,
 			CanUsePremiumLLM: true,
-			CopilotMessageQuota: Quota{
-				Limit:     1000,
-				Remaining: 900,
-				Window:    quotaWindow,
-			},
-			AIDescriptionQuota: Quota{
-				Limit:     1000,
-				Remaining: 850,
-				Window:    quotaWindow,
-			},
-			AIInteractionTurnQuota: Quota{
-				Limit:     24000,
-				Remaining: 23500,
-				Window:    quotaWindow,
-			},
-			AIInteractionArchiveQuota: Quota{
-				Limit:     16000,
-				Remaining: 15500,
-				Window:    quotaWindow,
+		}
+		wantQuotas := UserQuotas{
+			Limits: map[Resource]Quota{
+				ResourceCopilotMessage: {
+					QuotaPolicy: QuotaPolicy{
+						Name:     "copilotMessage:limit",
+						Resource: ResourceCopilotMessage,
+						Limit:    1000,
+						Window:   quotaWindow,
+					},
+					QuotaUsage: QuotaUsage{Used: 100},
+				},
+				ResourceAIDescription: {
+					QuotaPolicy: QuotaPolicy{
+						Name:     "aiDescription:limit",
+						Resource: ResourceAIDescription,
+						Limit:    1000,
+						Window:   quotaWindow,
+					},
+					QuotaUsage: QuotaUsage{Used: 150},
+				},
+				ResourceAIInteractionTurn: {
+					QuotaPolicy: QuotaPolicy{
+						Name:     "aiInteractionTurn:limit",
+						Resource: ResourceAIInteractionTurn,
+						Limit:    24000,
+						Window:   quotaWindow,
+					},
+					QuotaUsage: QuotaUsage{Used: 500},
+				},
+				ResourceAIInteractionArchive: {
+					QuotaPolicy: QuotaPolicy{
+						Name:     "aiInteractionArchive:limit",
+						Resource: ResourceAIInteractionArchive,
+						Limit:    16000,
+						Window:   quotaWindow,
+					},
+					QuotaUsage: QuotaUsage{Used: 500},
+				},
 			},
 		}
 
@@ -106,12 +136,17 @@ func TestAuthorizerMiddleware(t *testing.T) {
 			assert.Equal(t, "test-user", mUser.Username)
 			return wantCaps, nil
 		}
+		pdp.computeUserQuotasFunc = func(ctx context.Context, mUser *model.User) (UserQuotas, error) {
+			assert.Equal(t, int64(123), mUser.ID)
+			assert.Equal(t, "test-user", mUser.Username)
+			return wantQuotas, nil
+		}
 
 		quotaTracker := &mockQuotaTracker{}
 		authorizer := New(&gorm.DB{}, pdp, quotaTracker)
 
 		middleware := authorizer.Middleware()
-		handler := middleware(newTestHandler(t, &wantCaps))
+		handler := middleware(newTestHandler(t, &wantCaps, &wantQuotas))
 
 		testUser := newTestUser()
 		ctx := authn.NewContextWithUser(context.Background(), testUser)
@@ -135,7 +170,7 @@ func TestAuthorizerMiddleware(t *testing.T) {
 		authorizer := New(&gorm.DB{}, pdp, quotaTracker)
 
 		middleware := authorizer.Middleware()
-		handler := middleware(newTestHandler(t, nil))
+		handler := middleware(newTestHandler(t, nil, nil))
 
 		testUser := newTestUser()
 		ctx := authn.NewContextWithUser(context.Background(), testUser)

--- a/spx-backend/internal/authz/context.go
+++ b/spx-backend/internal/authz/context.go
@@ -29,3 +29,17 @@ func UserCapabilitiesFromContext(ctx context.Context) (UserCapabilities, bool) {
 	caps, ok := ctx.Value(userCapabilitiesContextKey{}).(UserCapabilities)
 	return caps, ok
 }
+
+// userQuotasContextKey is the context key type for user quotas.
+type userQuotasContextKey struct{}
+
+// NewContextWithUserQuotas creates a new context with the user quotas.
+func NewContextWithUserQuotas(ctx context.Context, quotas UserQuotas) context.Context {
+	return context.WithValue(ctx, userQuotasContextKey{}, quotas)
+}
+
+// UserQuotasFromContext gets the user quotas from context.
+func UserQuotasFromContext(ctx context.Context) (UserQuotas, bool) {
+	quotas, ok := ctx.Value(userQuotasContextKey{}).(UserQuotas)
+	return quotas, ok
+}

--- a/spx-backend/internal/authz/context_test.go
+++ b/spx-backend/internal/authz/context_test.go
@@ -3,6 +3,7 @@ package authz
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -16,29 +17,53 @@ func newTestAuthorizer() *Authorizer {
 }
 
 func newTestUserCapabilities() UserCapabilities {
-	const quotaWindow = 24 * 60 * 60
 	return UserCapabilities{
 		CanManageAssets:  true,
-		CanUsePremiumLLM: false,
-		CopilotMessageQuota: Quota{
-			Limit:     100,
-			Remaining: 85,
-			Window:    quotaWindow,
-		},
-		AIDescriptionQuota: Quota{
-			Limit:     300,
-			Remaining: 290,
-			Window:    quotaWindow,
-		},
-		AIInteractionTurnQuota: Quota{
-			Limit:     12000,
-			Remaining: 11700,
-			Window:    quotaWindow,
-		},
-		AIInteractionArchiveQuota: Quota{
-			Limit:     8000,
-			Remaining: 7600,
-			Window:    quotaWindow,
+		CanManageCourses: false,
+		CanUsePremiumLLM: true,
+	}
+}
+
+func newTestUserQuotas() UserQuotas {
+	const quotaWindow = 24 * time.Hour
+	return UserQuotas{
+		Limits: map[Resource]Quota{
+			ResourceCopilotMessage: {
+				QuotaPolicy: QuotaPolicy{
+					Name:     "copilotMessage:limit",
+					Resource: ResourceCopilotMessage,
+					Limit:    100,
+					Window:   quotaWindow,
+				},
+				QuotaUsage: QuotaUsage{Used: 15},
+			},
+			ResourceAIDescription: {
+				QuotaPolicy: QuotaPolicy{
+					Name:     "aiDescription:limit",
+					Resource: ResourceAIDescription,
+					Limit:    300,
+					Window:   quotaWindow,
+				},
+				QuotaUsage: QuotaUsage{Used: 10},
+			},
+			ResourceAIInteractionTurn: {
+				QuotaPolicy: QuotaPolicy{
+					Name:     "aiInteractionTurn:limit",
+					Resource: ResourceAIInteractionTurn,
+					Limit:    12000,
+					Window:   quotaWindow,
+				},
+				QuotaUsage: QuotaUsage{Used: 300},
+			},
+			ResourceAIInteractionArchive: {
+				QuotaPolicy: QuotaPolicy{
+					Name:     "aiInteractionArchive:limit",
+					Resource: ResourceAIInteractionArchive,
+					Limit:    8000,
+					Window:   quotaWindow,
+				},
+				QuotaUsage: QuotaUsage{Used: 400},
+			},
 		},
 	}
 }
@@ -126,5 +151,48 @@ func TestUserCapabilitiesFromContext(t *testing.T) {
 		caps, ok := UserCapabilitiesFromContext(ctx)
 		require.False(t, ok)
 		require.Zero(t, caps)
+	})
+}
+
+func TestNewContextWithUserQuotas(t *testing.T) {
+	t.Run("Normal", func(t *testing.T) {
+		wantQuotas := newTestUserQuotas()
+		ctx := NewContextWithUserQuotas(context.Background(), wantQuotas)
+
+		quotas, ok := ctx.Value(userQuotasContextKey{}).(UserQuotas)
+		require.True(t, ok)
+		assert.Equal(t, wantQuotas, quotas)
+	})
+
+	t.Run("ZeroQuotas", func(t *testing.T) {
+		ctx := NewContextWithUserQuotas(context.Background(), UserQuotas{})
+
+		value := ctx.Value(userQuotasContextKey{})
+		assert.Zero(t, value)
+	})
+}
+
+func TestUserQuotasFromContext(t *testing.T) {
+	t.Run("Normal", func(t *testing.T) {
+		wantQuotas := newTestUserQuotas()
+		ctx := NewContextWithUserQuotas(context.Background(), wantQuotas)
+
+		quotas, ok := UserQuotasFromContext(ctx)
+		require.True(t, ok)
+		assert.Equal(t, wantQuotas, quotas)
+	})
+
+	t.Run("NoQuotas", func(t *testing.T) {
+		quotas, ok := UserQuotasFromContext(context.Background())
+		require.False(t, ok)
+		require.Zero(t, quotas)
+	})
+
+	t.Run("WrongContextValue", func(t *testing.T) {
+		ctx := context.WithValue(context.Background(), userQuotasContextKey{}, "not-quotas")
+
+		quotas, ok := UserQuotasFromContext(ctx)
+		require.False(t, ok)
+		require.Zero(t, quotas)
 	})
 }

--- a/spx-backend/internal/authz/embpdp/embpdp_test.go
+++ b/spx-backend/internal/authz/embpdp/embpdp_test.go
@@ -12,6 +12,42 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var (
+	copilotQuotaLimitFree = quotaLimitForPlan(authz.ResourceCopilotMessage, model.UserPlanFree)
+	copilotQuotaLimitPlus = quotaLimitForPlan(authz.ResourceCopilotMessage, model.UserPlanPlus)
+	copilotQuotaWindow    = quotaWindowFor(authz.ResourceCopilotMessage)
+
+	aiDescriptionQuotaLimitFree = quotaLimitForPlan(authz.ResourceAIDescription, model.UserPlanFree)
+	aiDescriptionQuotaLimitPlus = quotaLimitForPlan(authz.ResourceAIDescription, model.UserPlanPlus)
+	aiDescriptionQuotaWindow    = quotaWindowFor(authz.ResourceAIDescription)
+
+	aiInteractionTurnQuotaLimitFree = quotaLimitForPlan(authz.ResourceAIInteractionTurn, model.UserPlanFree)
+	aiInteractionTurnQuotaLimitPlus = quotaLimitForPlan(authz.ResourceAIInteractionTurn, model.UserPlanPlus)
+	aiInteractionTurnQuotaWindow    = quotaWindowFor(authz.ResourceAIInteractionTurn)
+
+	aiInteractionArchiveQuotaLimitFree = quotaLimitForPlan(authz.ResourceAIInteractionArchive, model.UserPlanFree)
+	aiInteractionArchiveQuotaLimitPlus = quotaLimitForPlan(authz.ResourceAIInteractionArchive, model.UserPlanPlus)
+	aiInteractionArchiveQuotaWindow    = quotaWindowFor(authz.ResourceAIInteractionArchive)
+)
+
+func quotaLimitForPlan(resource authz.Resource, plan model.UserPlan) int64 {
+	for _, spec := range quotaLimitSpecs {
+		if spec.Resource == resource {
+			return spec.policy(plan).Limit
+		}
+	}
+	panic(fmt.Sprintf("unsupported quota resource %q", resource))
+}
+
+func quotaWindowFor(resource authz.Resource) time.Duration {
+	for _, spec := range quotaLimitSpecs {
+		if spec.Resource == resource {
+			return spec.Window
+		}
+	}
+	panic(fmt.Sprintf("unsupported quota resource %q", resource))
+}
+
 type mockQuotaTracker struct {
 	usage map[string]authz.QuotaUsage
 }
@@ -20,13 +56,13 @@ func newMockQuotaTracker() *mockQuotaTracker {
 	return &mockQuotaTracker{usage: make(map[string]authz.QuotaUsage)}
 }
 
-func (m *mockQuotaTracker) Usage(ctx context.Context, userID int64, resource authz.Resource) (authz.QuotaUsage, error) {
-	key := fmt.Sprintf("%d:%s", userID, resource)
+func (m *mockQuotaTracker) Usage(ctx context.Context, userID int64, policy authz.QuotaPolicy) (authz.QuotaUsage, error) {
+	key := fmt.Sprintf("%d:%s", userID, policy.Name)
 	return m.usage[key], nil
 }
 
-func (m *mockQuotaTracker) IncrementUsage(ctx context.Context, userID int64, resource authz.Resource, amount int64, policy authz.QuotaPolicy) error {
-	key := fmt.Sprintf("%d:%s", userID, resource)
+func (m *mockQuotaTracker) IncrementUsage(ctx context.Context, userID int64, policy authz.QuotaPolicy, amount int64) error {
+	key := fmt.Sprintf("%d:%s", userID, policy.Name)
 	entry := m.usage[key]
 	entry.Used += amount
 	if policy.Window > 0 {
@@ -36,8 +72,8 @@ func (m *mockQuotaTracker) IncrementUsage(ctx context.Context, userID int64, res
 	return nil
 }
 
-func (m *mockQuotaTracker) ResetUsage(ctx context.Context, userID int64, resource authz.Resource) error {
-	key := fmt.Sprintf("%d:%s", userID, resource)
+func (m *mockQuotaTracker) ResetUsage(ctx context.Context, userID int64, policy authz.QuotaPolicy) error {
+	key := fmt.Sprintf("%d:%s", userID, policy.Name)
 	m.usage[key] = authz.QuotaUsage{}
 	return nil
 }
@@ -58,13 +94,13 @@ func TestEmbeddedPDPComputeUserCapabilities(t *testing.T) {
 			wantCanManageCourses                bool
 			wantCanUsePremiumLLM                bool
 			wantCopilotMessageQuotaLimit        int64
-			wantCopilotMessageQuotaWindow       int64
+			wantCopilotMessageQuotaWindow       time.Duration
 			wantAIDescriptionQuotaLimit         int64
-			wantAIDescriptionQuotaWindow        int64
+			wantAIDescriptionQuotaWindow        time.Duration
 			wantAIInteractionTurnQuotaLimit     int64
-			wantAIInteractionTurnQuotaWindow    int64
+			wantAIInteractionTurnQuotaWindow    time.Duration
 			wantAIInteractionArchiveQuotaLimit  int64
-			wantAIInteractionArchiveQuotaWindow int64
+			wantAIInteractionArchiveQuotaWindow time.Duration
 		}{
 			{
 				name: "AssetAdminWithPlusPlan",
@@ -78,13 +114,13 @@ func TestEmbeddedPDPComputeUserCapabilities(t *testing.T) {
 				wantCanManageCourses:                false,
 				wantCanUsePremiumLLM:                true,
 				wantCopilotMessageQuotaLimit:        copilotQuotaLimitPlus,
-				wantCopilotMessageQuotaWindow:       quotaWindow,
+				wantCopilotMessageQuotaWindow:       copilotQuotaWindow,
 				wantAIDescriptionQuotaLimit:         aiDescriptionQuotaLimitPlus,
-				wantAIDescriptionQuotaWindow:        quotaWindow,
+				wantAIDescriptionQuotaWindow:        aiDescriptionQuotaWindow,
 				wantAIInteractionTurnQuotaLimit:     aiInteractionTurnQuotaLimitPlus,
-				wantAIInteractionTurnQuotaWindow:    quotaWindow,
+				wantAIInteractionTurnQuotaWindow:    aiInteractionTurnQuotaWindow,
 				wantAIInteractionArchiveQuotaLimit:  aiInteractionArchiveQuotaLimitPlus,
-				wantAIInteractionArchiveQuotaWindow: quotaWindow,
+				wantAIInteractionArchiveQuotaWindow: aiInteractionArchiveQuotaWindow,
 			},
 			{
 				name: "RegularPlusUser",
@@ -98,13 +134,13 @@ func TestEmbeddedPDPComputeUserCapabilities(t *testing.T) {
 				wantCanManageCourses:                false,
 				wantCanUsePremiumLLM:                true,
 				wantCopilotMessageQuotaLimit:        copilotQuotaLimitPlus,
-				wantCopilotMessageQuotaWindow:       quotaWindow,
+				wantCopilotMessageQuotaWindow:       copilotQuotaWindow,
 				wantAIDescriptionQuotaLimit:         aiDescriptionQuotaLimitPlus,
-				wantAIDescriptionQuotaWindow:        quotaWindow,
+				wantAIDescriptionQuotaWindow:        aiDescriptionQuotaWindow,
 				wantAIInteractionTurnQuotaLimit:     aiInteractionTurnQuotaLimitPlus,
-				wantAIInteractionTurnQuotaWindow:    quotaWindow,
+				wantAIInteractionTurnQuotaWindow:    aiInteractionTurnQuotaWindow,
 				wantAIInteractionArchiveQuotaLimit:  aiInteractionArchiveQuotaLimitPlus,
-				wantAIInteractionArchiveQuotaWindow: quotaWindow,
+				wantAIInteractionArchiveQuotaWindow: aiInteractionArchiveQuotaWindow,
 			},
 			{
 				name: "RegularFreeUser",
@@ -118,13 +154,13 @@ func TestEmbeddedPDPComputeUserCapabilities(t *testing.T) {
 				wantCanManageCourses:                false,
 				wantCanUsePremiumLLM:                false,
 				wantCopilotMessageQuotaLimit:        copilotQuotaLimitFree,
-				wantCopilotMessageQuotaWindow:       quotaWindow,
+				wantCopilotMessageQuotaWindow:       copilotQuotaWindow,
 				wantAIDescriptionQuotaLimit:         aiDescriptionQuotaLimitFree,
-				wantAIDescriptionQuotaWindow:        quotaWindow,
+				wantAIDescriptionQuotaWindow:        aiDescriptionQuotaWindow,
 				wantAIInteractionTurnQuotaLimit:     aiInteractionTurnQuotaLimitFree,
-				wantAIInteractionTurnQuotaWindow:    quotaWindow,
+				wantAIInteractionTurnQuotaWindow:    aiInteractionTurnQuotaWindow,
 				wantAIInteractionArchiveQuotaLimit:  aiInteractionArchiveQuotaLimitFree,
-				wantAIInteractionArchiveQuotaWindow: quotaWindow,
+				wantAIInteractionArchiveQuotaWindow: aiInteractionArchiveQuotaWindow,
 			},
 			{
 				name: "AdminWithFreePlan",
@@ -138,13 +174,13 @@ func TestEmbeddedPDPComputeUserCapabilities(t *testing.T) {
 				wantCanManageCourses:                false,
 				wantCanUsePremiumLLM:                false,
 				wantCopilotMessageQuotaLimit:        copilotQuotaLimitFree,
-				wantCopilotMessageQuotaWindow:       quotaWindow,
+				wantCopilotMessageQuotaWindow:       copilotQuotaWindow,
 				wantAIDescriptionQuotaLimit:         aiDescriptionQuotaLimitFree,
-				wantAIDescriptionQuotaWindow:        quotaWindow,
+				wantAIDescriptionQuotaWindow:        aiDescriptionQuotaWindow,
 				wantAIInteractionTurnQuotaLimit:     aiInteractionTurnQuotaLimitFree,
-				wantAIInteractionTurnQuotaWindow:    quotaWindow,
+				wantAIInteractionTurnQuotaWindow:    aiInteractionTurnQuotaWindow,
 				wantAIInteractionArchiveQuotaLimit:  aiInteractionArchiveQuotaLimitFree,
-				wantAIInteractionArchiveQuotaWindow: quotaWindow,
+				wantAIInteractionArchiveQuotaWindow: aiInteractionArchiveQuotaWindow,
 			},
 			{
 				name: "UserWithMultipleRoles",
@@ -158,13 +194,13 @@ func TestEmbeddedPDPComputeUserCapabilities(t *testing.T) {
 				wantCanManageCourses:                false,
 				wantCanUsePremiumLLM:                false,
 				wantCopilotMessageQuotaLimit:        copilotQuotaLimitFree,
-				wantCopilotMessageQuotaWindow:       quotaWindow,
+				wantCopilotMessageQuotaWindow:       copilotQuotaWindow,
 				wantAIDescriptionQuotaLimit:         aiDescriptionQuotaLimitFree,
-				wantAIDescriptionQuotaWindow:        quotaWindow,
+				wantAIDescriptionQuotaWindow:        aiDescriptionQuotaWindow,
 				wantAIInteractionTurnQuotaLimit:     aiInteractionTurnQuotaLimitFree,
-				wantAIInteractionTurnQuotaWindow:    quotaWindow,
+				wantAIInteractionTurnQuotaWindow:    aiInteractionTurnQuotaWindow,
 				wantAIInteractionArchiveQuotaLimit:  aiInteractionArchiveQuotaLimitFree,
-				wantAIInteractionArchiveQuotaWindow: quotaWindow,
+				wantAIInteractionArchiveQuotaWindow: aiInteractionArchiveQuotaWindow,
 			},
 			{
 				name: "CourseAdminUser",
@@ -178,13 +214,13 @@ func TestEmbeddedPDPComputeUserCapabilities(t *testing.T) {
 				wantCanManageCourses:                true,
 				wantCanUsePremiumLLM:                false,
 				wantCopilotMessageQuotaLimit:        copilotQuotaLimitFree,
-				wantCopilotMessageQuotaWindow:       quotaWindow,
+				wantCopilotMessageQuotaWindow:       copilotQuotaWindow,
 				wantAIDescriptionQuotaLimit:         aiDescriptionQuotaLimitFree,
-				wantAIDescriptionQuotaWindow:        quotaWindow,
+				wantAIDescriptionQuotaWindow:        aiDescriptionQuotaWindow,
 				wantAIInteractionTurnQuotaLimit:     aiInteractionTurnQuotaLimitFree,
-				wantAIInteractionTurnQuotaWindow:    quotaWindow,
+				wantAIInteractionTurnQuotaWindow:    aiInteractionTurnQuotaWindow,
 				wantAIInteractionArchiveQuotaLimit:  aiInteractionArchiveQuotaLimitFree,
-				wantAIInteractionArchiveQuotaWindow: quotaWindow,
+				wantAIInteractionArchiveQuotaWindow: aiInteractionArchiveQuotaWindow,
 			},
 			{
 				name: "UserWithMultipleAdminRoles",
@@ -198,13 +234,13 @@ func TestEmbeddedPDPComputeUserCapabilities(t *testing.T) {
 				wantCanManageCourses:                true,
 				wantCanUsePremiumLLM:                true,
 				wantCopilotMessageQuotaLimit:        copilotQuotaLimitPlus,
-				wantCopilotMessageQuotaWindow:       quotaWindow,
+				wantCopilotMessageQuotaWindow:       copilotQuotaWindow,
 				wantAIDescriptionQuotaLimit:         aiDescriptionQuotaLimitPlus,
-				wantAIDescriptionQuotaWindow:        quotaWindow,
+				wantAIDescriptionQuotaWindow:        aiDescriptionQuotaWindow,
 				wantAIInteractionTurnQuotaLimit:     aiInteractionTurnQuotaLimitPlus,
-				wantAIInteractionTurnQuotaWindow:    quotaWindow,
+				wantAIInteractionTurnQuotaWindow:    aiInteractionTurnQuotaWindow,
 				wantAIInteractionArchiveQuotaLimit:  aiInteractionArchiveQuotaLimitPlus,
-				wantAIInteractionArchiveQuotaWindow: quotaWindow,
+				wantAIInteractionArchiveQuotaWindow: aiInteractionArchiveQuotaWindow,
 			},
 		} {
 			t.Run(tt.name, func(t *testing.T) {
@@ -216,22 +252,37 @@ func TestEmbeddedPDPComputeUserCapabilities(t *testing.T) {
 				assert.Equal(t, tt.wantCanManageAssets, caps.CanManageAssets)
 				assert.Equal(t, tt.wantCanManageCourses, caps.CanManageCourses)
 				assert.Equal(t, tt.wantCanUsePremiumLLM, caps.CanUsePremiumLLM)
-				assert.Equal(t, tt.wantCopilotMessageQuotaLimit, caps.CopilotMessageQuota.Limit)
-				assert.Equal(t, tt.wantCopilotMessageQuotaWindow, caps.CopilotMessageQuota.Window)
-				assert.Equal(t, caps.CopilotMessageQuota.Limit, caps.CopilotMessageQuota.Remaining)
-				assert.Equal(t, caps.CopilotMessageQuota.Window, caps.CopilotMessageQuota.Reset())
-				assert.Equal(t, tt.wantAIDescriptionQuotaLimit, caps.AIDescriptionQuota.Limit)
-				assert.Equal(t, tt.wantAIDescriptionQuotaWindow, caps.AIDescriptionQuota.Window)
-				assert.Equal(t, caps.AIDescriptionQuota.Limit, caps.AIDescriptionQuota.Remaining)
-				assert.Equal(t, caps.AIDescriptionQuota.Window, caps.AIDescriptionQuota.Reset())
-				assert.Equal(t, tt.wantAIInteractionTurnQuotaLimit, caps.AIInteractionTurnQuota.Limit)
-				assert.Equal(t, tt.wantAIInteractionTurnQuotaWindow, caps.AIInteractionTurnQuota.Window)
-				assert.Equal(t, caps.AIInteractionTurnQuota.Limit, caps.AIInteractionTurnQuota.Remaining)
-				assert.Equal(t, caps.AIInteractionTurnQuota.Window, caps.AIInteractionTurnQuota.Reset())
-				assert.Equal(t, tt.wantAIInteractionArchiveQuotaLimit, caps.AIInteractionArchiveQuota.Limit)
-				assert.Equal(t, tt.wantAIInteractionArchiveQuotaWindow, caps.AIInteractionArchiveQuota.Window)
-				assert.Equal(t, caps.AIInteractionArchiveQuota.Limit, caps.AIInteractionArchiveQuota.Remaining)
-				assert.Equal(t, caps.AIInteractionArchiveQuota.Window, caps.AIInteractionArchiveQuota.Reset())
+
+				quotas, err := pdp.ComputeUserQuotas(context.Background(), tt.mUser)
+				require.NoError(t, err)
+
+				copilotMessage, ok := quotas.Limits[authz.ResourceCopilotMessage]
+				require.True(t, ok)
+				assert.Equal(t, tt.wantCopilotMessageQuotaLimit, copilotMessage.Limit)
+				assert.Equal(t, tt.wantCopilotMessageQuotaWindow, copilotMessage.Window)
+				assert.Equal(t, copilotMessage.Limit, copilotMessage.Remaining())
+				assert.Equal(t, int64(tt.wantCopilotMessageQuotaWindow/time.Second), copilotMessage.Reset())
+
+				aiDescription, ok := quotas.Limits[authz.ResourceAIDescription]
+				require.True(t, ok)
+				assert.Equal(t, tt.wantAIDescriptionQuotaLimit, aiDescription.Limit)
+				assert.Equal(t, tt.wantAIDescriptionQuotaWindow, aiDescription.Window)
+				assert.Equal(t, aiDescription.Limit, aiDescription.Remaining())
+				assert.Equal(t, int64(tt.wantAIDescriptionQuotaWindow/time.Second), aiDescription.Reset())
+
+				aiInteractionTurn, ok := quotas.Limits[authz.ResourceAIInteractionTurn]
+				require.True(t, ok)
+				assert.Equal(t, tt.wantAIInteractionTurnQuotaLimit, aiInteractionTurn.Limit)
+				assert.Equal(t, tt.wantAIInteractionTurnQuotaWindow, aiInteractionTurn.Window)
+				assert.Equal(t, aiInteractionTurn.Limit, aiInteractionTurn.Remaining())
+				assert.Equal(t, int64(tt.wantAIInteractionTurnQuotaWindow/time.Second), aiInteractionTurn.Reset())
+
+				aiInteractionArchive, ok := quotas.Limits[authz.ResourceAIInteractionArchive]
+				require.True(t, ok)
+				assert.Equal(t, tt.wantAIInteractionArchiveQuotaLimit, aiInteractionArchive.Limit)
+				assert.Equal(t, tt.wantAIInteractionArchiveQuotaWindow, aiInteractionArchive.Window)
+				assert.Equal(t, aiInteractionArchive.Limit, aiInteractionArchive.Remaining())
+				assert.Equal(t, int64(tt.wantAIInteractionArchiveQuotaWindow/time.Second), aiInteractionArchive.Reset())
 			})
 		}
 	})
@@ -247,38 +298,52 @@ func TestEmbeddedPDPComputeUserCapabilities(t *testing.T) {
 			Plan:     model.UserPlanFree,
 		}
 
-		window := quotaWindow * time.Second
-
 		err := quotaTracker.IncrementUsage(
 			context.Background(),
 			mUser.ID,
-			authz.ResourceCopilotMessage,
+			authz.QuotaPolicy{
+				Name:     "copilotMessage:limit",
+				Resource: authz.ResourceCopilotMessage,
+				Limit:    copilotQuotaLimitFree,
+				Window:   copilotQuotaWindow,
+			},
 			30,
-			authz.QuotaPolicy{Limit: copilotQuotaLimitFree, Window: window},
 		)
 		require.NoError(t, err)
 		err = quotaTracker.IncrementUsage(
 			context.Background(),
 			mUser.ID,
-			authz.ResourceAIDescription,
+			authz.QuotaPolicy{
+				Name:     "aiDescription:limit",
+				Resource: authz.ResourceAIDescription,
+				Limit:    aiDescriptionQuotaLimitFree,
+				Window:   aiDescriptionQuotaWindow,
+			},
 			5,
-			authz.QuotaPolicy{Limit: aiDescriptionQuotaLimitFree, Window: window},
 		)
 		require.NoError(t, err)
 		err = quotaTracker.IncrementUsage(
 			context.Background(),
 			mUser.ID,
-			authz.ResourceAIInteractionTurn,
+			authz.QuotaPolicy{
+				Name:     "aiInteractionTurn:limit",
+				Resource: authz.ResourceAIInteractionTurn,
+				Limit:    aiInteractionTurnQuotaLimitFree,
+				Window:   aiInteractionTurnQuotaWindow,
+			},
 			120,
-			authz.QuotaPolicy{Limit: aiInteractionTurnQuotaLimitFree, Window: window},
 		)
 		require.NoError(t, err)
 		err = quotaTracker.IncrementUsage(
 			context.Background(),
 			mUser.ID,
-			authz.ResourceAIInteractionArchive,
+			authz.QuotaPolicy{
+				Name:     "aiInteractionArchive:limit",
+				Resource: authz.ResourceAIInteractionArchive,
+				Limit:    aiInteractionArchiveQuotaLimitFree,
+				Window:   aiInteractionArchiveQuotaWindow,
+			},
 			10,
-			authz.QuotaPolicy{Limit: aiInteractionArchiveQuotaLimitFree, Window: window},
 		)
 		require.NoError(t, err)
 
@@ -287,22 +352,37 @@ func TestEmbeddedPDPComputeUserCapabilities(t *testing.T) {
 		assert.Equal(t, false, caps.CanManageAssets)
 		assert.Equal(t, false, caps.CanManageCourses)
 		assert.Equal(t, false, caps.CanUsePremiumLLM)
-		assert.Equal(t, int64(copilotQuotaLimitFree), caps.CopilotMessageQuota.Limit)
-		assert.Equal(t, int64(quotaWindow), caps.CopilotMessageQuota.Window)
-		assert.Equal(t, int64(copilotQuotaLimitFree-30), caps.CopilotMessageQuota.Remaining)
-		assert.Equal(t, int64(quotaWindow), caps.CopilotMessageQuota.Reset())
-		assert.Equal(t, int64(aiDescriptionQuotaLimitFree), caps.AIDescriptionQuota.Limit)
-		assert.Equal(t, int64(quotaWindow), caps.AIDescriptionQuota.Window)
-		assert.Equal(t, int64(aiDescriptionQuotaLimitFree-5), caps.AIDescriptionQuota.Remaining)
-		assert.Equal(t, int64(quotaWindow), caps.AIDescriptionQuota.Reset())
-		assert.Equal(t, int64(aiInteractionTurnQuotaLimitFree), caps.AIInteractionTurnQuota.Limit)
-		assert.Equal(t, int64(quotaWindow), caps.AIInteractionTurnQuota.Window)
-		assert.Equal(t, int64(aiInteractionTurnQuotaLimitFree-120), caps.AIInteractionTurnQuota.Remaining)
-		assert.Equal(t, int64(quotaWindow), caps.AIInteractionTurnQuota.Reset())
-		assert.Equal(t, int64(aiInteractionArchiveQuotaLimitFree), caps.AIInteractionArchiveQuota.Limit)
-		assert.Equal(t, int64(quotaWindow), caps.AIInteractionArchiveQuota.Window)
-		assert.Equal(t, int64(aiInteractionArchiveQuotaLimitFree-10), caps.AIInteractionArchiveQuota.Remaining)
-		assert.Equal(t, int64(quotaWindow), caps.AIInteractionArchiveQuota.Reset())
+
+		quotas, err := pdp.ComputeUserQuotas(context.Background(), mUser)
+		require.NoError(t, err)
+
+		copilotMessage, ok := quotas.Limits[authz.ResourceCopilotMessage]
+		require.True(t, ok)
+		assert.Equal(t, int64(copilotQuotaLimitFree), copilotMessage.Limit)
+		assert.Equal(t, copilotQuotaWindow, copilotMessage.Window)
+		assert.Equal(t, int64(copilotQuotaLimitFree-30), copilotMessage.Remaining())
+		assert.Equal(t, int64(copilotQuotaWindow/time.Second), copilotMessage.Reset())
+
+		aiDescription, ok := quotas.Limits[authz.ResourceAIDescription]
+		require.True(t, ok)
+		assert.Equal(t, int64(aiDescriptionQuotaLimitFree), aiDescription.Limit)
+		assert.Equal(t, aiDescriptionQuotaWindow, aiDescription.Window)
+		assert.Equal(t, int64(aiDescriptionQuotaLimitFree-5), aiDescription.Remaining())
+		assert.Equal(t, int64(aiDescriptionQuotaWindow/time.Second), aiDescription.Reset())
+
+		aiInteractionTurn, ok := quotas.Limits[authz.ResourceAIInteractionTurn]
+		require.True(t, ok)
+		assert.Equal(t, int64(aiInteractionTurnQuotaLimitFree), aiInteractionTurn.Limit)
+		assert.Equal(t, aiInteractionTurnQuotaWindow, aiInteractionTurn.Window)
+		assert.Equal(t, int64(aiInteractionTurnQuotaLimitFree-120), aiInteractionTurn.Remaining())
+		assert.Equal(t, int64(aiInteractionTurnQuotaWindow/time.Second), aiInteractionTurn.Reset())
+
+		aiInteractionArchive, ok := quotas.Limits[authz.ResourceAIInteractionArchive]
+		require.True(t, ok)
+		assert.Equal(t, int64(aiInteractionArchiveQuotaLimitFree), aiInteractionArchive.Limit)
+		assert.Equal(t, aiInteractionArchiveQuotaWindow, aiInteractionArchive.Window)
+		assert.Equal(t, int64(aiInteractionArchiveQuotaLimitFree-10), aiInteractionArchive.Remaining())
+		assert.Equal(t, int64(aiInteractionArchiveQuotaWindow/time.Second), aiInteractionArchive.Reset())
 	})
 
 	t.Run("QuotaExceeded", func(t *testing.T) {
@@ -316,122 +396,155 @@ func TestEmbeddedPDPComputeUserCapabilities(t *testing.T) {
 			Plan:     model.UserPlanFree,
 		}
 
-		window := quotaWindow * time.Second
-
 		err := quotaTracker.IncrementUsage(
 			context.Background(),
 			mUser.ID,
-			authz.ResourceCopilotMessage,
+			authz.QuotaPolicy{
+				Name:     "copilotMessage:limit",
+				Resource: authz.ResourceCopilotMessage,
+				Limit:    copilotQuotaLimitFree,
+				Window:   copilotQuotaWindow,
+			},
 			copilotQuotaLimitFree+50,
-			authz.QuotaPolicy{Limit: copilotQuotaLimitFree, Window: window},
 		)
 		require.NoError(t, err)
 		err = quotaTracker.IncrementUsage(
 			context.Background(),
 			mUser.ID,
-			authz.ResourceAIDescription,
+			authz.QuotaPolicy{
+				Name:     "aiDescription:limit",
+				Resource: authz.ResourceAIDescription,
+				Limit:    aiDescriptionQuotaLimitFree,
+				Window:   aiDescriptionQuotaWindow,
+			},
 			aiDescriptionQuotaLimitFree+100,
-			authz.QuotaPolicy{Limit: aiDescriptionQuotaLimitFree, Window: window},
 		)
 		require.NoError(t, err)
 		err = quotaTracker.IncrementUsage(
 			context.Background(),
 			mUser.ID,
-			authz.ResourceAIInteractionTurn,
+			authz.QuotaPolicy{
+				Name:     "aiInteractionTurn:limit",
+				Resource: authz.ResourceAIInteractionTurn,
+				Limit:    aiInteractionTurnQuotaLimitFree,
+				Window:   aiInteractionTurnQuotaWindow,
+			},
 			aiInteractionTurnQuotaLimitFree+5000,
-			authz.QuotaPolicy{Limit: aiInteractionTurnQuotaLimitFree, Window: window},
 		)
 		require.NoError(t, err)
 		err = quotaTracker.IncrementUsage(
 			context.Background(),
 			mUser.ID,
-			authz.ResourceAIInteractionArchive,
+			authz.QuotaPolicy{
+				Name:     "aiInteractionArchive:limit",
+				Resource: authz.ResourceAIInteractionArchive,
+				Limit:    aiInteractionArchiveQuotaLimitFree,
+				Window:   aiInteractionArchiveQuotaWindow,
+			},
 			aiInteractionArchiveQuotaLimitFree+3000,
-			authz.QuotaPolicy{Limit: aiInteractionArchiveQuotaLimitFree, Window: window},
 		)
 		require.NoError(t, err)
 
-		caps, err := pdp.ComputeUserCapabilities(context.Background(), mUser)
+		quotas, err := pdp.ComputeUserQuotas(context.Background(), mUser)
 		require.NoError(t, err)
-		assert.Equal(t, int64(copilotQuotaLimitFree), caps.CopilotMessageQuota.Limit)
-		assert.Equal(t, int64(quotaWindow), caps.CopilotMessageQuota.Window)
-		assert.Equal(t, int64(0), caps.CopilotMessageQuota.Remaining)
-		assert.Equal(t, int64(quotaWindow), caps.CopilotMessageQuota.Reset())
-		assert.Equal(t, int64(aiDescriptionQuotaLimitFree), caps.AIDescriptionQuota.Limit)
-		assert.Equal(t, int64(quotaWindow), caps.AIDescriptionQuota.Window)
-		assert.Equal(t, int64(0), caps.AIDescriptionQuota.Remaining)
-		assert.Equal(t, int64(quotaWindow), caps.AIDescriptionQuota.Reset())
-		assert.Equal(t, int64(aiInteractionTurnQuotaLimitFree), caps.AIInteractionTurnQuota.Limit)
-		assert.Equal(t, int64(quotaWindow), caps.AIInteractionTurnQuota.Window)
-		assert.Equal(t, int64(0), caps.AIInteractionTurnQuota.Remaining)
-		assert.Equal(t, int64(quotaWindow), caps.AIInteractionTurnQuota.Reset())
-		assert.Equal(t, int64(aiInteractionArchiveQuotaLimitFree), caps.AIInteractionArchiveQuota.Limit)
-		assert.Equal(t, int64(quotaWindow), caps.AIInteractionArchiveQuota.Window)
-		assert.Equal(t, int64(0), caps.AIInteractionArchiveQuota.Remaining)
-		assert.Equal(t, int64(quotaWindow), caps.AIInteractionArchiveQuota.Reset())
+		for resource, wantLimit := range map[authz.Resource]int64{
+			authz.ResourceCopilotMessage:       copilotQuotaLimitFree,
+			authz.ResourceAIDescription:        aiDescriptionQuotaLimitFree,
+			authz.ResourceAIInteractionTurn:    aiInteractionTurnQuotaLimitFree,
+			authz.ResourceAIInteractionArchive: aiInteractionArchiveQuotaLimitFree,
+		} {
+			quota, ok := quotas.Limits[resource]
+			require.True(t, ok)
+			assert.Equal(t, wantLimit, quota.Limit)
+			assert.Equal(t, quotaWindowFor(resource), quota.Window)
+			assert.Equal(t, int64(0), quota.Remaining())
+			assert.Equal(t, int64(quotaWindowFor(resource)/time.Second), quota.Reset())
+		}
 	})
 }
 
-func TestQuotaRemaining(t *testing.T) {
-	for _, tt := range []struct {
-		name  string
-		limit int64
-		usage authz.QuotaUsage
-		want  int64
-	}{
-		{
-			name:  "WithinLimit",
-			limit: 100,
-			usage: authz.QuotaUsage{Used: 20},
-			want:  80,
-		},
-		{
-			name:  "ExceedsLimit",
-			limit: 50,
-			usage: authz.QuotaUsage{Used: 80},
-			want:  0,
-		},
-		{
-			name:  "Unlimited",
-			limit: 0,
-			usage: authz.QuotaUsage{Used: 0},
-			want:  0,
-		},
-	} {
-		t.Run(tt.name, func(t *testing.T) {
-			got := quotaRemaining(tt.limit, tt.usage)
-			assert.Equal(t, tt.want, got)
-		})
-	}
+func TestQuotaSpec(t *testing.T) {
+	t.Run("DefaultLimitUsedWhenNoOverride", func(t *testing.T) {
+		spec := quotaSpec{
+			QuotaPolicy: authz.QuotaPolicy{
+				Name:     "default",
+				Resource: authz.ResourceCopilotMessage,
+				Limit:    50,
+				Window:   time.Minute,
+			},
+		}
+		policy := spec.policy(model.UserPlanFree)
+		assert.Equal(t, int64(50), policy.Limit)
+		assert.Equal(t, spec.QuotaPolicy, policy)
+		assert.Equal(t, spec.Name, policy.Name)
+		assert.Equal(t, spec.Resource, policy.Resource)
+		assert.Equal(t, spec.Window, policy.Window)
+	})
+
+	t.Run("OverrideAppliedForPlusPlan", func(t *testing.T) {
+		spec := quotaSpec{
+			QuotaPolicy: authz.QuotaPolicy{
+				Name:     "plus",
+				Resource: authz.ResourceAIDescription,
+				Limit:    75,
+				Window:   2 * time.Minute,
+			},
+			limitOverrides: map[model.UserPlan]int64{
+				model.UserPlanPlus: 125,
+			},
+		}
+		policy := spec.policy(model.UserPlanPlus)
+		assert.Equal(t, int64(125), policy.Limit)
+		assert.Equal(t, spec.Name, policy.Name)
+		assert.Equal(t, spec.Resource, policy.Resource)
+		assert.Equal(t, spec.Window, policy.Window)
+	})
+
+	t.Run("UnknownPlanFallsBackToDefault", func(t *testing.T) {
+		spec := quotaSpec{
+			QuotaPolicy: authz.QuotaPolicy{
+				Name:     "enterprise",
+				Resource: authz.ResourceAIInteractionTurn,
+				Limit:    200,
+				Window:   time.Hour,
+			},
+			limitOverrides: map[model.UserPlan]int64{
+				model.UserPlanPlus: 400,
+			},
+		}
+		policy := spec.policy(model.UserPlan(42))
+		assert.Equal(t, int64(200), policy.Limit)
+		assert.Equal(t, spec.Name, policy.Name)
+		assert.Equal(t, spec.Resource, policy.Resource)
+		assert.Equal(t, spec.Window, policy.Window)
+	})
 }
 
 func TestQuotaResetTime(t *testing.T) {
 	t.Run("TrackerProvidesReset", func(t *testing.T) {
-		resetAt := time.Now().Add(120 * time.Second)
+		resetAt := time.Now().Add(2 * time.Minute)
 		usage := authz.QuotaUsage{
 			Used:      10,
 			ResetTime: resetAt,
 		}
-		got := quotaResetTime(86400, usage)
+		got := quotaResetTime(24*time.Hour, usage)
 		require.True(t, got.Equal(resetAt))
 	})
 
 	t.Run("FreshWindowDefaultsToWindow", func(t *testing.T) {
-		const window = int64(3600)
+		const window = time.Hour
 		usage := authz.QuotaUsage{Used: 0}
 		got := quotaResetTime(window, usage)
 		require.False(t, got.IsZero())
 
 		remaining := time.Until(got)
 		require.Greater(t, remaining, 0*time.Second)
-
-		expected := time.Duration(window) * time.Second
-		assert.InDelta(t, float64(expected), float64(remaining), float64(time.Second))
+		assert.InDelta(t, float64(window), float64(remaining), float64(time.Second))
 	})
 
 	t.Run("NoResetInfo", func(t *testing.T) {
 		usage := authz.QuotaUsage{Used: 100}
-		got := quotaResetTime(3600, usage)
+		got := quotaResetTime(time.Hour, usage)
 		assert.True(t, got.IsZero())
 	})
 }

--- a/spx-backend/internal/authz/pdp.go
+++ b/spx-backend/internal/authz/pdp.go
@@ -10,10 +10,12 @@ import (
 type PolicyDecisionPoint interface {
 	// ComputeUserCapabilities computes the capabilities for a user.
 	ComputeUserCapabilities(ctx context.Context, mUser *model.User) (UserCapabilities, error)
+
+	// ComputeUserQuotas computes the quotas for a user.
+	ComputeUserQuotas(ctx context.Context, mUser *model.User) (UserQuotas, error)
 }
 
-// UserCapabilities represents user capabilities and quotas that control access
-// to features and services.
+// UserCapabilities represents user capabilities that control feature access.
 type UserCapabilities struct {
 	// CanManageAssets indicates if user can manage asset library.
 	CanManageAssets bool `json:"canManageAssets"`
@@ -23,32 +25,15 @@ type UserCapabilities struct {
 
 	// CanUsePremiumLLM indicates if user can access premium LLM models.
 	CanUsePremiumLLM bool `json:"canUsePremiumLLM"`
-
-	// CopilotMessageQuota represents quotas for copilot messages.
-	CopilotMessageQuota Quota `json:"-"`
-
-	// AIDescriptionQuota represents quotas for AI description generations.
-	AIDescriptionQuota Quota `json:"-"`
-
-	// AIInteractionTurnQuota represents quotas for AI interaction turns.
-	AIInteractionTurnQuota Quota `json:"-"`
-
-	// AIInteractionArchiveQuota represents quotas for AI interaction archive requests.
-	AIInteractionArchiveQuota Quota `json:"-"`
 }
 
-// Quota returns the quota for the given resource.
-func (uc UserCapabilities) Quota(resource Resource) (Quota, bool) {
-	switch resource {
-	case ResourceCopilotMessage:
-		return uc.CopilotMessageQuota, true
-	case ResourceAIDescription:
-		return uc.AIDescriptionQuota, true
-	case ResourceAIInteractionTurn:
-		return uc.AIInteractionTurnQuota, true
-	case ResourceAIInteractionArchive:
-		return uc.AIInteractionArchiveQuota, true
-	default:
-		return Quota{}, false
-	}
+// UserQuotas represents user quotas grouped by long-lived limits and
+// short-window rate limits.
+type UserQuotas struct {
+	// Limits stores long-lived limits per resource.
+	Limits map[Resource]Quota
+
+	// RateLimits stores short-window rate limits per resource, ordered from
+	// shortest to longest window.
+	RateLimits map[Resource][]Quota
 }

--- a/spx-backend/internal/authz/pdp_test.go
+++ b/spx-backend/internal/authz/pdp_test.go
@@ -2,12 +2,14 @@ package authz
 
 import (
 	"context"
+	"time"
 
 	"github.com/goplus/builder/spx-backend/internal/model"
 )
 
 type mockPolicyDecisionPoint struct {
 	computeUserCapabilitiesFunc func(ctx context.Context, mUser *model.User) (UserCapabilities, error)
+	computeUserQuotasFunc       func(ctx context.Context, mUser *model.User) (UserQuotas, error)
 }
 
 func (m *mockPolicyDecisionPoint) ComputeUserCapabilities(ctx context.Context, mUser *model.User) (UserCapabilities, error) {
@@ -16,26 +18,33 @@ func (m *mockPolicyDecisionPoint) ComputeUserCapabilities(ctx context.Context, m
 	}
 	return UserCapabilities{
 		CanManageAssets:  true,
+		CanManageCourses: false,
 		CanUsePremiumLLM: false,
-		CopilotMessageQuota: Quota{
-			Limit:     100,
-			Remaining: 80,
-			Window:    24 * 60 * 60,
-		},
-		AIDescriptionQuota: Quota{
-			Limit:     300,
-			Remaining: 280,
-			Window:    24 * 60 * 60,
-		},
-		AIInteractionTurnQuota: Quota{
-			Limit:     12000,
-			Remaining: 11600,
-			Window:    24 * 60 * 60,
-		},
-		AIInteractionArchiveQuota: Quota{
-			Limit:     8000,
-			Remaining: 7620,
-			Window:    24 * 60 * 60,
+	}, nil
+}
+
+func (m *mockPolicyDecisionPoint) ComputeUserQuotas(ctx context.Context, mUser *model.User) (UserQuotas, error) {
+	if m.computeUserQuotasFunc != nil {
+		return m.computeUserQuotasFunc(ctx, mUser)
+	}
+	return UserQuotas{
+		Limits: map[Resource]Quota{
+			ResourceCopilotMessage: {
+				QuotaPolicy: QuotaPolicy{Limit: 100, Window: 24 * time.Hour},
+				QuotaUsage:  QuotaUsage{Used: 20},
+			},
+			ResourceAIDescription: {
+				QuotaPolicy: QuotaPolicy{Limit: 300, Window: 24 * time.Hour},
+				QuotaUsage:  QuotaUsage{Used: 20},
+			},
+			ResourceAIInteractionTurn: {
+				QuotaPolicy: QuotaPolicy{Limit: 12000, Window: 24 * time.Hour},
+				QuotaUsage:  QuotaUsage{Used: 400},
+			},
+			ResourceAIInteractionArchive: {
+				QuotaPolicy: QuotaPolicy{Limit: 8000, Window: 24 * time.Hour},
+				QuotaUsage:  QuotaUsage{Used: 380},
+			},
 		},
 	}, nil
 }

--- a/spx-backend/internal/authz/quota/nop.go
+++ b/spx-backend/internal/authz/quota/nop.go
@@ -15,16 +15,16 @@ func NewNopQuotaTracker() authz.QuotaTracker {
 }
 
 // Usage implements [authz.QuotaTracker].
-func (*nopQuotaTracker) Usage(context.Context, int64, authz.Resource) (authz.QuotaUsage, error) {
+func (*nopQuotaTracker) Usage(context.Context, int64, authz.QuotaPolicy) (authz.QuotaUsage, error) {
 	return authz.QuotaUsage{}, nil
 }
 
 // IncrementUsage implements [authz.QuotaTracker].
-func (*nopQuotaTracker) IncrementUsage(context.Context, int64, authz.Resource, int64, authz.QuotaPolicy) error {
+func (*nopQuotaTracker) IncrementUsage(context.Context, int64, authz.QuotaPolicy, int64) error {
 	return nil
 }
 
 // ResetUsage implements [authz.QuotaTracker].
-func (*nopQuotaTracker) ResetUsage(context.Context, int64, authz.Resource) error {
+func (*nopQuotaTracker) ResetUsage(context.Context, int64, authz.QuotaPolicy) error {
 	return nil
 }

--- a/spx-backend/internal/authz/quota/nop_test.go
+++ b/spx-backend/internal/authz/quota/nop_test.go
@@ -14,7 +14,7 @@ func TestNopQuotaTrackerUsage(t *testing.T) {
 		ctx := context.Background()
 		tracker := NewNopQuotaTracker()
 
-		usage, err := tracker.Usage(ctx, 123, authz.ResourceCopilotMessage)
+		usage, err := tracker.Usage(ctx, 123, authz.QuotaPolicy{Name: "copilotMessage:limit"})
 		require.NoError(t, err)
 		assert.Equal(t, int64(0), usage.Used)
 		assert.True(t, usage.ResetTime.IsZero())
@@ -24,12 +24,12 @@ func TestNopQuotaTrackerUsage(t *testing.T) {
 		ctx := context.Background()
 		tracker := NewNopQuotaTracker()
 
-		usage1, err := tracker.Usage(ctx, 123, authz.ResourceCopilotMessage)
+		usage1, err := tracker.Usage(ctx, 123, authz.QuotaPolicy{Name: "copilotMessage:limit"})
 		require.NoError(t, err)
 		assert.Equal(t, int64(0), usage1.Used)
 		assert.True(t, usage1.ResetTime.IsZero())
 
-		usage2, err := tracker.Usage(ctx, 456, authz.ResourceCopilotMessage)
+		usage2, err := tracker.Usage(ctx, 456, authz.QuotaPolicy{Name: "copilotMessage:limit"})
 		require.NoError(t, err)
 		assert.Equal(t, int64(0), usage2.Used)
 		assert.True(t, usage2.ResetTime.IsZero())
@@ -41,7 +41,7 @@ func TestNopQuotaTrackerIncrementUsage(t *testing.T) {
 		ctx := context.Background()
 		tracker := NewNopQuotaTracker()
 
-		err := tracker.IncrementUsage(ctx, 123, authz.ResourceCopilotMessage, 10, authz.QuotaPolicy{})
+		err := tracker.IncrementUsage(ctx, 123, authz.QuotaPolicy{Name: "copilotMessage:limit"}, 10)
 		require.NoError(t, err)
 	})
 
@@ -49,10 +49,10 @@ func TestNopQuotaTrackerIncrementUsage(t *testing.T) {
 		ctx := context.Background()
 		tracker := NewNopQuotaTracker()
 
-		err := tracker.IncrementUsage(ctx, 123, authz.ResourceCopilotMessage, 10, authz.QuotaPolicy{})
+		err := tracker.IncrementUsage(ctx, 123, authz.QuotaPolicy{Name: "copilotMessage:limit"}, 10)
 		require.NoError(t, err)
 
-		usage, err := tracker.Usage(ctx, 123, authz.ResourceCopilotMessage)
+		usage, err := tracker.Usage(ctx, 123, authz.QuotaPolicy{Name: "copilotMessage:limit"})
 		require.NoError(t, err)
 		assert.Equal(t, int64(0), usage.Used)
 		assert.True(t, usage.ResetTime.IsZero())
@@ -62,13 +62,13 @@ func TestNopQuotaTrackerIncrementUsage(t *testing.T) {
 		ctx := context.Background()
 		tracker := NewNopQuotaTracker()
 
-		err := tracker.IncrementUsage(ctx, 123, authz.ResourceCopilotMessage, 5, authz.QuotaPolicy{})
+		err := tracker.IncrementUsage(ctx, 123, authz.QuotaPolicy{Name: "copilotMessage:limit"}, 5)
 		require.NoError(t, err)
 
-		err = tracker.IncrementUsage(ctx, 123, authz.ResourceCopilotMessage, 15, authz.QuotaPolicy{})
+		err = tracker.IncrementUsage(ctx, 123, authz.QuotaPolicy{Name: "copilotMessage:limit"}, 15)
 		require.NoError(t, err)
 
-		usage, err := tracker.Usage(ctx, 123, authz.ResourceCopilotMessage)
+		usage, err := tracker.Usage(ctx, 123, authz.QuotaPolicy{Name: "copilotMessage:limit"})
 		require.NoError(t, err)
 		assert.Equal(t, int64(0), usage.Used)
 		assert.True(t, usage.ResetTime.IsZero())
@@ -78,7 +78,7 @@ func TestNopQuotaTrackerIncrementUsage(t *testing.T) {
 		ctx := context.Background()
 		tracker := NewNopQuotaTracker()
 
-		err := tracker.IncrementUsage(ctx, 123, authz.ResourceCopilotMessage, 0, authz.QuotaPolicy{})
+		err := tracker.IncrementUsage(ctx, 123, authz.QuotaPolicy{Name: "copilotMessage:limit"}, 0)
 		require.NoError(t, err)
 	})
 
@@ -86,7 +86,7 @@ func TestNopQuotaTrackerIncrementUsage(t *testing.T) {
 		ctx := context.Background()
 		tracker := NewNopQuotaTracker()
 
-		err := tracker.IncrementUsage(ctx, 123, authz.ResourceCopilotMessage, -5, authz.QuotaPolicy{})
+		err := tracker.IncrementUsage(ctx, 123, authz.QuotaPolicy{Name: "copilotMessage:limit"}, -5)
 		require.NoError(t, err)
 	})
 }
@@ -96,7 +96,7 @@ func TestNopQuotaTrackerResetUsage(t *testing.T) {
 		ctx := context.Background()
 		tracker := NewNopQuotaTracker()
 
-		err := tracker.ResetUsage(ctx, 123, authz.ResourceCopilotMessage)
+		err := tracker.ResetUsage(ctx, 123, authz.QuotaPolicy{Name: "copilotMessage:limit"})
 		require.NoError(t, err)
 	})
 
@@ -104,10 +104,10 @@ func TestNopQuotaTrackerResetUsage(t *testing.T) {
 		ctx := context.Background()
 		tracker := NewNopQuotaTracker()
 
-		err := tracker.ResetUsage(ctx, 123, authz.ResourceCopilotMessage)
+		err := tracker.ResetUsage(ctx, 123, authz.QuotaPolicy{Name: "copilotMessage:limit"})
 		require.NoError(t, err)
 
-		usage, err := tracker.Usage(ctx, 123, authz.ResourceCopilotMessage)
+		usage, err := tracker.Usage(ctx, 123, authz.QuotaPolicy{Name: "copilotMessage:limit"})
 		require.NoError(t, err)
 		assert.Equal(t, int64(0), usage.Used)
 		assert.True(t, usage.ResetTime.IsZero())
@@ -117,13 +117,13 @@ func TestNopQuotaTrackerResetUsage(t *testing.T) {
 		ctx := context.Background()
 		tracker := NewNopQuotaTracker()
 
-		err := tracker.IncrementUsage(ctx, 123, authz.ResourceCopilotMessage, 100, authz.QuotaPolicy{})
+		err := tracker.IncrementUsage(ctx, 123, authz.QuotaPolicy{Name: "copilotMessage:limit"}, 100)
 		require.NoError(t, err)
 
-		err = tracker.ResetUsage(ctx, 123, authz.ResourceCopilotMessage)
+		err = tracker.ResetUsage(ctx, 123, authz.QuotaPolicy{Name: "copilotMessage:limit"})
 		require.NoError(t, err)
 
-		usage, err := tracker.Usage(ctx, 123, authz.ResourceCopilotMessage)
+		usage, err := tracker.Usage(ctx, 123, authz.QuotaPolicy{Name: "copilotMessage:limit"})
 		require.NoError(t, err)
 		assert.Equal(t, int64(0), usage.Used)
 		assert.True(t, usage.ResetTime.IsZero())

--- a/spx-backend/internal/authz/quota/redis_test.go
+++ b/spx-backend/internal/authz/quota/redis_test.go
@@ -17,11 +17,18 @@ func TestRedisQuotaTrackerUsage(t *testing.T) {
 		ctx := context.Background()
 		client, mock := redismock.NewClientMock()
 		tracker := &redisQuotaTracker{client: client}
+		policy := authz.QuotaPolicy{
+			Name:     "copilotMessage:limit",
+			Resource: authz.ResourceCopilotMessage,
+			Limit:    100,
+			Window:   24 * time.Hour,
+		}
+		key := quotaKey(123, policy)
 
-		mock.ExpectGet("123:copilotMessage").RedisNil()
-		mock.ExpectPTTL("123:copilotMessage").SetVal(0)
+		mock.ExpectGet(key).RedisNil()
+		mock.ExpectPTTL(key).SetVal(0)
 
-		usage, err := tracker.Usage(ctx, 123, authz.ResourceCopilotMessage)
+		usage, err := tracker.Usage(ctx, 123, policy)
 		require.NoError(t, err)
 		assert.Equal(t, int64(0), usage.Used)
 		assert.True(t, usage.ResetTime.IsZero())
@@ -31,11 +38,17 @@ func TestRedisQuotaTrackerUsage(t *testing.T) {
 		ctx := context.Background()
 		client, mock := redismock.NewClientMock()
 		tracker := &redisQuotaTracker{client: client}
+		policy := authz.QuotaPolicy{
+			Name:     "copilotMessage:limit",
+			Resource: authz.ResourceCopilotMessage,
+			Limit:    100,
+			Window:   24 * time.Hour,
+		}
+		key := quotaKey(123, policy)
+		mock.ExpectGet(key).SetVal("25")
+		mock.ExpectPTTL(key).SetVal(30 * time.Second)
 
-		mock.ExpectGet("123:copilotMessage").SetVal("25")
-		mock.ExpectPTTL("123:copilotMessage").SetVal(30 * time.Second)
-
-		usage, err := tracker.Usage(ctx, 123, authz.ResourceCopilotMessage)
+		usage, err := tracker.Usage(ctx, 123, policy)
 		require.NoError(t, err)
 		assert.Equal(t, int64(25), usage.Used)
 		remaining := time.Until(usage.ResetTime)
@@ -49,11 +62,18 @@ func TestRedisQuotaTrackerUsage(t *testing.T) {
 		ctx := context.Background()
 		client, mock := redismock.NewClientMock()
 		tracker := &redisQuotaTracker{client: client}
+		policy := authz.QuotaPolicy{
+			Name:     "copilotMessage:limit",
+			Resource: authz.ResourceCopilotMessage,
+			Limit:    100,
+			Window:   24 * time.Hour,
+		}
+		key := quotaKey(999, policy)
 
-		mock.ExpectGet("999:copilotMessage").RedisNil()
-		mock.ExpectPTTL("999:copilotMessage").SetVal(0)
+		mock.ExpectGet(key).RedisNil()
+		mock.ExpectPTTL(key).SetVal(0)
 
-		usage, err := tracker.Usage(ctx, 999, authz.ResourceCopilotMessage)
+		usage, err := tracker.Usage(ctx, 999, policy)
 		require.NoError(t, err)
 		assert.Equal(t, int64(0), usage.Used)
 		assert.True(t, usage.ResetTime.IsZero())
@@ -63,10 +83,16 @@ func TestRedisQuotaTrackerUsage(t *testing.T) {
 		ctx := context.Background()
 		client, mock := redismock.NewClientMock()
 		tracker := &redisQuotaTracker{client: client}
+		policy := authz.QuotaPolicy{
+			Name:     "copilotMessage:limit",
+			Resource: authz.ResourceCopilotMessage,
+			Limit:    100,
+			Window:   24 * time.Hour,
+		}
+		key := quotaKey(123, policy)
 
-		mock.ExpectGet("123:copilotMessage").SetErr(errors.New("redis get error"))
-
-		usage, err := tracker.Usage(ctx, 123, authz.ResourceCopilotMessage)
+		mock.ExpectGet(key).SetErr(errors.New("redis get error"))
+		usage, err := tracker.Usage(ctx, 123, policy)
 		assert.Error(t, err)
 		assert.Equal(t, int64(0), usage.Used)
 		assert.True(t, usage.ResetTime.IsZero())
@@ -76,10 +102,16 @@ func TestRedisQuotaTrackerUsage(t *testing.T) {
 		ctx := context.Background()
 		client, mock := redismock.NewClientMock()
 		tracker := &redisQuotaTracker{client: client}
+		policy := authz.QuotaPolicy{
+			Name:     "copilotMessage:limit",
+			Resource: authz.ResourceCopilotMessage,
+			Limit:    100,
+			Window:   24 * time.Hour,
+		}
+		key := quotaKey(123, policy)
 
-		mock.ExpectGet("123:copilotMessage").SetVal("invalid-number")
-
-		usage, err := tracker.Usage(ctx, 123, authz.ResourceCopilotMessage)
+		mock.ExpectGet(key).SetVal("invalid-number")
+		usage, err := tracker.Usage(ctx, 123, policy)
 		assert.Error(t, err)
 		assert.Equal(t, int64(0), usage.Used)
 		assert.True(t, usage.ResetTime.IsZero())
@@ -93,12 +125,18 @@ func TestRedisQuotaTrackerIncrementUsage(t *testing.T) {
 		ctx := context.Background()
 		client, mock := redismock.NewClientMock()
 		tracker := &redisQuotaTracker{client: client}
-		policy := authz.QuotaPolicy{Limit: 100, Window: 24 * time.Hour}
+		policy := authz.QuotaPolicy{
+			Name:     "copilotMessage:limit",
+			Resource: authz.ResourceCopilotMessage,
+			Limit:    100,
+			Window:   24 * time.Hour,
+		}
+		key := quotaKey(123, policy)
 
-		mock.ExpectIncrBy("123:copilotMessage", 10).SetVal(10)
-		mock.ExpectExpireNX("123:copilotMessage", policy.Window).SetVal(true)
+		mock.ExpectIncrBy(key, 10).SetVal(10)
+		mock.ExpectExpireNX(key, policy.Window).SetVal(true)
 
-		err := tracker.IncrementUsage(ctx, 123, authz.ResourceCopilotMessage, 10, policy)
+		err := tracker.IncrementUsage(ctx, 123, policy, 10)
 		require.NoError(t, err)
 
 		require.NoError(t, mock.ExpectationsWereMet())
@@ -108,17 +146,23 @@ func TestRedisQuotaTrackerIncrementUsage(t *testing.T) {
 		ctx := context.Background()
 		client, mock := redismock.NewClientMock()
 		tracker := &redisQuotaTracker{client: client}
-		policy := authz.QuotaPolicy{Limit: 100, Window: 24 * time.Hour}
+		policy := authz.QuotaPolicy{
+			Name:     "copilotMessage:limit",
+			Resource: authz.ResourceCopilotMessage,
+			Limit:    100,
+			Window:   24 * time.Hour,
+		}
+		key := quotaKey(123, policy)
 
-		mock.ExpectIncrBy("123:copilotMessage", 10).SetVal(10)
-		mock.ExpectExpireNX("123:copilotMessage", policy.Window).SetVal(true)
-		mock.ExpectIncrBy("123:copilotMessage", 5).SetVal(15)
-		mock.ExpectExpireNX("123:copilotMessage", policy.Window).SetVal(false)
+		mock.ExpectIncrBy(key, 10).SetVal(10)
+		mock.ExpectExpireNX(key, policy.Window).SetVal(true)
+		mock.ExpectIncrBy(key, 5).SetVal(15)
+		mock.ExpectExpireNX(key, policy.Window).SetVal(false)
 
-		err := tracker.IncrementUsage(ctx, 123, authz.ResourceCopilotMessage, 10, policy)
+		err := tracker.IncrementUsage(ctx, 123, policy, 10)
 		require.NoError(t, err)
 
-		err = tracker.IncrementUsage(ctx, 123, authz.ResourceCopilotMessage, 5, policy)
+		err = tracker.IncrementUsage(ctx, 123, policy, 5)
 		require.NoError(t, err)
 
 		require.NoError(t, mock.ExpectationsWereMet())
@@ -128,17 +172,24 @@ func TestRedisQuotaTrackerIncrementUsage(t *testing.T) {
 		ctx := context.Background()
 		client, mock := redismock.NewClientMock()
 		tracker := &redisQuotaTracker{client: client}
-		policy := authz.QuotaPolicy{Limit: 100, Window: 24 * time.Hour}
+		policy := authz.QuotaPolicy{
+			Name:     "copilotMessage:limit",
+			Resource: authz.ResourceCopilotMessage,
+			Limit:    100,
+			Window:   24 * time.Hour,
+		}
+		key123 := quotaKey(123, policy)
+		key456 := quotaKey(456, policy)
 
-		mock.ExpectIncrBy("123:copilotMessage", 15).SetVal(15)
-		mock.ExpectExpireNX("123:copilotMessage", policy.Window).SetVal(true)
-		mock.ExpectIncrBy("456:copilotMessage", 20).SetVal(20)
-		mock.ExpectExpireNX("456:copilotMessage", policy.Window).SetVal(true)
+		mock.ExpectIncrBy(key123, 15).SetVal(15)
+		mock.ExpectExpireNX(key123, policy.Window).SetVal(true)
+		mock.ExpectIncrBy(key456, 20).SetVal(20)
+		mock.ExpectExpireNX(key456, policy.Window).SetVal(true)
 
-		err := tracker.IncrementUsage(ctx, 123, authz.ResourceCopilotMessage, 15, policy)
+		err := tracker.IncrementUsage(ctx, 123, policy, 15)
 		require.NoError(t, err)
 
-		err = tracker.IncrementUsage(ctx, 456, authz.ResourceCopilotMessage, 20, policy)
+		err = tracker.IncrementUsage(ctx, 456, policy, 20)
 		require.NoError(t, err)
 
 		require.NoError(t, mock.ExpectationsWereMet())
@@ -148,12 +199,18 @@ func TestRedisQuotaTrackerIncrementUsage(t *testing.T) {
 		ctx := context.Background()
 		client, mock := redismock.NewClientMock()
 		tracker := &redisQuotaTracker{client: client}
-		policy := authz.QuotaPolicy{Limit: 100, Window: 24 * time.Hour}
+		policy := authz.QuotaPolicy{
+			Name:     "copilotMessage:limit",
+			Resource: authz.ResourceCopilotMessage,
+			Limit:    100,
+			Window:   24 * time.Hour,
+		}
+		key := quotaKey(123, policy)
 
-		mock.ExpectIncrBy("123:copilotMessage", 10).SetErr(errors.New("redis incr error"))
-		mock.ExpectExpireNX("123:copilotMessage", policy.Window).SetVal(true)
+		mock.ExpectIncrBy(key, 10).SetErr(errors.New("redis incr error"))
+		mock.ExpectExpireNX(key, policy.Window).SetVal(true)
 
-		err := tracker.IncrementUsage(ctx, 123, authz.ResourceCopilotMessage, 10, policy)
+		err := tracker.IncrementUsage(ctx, 123, policy, 10)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to increment usage in Redis")
 	})
@@ -162,12 +219,18 @@ func TestRedisQuotaTrackerIncrementUsage(t *testing.T) {
 		ctx := context.Background()
 		client, mock := redismock.NewClientMock()
 		tracker := &redisQuotaTracker{client: client}
-		policy := authz.QuotaPolicy{Limit: 100, Window: 24 * time.Hour}
+		policy := authz.QuotaPolicy{
+			Name:     "copilotMessage:limit",
+			Resource: authz.ResourceCopilotMessage,
+			Limit:    100,
+			Window:   24 * time.Hour,
+		}
+		key := quotaKey(123, policy)
 
-		mock.ExpectIncrBy("123:copilotMessage", 10).SetVal(10)
-		mock.ExpectExpireNX("123:copilotMessage", policy.Window).SetErr(errors.New("redis expire error"))
+		mock.ExpectIncrBy(key, 10).SetVal(10)
+		mock.ExpectExpireNX(key, policy.Window).SetErr(errors.New("redis expire error"))
 
-		err := tracker.IncrementUsage(ctx, 123, authz.ResourceCopilotMessage, 10, policy)
+		err := tracker.IncrementUsage(ctx, 123, policy, 10)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to increment usage in Redis")
 	})
@@ -176,13 +239,19 @@ func TestRedisQuotaTrackerIncrementUsage(t *testing.T) {
 		ctx := context.Background()
 		client, mock := redismock.NewClientMock()
 		tracker := &redisQuotaTracker{client: client}
-		policy := authz.QuotaPolicy{Limit: 100, Window: 24 * time.Hour}
+		policy := authz.QuotaPolicy{
+			Name:     "copilotMessage:limit",
+			Resource: authz.ResourceCopilotMessage,
+			Limit:    100,
+			Window:   24 * time.Hour,
+		}
+		key := quotaKey(123, policy)
 
 		wantTTL := policy.Window
-		mock.ExpectIncrBy("123:copilotMessage", 1).SetVal(1)
-		mock.ExpectExpireNX("123:copilotMessage", wantTTL).SetVal(true)
+		mock.ExpectIncrBy(key, 1).SetVal(1)
+		mock.ExpectExpireNX(key, wantTTL).SetVal(true)
 
-		err := tracker.IncrementUsage(ctx, 123, authz.ResourceCopilotMessage, 1, policy)
+		err := tracker.IncrementUsage(ctx, 123, policy, 1)
 		require.NoError(t, err)
 
 		require.NoError(t, mock.ExpectationsWereMet())
@@ -192,12 +261,18 @@ func TestRedisQuotaTrackerIncrementUsage(t *testing.T) {
 		ctx := context.Background()
 		client, mock := redismock.NewClientMock()
 		tracker := &redisQuotaTracker{client: client}
-		policy := authz.QuotaPolicy{Limit: 100, Window: 24 * time.Hour}
+		policy := authz.QuotaPolicy{
+			Name:     "copilotMessage:limit",
+			Resource: authz.ResourceCopilotMessage,
+			Limit:    100,
+			Window:   24 * time.Hour,
+		}
+		key := quotaKey(123, policy)
 
-		mock.ExpectIncrBy("123:copilotMessage", 0).SetVal(5)
-		mock.ExpectExpireNX("123:copilotMessage", policy.Window).SetVal(true)
+		mock.ExpectIncrBy(key, 0).SetVal(5)
+		mock.ExpectExpireNX(key, policy.Window).SetVal(true)
 
-		err := tracker.IncrementUsage(ctx, 123, authz.ResourceCopilotMessage, 0, policy)
+		err := tracker.IncrementUsage(ctx, 123, policy, 0)
 		require.NoError(t, err)
 
 		require.NoError(t, mock.ExpectationsWereMet())
@@ -207,12 +282,18 @@ func TestRedisQuotaTrackerIncrementUsage(t *testing.T) {
 		ctx := context.Background()
 		client, mock := redismock.NewClientMock()
 		tracker := &redisQuotaTracker{client: client}
-		policy := authz.QuotaPolicy{Limit: 100, Window: 24 * time.Hour}
+		policy := authz.QuotaPolicy{
+			Name:     "copilotMessage:limit",
+			Resource: authz.ResourceCopilotMessage,
+			Limit:    100,
+			Window:   24 * time.Hour,
+		}
+		key := quotaKey(123, policy)
 
-		mock.ExpectIncrBy("123:copilotMessage", -5).SetVal(5)
-		mock.ExpectExpireNX("123:copilotMessage", policy.Window).SetVal(true)
+		mock.ExpectIncrBy(key, -5).SetVal(5)
+		mock.ExpectExpireNX(key, policy.Window).SetVal(true)
 
-		err := tracker.IncrementUsage(ctx, 123, authz.ResourceCopilotMessage, -5, policy)
+		err := tracker.IncrementUsage(ctx, 123, policy, -5)
 		require.NoError(t, err)
 
 		require.NoError(t, mock.ExpectationsWereMet())
@@ -224,10 +305,17 @@ func TestRedisQuotaTrackerResetUsage(t *testing.T) {
 		ctx := context.Background()
 		client, mock := redismock.NewClientMock()
 		tracker := &redisQuotaTracker{client: client}
+		policy := authz.QuotaPolicy{
+			Name:     "copilotMessage:limit",
+			Resource: authz.ResourceCopilotMessage,
+			Limit:    100,
+			Window:   24 * time.Hour,
+		}
 
-		mock.ExpectDel("123:copilotMessage").SetVal(1)
+		key := quotaKey(123, policy)
+		mock.ExpectDel(key).SetVal(1)
 
-		err := tracker.ResetUsage(ctx, 123, authz.ResourceCopilotMessage)
+		err := tracker.ResetUsage(ctx, 123, policy)
 		require.NoError(t, err)
 
 		require.NoError(t, mock.ExpectationsWereMet())
@@ -237,10 +325,17 @@ func TestRedisQuotaTrackerResetUsage(t *testing.T) {
 		ctx := context.Background()
 		client, mock := redismock.NewClientMock()
 		tracker := &redisQuotaTracker{client: client}
+		policy := authz.QuotaPolicy{
+			Name:     "copilotMessage:limit",
+			Resource: authz.ResourceCopilotMessage,
+			Limit:    100,
+			Window:   24 * time.Hour,
+		}
 
-		mock.ExpectDel("999:copilotMessage").SetVal(0)
+		key := quotaKey(999, policy)
+		mock.ExpectDel(key).SetVal(0)
 
-		err := tracker.ResetUsage(ctx, 999, authz.ResourceCopilotMessage)
+		err := tracker.ResetUsage(ctx, 999, policy)
 		require.NoError(t, err)
 
 		require.NoError(t, mock.ExpectationsWereMet())
@@ -250,10 +345,17 @@ func TestRedisQuotaTrackerResetUsage(t *testing.T) {
 		ctx := context.Background()
 		client, mock := redismock.NewClientMock()
 		tracker := &redisQuotaTracker{client: client}
+		policy := authz.QuotaPolicy{
+			Name:     "copilotMessage:limit",
+			Resource: authz.ResourceCopilotMessage,
+			Limit:    100,
+			Window:   24 * time.Hour,
+		}
 
-		mock.ExpectDel("111:copilotMessage").SetVal(1)
+		key := quotaKey(111, policy)
+		mock.ExpectDel(key).SetVal(1)
 
-		err := tracker.ResetUsage(ctx, 111, authz.ResourceCopilotMessage)
+		err := tracker.ResetUsage(ctx, 111, policy)
 		require.NoError(t, err)
 
 		require.NoError(t, mock.ExpectationsWereMet())
@@ -263,10 +365,17 @@ func TestRedisQuotaTrackerResetUsage(t *testing.T) {
 		ctx := context.Background()
 		client, mock := redismock.NewClientMock()
 		tracker := &redisQuotaTracker{client: client}
+		policy := authz.QuotaPolicy{
+			Name:     "copilotMessage:limit",
+			Resource: authz.ResourceCopilotMessage,
+			Limit:    100,
+			Window:   24 * time.Hour,
+		}
 
-		mock.ExpectDel("123:copilotMessage").SetErr(errors.New("redis del error"))
+		key := quotaKey(123, policy)
+		mock.ExpectDel(key).SetErr(errors.New("redis del error"))
 
-		err := tracker.ResetUsage(ctx, 123, authz.ResourceCopilotMessage)
+		err := tracker.ResetUsage(ctx, 123, policy)
 		assert.Error(t, err)
 	})
 }
@@ -280,5 +389,19 @@ func TestRedisQuotaTrackerClose(t *testing.T) {
 		require.NoError(t, err)
 
 		require.NoError(t, mock.ExpectationsWereMet())
+	})
+}
+
+func TestQuotaKey(t *testing.T) {
+	t.Run("UsesPolicyName", func(t *testing.T) {
+		policy := authz.QuotaPolicy{Name: "copilotMessage:limit", Resource: authz.ResourceCopilotMessage}
+		key := quotaKey(123, policy)
+		assert.Equal(t, "123:copilotMessage:limit", key)
+	})
+
+	t.Run("FallsBackToResourceWhenNameEmpty", func(t *testing.T) {
+		policy := authz.QuotaPolicy{Name: "", Resource: authz.ResourceAIDescription}
+		key := quotaKey(456, policy)
+		assert.Equal(t, "456:aiDescription", key)
 	})
 }

--- a/spx-backend/internal/authz/quota_test.go
+++ b/spx-backend/internal/authz/quota_test.go
@@ -10,28 +10,28 @@ import (
 )
 
 type mockQuotaTracker struct {
-	usageFunc          func(ctx context.Context, userID int64, resource Resource) (QuotaUsage, error)
-	incrementUsageFunc func(ctx context.Context, userID int64, resource Resource, amount int64, policy QuotaPolicy) error
-	resetUsageFunc     func(ctx context.Context, userID int64, resource Resource) error
+	usageFunc          func(ctx context.Context, userID int64, policy QuotaPolicy) (QuotaUsage, error)
+	incrementUsageFunc func(ctx context.Context, userID int64, policy QuotaPolicy, amount int64) error
+	resetUsageFunc     func(ctx context.Context, userID int64, policy QuotaPolicy) error
 }
 
-func (m *mockQuotaTracker) Usage(ctx context.Context, userID int64, resource Resource) (QuotaUsage, error) {
+func (m *mockQuotaTracker) Usage(ctx context.Context, userID int64, policy QuotaPolicy) (QuotaUsage, error) {
 	if m.usageFunc != nil {
-		return m.usageFunc(ctx, userID, resource)
+		return m.usageFunc(ctx, userID, policy)
 	}
 	return QuotaUsage{Used: 20}, nil
 }
 
-func (m *mockQuotaTracker) IncrementUsage(ctx context.Context, userID int64, resource Resource, amount int64, policy QuotaPolicy) error {
+func (m *mockQuotaTracker) IncrementUsage(ctx context.Context, userID int64, policy QuotaPolicy, amount int64) error {
 	if m.incrementUsageFunc != nil {
-		return m.incrementUsageFunc(ctx, userID, resource, amount, policy)
+		return m.incrementUsageFunc(ctx, userID, policy, amount)
 	}
 	return nil
 }
 
-func (m *mockQuotaTracker) ResetUsage(ctx context.Context, userID int64, resource Resource) error {
+func (m *mockQuotaTracker) ResetUsage(ctx context.Context, userID int64, policy QuotaPolicy) error {
 	if m.resetUsageFunc != nil {
-		return m.resetUsageFunc(ctx, userID, resource)
+		return m.resetUsageFunc(ctx, userID, policy)
 	}
 	return nil
 }
@@ -39,25 +39,24 @@ func (m *mockQuotaTracker) ResetUsage(ctx context.Context, userID int64, resourc
 func TestQuotaReset(t *testing.T) {
 	t.Run("FreshWindowFullRemaining", func(t *testing.T) {
 		quota := Quota{
-			Limit:     100,
-			Remaining: 100,
-			Window:    3600,
+			QuotaPolicy: QuotaPolicy{Limit: 100, Window: 3600 * time.Second},
 		}
 		assert.Equal(t, int64(3600), quota.Reset())
 	})
 
 	t.Run("FreshWindowPartiallyConsumed", func(t *testing.T) {
 		quota := Quota{
-			Limit:     100,
-			Remaining: 80,
-			Window:    3600,
+			QuotaPolicy: QuotaPolicy{Limit: 100, Window: 3600 * time.Second},
+			QuotaUsage:  QuotaUsage{Used: 20},
 		}
 		assert.Equal(t, int64(0), quota.Reset())
 	})
 
 	t.Run("WithFutureResetTime", func(t *testing.T) {
 		quota := Quota{
-			ResetTime: time.Now().Add(5 * time.Second),
+			QuotaUsage: QuotaUsage{
+				ResetTime: time.Now().Add(5 * time.Second),
+			},
 		}
 		got := quota.Reset()
 		require.GreaterOrEqual(t, got, int64(4))
@@ -66,7 +65,9 @@ func TestQuotaReset(t *testing.T) {
 
 	t.Run("WithPastResetTime", func(t *testing.T) {
 		quota := Quota{
-			ResetTime: time.Now().Add(-1 * time.Second),
+			QuotaUsage: QuotaUsage{
+				ResetTime: time.Now().Add(-1 * time.Second),
+			},
 		}
 		assert.Equal(t, int64(0), quota.Reset())
 	})
@@ -75,4 +76,74 @@ func TestQuotaReset(t *testing.T) {
 		var quota Quota
 		assert.Equal(t, int64(0), quota.Reset())
 	})
+}
+
+func TestQuotaRemaining(t *testing.T) {
+	for _, tt := range []struct {
+		name  string
+		quota Quota
+		want  int64
+	}{
+		{
+			name: "WithinLimit",
+			quota: Quota{
+				QuotaPolicy: QuotaPolicy{Limit: 100},
+				QuotaUsage:  QuotaUsage{Used: 20},
+			},
+			want: 80,
+		},
+		{
+			name: "OverLimit",
+			quota: Quota{
+				QuotaPolicy: QuotaPolicy{Limit: 50},
+				QuotaUsage:  QuotaUsage{Used: 80},
+			},
+			want: 0,
+		},
+		{
+			name: "Unlimited",
+			quota: Quota{
+				QuotaPolicy: QuotaPolicy{Limit: 0},
+			},
+			want: 0,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.quota.Remaining())
+		})
+	}
+}
+
+func TestCeilSeconds(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		d    time.Duration
+		want int64
+	}{
+		{
+			name: "Zero",
+			d:    0,
+			want: 0,
+		},
+		{
+			name: "Negative",
+			d:    -500 * time.Millisecond,
+			want: 0,
+		},
+		{
+			name: "ExactSecond",
+			d:    2 * time.Second,
+			want: 2,
+		},
+		{
+			name: "Fractional",
+			d:    1500 * time.Millisecond,
+			want: 2,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ceilSeconds(tt.d)
+			assert.Equal(t, tt.want, got)
+		})
+	}
 }

--- a/spx-backend/internal/controller/user_test.go
+++ b/spx-backend/internal/controller/user_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"regexp"
 	"testing"
+	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/goplus/builder/spx-backend/internal/authn"
@@ -36,26 +37,46 @@ func newContextWithTestUser(ctx context.Context) context.Context {
 	ctx = authn.NewContextWithUser(ctx, testUser)
 	ctx = authz.NewContextWithUserCapabilities(ctx, authz.UserCapabilities{
 		CanManageAssets:  false,
+		CanManageCourses: false,
 		CanUsePremiumLLM: false,
-		CopilotMessageQuota: authz.Quota{
-			Limit:     100,
-			Remaining: 100,
-			Window:    24 * 60 * 60,
-		},
-		AIDescriptionQuota: authz.Quota{
-			Limit:     300,
-			Remaining: 295,
-			Window:    24 * 60 * 60,
-		},
-		AIInteractionTurnQuota: authz.Quota{
-			Limit:     12000,
-			Remaining: 11900,
-			Window:    24 * 60 * 60,
-		},
-		AIInteractionArchiveQuota: authz.Quota{
-			Limit:     8000,
-			Remaining: 7980,
-			Window:    24 * 60 * 60,
+	})
+	ctx = authz.NewContextWithUserQuotas(ctx, authz.UserQuotas{
+		Limits: map[authz.Resource]authz.Quota{
+			authz.ResourceCopilotMessage: {
+				QuotaPolicy: authz.QuotaPolicy{
+					Name:     "copilotMessage:limit",
+					Resource: authz.ResourceCopilotMessage,
+					Limit:    100,
+					Window:   24 * time.Hour,
+				},
+			},
+			authz.ResourceAIDescription: {
+				QuotaPolicy: authz.QuotaPolicy{
+					Name:     "aiDescription:limit",
+					Resource: authz.ResourceAIDescription,
+					Limit:    300,
+					Window:   24 * time.Hour,
+				},
+				QuotaUsage: authz.QuotaUsage{Used: 5},
+			},
+			authz.ResourceAIInteractionTurn: {
+				QuotaPolicy: authz.QuotaPolicy{
+					Name:     "aiInteractionTurn:limit",
+					Resource: authz.ResourceAIInteractionTurn,
+					Limit:    12000,
+					Window:   24 * time.Hour,
+				},
+				QuotaUsage: authz.QuotaUsage{Used: 100},
+			},
+			authz.ResourceAIInteractionArchive: {
+				QuotaPolicy: authz.QuotaPolicy{
+					Name:     "aiInteractionArchive:limit",
+					Resource: authz.ResourceAIInteractionArchive,
+					Limit:    8000,
+					Window:   24 * time.Hour,
+				},
+				QuotaUsage: authz.QuotaUsage{Used: 20},
+			},
 		},
 	})
 	return ctx


### PR DESCRIPTION
- Inject per-request quota snapshots via the AuthZ middleware so downstream helpers can consume limits directly from context
- Introduce `UserQuotas` with named `QuotaPolicy` structs and update `ConsumeQuota` together with all `QuotaTracker` implementations to operate on policies instead of bare resources
- Rebuild the embedded PDP quota spec to load plan-aware limits and usage