### PR TITLE
chore(ci): disable `provenance` and `sbom` in Docker publish

### DIFF
--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -24,6 +24,8 @@ jobs:
           context: .
           build-args: |
             NODE_ENV=staging
+          provenance: false
+          sbom: false
           cache-from: type=gha
           cache-to: type=gha,mode=max
           push: ${{ github.event_name == 'push' && github.ref_name == 'dev' }}


### PR DESCRIPTION
- Stop emitting provenance/SBOM attachments to avoid `unknown/unknown` entries on GHCR[^1]

[^1]: https://github.com/docker/build-push-action/issues/900