### PR TITLE
fix(scripts/nginx.conf): preserve stream paths when proxying

### DIFF
--- a/scripts/nginx.conf
+++ b/scripts/nginx.conf
@@ -2,6 +2,8 @@ server {
     listen 80 default_server;
     server_name _;
 
+    client_max_body_size 200M;
+
     # Gzip Settings
     gzip on;
     gzip_vary on;
@@ -15,15 +17,18 @@ server {
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header X-Forwarded-Proto $scheme;
 
-    location ~ ^/api/(copilot|workflow)/stream/ {
-        proxy_pass http://localhost:8080/;
-        client_max_body_size 200M;
+    location /api/copilot/stream/ {
+        proxy_pass http://localhost:8080/copilot/stream/;
+        proxy_buffering off;
+    }
+
+    location /api/workflow/stream/ {
+        proxy_pass http://localhost:8080/workflow/stream/;
         proxy_buffering off;
     }
 
     location /api/ {
         proxy_pass http://localhost:8080/;
-        client_max_body_size 200M;
     }
 
     location ~* \.(js|css|jpg|jpeg|png|gif|ico|woff|woff2|ttf|eot|otf)$ {


### PR DESCRIPTION
This follows up on #2479.