### PR TITLE
fix: inline community project sign-in prompt SVG

### DIFF
--- a/spx-gui/src/pages/community/project.vue
+++ b/spx-gui/src/pages/community/project.vue
@@ -38,7 +38,7 @@ import { useCreateProject, useRemoveProject, useShareProject, useUnpublishProjec
 import CommunityCard from '@/components/community/CommunityCard.vue'
 import ReleaseHistory from '@/components/community/project/ReleaseHistory.vue'
 import TextView from '@/components/community/TextView.vue'
-import kikoWaveSvg from './kiko-wave.svg'
+import kikoWaveSvg from './kiko-wave.svg?raw'
 
 const props = defineProps<{
   owner: string
@@ -341,7 +341,8 @@ const remixesRet = useQuery(
                     <template v-if="runnerState === 'initial'">
                       <div v-if="needsSignInToRun" class="sign-in-prompt">
                         <div class="sign-in-card">
-                          <img :src="kikoWaveSvg" class="kiko-wave" alt="" />
+                          <!-- eslint-disable-next-line vue/no-v-html -->
+                          <div class="kiko-wave" aria-hidden="true" v-html="kikoWaveSvg"></div>
                           <p class="message">
                             {{
                               $t({
@@ -671,6 +672,14 @@ const remixesRet = useQuery(
       .kiko-wave {
         position: absolute;
         top: -56px;
+        width: 340px;
+        line-height: 0;
+
+        :deep(svg) {
+          display: block;
+          width: 100%;
+          height: auto;
+        }
       }
 
       .message {


### PR DESCRIPTION
- Embed the project details sign-in illustration via `?raw` + `v-html` to keep Safari from rasterizing it[^1]
- Restyle the container so the inline SVG keeps the original layout and stays decorative-only

[^1]: https://bugs.webkit.org/show_bug.cgi?id=231796

---

<img width="1121" height="792" alt="Screenshot 2025-11-13 at 09 34 52" src="https://github.com/user-attachments/assets/16ee923f-9dfa-4f04-9d85-138df80b37bf" />
