### PR TITLE
fix(spx-gui): adjust grid auto row in tutorial/course-series

### DIFF
--- a/spx-gui/src/pages/tutorials/course-series.vue
+++ b/spx-gui/src/pages/tutorials/course-series.vue
@@ -21,6 +21,7 @@ import CommunityFooter from '@/components/community/footer/CommunityFooter.vue'
 
 const coursePadding = 20
 const numInColumn = 2
+const height = numInColumn * (courseItemHeight + coursePadding) - coursePadding
 
 const props = defineProps<{
   courseSeriesId: string
@@ -60,9 +61,6 @@ const page = useRouteQueryParamInt('p', 1)
 const isDesktopLarge = useResponsive('desktop-large')
 const numInRow = computed(() => (isDesktopLarge.value ? 5 : 4))
 const pageSize = computed(() => numInRow.value * numInColumn)
-const height = computed(
-  () => Math.ceil(pageSize.value / numInRow.value) * (courseItemHeight + coursePadding) - coursePadding
-)
 const pageTotal = computed(() => Math.ceil((courseQuery.data.value?.total ?? 0) / pageSize.value))
 
 const courseQuery = useQuery(
@@ -132,7 +130,7 @@ const { fn: handleCourseClick } = useMessageHandle(
       </CommunityCard>
 
       <div class="courses-wrapper">
-        <div v-if="courseSeries" :style="{ '--list-wrapper-height': `${height}px`, '--num-in-row': numInRow }">
+        <div v-if="courseSeries" :style="{ '--num-in-row': numInRow }">
           <ListResultWrapper :query-ret="courseQuery" :height="height">
             <template #empty="{ style }">
               <UIEmpty size="large" img="game" :style="style">
@@ -233,9 +231,7 @@ const { fn: handleCourseClick } = useMessageHandle(
 
   .course-list {
     display: grid;
-    grid-auto-rows: max-content;
     grid-template-columns: repeat(var(--num-in-row), 1fr);
-    height: var(--list-wrapper-height);
     gap: 20px;
   }
 

--- a/spx-gui/src/pages/tutorials/index.vue
+++ b/spx-gui/src/pages/tutorials/index.vue
@@ -8,7 +8,7 @@
     <CenteredWrapper
       v-radar="{ name: 'Course series list', desc: 'Scroll to view the course series' }"
       class="centered-wrapper"
-      :style="{ '--list-wrapper-height': `${height}px`, '--num-in-row': numInRow }"
+      :style="{ '--num-in-row': numInRow }"
     >
       <ListResultWrapper :query-ret="courseSeriesQuery" :height="height">
         <template #empty>
@@ -53,17 +53,14 @@ usePageTitle({
   zh: '教程'
 })
 
-const courseSeriesPadding = 16
 const numInColumn = 4
+const courseSeriesPadding = 16
+const height = numInColumn * (courseSeriesItemHeight + courseSeriesPadding) - courseSeriesPadding
 
 const page = useRouteQueryParamInt('p', 1)
 const isDesktopLarge = useResponsive('desktop-large')
 const numInRow = computed(() => (isDesktopLarge.value ? 5 : 4))
 const pageSize = computed(() => numInRow.value * numInColumn)
-const height = computed(
-  () =>
-    Math.ceil(pageSize.value / numInRow.value) * (courseSeriesItemHeight + courseSeriesPadding) - courseSeriesPadding
-)
 const pageTotal = computed(() => Math.ceil((courseSeriesQuery.data.value?.total ?? 0) / pageSize.value))
 
 const courseSeriesQuery = useQuery(
@@ -103,10 +100,8 @@ const courseSeriesQuery = useQuery(
 
     .course-series-list {
       display: grid;
-      grid-auto-rows: max-content;
       grid-template-columns: repeat(var(--num-in-row), 1fr);
       gap: var(--ui-gap-middle);
-      height: var(--list-wrapper-height);
     }
 
     .pagination {


### PR DESCRIPTION
Fix the tutorial and course-series pages: when the list container height is greater than the content, the rows should calculate their height based on max-content rather than utilizing the remaining space.