### PR TITLE
refactor(spx-backend): inject quota policies only without usage in AuthZ middleware

### DIFF
--- a/spx-backend/internal/authz/authz.go
+++ b/spx-backend/internal/authz/authz.go
@@ -35,8 +35,8 @@ func (a *Authorizer) Middleware() func(http.Handler) http.Handler {
 			// Inject the authorizer instance into the context.
 			ctx = newContextWithAuthorizer(ctx, a)
 
-			// Compute user capabilities and quotas for authenticated users
-			// and inject them into the context.
+			// Compute user capabilities and quota policies for authenticated
+			// users and inject them into the context.
 			if mUser, ok := authn.UserFromContext(ctx); ok {
 				caps, err := a.pdp.ComputeUserCapabilities(ctx, mUser)
 				if err != nil {
@@ -46,13 +46,13 @@ func (a *Authorizer) Middleware() func(http.Handler) http.Handler {
 				}
 				ctx = NewContextWithUserCapabilities(ctx, caps)
 
-				quotas, err := a.pdp.ComputeUserQuotas(ctx, mUser)
+				quotaPolicies, err := a.pdp.ComputeUserQuotaPolicies(ctx, mUser)
 				if err != nil {
 					logger.Printf("authorization system error: %v", err)
 					http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 					return
 				}
-				ctx = NewContextWithUserQuotas(ctx, quotas)
+				ctx = NewContextWithUserQuotaPolicies(ctx, quotaPolicies)
 			}
 
 			next.ServeHTTP(w, r.WithContext(ctx))

--- a/spx-backend/internal/authz/context.go
+++ b/spx-backend/internal/authz/context.go
@@ -30,16 +30,16 @@ func UserCapabilitiesFromContext(ctx context.Context) (UserCapabilities, bool) {
 	return caps, ok
 }
 
-// userQuotasContextKey is the context key type for user quotas.
-type userQuotasContextKey struct{}
+// userQuotaPoliciesContextKey is the context key type for user quota policies.
+type userQuotaPoliciesContextKey struct{}
 
-// NewContextWithUserQuotas creates a new context with the user quotas.
-func NewContextWithUserQuotas(ctx context.Context, quotas UserQuotas) context.Context {
-	return context.WithValue(ctx, userQuotasContextKey{}, quotas)
+// NewContextWithUserQuotaPolicies creates a new context with the user quota policies.
+func NewContextWithUserQuotaPolicies(ctx context.Context, quotas UserQuotaPolicies) context.Context {
+	return context.WithValue(ctx, userQuotaPoliciesContextKey{}, quotas)
 }
 
-// UserQuotasFromContext gets the user quotas from context.
-func UserQuotasFromContext(ctx context.Context) (UserQuotas, bool) {
-	quotas, ok := ctx.Value(userQuotasContextKey{}).(UserQuotas)
-	return quotas, ok
+// UserQuotaPoliciesFromContext gets the user quota policies from context.
+func UserQuotaPoliciesFromContext(ctx context.Context) (UserQuotaPolicies, bool) {
+	quotaPolicies, ok := ctx.Value(userQuotaPoliciesContextKey{}).(UserQuotaPolicies)
+	return quotaPolicies, ok
 }

--- a/spx-backend/internal/authz/context_test.go
+++ b/spx-backend/internal/authz/context_test.go
@@ -24,45 +24,32 @@ func newTestUserCapabilities() UserCapabilities {
 	}
 }
 
-func newTestUserQuotas() UserQuotas {
-	const quotaWindow = 24 * time.Hour
-	return UserQuotas{
-		Limits: map[Resource]Quota{
+func newTestUserQuotaPolicies() UserQuotaPolicies {
+	return UserQuotaPolicies{
+		Limits: map[Resource]QuotaPolicy{
 			ResourceCopilotMessage: {
-				QuotaPolicy: QuotaPolicy{
-					Name:     "copilotMessage:limit",
-					Resource: ResourceCopilotMessage,
-					Limit:    100,
-					Window:   quotaWindow,
-				},
-				QuotaUsage: QuotaUsage{Used: 15},
+				Name:     "copilotMessage:limit",
+				Resource: ResourceCopilotMessage,
+				Limit:    100,
+				Window:   24 * time.Hour,
 			},
 			ResourceAIDescription: {
-				QuotaPolicy: QuotaPolicy{
-					Name:     "aiDescription:limit",
-					Resource: ResourceAIDescription,
-					Limit:    300,
-					Window:   quotaWindow,
-				},
-				QuotaUsage: QuotaUsage{Used: 10},
+				Name:     "aiDescription:limit",
+				Resource: ResourceAIDescription,
+				Limit:    300,
+				Window:   24 * time.Hour,
 			},
 			ResourceAIInteractionTurn: {
-				QuotaPolicy: QuotaPolicy{
-					Name:     "aiInteractionTurn:limit",
-					Resource: ResourceAIInteractionTurn,
-					Limit:    12000,
-					Window:   quotaWindow,
-				},
-				QuotaUsage: QuotaUsage{Used: 300},
+				Name:     "aiInteractionTurn:limit",
+				Resource: ResourceAIInteractionTurn,
+				Limit:    12000,
+				Window:   24 * time.Hour,
 			},
 			ResourceAIInteractionArchive: {
-				QuotaPolicy: QuotaPolicy{
-					Name:     "aiInteractionArchive:limit",
-					Resource: ResourceAIInteractionArchive,
-					Limit:    8000,
-					Window:   quotaWindow,
-				},
-				QuotaUsage: QuotaUsage{Used: 400},
+				Name:     "aiInteractionArchive:limit",
+				Resource: ResourceAIInteractionArchive,
+				Limit:    8000,
+				Window:   24 * time.Hour,
 			},
 		},
 	}
@@ -154,45 +141,45 @@ func TestUserCapabilitiesFromContext(t *testing.T) {
 	})
 }
 
-func TestNewContextWithUserQuotas(t *testing.T) {
+func TestNewContextWithUserQuotaPolicies(t *testing.T) {
 	t.Run("Normal", func(t *testing.T) {
-		wantQuotas := newTestUserQuotas()
-		ctx := NewContextWithUserQuotas(context.Background(), wantQuotas)
+		wantQuotaPolicies := newTestUserQuotaPolicies()
+		ctx := NewContextWithUserQuotaPolicies(context.Background(), wantQuotaPolicies)
 
-		quotas, ok := ctx.Value(userQuotasContextKey{}).(UserQuotas)
+		quotaPolicies, ok := ctx.Value(userQuotaPoliciesContextKey{}).(UserQuotaPolicies)
 		require.True(t, ok)
-		assert.Equal(t, wantQuotas, quotas)
+		assert.Equal(t, wantQuotaPolicies, quotaPolicies)
 	})
 
-	t.Run("ZeroQuotas", func(t *testing.T) {
-		ctx := NewContextWithUserQuotas(context.Background(), UserQuotas{})
+	t.Run("ZeroQuotaPolicies", func(t *testing.T) {
+		ctx := NewContextWithUserQuotaPolicies(context.Background(), UserQuotaPolicies{})
 
-		value := ctx.Value(userQuotasContextKey{})
+		value := ctx.Value(userQuotaPoliciesContextKey{})
 		assert.Zero(t, value)
 	})
 }
 
-func TestUserQuotasFromContext(t *testing.T) {
+func TestUserQuotaPoliciesFromContext(t *testing.T) {
 	t.Run("Normal", func(t *testing.T) {
-		wantQuotas := newTestUserQuotas()
-		ctx := NewContextWithUserQuotas(context.Background(), wantQuotas)
+		wantQuotaPolicies := newTestUserQuotaPolicies()
+		ctx := NewContextWithUserQuotaPolicies(context.Background(), wantQuotaPolicies)
 
-		quotas, ok := UserQuotasFromContext(ctx)
+		quotaPolicies, ok := UserQuotaPoliciesFromContext(ctx)
 		require.True(t, ok)
-		assert.Equal(t, wantQuotas, quotas)
+		assert.Equal(t, wantQuotaPolicies, quotaPolicies)
 	})
 
-	t.Run("NoQuotas", func(t *testing.T) {
-		quotas, ok := UserQuotasFromContext(context.Background())
+	t.Run("NoQuotaPolicies", func(t *testing.T) {
+		quotas, ok := UserQuotaPoliciesFromContext(context.Background())
 		require.False(t, ok)
 		require.Zero(t, quotas)
 	})
 
 	t.Run("WrongContextValue", func(t *testing.T) {
-		ctx := context.WithValue(context.Background(), userQuotasContextKey{}, "not-quotas")
+		ctx := context.WithValue(context.Background(), userQuotaPoliciesContextKey{}, "not-quotas")
 
-		quotas, ok := UserQuotasFromContext(ctx)
+		quotaPolicies, ok := UserQuotaPoliciesFromContext(ctx)
 		require.False(t, ok)
-		require.Zero(t, quotas)
+		require.Zero(t, quotaPolicies)
 	})
 }

--- a/spx-backend/internal/authz/helper_test.go
+++ b/spx-backend/internal/authz/helper_test.go
@@ -161,58 +161,46 @@ func TestTryConsumeQuota(t *testing.T) {
 		ctx := context.Background()
 		ctx = authn.NewContextWithUser(ctx, testUser)
 		ctx = newContextWithAuthorizer(ctx, authorizer)
-		ctx = NewContextWithUserQuotas(ctx, UserQuotas{
-			Limits: map[Resource]Quota{
+		ctx = NewContextWithUserQuotaPolicies(ctx, UserQuotaPolicies{
+			Limits: map[Resource]QuotaPolicy{
 				ResourceCopilotMessage: {
-					QuotaPolicy: QuotaPolicy{
-						Name:     "copilotMessage:limit",
-						Resource: ResourceCopilotMessage,
-						Limit:    100,
-						Window:   24 * time.Hour,
-					},
+					Name:     "copilotMessage:limit",
+					Resource: ResourceCopilotMessage,
+					Limit:    100,
+					Window:   24 * time.Hour,
 				},
 				ResourceAIDescription: {
-					QuotaPolicy: QuotaPolicy{
-						Name:     "aiDescription:limit",
-						Resource: ResourceAIDescription,
-						Limit:    300,
-						Window:   24 * time.Hour,
-					},
+					Name:     "aiDescription:limit",
+					Resource: ResourceAIDescription,
+					Limit:    300,
+					Window:   24 * time.Hour,
 				},
 				ResourceAIInteractionTurn: {
-					QuotaPolicy: QuotaPolicy{
-						Name:     "aiInteractionTurn:limit",
-						Resource: ResourceAIInteractionTurn,
-						Limit:    12000,
-						Window:   24 * time.Hour,
-					},
+					Name:     "aiInteractionTurn:limit",
+					Resource: ResourceAIInteractionTurn,
+					Limit:    12000,
+					Window:   24 * time.Hour,
 				},
 				ResourceAIInteractionArchive: {
-					QuotaPolicy: QuotaPolicy{
-						Name:     "aiInteractionArchive:limit",
-						Resource: ResourceAIInteractionArchive,
-						Limit:    8000,
-						Window:   24 * time.Hour,
-					},
+					Name:     "aiInteractionArchive:limit",
+					Resource: ResourceAIInteractionArchive,
+					Limit:    8000,
+					Window:   24 * time.Hour,
 				},
 			},
-			RateLimits: map[Resource][]Quota{
+			RateLimits: map[Resource][]QuotaPolicy{
 				ResourceCopilotMessage: {
 					{
-						QuotaPolicy: QuotaPolicy{
-							Name:     "copilotMessage:rateLimit:1m",
-							Resource: ResourceCopilotMessage,
-							Limit:    30,
-							Window:   time.Minute,
-						},
+						Name:     "copilotMessage:rateLimit:1m",
+						Resource: ResourceCopilotMessage,
+						Limit:    30,
+						Window:   time.Minute,
 					},
 					{
-						QuotaPolicy: QuotaPolicy{
-							Name:     "copilotMessage:rateLimit:5m",
-							Resource: ResourceCopilotMessage,
-							Limit:    150,
-							Window:   5 * time.Minute,
-						},
+						Name:     "copilotMessage:rateLimit:5m",
+						Resource: ResourceCopilotMessage,
+						Limit:    150,
+						Window:   5 * time.Minute,
 					},
 				},
 			},
@@ -242,16 +230,14 @@ func TestTryConsumeQuota(t *testing.T) {
 		ctx := context.Background()
 		ctx = authn.NewContextWithUser(ctx, testUser)
 		ctx = newContextWithAuthorizer(ctx, authorizer)
-		ctx = NewContextWithUserQuotas(ctx, UserQuotas{
-			RateLimits: map[Resource][]Quota{
+		ctx = NewContextWithUserQuotaPolicies(ctx, UserQuotaPolicies{
+			RateLimits: map[Resource][]QuotaPolicy{
 				ResourceCopilotMessage: {
 					{
-						QuotaPolicy: QuotaPolicy{
-							Name:     "copilotMessage:rateLimit:1m",
-							Resource: ResourceCopilotMessage,
-							Limit:    30,
-							Window:   time.Minute,
-						},
+						Name:     "copilotMessage:rateLimit:1m",
+						Resource: ResourceCopilotMessage,
+						Limit:    30,
+						Window:   time.Minute,
 					},
 				},
 			},
@@ -298,39 +284,31 @@ func TestTryConsumeQuota(t *testing.T) {
 		ctx := context.Background()
 		ctx = authn.NewContextWithUser(ctx, testUser)
 		ctx = newContextWithAuthorizer(ctx, authorizer)
-		ctx = NewContextWithUserQuotas(ctx, UserQuotas{
-			Limits: map[Resource]Quota{
+		ctx = NewContextWithUserQuotaPolicies(ctx, UserQuotaPolicies{
+			Limits: map[Resource]QuotaPolicy{
 				ResourceCopilotMessage: {
-					QuotaPolicy: QuotaPolicy{
-						Name:     "copilotMessage:limit",
-						Resource: ResourceCopilotMessage,
-						Limit:    100,
-						Window:   24 * time.Hour,
-					},
+					Name:     "copilotMessage:limit",
+					Resource: ResourceCopilotMessage,
+					Limit:    100,
+					Window:   24 * time.Hour,
 				},
 				ResourceAIDescription: {
-					QuotaPolicy: QuotaPolicy{
-						Name:     "aiDescription:limit",
-						Resource: ResourceAIDescription,
-						Limit:    300,
-						Window:   24 * time.Hour,
-					},
+					Name:     "aiDescription:limit",
+					Resource: ResourceAIDescription,
+					Limit:    300,
+					Window:   24 * time.Hour,
 				},
 				ResourceAIInteractionTurn: {
-					QuotaPolicy: QuotaPolicy{
-						Name:     "aiInteractionTurn:limit",
-						Resource: ResourceAIInteractionTurn,
-						Limit:    12000,
-						Window:   24 * time.Hour,
-					},
+					Name:     "aiInteractionTurn:limit",
+					Resource: ResourceAIInteractionTurn,
+					Limit:    12000,
+					Window:   24 * time.Hour,
 				},
 				ResourceAIInteractionArchive: {
-					QuotaPolicy: QuotaPolicy{
-						Name:     "aiInteractionArchive:limit",
-						Resource: ResourceAIInteractionArchive,
-						Limit:    8000,
-						Window:   24 * time.Hour,
-					},
+					Name:     "aiInteractionArchive:limit",
+					Resource: ResourceAIInteractionArchive,
+					Limit:    8000,
+					Window:   24 * time.Hour,
 				},
 			},
 		})
@@ -352,7 +330,7 @@ func TestTryConsumeQuota(t *testing.T) {
 
 		_, err := TryConsumeQuota(ctx, ResourceCopilotMessage, 1)
 		require.Error(t, err)
-		assert.EqualError(t, err, "missing user quotas in context")
+		assert.EqualError(t, err, "missing user quota policies in context")
 	})
 
 	t.Run("WrongAuthorizerContextValue", func(t *testing.T) {

--- a/spx-backend/internal/authz/pdp.go
+++ b/spx-backend/internal/authz/pdp.go
@@ -11,8 +11,8 @@ type PolicyDecisionPoint interface {
 	// ComputeUserCapabilities computes the capabilities for a user.
 	ComputeUserCapabilities(ctx context.Context, mUser *model.User) (UserCapabilities, error)
 
-	// ComputeUserQuotas computes the quotas for a user.
-	ComputeUserQuotas(ctx context.Context, mUser *model.User) (UserQuotas, error)
+	// ComputeUserQuotaPolicies computes the quota policies for a user.
+	ComputeUserQuotaPolicies(ctx context.Context, mUser *model.User) (UserQuotaPolicies, error)
 }
 
 // UserCapabilities represents user capabilities that control feature access.
@@ -27,13 +27,13 @@ type UserCapabilities struct {
 	CanUsePremiumLLM bool `json:"canUsePremiumLLM"`
 }
 
-// UserQuotas represents user quotas grouped by long-lived limits and
+// UserQuotaPolicies represents quota policies grouped by long-lived limits and
 // short-window rate limits.
-type UserQuotas struct {
-	// Limits stores long-lived limits per resource.
-	Limits map[Resource]Quota
+type UserQuotaPolicies struct {
+	// Limits stores long-lived limit policies per resource.
+	Limits map[Resource]QuotaPolicy
 
-	// RateLimits stores short-window rate limits per resource, ordered from
-	// shortest to longest window.
-	RateLimits map[Resource][]Quota
+	// RateLimits stores short-window rate limit policies per resource,
+	// ordered from shortest to longest window.
+	RateLimits map[Resource][]QuotaPolicy
 }

--- a/spx-backend/internal/authz/pdp_test.go
+++ b/spx-backend/internal/authz/pdp_test.go
@@ -8,8 +8,8 @@ import (
 )
 
 type mockPolicyDecisionPoint struct {
-	computeUserCapabilitiesFunc func(ctx context.Context, mUser *model.User) (UserCapabilities, error)
-	computeUserQuotasFunc       func(ctx context.Context, mUser *model.User) (UserQuotas, error)
+	computeUserCapabilitiesFunc  func(ctx context.Context, mUser *model.User) (UserCapabilities, error)
+	computeUserQuotaPoliciesFunc func(ctx context.Context, mUser *model.User) (UserQuotaPolicies, error)
 }
 
 func (m *mockPolicyDecisionPoint) ComputeUserCapabilities(ctx context.Context, mUser *model.User) (UserCapabilities, error) {
@@ -23,28 +23,16 @@ func (m *mockPolicyDecisionPoint) ComputeUserCapabilities(ctx context.Context, m
 	}, nil
 }
 
-func (m *mockPolicyDecisionPoint) ComputeUserQuotas(ctx context.Context, mUser *model.User) (UserQuotas, error) {
-	if m.computeUserQuotasFunc != nil {
-		return m.computeUserQuotasFunc(ctx, mUser)
+func (m *mockPolicyDecisionPoint) ComputeUserQuotaPolicies(ctx context.Context, mUser *model.User) (UserQuotaPolicies, error) {
+	if m.computeUserQuotaPoliciesFunc != nil {
+		return m.computeUserQuotaPoliciesFunc(ctx, mUser)
 	}
-	return UserQuotas{
-		Limits: map[Resource]Quota{
-			ResourceCopilotMessage: {
-				QuotaPolicy: QuotaPolicy{Limit: 100, Window: 24 * time.Hour},
-				QuotaUsage:  QuotaUsage{Used: 20},
-			},
-			ResourceAIDescription: {
-				QuotaPolicy: QuotaPolicy{Limit: 300, Window: 24 * time.Hour},
-				QuotaUsage:  QuotaUsage{Used: 20},
-			},
-			ResourceAIInteractionTurn: {
-				QuotaPolicy: QuotaPolicy{Limit: 12000, Window: 24 * time.Hour},
-				QuotaUsage:  QuotaUsage{Used: 400},
-			},
-			ResourceAIInteractionArchive: {
-				QuotaPolicy: QuotaPolicy{Limit: 8000, Window: 24 * time.Hour},
-				QuotaUsage:  QuotaUsage{Used: 380},
-			},
+	return UserQuotaPolicies{
+		Limits: map[Resource]QuotaPolicy{
+			ResourceCopilotMessage:       {Limit: 100, Window: 24 * time.Hour},
+			ResourceAIDescription:        {Limit: 300, Window: 24 * time.Hour},
+			ResourceAIInteractionTurn:    {Limit: 12000, Window: 24 * time.Hour},
+			ResourceAIInteractionArchive: {Limit: 8000, Window: 24 * time.Hour},
 		},
 	}, nil
 }

--- a/spx-backend/internal/authz/quota.go
+++ b/spx-backend/internal/authz/quota.go
@@ -7,17 +7,19 @@ import (
 
 // QuotaTracker defines the interface for tracking resource usage quotas.
 type QuotaTracker interface {
-	// Usage returns the current usage for a user and quota policy.
-	Usage(ctx context.Context, userID int64, policy QuotaPolicy) (QuotaUsage, error)
-
-	// ResetUsage resets the usage counter for a user and quota policy.
-	ResetUsage(ctx context.Context, userID int64, policy QuotaPolicy) error
-
 	// TryConsume tries to consume the given amount of quotas across all
 	// provided quota policies in one atomic step. It returns a non-nil
 	// [*Quota] only when consumption would exceed that quota and no system
 	// failure occurs.
 	TryConsume(ctx context.Context, userID int64, policies []QuotaPolicy, amount int64) (*Quota, error)
+
+	// Usage returns the current usage for the given user and quota
+	// policies. It returns a slice containing one [QuotaUsage] per policy,
+	// in the same order as the input, when no error occurs.
+	Usage(ctx context.Context, userID int64, policies []QuotaPolicy) ([]QuotaUsage, error)
+
+	// ResetUsage resets the usage counters for the given user and quota policies.
+	ResetUsage(ctx context.Context, userID int64, policies []QuotaPolicy) error
 }
 
 // QuotaPolicy defines the quota configuration for a usage update.

--- a/spx-backend/internal/authz/quota/nop.go
+++ b/spx-backend/internal/authz/quota/nop.go
@@ -14,17 +14,17 @@ func NewNopQuotaTracker() authz.QuotaTracker {
 	return &nopQuotaTracker{}
 }
 
-// Usage implements [authz.QuotaTracker].
-func (*nopQuotaTracker) Usage(context.Context, int64, authz.QuotaPolicy) (authz.QuotaUsage, error) {
-	return authz.QuotaUsage{}, nil
-}
-
-// ResetUsage implements [authz.QuotaTracker].
-func (*nopQuotaTracker) ResetUsage(context.Context, int64, authz.QuotaPolicy) error {
-	return nil
-}
-
 // TryConsume implements [authz.QuotaTracker].
 func (*nopQuotaTracker) TryConsume(context.Context, int64, []authz.QuotaPolicy, int64) (*authz.Quota, error) {
 	return nil, nil
+}
+
+// Usage implements [authz.QuotaTracker].
+func (*nopQuotaTracker) Usage(ctx context.Context, userID int64, policies []authz.QuotaPolicy) ([]authz.QuotaUsage, error) {
+	return make([]authz.QuotaUsage, len(policies)), nil
+}
+
+// ResetUsage implements [authz.QuotaTracker].
+func (*nopQuotaTracker) ResetUsage(context.Context, int64, []authz.QuotaPolicy) error {
+	return nil
 }

--- a/spx-backend/internal/authz/quota/nop_test.go
+++ b/spx-backend/internal/authz/quota/nop_test.go
@@ -9,30 +9,42 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestNopQuotaTrackerTryConsume(t *testing.T) {
+	ctx := context.Background()
+	tracker := NewNopQuotaTracker()
+
+	quota, err := tracker.TryConsume(ctx, 123, []authz.QuotaPolicy{{Name: "copilotMessage:limit"}}, 10)
+	require.NoError(t, err)
+	assert.Nil(t, quota)
+}
+
 func TestNopQuotaTrackerUsage(t *testing.T) {
 	t.Run("AlwaysReturnsZero", func(t *testing.T) {
 		ctx := context.Background()
 		tracker := NewNopQuotaTracker()
 
-		usage, err := tracker.Usage(ctx, 123, authz.QuotaPolicy{Name: "copilotMessage:limit"})
+		usages, err := tracker.Usage(ctx, 123, []authz.QuotaPolicy{{Name: "copilotMessage:limit"}})
 		require.NoError(t, err)
-		assert.Equal(t, int64(0), usage.Used)
-		assert.True(t, usage.ResetTime.IsZero())
+		require.Len(t, usages, 1)
+		assert.Equal(t, int64(0), usages[0].Used)
+		assert.True(t, usages[0].ResetTime.IsZero())
 	})
 
 	t.Run("DifferentUsersReturnZero", func(t *testing.T) {
 		ctx := context.Background()
 		tracker := NewNopQuotaTracker()
 
-		usage1, err := tracker.Usage(ctx, 123, authz.QuotaPolicy{Name: "copilotMessage:limit"})
+		usages1, err := tracker.Usage(ctx, 123, []authz.QuotaPolicy{{Name: "copilotMessage:limit"}})
 		require.NoError(t, err)
-		assert.Equal(t, int64(0), usage1.Used)
-		assert.True(t, usage1.ResetTime.IsZero())
+		require.Len(t, usages1, 1)
+		assert.Equal(t, int64(0), usages1[0].Used)
+		assert.True(t, usages1[0].ResetTime.IsZero())
 
-		usage2, err := tracker.Usage(ctx, 456, authz.QuotaPolicy{Name: "copilotMessage:limit"})
+		usages2, err := tracker.Usage(ctx, 456, []authz.QuotaPolicy{{Name: "copilotMessage:limit"}})
 		require.NoError(t, err)
-		assert.Equal(t, int64(0), usage2.Used)
-		assert.True(t, usage2.ResetTime.IsZero())
+		require.Len(t, usages2, 1)
+		assert.Equal(t, int64(0), usages2[0].Used)
+		assert.True(t, usages2[0].ResetTime.IsZero())
 	})
 }
 
@@ -41,7 +53,7 @@ func TestNopQuotaTrackerResetUsage(t *testing.T) {
 		ctx := context.Background()
 		tracker := NewNopQuotaTracker()
 
-		err := tracker.ResetUsage(ctx, 123, authz.QuotaPolicy{Name: "copilotMessage:limit"})
+		err := tracker.ResetUsage(ctx, 123, []authz.QuotaPolicy{{Name: "copilotMessage:limit"}})
 		require.NoError(t, err)
 	})
 
@@ -49,21 +61,13 @@ func TestNopQuotaTrackerResetUsage(t *testing.T) {
 		ctx := context.Background()
 		tracker := NewNopQuotaTracker()
 
-		err := tracker.ResetUsage(ctx, 123, authz.QuotaPolicy{Name: "copilotMessage:limit"})
+		err := tracker.ResetUsage(ctx, 123, []authz.QuotaPolicy{{Name: "copilotMessage:limit"}})
 		require.NoError(t, err)
 
-		usage, err := tracker.Usage(ctx, 123, authz.QuotaPolicy{Name: "copilotMessage:limit"})
+		usages, err := tracker.Usage(ctx, 123, []authz.QuotaPolicy{{Name: "copilotMessage:limit"}})
 		require.NoError(t, err)
-		assert.Equal(t, int64(0), usage.Used)
-		assert.True(t, usage.ResetTime.IsZero())
+		require.Len(t, usages, 1)
+		assert.Equal(t, int64(0), usages[0].Used)
+		assert.True(t, usages[0].ResetTime.IsZero())
 	})
-}
-
-func TestNopQuotaTrackerTryConsume(t *testing.T) {
-	ctx := context.Background()
-	tracker := NewNopQuotaTracker()
-
-	quota, err := tracker.TryConsume(ctx, 123, []authz.QuotaPolicy{{Name: "copilotMessage:limit"}}, 10)
-	require.NoError(t, err)
-	assert.Nil(t, quota)
 }

--- a/spx-backend/internal/authz/quota/redis_test.go
+++ b/spx-backend/internal/authz/quota/redis_test.go
@@ -12,194 +12,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestRedisQuotaTrackerUsage(t *testing.T) {
-	t.Run("InitialUsageShouldBeZero", func(t *testing.T) {
-		ctx := context.Background()
-		client, mock := redismock.NewClientMock()
-		tracker := &redisQuotaTracker{client: client}
-		policy := authz.QuotaPolicy{
-			Name:     "copilotMessage:limit",
-			Resource: authz.ResourceCopilotMessage,
-			Limit:    100,
-			Window:   24 * time.Hour,
-		}
-		key := quotaKey(123, policy)
-
-		mock.ExpectGet(key).RedisNil()
-		mock.ExpectPTTL(key).SetVal(0)
-
-		usage, err := tracker.Usage(ctx, 123, policy)
-		require.NoError(t, err)
-		assert.Equal(t, int64(0), usage.Used)
-		assert.True(t, usage.ResetTime.IsZero())
-	})
-
-	t.Run("ExistingUsageReturned", func(t *testing.T) {
-		ctx := context.Background()
-		client, mock := redismock.NewClientMock()
-		tracker := &redisQuotaTracker{client: client}
-		policy := authz.QuotaPolicy{
-			Name:     "copilotMessage:limit",
-			Resource: authz.ResourceCopilotMessage,
-			Limit:    100,
-			Window:   24 * time.Hour,
-		}
-		key := quotaKey(123, policy)
-		mock.ExpectGet(key).SetVal("25")
-		mock.ExpectPTTL(key).SetVal(30 * time.Second)
-
-		usage, err := tracker.Usage(ctx, 123, policy)
-		require.NoError(t, err)
-		assert.Equal(t, int64(25), usage.Used)
-		remaining := time.Until(usage.ResetTime)
-		assert.Greater(t, remaining, 0*time.Second)
-		assert.InDelta(t, float64(30*time.Second), float64(remaining), float64(time.Second))
-
-		require.NoError(t, mock.ExpectationsWereMet())
-	})
-
-	t.Run("NonExistentUserShouldReturnZero", func(t *testing.T) {
-		ctx := context.Background()
-		client, mock := redismock.NewClientMock()
-		tracker := &redisQuotaTracker{client: client}
-		policy := authz.QuotaPolicy{
-			Name:     "copilotMessage:limit",
-			Resource: authz.ResourceCopilotMessage,
-			Limit:    100,
-			Window:   24 * time.Hour,
-		}
-		key := quotaKey(999, policy)
-
-		mock.ExpectGet(key).RedisNil()
-		mock.ExpectPTTL(key).SetVal(0)
-
-		usage, err := tracker.Usage(ctx, 999, policy)
-		require.NoError(t, err)
-		assert.Equal(t, int64(0), usage.Used)
-		assert.True(t, usage.ResetTime.IsZero())
-	})
-
-	t.Run("RedisError", func(t *testing.T) {
-		ctx := context.Background()
-		client, mock := redismock.NewClientMock()
-		tracker := &redisQuotaTracker{client: client}
-		policy := authz.QuotaPolicy{
-			Name:     "copilotMessage:limit",
-			Resource: authz.ResourceCopilotMessage,
-			Limit:    100,
-			Window:   24 * time.Hour,
-		}
-		key := quotaKey(123, policy)
-
-		mock.ExpectGet(key).SetErr(errors.New("redis get error"))
-		usage, err := tracker.Usage(ctx, 123, policy)
-		assert.Error(t, err)
-		assert.Equal(t, int64(0), usage.Used)
-		assert.True(t, usage.ResetTime.IsZero())
-	})
-
-	t.Run("InvalidValueInRedis", func(t *testing.T) {
-		ctx := context.Background()
-		client, mock := redismock.NewClientMock()
-		tracker := &redisQuotaTracker{client: client}
-		policy := authz.QuotaPolicy{
-			Name:     "copilotMessage:limit",
-			Resource: authz.ResourceCopilotMessage,
-			Limit:    100,
-			Window:   24 * time.Hour,
-		}
-		key := quotaKey(123, policy)
-
-		mock.ExpectGet(key).SetVal("invalid-number")
-		usage, err := tracker.Usage(ctx, 123, policy)
-		assert.Error(t, err)
-		assert.Equal(t, int64(0), usage.Used)
-		assert.True(t, usage.ResetTime.IsZero())
-
-		require.NoError(t, mock.ExpectationsWereMet())
-	})
-}
-
-func TestRedisQuotaTrackerResetUsage(t *testing.T) {
-	t.Run("ResetExistingUsage", func(t *testing.T) {
-		ctx := context.Background()
-		client, mock := redismock.NewClientMock()
-		tracker := &redisQuotaTracker{client: client}
-		policy := authz.QuotaPolicy{
-			Name:     "copilotMessage:limit",
-			Resource: authz.ResourceCopilotMessage,
-			Limit:    100,
-			Window:   24 * time.Hour,
-		}
-
-		key := quotaKey(123, policy)
-		mock.ExpectDel(key).SetVal(1)
-
-		err := tracker.ResetUsage(ctx, 123, policy)
-		require.NoError(t, err)
-
-		require.NoError(t, mock.ExpectationsWereMet())
-	})
-
-	t.Run("ResetNonExistentUsage", func(t *testing.T) {
-		ctx := context.Background()
-		client, mock := redismock.NewClientMock()
-		tracker := &redisQuotaTracker{client: client}
-		policy := authz.QuotaPolicy{
-			Name:     "copilotMessage:limit",
-			Resource: authz.ResourceCopilotMessage,
-			Limit:    100,
-			Window:   24 * time.Hour,
-		}
-
-		key := quotaKey(999, policy)
-		mock.ExpectDel(key).SetVal(0)
-
-		err := tracker.ResetUsage(ctx, 999, policy)
-		require.NoError(t, err)
-
-		require.NoError(t, mock.ExpectationsWereMet())
-	})
-
-	t.Run("ResetOnlyAffectsSpecificUser", func(t *testing.T) {
-		ctx := context.Background()
-		client, mock := redismock.NewClientMock()
-		tracker := &redisQuotaTracker{client: client}
-		policy := authz.QuotaPolicy{
-			Name:     "copilotMessage:limit",
-			Resource: authz.ResourceCopilotMessage,
-			Limit:    100,
-			Window:   24 * time.Hour,
-		}
-
-		key := quotaKey(111, policy)
-		mock.ExpectDel(key).SetVal(1)
-
-		err := tracker.ResetUsage(ctx, 111, policy)
-		require.NoError(t, err)
-
-		require.NoError(t, mock.ExpectationsWereMet())
-	})
-
-	t.Run("RedisError", func(t *testing.T) {
-		ctx := context.Background()
-		client, mock := redismock.NewClientMock()
-		tracker := &redisQuotaTracker{client: client}
-		policy := authz.QuotaPolicy{
-			Name:     "copilotMessage:limit",
-			Resource: authz.ResourceCopilotMessage,
-			Limit:    100,
-			Window:   24 * time.Hour,
-		}
-
-		key := quotaKey(123, policy)
-		mock.ExpectDel(key).SetErr(errors.New("redis del error"))
-
-		err := tracker.ResetUsage(ctx, 123, policy)
-		assert.Error(t, err)
-	})
-}
-
 func TestRedisQuotaTrackerTryConsume(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
 		ctx := context.Background()
@@ -307,6 +119,195 @@ func TestRedisQuotaTrackerTryConsume(t *testing.T) {
 		quota, err := tracker.TryConsume(ctx, 123, []authz.QuotaPolicy{policy}, 1)
 		require.Error(t, err)
 		assert.Nil(t, quota)
+	})
+}
+
+func TestRedisQuotaTrackerUsage(t *testing.T) {
+	t.Run("InitialUsageShouldBeZero", func(t *testing.T) {
+		ctx := context.Background()
+		client, mock := redismock.NewClientMock()
+		tracker := &redisQuotaTracker{client: client}
+		policy := authz.QuotaPolicy{
+			Name:     "copilotMessage:limit",
+			Resource: authz.ResourceCopilotMessage,
+			Limit:    100,
+			Window:   24 * time.Hour,
+		}
+		key := quotaKey(123, policy)
+
+		mock.ExpectGet(key).RedisNil()
+		mock.ExpectPTTL(key).SetVal(0)
+
+		usages, err := tracker.Usage(ctx, 123, []authz.QuotaPolicy{policy})
+		require.NoError(t, err)
+		require.Len(t, usages, 1)
+		assert.Equal(t, int64(0), usages[0].Used)
+		assert.True(t, usages[0].ResetTime.IsZero())
+	})
+
+	t.Run("ExistingUsageReturned", func(t *testing.T) {
+		ctx := context.Background()
+		client, mock := redismock.NewClientMock()
+		tracker := &redisQuotaTracker{client: client}
+		policy := authz.QuotaPolicy{
+			Name:     "copilotMessage:limit",
+			Resource: authz.ResourceCopilotMessage,
+			Limit:    100,
+			Window:   24 * time.Hour,
+		}
+		key := quotaKey(123, policy)
+		mock.ExpectGet(key).SetVal("25")
+		mock.ExpectPTTL(key).SetVal(30 * time.Second)
+
+		usages, err := tracker.Usage(ctx, 123, []authz.QuotaPolicy{policy})
+		require.NoError(t, err)
+		require.Len(t, usages, 1)
+		assert.Equal(t, int64(25), usages[0].Used)
+		remaining := time.Until(usages[0].ResetTime)
+		assert.Greater(t, remaining, 0*time.Second)
+		assert.InDelta(t, float64(30*time.Second), float64(remaining), float64(time.Second))
+
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("NonExistentUserShouldReturnZero", func(t *testing.T) {
+		ctx := context.Background()
+		client, mock := redismock.NewClientMock()
+		tracker := &redisQuotaTracker{client: client}
+		policy := authz.QuotaPolicy{
+			Name:     "copilotMessage:limit",
+			Resource: authz.ResourceCopilotMessage,
+			Limit:    100,
+			Window:   24 * time.Hour,
+		}
+		key := quotaKey(999, policy)
+
+		mock.ExpectGet(key).RedisNil()
+		mock.ExpectPTTL(key).SetVal(0)
+
+		usages, err := tracker.Usage(ctx, 999, []authz.QuotaPolicy{policy})
+		require.NoError(t, err)
+		require.Len(t, usages, 1)
+		assert.Equal(t, int64(0), usages[0].Used)
+		assert.True(t, usages[0].ResetTime.IsZero())
+	})
+
+	t.Run("RedisError", func(t *testing.T) {
+		ctx := context.Background()
+		client, mock := redismock.NewClientMock()
+		tracker := &redisQuotaTracker{client: client}
+		policy := authz.QuotaPolicy{
+			Name:     "copilotMessage:limit",
+			Resource: authz.ResourceCopilotMessage,
+			Limit:    100,
+			Window:   24 * time.Hour,
+		}
+		key := quotaKey(123, policy)
+
+		mock.ExpectGet(key).SetErr(errors.New("redis get error"))
+		usages, err := tracker.Usage(ctx, 123, []authz.QuotaPolicy{policy})
+		assert.Error(t, err)
+		assert.Nil(t, usages)
+	})
+
+	t.Run("InvalidValueInRedis", func(t *testing.T) {
+		ctx := context.Background()
+		client, mock := redismock.NewClientMock()
+		tracker := &redisQuotaTracker{client: client}
+		policy := authz.QuotaPolicy{
+			Name:     "copilotMessage:limit",
+			Resource: authz.ResourceCopilotMessage,
+			Limit:    100,
+			Window:   24 * time.Hour,
+		}
+		key := quotaKey(123, policy)
+
+		mock.ExpectGet(key).SetVal("invalid-number")
+		usages, err := tracker.Usage(ctx, 123, []authz.QuotaPolicy{policy})
+		assert.Error(t, err)
+		assert.Nil(t, usages)
+
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+}
+
+func TestRedisQuotaTrackerResetUsage(t *testing.T) {
+	t.Run("ResetExistingUsage", func(t *testing.T) {
+		ctx := context.Background()
+		client, mock := redismock.NewClientMock()
+		tracker := &redisQuotaTracker{client: client}
+		policy := authz.QuotaPolicy{
+			Name:     "copilotMessage:limit",
+			Resource: authz.ResourceCopilotMessage,
+			Limit:    100,
+			Window:   24 * time.Hour,
+		}
+
+		key := quotaKey(123, policy)
+		mock.ExpectDel(key).SetVal(1)
+
+		err := tracker.ResetUsage(ctx, 123, []authz.QuotaPolicy{policy})
+		require.NoError(t, err)
+
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("ResetNonExistentUsage", func(t *testing.T) {
+		ctx := context.Background()
+		client, mock := redismock.NewClientMock()
+		tracker := &redisQuotaTracker{client: client}
+		policy := authz.QuotaPolicy{
+			Name:     "copilotMessage:limit",
+			Resource: authz.ResourceCopilotMessage,
+			Limit:    100,
+			Window:   24 * time.Hour,
+		}
+
+		key := quotaKey(999, policy)
+		mock.ExpectDel(key).SetVal(0)
+
+		err := tracker.ResetUsage(ctx, 999, []authz.QuotaPolicy{policy})
+		require.NoError(t, err)
+
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("ResetOnlyAffectsSpecificUser", func(t *testing.T) {
+		ctx := context.Background()
+		client, mock := redismock.NewClientMock()
+		tracker := &redisQuotaTracker{client: client}
+		policy := authz.QuotaPolicy{
+			Name:     "copilotMessage:limit",
+			Resource: authz.ResourceCopilotMessage,
+			Limit:    100,
+			Window:   24 * time.Hour,
+		}
+
+		key := quotaKey(111, policy)
+		mock.ExpectDel(key).SetVal(1)
+
+		err := tracker.ResetUsage(ctx, 111, []authz.QuotaPolicy{policy})
+		require.NoError(t, err)
+
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("RedisError", func(t *testing.T) {
+		ctx := context.Background()
+		client, mock := redismock.NewClientMock()
+		tracker := &redisQuotaTracker{client: client}
+		policy := authz.QuotaPolicy{
+			Name:     "copilotMessage:limit",
+			Resource: authz.ResourceCopilotMessage,
+			Limit:    100,
+			Window:   24 * time.Hour,
+		}
+
+		key := quotaKey(123, policy)
+		mock.ExpectDel(key).SetErr(errors.New("redis del error"))
+
+		err := tracker.ResetUsage(ctx, 123, []authz.QuotaPolicy{policy})
+		assert.Error(t, err)
 	})
 }
 

--- a/spx-backend/internal/controller/user_test.go
+++ b/spx-backend/internal/controller/user_test.go
@@ -40,42 +40,31 @@ func newContextWithTestUser(ctx context.Context) context.Context {
 		CanManageCourses: false,
 		CanUsePremiumLLM: false,
 	})
-	ctx = authz.NewContextWithUserQuotas(ctx, authz.UserQuotas{
-		Limits: map[authz.Resource]authz.Quota{
+	ctx = authz.NewContextWithUserQuotaPolicies(ctx, authz.UserQuotaPolicies{
+		Limits: map[authz.Resource]authz.QuotaPolicy{
 			authz.ResourceCopilotMessage: {
-				QuotaPolicy: authz.QuotaPolicy{
-					Name:     "copilotMessage:limit",
-					Resource: authz.ResourceCopilotMessage,
-					Limit:    100,
-					Window:   24 * time.Hour,
-				},
+				Name:     "copilotMessage:limit",
+				Resource: authz.ResourceCopilotMessage,
+				Limit:    100,
+				Window:   24 * time.Hour,
 			},
 			authz.ResourceAIDescription: {
-				QuotaPolicy: authz.QuotaPolicy{
-					Name:     "aiDescription:limit",
-					Resource: authz.ResourceAIDescription,
-					Limit:    300,
-					Window:   24 * time.Hour,
-				},
-				QuotaUsage: authz.QuotaUsage{Used: 5},
+				Name:     "aiDescription:limit",
+				Resource: authz.ResourceAIDescription,
+				Limit:    300,
+				Window:   24 * time.Hour,
 			},
 			authz.ResourceAIInteractionTurn: {
-				QuotaPolicy: authz.QuotaPolicy{
-					Name:     "aiInteractionTurn:limit",
-					Resource: authz.ResourceAIInteractionTurn,
-					Limit:    12000,
-					Window:   24 * time.Hour,
-				},
-				QuotaUsage: authz.QuotaUsage{Used: 100},
+				Name:     "aiInteractionTurn:limit",
+				Resource: authz.ResourceAIInteractionTurn,
+				Limit:    12000,
+				Window:   24 * time.Hour,
 			},
 			authz.ResourceAIInteractionArchive: {
-				QuotaPolicy: authz.QuotaPolicy{
-					Name:     "aiInteractionArchive:limit",
-					Resource: authz.ResourceAIInteractionArchive,
-					Limit:    8000,
-					Window:   24 * time.Hour,
-				},
-				QuotaUsage: authz.QuotaUsage{Used: 20},
+				Name:     "aiInteractionArchive:limit",
+				Resource: authz.ResourceAIInteractionArchive,
+				Limit:    8000,
+				Window:   24 * time.Hour,
 			},
 		},
 	})


### PR DESCRIPTION
- Compute and store only quota policies in AuthZ middleware, leaving usage to trackers at consumption time
- Batch quota usage/reset operations in trackers and pipeline Redis implementations for lower latency

Fixes #2456