### PR TITLE
Support startTime and duration parameters for frame extraction

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1837,6 +1837,7 @@ paths:
                       type: object
                       required:
                         - videoUrl
+                        - duration
                       properties:
                         videoUrl:
                           description: URL of the video to extract frames from.
@@ -1844,10 +1845,29 @@ paths:
                           format: uri
                           examples:
                             - https://example.com/animation.mp4
-                        interval:
-                          description: Interval between frames in milliseconds.
+                        startTime:
+                          description: Start time (in milliseconds) from which to extract frames. Precision is 100ms.
                           type: integer
-                          minimum: 50
+                          minimum: 0
+                          multipleOf: 100
+                          default: 0
+                          examples:
+                            - 0
+                            - 1500
+                        duration:
+                          description: Duration (in milliseconds) of the segment to extract frames from. Precision is 100ms.
+                          type: integer
+                          minimum: 0
+                          multipleOf: 100
+                          maximum: 60000
+                          examples:
+                            - 3000
+                            - 10000
+                        interval:
+                          description: Interval between frames in milliseconds. Precision is 100ms.
+                          type: integer
+                          minimum: 100
+                          multipleOf: 100
                           maximum: 1000
                           default: 100
                           examples:


### PR DESCRIPTION
https://github.com/goplus/builder-backend/pull/49#discussion_r2650252268

> 这里我忘了调整接口了...create task 接口的 parameters 也该支持 startTime 和 duration 的，否则还需要在端上对视频做下裁剪再上传然后才能截帧，有点没必要
> 
> 我晚点改下

