### PR TITLE
docs(api-spec): change AIGC task cancellation response from 200 to 202

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -2031,8 +2031,8 @@ paths:
           schema:
             type: string
       responses:
-        "200":
-          description: Cancellation accepted or task already cancelled.
+        "202":
+          description: Cancellation request accepted.
           content:
             application/json:
               schema:


### PR DESCRIPTION
The cancellation endpoint now returns `202 Accepted` instead of `200 OK`.

When a task is in "processing" state, cancellation is asynchronous: the API immediately returns with status "cancelling", while the actual cancellation completes later via the worker. Using 202 accurately reflects this "request accepted, processing not yet complete" semantic.

Although tasks in "pending" state are cancelled synchronously, returning a unified 202 for all successful cases follows industry practice (e.g., GitHub Actions[^1]) and simplifies client handling. Clients should check the response body's status field to determine the actual state.

Updates #2631

[^1]: https://docs.github.com/en/rest/actions/workflow-runs#cancel-a-workflow-run