### PR TITLE
fix: resolve Safari layout bug in project runner

### DIFF
--- a/spx-gui/src/components/project/runner/ProjectRunner.vue
+++ b/spx-gui/src/components/project/runner/ProjectRunner.vue
@@ -417,7 +417,8 @@ defineExpose({
 <style lang="scss" scoped>
 .iframe-container {
   position: relative;
-  aspect-ratio: 4 / 3;
+  width: 100%;
+  height: 100%;
   display: flex;
   justify-content: center;
   align-items: center;

--- a/spx-gui/src/components/project/runner/ProjectRunnerSurface.vue
+++ b/spx-gui/src/components/project/runner/ProjectRunnerSurface.vue
@@ -683,6 +683,7 @@ defineExpose({
     height: 100%;
     max-width: 100%;
     max-height: 100%;
+    aspect-ratio: 4 / 3;
     overflow: hidden;
   }
 }


### PR DESCRIPTION
- Remove duplicate `aspect-ratio` from `iframe-container` in `ProjectRunner.vue` and apply it to fullscreen mode in `ProjectRunnerSurface.vue` instead

Fixes #2565