### PR TITLE
AnglePicker snaps back to the previous value after a quick click

### DIFF
--- a/spx-gui/src/components/editor/common/config/sprite/SpriteDirection.vue
+++ b/spx-gui/src/components/editor/common/config/sprite/SpriteDirection.vue
@@ -52,7 +52,11 @@ const handleRotationStyleUpdate = wrapUpdateHandler(
   spriteContext,
   false
 )
-const handleHeadingUpdate = wrapUpdateHandler((h: number | null) => props.sprite.setHeading(h ?? 0), spriteContext)
+const handleHeadingUpdate = wrapUpdateHandler(
+  (h: number | null) => props.sprite.setHeading(h ?? 0),
+  spriteContext,
+  false
+)
 </script>
 
 <!-- eslint-disable vue/no-v-html -->


### PR DESCRIPTION
Fixed #2559 