### PR TITLE
chore: fold spx asset prep into npm lifecycle

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -36,9 +36,6 @@ jobs:
       - name: Install Node modules
         run: npm ci --prefer-offline
 
-      - name: Install spx
-        run: ./install-spx.sh
-
       - name: Run Vue TSC
         run: npm run type-check
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,12 +25,10 @@ FROM ${NODE_BASE_IMAGE} AS frontend-builder
 WORKDIR /app/spx-gui
 
 COPY spx-gui/package.json spx-gui/package-lock.json .
-ARG NPM_CONFIG_REGISTRY
-RUN npm install
-
 COPY spx-gui/public ./public
 COPY spx-gui/install-spx.sh .
-RUN ./install-spx.sh
+ARG NPM_CONFIG_REGISTRY
+RUN npm install
 
 COPY spx-gui .
 COPY docs ../docs

--- a/spx-gui/README.md
+++ b/spx-gui/README.md
@@ -9,13 +9,11 @@
 
 ```bash
 npm install
-./install-spx.sh
 ```
 
 ## Run the Project in Development Mode
 
 ```bash
-./build-wasm.sh
 npm run dev
 ```
 

--- a/spx-gui/build-wasm.sh
+++ b/spx-gui/build-wasm.sh
@@ -1,11 +1,10 @@
 #!/bin/bash
 set -e
 
-echo "Run this script from 'spx-gui' directory"
+cd "$(dirname "$0")"
 
 # Copy Go wasm_exec.js
 cp -f "$(go env GOROOT)/lib/wasm/wasm_exec.js" src/assets/wasm/wasm_exec.js
-
 
 # Build and copy spxls.wasm and spxls-pkgdata.zip
 ( cd ../tools/spxls && ./build.sh )

--- a/spx-gui/install-spx.sh
+++ b/spx-gui/install-spx.sh
@@ -1,12 +1,19 @@
 #!/bin/bash
 set -e
 
+cd "$(dirname "$0")"
+
 # Version of spx, keep in sync with the version in `.env`.
 SPX_VERSION=2.0.0-pre.36
 SPX_NAME="spx_${SPX_VERSION}"
 SPX_FILE_NAME="${SPX_NAME}.zip"
 SPX_FILE_URL="https://github.com/goplus/spx/releases/download/v${SPX_VERSION}/spx_web.zip"
+SPX_TARGET_DIR="./public/${SPX_NAME}"
+
+if [[ -d "${SPX_TARGET_DIR}" ]]; then
+	exit 0
+fi
 
 wget -O "${SPX_FILE_NAME}" "${SPX_FILE_URL}"
-unzip -o "${SPX_FILE_NAME}" -d "./public/${SPX_NAME}"
+unzip -o "${SPX_FILE_NAME}" -d "${SPX_TARGET_DIR}"
 rm "${SPX_FILE_NAME}"

--- a/spx-gui/package.json
+++ b/spx-gui/package.json
@@ -4,6 +4,8 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "postinstall": "./install-spx.sh",
+    "predev": "./install-spx.sh && ./build-wasm.sh",
     "dev": "vite",
     "build": "vue-tsc --build --force && vite build --mode ${NODE_ENV:-production}",
     "preview": "vite preview",

--- a/spx-gui/vercel-install.sh
+++ b/spx-gui/vercel-install.sh
@@ -11,4 +11,3 @@ tar -C /usr/local -xzf ./go1.24.4.linux-amd64.tar.gz
 /usr/local/go/bin/go version
 
 npm install
-./install-spx.sh


### PR DESCRIPTION
- Run `install-spx.sh` on `postinstall` and `predev` builds Wasm assets
- Make install/build scripts `cd`-safe and skip re-download when dir exists
- Rely on lifecycle hooks in Docker/Vercel builds, drop redundant calls
- Remove explicit spx install step from `validate.yml` workflow