### PR TITLE
fix(spx-backend): co-locate quota keys in Redis Cluster using hash tags

### DIFF
--- a/spx-backend/internal/authz/quota/redis.go
+++ b/spx-backend/internal/authz/quota/redis.go
@@ -213,5 +213,6 @@ func quotaKey(userID int64, policy authz.QuotaPolicy) string {
 	if name == "" {
 		name = string(policy.Resource)
 	}
-	return fmt.Sprintf("%d:%s", userID, name)
+	// Use a hash tag to keep all quota keys for the same user in one hash slot on Redis Cluster.
+	return fmt.Sprintf("quota:{user:%d}:%s", userID, name)
 }

--- a/spx-backend/internal/authz/quota/redis_test.go
+++ b/spx-backend/internal/authz/quota/redis_test.go
@@ -327,12 +327,12 @@ func TestQuotaKey(t *testing.T) {
 	t.Run("UsesPolicyName", func(t *testing.T) {
 		policy := authz.QuotaPolicy{Name: "copilotMessage:limit", Resource: authz.ResourceCopilotMessage}
 		key := quotaKey(123, policy)
-		assert.Equal(t, "123:copilotMessage:limit", key)
+		assert.Equal(t, "quota:{user:123}:copilotMessage:limit", key)
 	})
 
 	t.Run("FallsBackToResourceWhenNameEmpty", func(t *testing.T) {
 		policy := authz.QuotaPolicy{Name: "", Resource: authz.ResourceAIDescription}
 		key := quotaKey(456, policy)
-		assert.Equal(t, "456:aiDescription", key)
+		assert.Equal(t, "quota:{user:456}:aiDescription", key)
 	})
 }


### PR DESCRIPTION
Sync https://github.com/goplus/builder/pull/2494 to `dev`