### PR TITLE
chore(scripts): enable Nginx gzip for buffered API responses

### DIFF
--- a/scripts/nginx.conf
+++ b/scripts/nginx.conf
@@ -5,18 +5,25 @@ server {
     # Gzip Settings
     gzip on;
     gzip_vary on;
-    gzip_proxied no-cache no-store private expired auth;
+    gzip_proxied any;
+    gzip_min_length 1024;
+    gzip_comp_level 6;
     gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript application/vnd.ms-fontobject application/x-font-ttf font/opentype image/svg+xml image/x-icon application/wasm;
+
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+
+    location ~ ^/api/(copilot|workflow)/stream/ {
+        proxy_pass http://localhost:8080/;
+        client_max_body_size 200M;
+        proxy_buffering off;
+    }
 
     location /api/ {
         proxy_pass http://localhost:8080/;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-
         client_max_body_size 200M;
-        proxy_buffering off; 
     }
 
     location ~* \.(js|css|jpg|jpeg|png|gif|ico|woff|woff2|ttf|eot|otf)$ {


### PR DESCRIPTION
- Let Nginx buffer `/api/` responses so Gzip can run and set `gzip_proxied any`
- Tighten Gzip behavior via `gzip_min_length 1024` and `gzip_comp_level 6`
- Keep streaming Copilot/workflow endpoints in dedicated locations with buffering disabled