### PR TITLE
chore: add optional dev API proxy config

### DIFF
--- a/spx-gui/.env
+++ b/spx-gui/.env
@@ -14,11 +14,21 @@ VITE_API_BASE_URL=""
 # Required.
 VITE_VERCEL_PROXIED_API_BASE_URL=""
 
+# Base URL of the spx-backend API that the Vite dev server proxies '/api/(.*)'
+# requests to, with the '/api' prefix stripped, during local development so the
+# browser remains on the same origin.
+#
+# Optional. Only used when running `npm run dev`.
+VITE_DEV_PROXIED_API_BASE_URL=""
+
 # Base URL for user-generated content files (e.g., images, audio) used in projects.
+#
 # NOTE: Must be synchronized with `KODO_BASE_URL` in spx-backend `.env` file.
 VITE_USERCONTENT_BASE_URL=""
+
 # Base URL for user-generated content files (e.g., images, audio) uploading.
-# NOTICE: Must be synchronized with `KODO_BUCKET_REGION` in spx-backend `.env` file.
+#
+# NOTE: Must be synchronized with `KODO_BUCKET_REGION` in spx-backend `.env` file.
 VITE_USERCONTENT_UPLOAD_BASE_URL=""
 
 # Casdoor configuration.

--- a/spx-gui/vite.config.ts
+++ b/spx-gui/vite.config.ts
@@ -50,15 +50,26 @@ export default defineConfig(({ mode }) => {
         // Alias for `monaco-editor` to avoid `Failed to resolve entry for package "monaco-editor"`, for details: https://github.com/vitest-dev/vitest/discussions/1806
         {
           find: /^monaco-editor$/,
-          replacement: resolve('node_modules/monaco-editor/esm/vs/editor/editor.api'),
-        },
-      ],
+          replacement: resolve('node_modules/monaco-editor/esm/vs/editor/editor.api')
+        }
+      ]
     },
     server: {
       headers: {
         'Cross-Origin-Embedder-Policy': 'require-corp',
-        'Cross-Origin-Opener-Policy': 'same-origin',
+        'Cross-Origin-Opener-Policy': 'same-origin'
       },
+      proxy: (() => {
+        const target = env.VITE_DEV_PROXIED_API_BASE_URL
+        if (!target) return undefined
+        return {
+          '/api': {
+            target,
+            changeOrigin: true,
+            rewrite: (path: string) => path.replace(/^\/api/, '')
+          }
+        }
+      })()
     },
     vercel: {
       // prevent redirection from `*/foo.html` (e.g., `spx_2.0.1/runner.html`) to `*/foo`


### PR DESCRIPTION
Since #2490 moved CORS headers to the gateway and spx-backend no longer sets them directly, local spx-gui dev now needs its own `/api` proxy target to stay same origin and avoid CORS issues.