### PR TITLE
refactor(spx-backend): make quota consumption atomic with Redis Lua

### DIFF
--- a/spx-backend/cmd/spx-backend/post_ai_description.yap
+++ b/spx-backend/cmd/spx-backend/post_ai_description.yap
@@ -13,11 +13,7 @@ if _, ok := ensureAuthenticatedUser(ctx); !ok {
 	return
 }
 
-const (
-	quotaResource = authz.ResourceAIDescription
-	quotaAmount   = 1
-)
-if !ensureQuotaRemaining(ctx, quotaResource, quotaAmount) {
+if !ensureQuotaRemaining(ctx, authz.ResourceAIDescription, 1) {
 	return
 }
 
@@ -35,7 +31,5 @@ if err != nil {
 	replyWithInnerError(ctx, err)
 	return
 }
-
-consumeQuota(ctx, quotaResource, quotaAmount)
 
 json result

--- a/spx-backend/cmd/spx-backend/post_ai_interaction_archive.yap
+++ b/spx-backend/cmd/spx-backend/post_ai_interaction_archive.yap
@@ -13,11 +13,7 @@ if _, ok := ensureAuthenticatedUser(ctx); !ok {
 	return
 }
 
-const (
-	quotaResource = authz.ResourceAIInteractionArchive
-	quotaAmount   = 1
-)
-if !ensureQuotaRemaining(ctx, quotaResource, quotaAmount) {
+if !ensureQuotaRemaining(ctx, authz.ResourceAIInteractionArchive, 1) {
 	return
 }
 
@@ -35,7 +31,5 @@ if err != nil {
 	replyWithInnerError(ctx, err)
 	return
 }
-
-consumeQuota(ctx, quotaResource, quotaAmount)
 
 json result

--- a/spx-backend/cmd/spx-backend/post_ai_interaction_turn.yap
+++ b/spx-backend/cmd/spx-backend/post_ai_interaction_turn.yap
@@ -13,11 +13,7 @@ if _, ok := ensureAuthenticatedUser(ctx); !ok {
 	return
 }
 
-const (
-	quotaResource = authz.ResourceAIInteractionTurn
-	quotaAmount   = 1
-)
-if !ensureQuotaRemaining(ctx, quotaResource, quotaAmount) {
+if !ensureQuotaRemaining(ctx, authz.ResourceAIInteractionTurn, 1) {
 	return
 }
 
@@ -35,7 +31,5 @@ if err != nil {
 	replyWithInnerError(ctx, err)
 	return
 }
-
-consumeQuota(ctx, quotaResource, quotaAmount)
 
 json result

--- a/spx-backend/cmd/spx-backend/post_copilot_message.yap
+++ b/spx-backend/cmd/spx-backend/post_copilot_message.yap
@@ -13,11 +13,7 @@ if _, ok := ensureAuthenticatedUser(ctx); !ok {
 	return
 }
 
-const (
-	quotaResource = authz.ResourceCopilotMessage
-	quotaAmount   = 1
-)
-if !ensureQuotaRemaining(ctx, quotaResource, quotaAmount) {
+if !ensureQuotaRemaining(ctx, authz.ResourceCopilotMessage, 1) {
 	return
 }
 
@@ -36,7 +32,5 @@ if err != nil {
 	replyWithInnerError(ctx, err)
 	return
 }
-
-consumeQuota(ctx, quotaResource, quotaAmount)
 
 json result

--- a/spx-backend/cmd/spx-backend/post_copilot_stream_message.yap
+++ b/spx-backend/cmd/spx-backend/post_copilot_stream_message.yap
@@ -13,11 +13,7 @@ if _, ok := ensureAuthenticatedUser(ctx); !ok {
 	return
 }
 
-const (
-	quotaResource = authz.ResourceCopilotMessage
-	quotaAmount   = 1
-)
-if !ensureQuotaRemaining(ctx, quotaResource, quotaAmount) {
+if !ensureQuotaRemaining(ctx, authz.ResourceCopilotMessage, 1) {
 	return
 }
 
@@ -37,8 +33,6 @@ if err != nil {
 	return
 }
 defer read.Close()
-
-consumeQuota(ctx, quotaResource, quotaAmount)
 
 buf := make([]byte, 4096)
 stream read, buf

--- a/spx-backend/cmd/spx-backend/post_workflow_stream_message.yap
+++ b/spx-backend/cmd/spx-backend/post_workflow_stream_message.yap
@@ -13,11 +13,7 @@ if _, ok := ensureAuthenticatedUser(ctx); !ok {
 	return
 }
 
-const (
-	quotaResource = authz.ResourceCopilotMessage
-	quotaAmount   = 1
-)
-if !ensureQuotaRemaining(ctx, quotaResource, quotaAmount) {
+if !ensureQuotaRemaining(ctx, authz.ResourceCopilotMessage, 1) {
 	return
 }
 
@@ -37,8 +33,6 @@ if err != nil {
 	return
 }
 defer read.Close()
-
-consumeQuota(ctx, quotaResource, quotaAmount)
 
 buf := make([]byte, 4096)
 stream read, buf

--- a/spx-backend/cmd/spx-backend/xgo_autogen.go
+++ b/spx-backend/cmd/spx-backend/xgo_autogen.go
@@ -1491,43 +1491,36 @@ func (this *post_ai_description) Main(_xgo_arg0 *yap.Context) {
 		return
 	}
 //line cmd/spx-backend/post_ai_description.yap:16:1
-	const (
-		quotaResource = authz.ResourceAIDescription
-		quotaAmount   = 1
-	)
+	if !ensureQuotaRemaining(ctx, authz.ResourceAIDescription, 1) {
+//line cmd/spx-backend/post_ai_description.yap:17:1
+		return
+	}
 //line cmd/spx-backend/post_ai_description.yap:20:1
-	if !ensureQuotaRemaining(ctx, quotaResource, quotaAmount) {
+	params := &controller.AIDescriptionParams{}
 //line cmd/spx-backend/post_ai_description.yap:21:1
+	if !parseJSON(ctx, params) {
+//line cmd/spx-backend/post_ai_description.yap:22:1
 		return
 	}
 //line cmd/spx-backend/post_ai_description.yap:24:1
-	params := &controller.AIDescriptionParams{}
+	if
+//line cmd/spx-backend/post_ai_description.yap:24:1
+	ok, msg := params.Validate(); !ok {
 //line cmd/spx-backend/post_ai_description.yap:25:1
-	if !parseJSON(ctx, params) {
+		replyWithCodeMsg(ctx, errorInvalidArgs, msg)
 //line cmd/spx-backend/post_ai_description.yap:26:1
 		return
 	}
-//line cmd/spx-backend/post_ai_description.yap:28:1
-	if
-//line cmd/spx-backend/post_ai_description.yap:28:1
-	ok, msg := params.Validate(); !ok {
 //line cmd/spx-backend/post_ai_description.yap:29:1
-		replyWithCodeMsg(ctx, errorInvalidArgs, msg)
-//line cmd/spx-backend/post_ai_description.yap:30:1
-		return
-	}
-//line cmd/spx-backend/post_ai_description.yap:33:1
 	result, err := this.ctrl.GenerateAIDescription(ctx.Context(), params)
-//line cmd/spx-backend/post_ai_description.yap:34:1
+//line cmd/spx-backend/post_ai_description.yap:30:1
 	if err != nil {
-//line cmd/spx-backend/post_ai_description.yap:35:1
+//line cmd/spx-backend/post_ai_description.yap:31:1
 		replyWithInnerError(ctx, err)
-//line cmd/spx-backend/post_ai_description.yap:36:1
+//line cmd/spx-backend/post_ai_description.yap:32:1
 		return
 	}
-//line cmd/spx-backend/post_ai_description.yap:39:1
-	consumeQuota(ctx, quotaResource, quotaAmount)
-//line cmd/spx-backend/post_ai_description.yap:41:1
+//line cmd/spx-backend/post_ai_description.yap:35:1
 	this.Json__1(result)
 }
 func (this *post_ai_description) Classfname() string {
@@ -1550,43 +1543,36 @@ func (this *post_ai_interaction_archive) Main(_xgo_arg0 *yap.Context) {
 		return
 	}
 //line cmd/spx-backend/post_ai_interaction_archive.yap:16:1
-	const (
-		quotaResource = authz.ResourceAIInteractionArchive
-		quotaAmount   = 1
-	)
+	if !ensureQuotaRemaining(ctx, authz.ResourceAIInteractionArchive, 1) {
+//line cmd/spx-backend/post_ai_interaction_archive.yap:17:1
+		return
+	}
 //line cmd/spx-backend/post_ai_interaction_archive.yap:20:1
-	if !ensureQuotaRemaining(ctx, quotaResource, quotaAmount) {
+	params := &controller.AIInteractionArchiveParams{}
 //line cmd/spx-backend/post_ai_interaction_archive.yap:21:1
+	if !parseJSON(ctx, params) {
+//line cmd/spx-backend/post_ai_interaction_archive.yap:22:1
 		return
 	}
 //line cmd/spx-backend/post_ai_interaction_archive.yap:24:1
-	params := &controller.AIInteractionArchiveParams{}
+	if
+//line cmd/spx-backend/post_ai_interaction_archive.yap:24:1
+	ok, msg := params.Validate(); !ok {
 //line cmd/spx-backend/post_ai_interaction_archive.yap:25:1
-	if !parseJSON(ctx, params) {
+		replyWithCodeMsg(ctx, errorInvalidArgs, msg)
 //line cmd/spx-backend/post_ai_interaction_archive.yap:26:1
 		return
 	}
-//line cmd/spx-backend/post_ai_interaction_archive.yap:28:1
-	if
-//line cmd/spx-backend/post_ai_interaction_archive.yap:28:1
-	ok, msg := params.Validate(); !ok {
 //line cmd/spx-backend/post_ai_interaction_archive.yap:29:1
-		replyWithCodeMsg(ctx, errorInvalidArgs, msg)
-//line cmd/spx-backend/post_ai_interaction_archive.yap:30:1
-		return
-	}
-//line cmd/spx-backend/post_ai_interaction_archive.yap:33:1
 	result, err := this.ctrl.PerformAIInteractionArchive(ctx.Context(), params)
-//line cmd/spx-backend/post_ai_interaction_archive.yap:34:1
+//line cmd/spx-backend/post_ai_interaction_archive.yap:30:1
 	if err != nil {
-//line cmd/spx-backend/post_ai_interaction_archive.yap:35:1
+//line cmd/spx-backend/post_ai_interaction_archive.yap:31:1
 		replyWithInnerError(ctx, err)
-//line cmd/spx-backend/post_ai_interaction_archive.yap:36:1
+//line cmd/spx-backend/post_ai_interaction_archive.yap:32:1
 		return
 	}
-//line cmd/spx-backend/post_ai_interaction_archive.yap:39:1
-	consumeQuota(ctx, quotaResource, quotaAmount)
-//line cmd/spx-backend/post_ai_interaction_archive.yap:41:1
+//line cmd/spx-backend/post_ai_interaction_archive.yap:35:1
 	this.Json__1(result)
 }
 func (this *post_ai_interaction_archive) Classfname() string {
@@ -1609,43 +1595,36 @@ func (this *post_ai_interaction_turn) Main(_xgo_arg0 *yap.Context) {
 		return
 	}
 //line cmd/spx-backend/post_ai_interaction_turn.yap:16:1
-	const (
-		quotaResource = authz.ResourceAIInteractionTurn
-		quotaAmount   = 1
-	)
+	if !ensureQuotaRemaining(ctx, authz.ResourceAIInteractionTurn, 1) {
+//line cmd/spx-backend/post_ai_interaction_turn.yap:17:1
+		return
+	}
 //line cmd/spx-backend/post_ai_interaction_turn.yap:20:1
-	if !ensureQuotaRemaining(ctx, quotaResource, quotaAmount) {
+	params := &controller.AIInteractionTurnParams{}
 //line cmd/spx-backend/post_ai_interaction_turn.yap:21:1
+	if !parseJSON(ctx, params) {
+//line cmd/spx-backend/post_ai_interaction_turn.yap:22:1
 		return
 	}
 //line cmd/spx-backend/post_ai_interaction_turn.yap:24:1
-	params := &controller.AIInteractionTurnParams{}
+	if
+//line cmd/spx-backend/post_ai_interaction_turn.yap:24:1
+	ok, msg := params.Validate(); !ok {
 //line cmd/spx-backend/post_ai_interaction_turn.yap:25:1
-	if !parseJSON(ctx, params) {
+		replyWithCodeMsg(ctx, errorInvalidArgs, msg)
 //line cmd/spx-backend/post_ai_interaction_turn.yap:26:1
 		return
 	}
-//line cmd/spx-backend/post_ai_interaction_turn.yap:28:1
-	if
-//line cmd/spx-backend/post_ai_interaction_turn.yap:28:1
-	ok, msg := params.Validate(); !ok {
 //line cmd/spx-backend/post_ai_interaction_turn.yap:29:1
-		replyWithCodeMsg(ctx, errorInvalidArgs, msg)
-//line cmd/spx-backend/post_ai_interaction_turn.yap:30:1
-		return
-	}
-//line cmd/spx-backend/post_ai_interaction_turn.yap:33:1
 	result, err := this.ctrl.PerformAIInteractionTurn(ctx.Context(), params)
-//line cmd/spx-backend/post_ai_interaction_turn.yap:34:1
+//line cmd/spx-backend/post_ai_interaction_turn.yap:30:1
 	if err != nil {
-//line cmd/spx-backend/post_ai_interaction_turn.yap:35:1
+//line cmd/spx-backend/post_ai_interaction_turn.yap:31:1
 		replyWithInnerError(ctx, err)
-//line cmd/spx-backend/post_ai_interaction_turn.yap:36:1
+//line cmd/spx-backend/post_ai_interaction_turn.yap:32:1
 		return
 	}
-//line cmd/spx-backend/post_ai_interaction_turn.yap:39:1
-	consumeQuota(ctx, quotaResource, quotaAmount)
-//line cmd/spx-backend/post_ai_interaction_turn.yap:41:1
+//line cmd/spx-backend/post_ai_interaction_turn.yap:35:1
 	this.Json__1(result)
 }
 func (this *post_ai_interaction_turn) Classfname() string {
@@ -1772,45 +1751,38 @@ func (this *post_copilot_message) Main(_xgo_arg0 *yap.Context) {
 		return
 	}
 //line cmd/spx-backend/post_copilot_message.yap:16:1
-	const (
-		quotaResource = authz.ResourceCopilotMessage
-		quotaAmount   = 1
-	)
+	if !ensureQuotaRemaining(ctx, authz.ResourceCopilotMessage, 1) {
+//line cmd/spx-backend/post_copilot_message.yap:17:1
+		return
+	}
 //line cmd/spx-backend/post_copilot_message.yap:20:1
-	if !ensureQuotaRemaining(ctx, quotaResource, quotaAmount) {
+	params := &controller.GenerateMessageParams{}
 //line cmd/spx-backend/post_copilot_message.yap:21:1
+	if !parseJSON(ctx, params) {
+//line cmd/spx-backend/post_copilot_message.yap:22:1
 		return
 	}
 //line cmd/spx-backend/post_copilot_message.yap:24:1
-	params := &controller.GenerateMessageParams{}
+	if
+//line cmd/spx-backend/post_copilot_message.yap:24:1
+	ok, msg := params.Validate(); !ok {
 //line cmd/spx-backend/post_copilot_message.yap:25:1
-	if !parseJSON(ctx, params) {
+		replyWithCodeMsg(ctx, errorInvalidArgs, msg)
 //line cmd/spx-backend/post_copilot_message.yap:26:1
 		return
 	}
-//line cmd/spx-backend/post_copilot_message.yap:28:1
-	if
-//line cmd/spx-backend/post_copilot_message.yap:28:1
-	ok, msg := params.Validate(); !ok {
 //line cmd/spx-backend/post_copilot_message.yap:29:1
-		replyWithCodeMsg(ctx, errorInvalidArgs, msg)
-//line cmd/spx-backend/post_copilot_message.yap:30:1
-		return
-	}
-//line cmd/spx-backend/post_copilot_message.yap:33:1
 	canUsePremium := authz.CanUsePremiumLLM(ctx.Context())
-//line cmd/spx-backend/post_copilot_message.yap:34:1
+//line cmd/spx-backend/post_copilot_message.yap:30:1
 	result, err := this.ctrl.GenerateMessage(ctx.Context(), params, canUsePremium)
-//line cmd/spx-backend/post_copilot_message.yap:35:1
+//line cmd/spx-backend/post_copilot_message.yap:31:1
 	if err != nil {
-//line cmd/spx-backend/post_copilot_message.yap:36:1
+//line cmd/spx-backend/post_copilot_message.yap:32:1
 		replyWithInnerError(ctx, err)
-//line cmd/spx-backend/post_copilot_message.yap:37:1
+//line cmd/spx-backend/post_copilot_message.yap:33:1
 		return
 	}
-//line cmd/spx-backend/post_copilot_message.yap:40:1
-	consumeQuota(ctx, quotaResource, quotaAmount)
-//line cmd/spx-backend/post_copilot_message.yap:42:1
+//line cmd/spx-backend/post_copilot_message.yap:36:1
 	this.Json__1(result)
 }
 func (this *post_copilot_message) Classfname() string {
@@ -1833,49 +1805,42 @@ func (this *post_copilot_stream_message) Main(_xgo_arg0 *yap.Context) {
 		return
 	}
 //line cmd/spx-backend/post_copilot_stream_message.yap:16:1
-	const (
-		quotaResource = authz.ResourceCopilotMessage
-		quotaAmount   = 1
-	)
+	if !ensureQuotaRemaining(ctx, authz.ResourceCopilotMessage, 1) {
+//line cmd/spx-backend/post_copilot_stream_message.yap:17:1
+		return
+	}
 //line cmd/spx-backend/post_copilot_stream_message.yap:20:1
-	if !ensureQuotaRemaining(ctx, quotaResource, quotaAmount) {
+	params := &controller.GenerateMessageParams{}
 //line cmd/spx-backend/post_copilot_stream_message.yap:21:1
+	if !parseJSON(ctx, params) {
+//line cmd/spx-backend/post_copilot_stream_message.yap:22:1
 		return
 	}
 //line cmd/spx-backend/post_copilot_stream_message.yap:24:1
-	params := &controller.GenerateMessageParams{}
+	if
+//line cmd/spx-backend/post_copilot_stream_message.yap:24:1
+	ok, msg := params.Validate(); !ok {
 //line cmd/spx-backend/post_copilot_stream_message.yap:25:1
-	if !parseJSON(ctx, params) {
+		replyWithCodeMsg(ctx, errorInvalidArgs, msg)
 //line cmd/spx-backend/post_copilot_stream_message.yap:26:1
 		return
 	}
-//line cmd/spx-backend/post_copilot_stream_message.yap:28:1
-	if
-//line cmd/spx-backend/post_copilot_stream_message.yap:28:1
-	ok, msg := params.Validate(); !ok {
 //line cmd/spx-backend/post_copilot_stream_message.yap:29:1
-		replyWithCodeMsg(ctx, errorInvalidArgs, msg)
-//line cmd/spx-backend/post_copilot_stream_message.yap:30:1
-		return
-	}
-//line cmd/spx-backend/post_copilot_stream_message.yap:33:1
 	canUsePremium := authz.CanUsePremiumLLM(ctx.Context())
-//line cmd/spx-backend/post_copilot_stream_message.yap:34:1
+//line cmd/spx-backend/post_copilot_stream_message.yap:30:1
 	read, err := this.ctrl.GenerateMessageStream(ctx.Context(), params, canUsePremium)
-//line cmd/spx-backend/post_copilot_stream_message.yap:35:1
+//line cmd/spx-backend/post_copilot_stream_message.yap:31:1
 	if err != nil {
-//line cmd/spx-backend/post_copilot_stream_message.yap:36:1
+//line cmd/spx-backend/post_copilot_stream_message.yap:32:1
 		replyWithInnerError(ctx, err)
-//line cmd/spx-backend/post_copilot_stream_message.yap:37:1
+//line cmd/spx-backend/post_copilot_stream_message.yap:33:1
 		return
 	}
-//line cmd/spx-backend/post_copilot_stream_message.yap:39:1
+//line cmd/spx-backend/post_copilot_stream_message.yap:35:1
 	defer read.Close()
-//line cmd/spx-backend/post_copilot_stream_message.yap:41:1
-	consumeQuota(ctx, quotaResource, quotaAmount)
-//line cmd/spx-backend/post_copilot_stream_message.yap:43:1
+//line cmd/spx-backend/post_copilot_stream_message.yap:37:1
 	buf := make([]byte, 4096)
-//line cmd/spx-backend/post_copilot_stream_message.yap:44:1
+//line cmd/spx-backend/post_copilot_stream_message.yap:38:1
 	this.Stream__2(read, buf)
 }
 func (this *post_copilot_stream_message) Classfname() string {
@@ -2237,49 +2202,42 @@ func (this *post_workflow_stream_message) Main(_xgo_arg0 *yap.Context) {
 		return
 	}
 //line cmd/spx-backend/post_workflow_stream_message.yap:16:1
-	const (
-		quotaResource = authz.ResourceCopilotMessage
-		quotaAmount   = 1
-	)
+	if !ensureQuotaRemaining(ctx, authz.ResourceCopilotMessage, 1) {
+//line cmd/spx-backend/post_workflow_stream_message.yap:17:1
+		return
+	}
 //line cmd/spx-backend/post_workflow_stream_message.yap:20:1
-	if !ensureQuotaRemaining(ctx, quotaResource, quotaAmount) {
+	params := &controller.WorkflowMessageParams{}
 //line cmd/spx-backend/post_workflow_stream_message.yap:21:1
+	if !parseJSON(ctx, params) {
+//line cmd/spx-backend/post_workflow_stream_message.yap:22:1
 		return
 	}
 //line cmd/spx-backend/post_workflow_stream_message.yap:24:1
-	params := &controller.WorkflowMessageParams{}
+	if
+//line cmd/spx-backend/post_workflow_stream_message.yap:24:1
+	ok, msg := params.Validate(); !ok {
 //line cmd/spx-backend/post_workflow_stream_message.yap:25:1
-	if !parseJSON(ctx, params) {
+		replyWithCodeMsg(ctx, errorInvalidArgs, msg)
 //line cmd/spx-backend/post_workflow_stream_message.yap:26:1
 		return
 	}
-//line cmd/spx-backend/post_workflow_stream_message.yap:28:1
-	if
-//line cmd/spx-backend/post_workflow_stream_message.yap:28:1
-	ok, msg := params.Validate(); !ok {
 //line cmd/spx-backend/post_workflow_stream_message.yap:29:1
-		replyWithCodeMsg(ctx, errorInvalidArgs, msg)
-//line cmd/spx-backend/post_workflow_stream_message.yap:30:1
-		return
-	}
-//line cmd/spx-backend/post_workflow_stream_message.yap:33:1
 	canUsePremium := authz.CanUsePremiumLLM(ctx.Context())
-//line cmd/spx-backend/post_workflow_stream_message.yap:34:1
+//line cmd/spx-backend/post_workflow_stream_message.yap:30:1
 	read, err := this.ctrl.WorkflowMessageStream(ctx.Context(), params, canUsePremium)
-//line cmd/spx-backend/post_workflow_stream_message.yap:35:1
+//line cmd/spx-backend/post_workflow_stream_message.yap:31:1
 	if err != nil {
-//line cmd/spx-backend/post_workflow_stream_message.yap:36:1
+//line cmd/spx-backend/post_workflow_stream_message.yap:32:1
 		replyWithInnerError(ctx, err)
-//line cmd/spx-backend/post_workflow_stream_message.yap:37:1
+//line cmd/spx-backend/post_workflow_stream_message.yap:33:1
 		return
 	}
-//line cmd/spx-backend/post_workflow_stream_message.yap:39:1
+//line cmd/spx-backend/post_workflow_stream_message.yap:35:1
 	defer read.Close()
-//line cmd/spx-backend/post_workflow_stream_message.yap:41:1
-	consumeQuota(ctx, quotaResource, quotaAmount)
-//line cmd/spx-backend/post_workflow_stream_message.yap:43:1
+//line cmd/spx-backend/post_workflow_stream_message.yap:37:1
 	buf := make([]byte, 4096)
-//line cmd/spx-backend/post_workflow_stream_message.yap:44:1
+//line cmd/spx-backend/post_workflow_stream_message.yap:38:1
 	this.Stream__2(read, buf)
 }
 func (this *post_workflow_stream_message) Classfname() string {

--- a/spx-backend/internal/authz/quota/nop.go
+++ b/spx-backend/internal/authz/quota/nop.go
@@ -19,12 +19,12 @@ func (*nopQuotaTracker) Usage(context.Context, int64, authz.QuotaPolicy) (authz.
 	return authz.QuotaUsage{}, nil
 }
 
-// IncrementUsage implements [authz.QuotaTracker].
-func (*nopQuotaTracker) IncrementUsage(context.Context, int64, authz.QuotaPolicy, int64) error {
-	return nil
-}
-
 // ResetUsage implements [authz.QuotaTracker].
 func (*nopQuotaTracker) ResetUsage(context.Context, int64, authz.QuotaPolicy) error {
 	return nil
+}
+
+// TryConsume implements [authz.QuotaTracker].
+func (*nopQuotaTracker) TryConsume(context.Context, int64, []authz.QuotaPolicy, int64) (*authz.Quota, error) {
+	return nil, nil
 }

--- a/spx-backend/internal/authz/quota/nop_test.go
+++ b/spx-backend/internal/authz/quota/nop_test.go
@@ -36,61 +36,6 @@ func TestNopQuotaTrackerUsage(t *testing.T) {
 	})
 }
 
-func TestNopQuotaTrackerIncrementUsage(t *testing.T) {
-	t.Run("NoErrorOnIncrement", func(t *testing.T) {
-		ctx := context.Background()
-		tracker := NewNopQuotaTracker()
-
-		err := tracker.IncrementUsage(ctx, 123, authz.QuotaPolicy{Name: "copilotMessage:limit"}, 10)
-		require.NoError(t, err)
-	})
-
-	t.Run("UsageRemainsZeroAfterIncrement", func(t *testing.T) {
-		ctx := context.Background()
-		tracker := NewNopQuotaTracker()
-
-		err := tracker.IncrementUsage(ctx, 123, authz.QuotaPolicy{Name: "copilotMessage:limit"}, 10)
-		require.NoError(t, err)
-
-		usage, err := tracker.Usage(ctx, 123, authz.QuotaPolicy{Name: "copilotMessage:limit"})
-		require.NoError(t, err)
-		assert.Equal(t, int64(0), usage.Used)
-		assert.True(t, usage.ResetTime.IsZero())
-	})
-
-	t.Run("MultipleIncrementsHaveNoEffect", func(t *testing.T) {
-		ctx := context.Background()
-		tracker := NewNopQuotaTracker()
-
-		err := tracker.IncrementUsage(ctx, 123, authz.QuotaPolicy{Name: "copilotMessage:limit"}, 5)
-		require.NoError(t, err)
-
-		err = tracker.IncrementUsage(ctx, 123, authz.QuotaPolicy{Name: "copilotMessage:limit"}, 15)
-		require.NoError(t, err)
-
-		usage, err := tracker.Usage(ctx, 123, authz.QuotaPolicy{Name: "copilotMessage:limit"})
-		require.NoError(t, err)
-		assert.Equal(t, int64(0), usage.Used)
-		assert.True(t, usage.ResetTime.IsZero())
-	})
-
-	t.Run("ZeroIncrement", func(t *testing.T) {
-		ctx := context.Background()
-		tracker := NewNopQuotaTracker()
-
-		err := tracker.IncrementUsage(ctx, 123, authz.QuotaPolicy{Name: "copilotMessage:limit"}, 0)
-		require.NoError(t, err)
-	})
-
-	t.Run("NegativeIncrement", func(t *testing.T) {
-		ctx := context.Background()
-		tracker := NewNopQuotaTracker()
-
-		err := tracker.IncrementUsage(ctx, 123, authz.QuotaPolicy{Name: "copilotMessage:limit"}, -5)
-		require.NoError(t, err)
-	})
-}
-
 func TestNopQuotaTrackerResetUsage(t *testing.T) {
 	t.Run("NoErrorOnReset", func(t *testing.T) {
 		ctx := context.Background()
@@ -112,20 +57,13 @@ func TestNopQuotaTrackerResetUsage(t *testing.T) {
 		assert.Equal(t, int64(0), usage.Used)
 		assert.True(t, usage.ResetTime.IsZero())
 	})
+}
 
-	t.Run("ResetAfterIncrementHasNoEffect", func(t *testing.T) {
-		ctx := context.Background()
-		tracker := NewNopQuotaTracker()
+func TestNopQuotaTrackerTryConsume(t *testing.T) {
+	ctx := context.Background()
+	tracker := NewNopQuotaTracker()
 
-		err := tracker.IncrementUsage(ctx, 123, authz.QuotaPolicy{Name: "copilotMessage:limit"}, 100)
-		require.NoError(t, err)
-
-		err = tracker.ResetUsage(ctx, 123, authz.QuotaPolicy{Name: "copilotMessage:limit"})
-		require.NoError(t, err)
-
-		usage, err := tracker.Usage(ctx, 123, authz.QuotaPolicy{Name: "copilotMessage:limit"})
-		require.NoError(t, err)
-		assert.Equal(t, int64(0), usage.Used)
-		assert.True(t, usage.ResetTime.IsZero())
-	})
+	quota, err := tracker.TryConsume(ctx, 123, []authz.QuotaPolicy{{Name: "copilotMessage:limit"}}, 10)
+	require.NoError(t, err)
+	assert.Nil(t, quota)
 }

--- a/spx-backend/internal/authz/quota/redis.go
+++ b/spx-backend/internal/authz/quota/redis.go
@@ -74,21 +74,6 @@ func (t *redisQuotaTracker) Usage(ctx context.Context, userID int64, policy auth
 	return usage, nil
 }
 
-// IncrementUsage implements [authz.QuotaTracker].
-func (t *redisQuotaTracker) IncrementUsage(ctx context.Context, userID int64, policy authz.QuotaPolicy, amount int64) error {
-	key := quotaKey(userID, policy)
-
-	// Use pipeline to atomically increment and set TTL.
-	pipe := t.client.Pipeline()
-	pipe.IncrBy(ctx, key, amount)
-	pipe.ExpireNX(ctx, key, policy.Window)
-
-	if _, err := pipe.Exec(ctx); err != nil {
-		return fmt.Errorf("failed to increment usage in Redis: %w", err)
-	}
-	return nil
-}
-
 // ResetUsage implements [authz.QuotaTracker].
 func (t *redisQuotaTracker) ResetUsage(ctx context.Context, userID int64, policy authz.QuotaPolicy) error {
 	key := quotaKey(userID, policy)
@@ -97,6 +82,106 @@ func (t *redisQuotaTracker) ResetUsage(ctx context.Context, userID int64, policy
 		return fmt.Errorf("failed to reset usage in Redis: %w", err)
 	}
 	return nil
+}
+
+// luaTryConsume performs an atomic check-and-increment across multiple quota
+// keys. It returns {1} on success, or {0, failedIndex, used, ttl} on exhaustion
+// at KEYS[failedIndex] without mutating state.
+var luaTryConsume = redis.NewScript(`
+local amount = tonumber(ARGV[1])
+local n = tonumber(ARGV[2])
+
+-- First pass: check limits without mutating state.
+local argPos = 3
+for i = 1, n do
+    local limit = tonumber(ARGV[argPos])
+    local window = tonumber(ARGV[argPos + 1])
+    argPos = argPos + 2
+
+    if limit <= 0 then
+        return {0, i, 0, 0}
+    end
+
+    local used = tonumber(redis.call("GET", KEYS[i]) or "0")
+    if used + amount > limit then
+        local ttl = redis.call("PTTL", KEYS[i])
+        if ttl < 0 then
+            ttl = window
+        end
+        return {0, i, used, ttl}
+    end
+end
+
+-- Second pass: apply increments and set TTL when absent.
+argPos = 3
+for i = 1, n do
+    local limit = tonumber(ARGV[argPos])
+    local window = tonumber(ARGV[argPos + 1])
+    argPos = argPos + 2
+
+    redis.call("INCRBY", KEYS[i], amount)
+    if window > 0 then
+        local ttl = redis.call("PTTL", KEYS[i])
+        if ttl < 0 then
+            redis.call("PEXPIRE", KEYS[i], window)
+        end
+    end
+end
+
+return {1}
+`)
+
+// TryConsume implements [authz.QuotaTracker].
+func (t *redisQuotaTracker) TryConsume(ctx context.Context, userID int64, policies []authz.QuotaPolicy, amount int64) (*authz.Quota, error) {
+	if len(policies) == 0 || amount <= 0 {
+		return nil, nil
+	}
+
+	keys := make([]string, 0, len(policies))
+	args := make([]any, 0, 2*len(policies)+2)
+	args = append(args, amount, len(policies))
+	for _, policy := range policies {
+		keys = append(keys, quotaKey(userID, policy))
+		args = append(args, policy.Limit, policy.Window.Milliseconds())
+	}
+
+	result, err := luaTryConsume.Run(ctx, t.client, keys, args...).Result()
+	if err != nil {
+		return nil, fmt.Errorf("failed to execute quota script: %w", err)
+	}
+
+	data, ok := result.([]any)
+	if !ok || len(data) == 0 {
+		return nil, fmt.Errorf("unexpected script return: %v", result)
+	}
+
+	success, _ := data[0].(int64)
+	if success == 1 {
+		return nil, nil
+	} else if len(data) != 4 {
+		return nil, fmt.Errorf("unexpected script return: %v", result)
+	}
+	failedIndex, _ := data[1].(int64)
+	used, _ := data[2].(int64)
+	ttl, _ := data[3].(int64)
+
+	if failedIndex <= 0 || int(failedIndex) > len(policies) {
+		return nil, fmt.Errorf("invalid failed index from script: %d", failedIndex)
+	}
+	policy := policies[failedIndex-1]
+
+	var resetTime time.Time
+	if ttl > 0 {
+		resetTime = time.Now().Add(time.Duration(ttl) * time.Millisecond)
+	}
+
+	return &authz.Quota{
+		QuotaPolicy: policy,
+		QuotaUsage: authz.QuotaUsage{
+			Used:      used,
+			ResetTime: resetTime,
+		},
+	}, nil
 }
 
 // Close closes the Redis connection.


### PR DESCRIPTION
- Simplify `authz.QuotaTracker` by replacing `IncrementUsage` with `TryConsume`
- Replace the check-then-consume flow with `authz.TryConsume` to remove quota races under concurrent requests
- Add a Redis Lua script to check multiple quota policies and increment counters in one atomic call

Updates #2456