### PR TITLE
Implement asset-doption & use universal URL for AIGC tasks

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1806,11 +1806,11 @@ paths:
                         - imageUrl
                       properties:
                         imageUrl:
-                          description: URL of the image to remove background from.
+                          description: Universal URL of the image to remove background from (e.g. kodo://bucket/key).
                           type: string
                           format: uri
                           examples:
-                            - https://example.com/character.png
+                            - kodo://bucket/character.png
                     - title: generateCostume
                       type: object
                       required:
@@ -1840,11 +1840,11 @@ paths:
                         - duration
                       properties:
                         videoUrl:
-                          description: URL of the video to extract frames from.
+                          description: Universal URL of the video to extract frames from (e.g. kodo://bucket/key).
                           type: string
                           format: uri
                           examples:
-                            - https://example.com/animation.mp4
+                            - kodo://bucket/animation.mp4
                         startTime:
                           description: Start time (in milliseconds) from which to extract frames. Precision is 100ms.
                           type: integer
@@ -1973,7 +1973,7 @@ paths:
         data: {"id": "task-123", "status": "processing"}
 
         event: completed
-        data: {"result": {"imageUrls": ["https://..."]}}
+        data: {"result": {"imageUrls": ["kodo://bucket/path/to/file.png"]}}
         ```
 
         #### Example: task already completed
@@ -1982,7 +1982,7 @@ paths:
         GET /aigc/task/task-456/events
 
         event: snapshot
-        data: {"id": "task-456", "status": "completed", "result": {"imageUrls": ["https://..."]}}
+        data: {"id": "task-456", "status": "completed", "result": {"imageUrls": ["kodo://bucket/path/to/file.png"]}}
 
         (connection closed)
         ```
@@ -1996,7 +1996,7 @@ paths:
         data: {"id": "task-789", "status": "pending"}
 
         event: completed
-        data: {"result": {"imageUrls": ["https://..."]}}
+        data: {"result": {"imageUrls": ["kodo://bucket/path/to/file.png"]}}
         ```
 
         #### Example: task cancelled
@@ -3016,7 +3016,7 @@ components:
               type: object
               properties:
                 imageUrl:
-                  description: URL of the image with background removed.
+                  description: Universal URL of the image with background removed (e.g. kodo://bucket/key).
                   type: string
                   format: uri
             - title: generateCostume
@@ -3025,7 +3025,7 @@ components:
                 - imageUrls
               properties:
                 imageUrls:
-                  description: URLs of the generated costume images.
+                  description: Universal URLs of the generated costume images (e.g. kodo://bucket/key).
                   type: array
                   items:
                     type: string
@@ -3034,14 +3034,14 @@ components:
               type: object
               properties:
                 videoUrl:
-                  description: URL of the generated animation video.
+                  description: Universal URL of the generated animation video (e.g. kodo://bucket/key).
                   type: string
                   format: uri
             - title: extractVideoFrames
               type: object
               properties:
                 frameUrls:
-                  description: URLs of the extracted frame images.
+                  description: Universal URLs of the extracted frame images (e.g. kodo://bucket/key).
                   type: array
                   items:
                     type: string
@@ -3052,7 +3052,7 @@ components:
                 - imageUrls
               properties:
                 imageUrls:
-                  description: URLs of the generated backdrop images.
+                  description: Universal URLs of the generated backdrop images (e.g. kodo://bucket/key).
                   type: array
                   items:
                     type: string
@@ -3170,7 +3170,7 @@ components:
         - type: object
           properties:
             referenceImageUrl:
-              description: URL of the reference image to guide the costume generation.
+              description: Universal URL of the reference image to guide the costume generation (e.g. kodo://bucket/key).
               type:
                 - string
                 - "null"
@@ -3192,7 +3192,7 @@ components:
         - type: object
           properties:
             referenceFrameUrl:
-              description: URL of the reference frame image to guide the animation generation.
+              description: Universal URL of the reference frame image to guide the animation generation (e.g. kodo://bucket/key).
               type:
                 - string
                 - "null"

--- a/spx-gui/src/apis/aigc.ts
+++ b/spx-gui/src/apis/aigc.ts
@@ -2,7 +2,17 @@
  * @desc AIGC-related APIs of spx-backend
  */
 
-import { AnimationLoopMode, ArtStyle, BackdropCategory, client, Perspective, SpriteCategory } from './common'
+import {
+  AnimationLoopMode,
+  ArtStyle,
+  BackdropCategory,
+  client,
+  type FileCollection,
+  Perspective,
+  SpriteCategory,
+  type UniversalUrl
+} from './common'
+import type { AssetExtraSettings, AssetType } from './asset'
 
 /**
  * @deprecated Use createTask() with TaskType.RemoveBackground instead
@@ -43,7 +53,7 @@ export type CostumeSettings = {
   facing: Facing
   artStyle: ArtStyle
   perspective: Perspective
-  referenceImageUrl: string | null
+  referenceImageUrl: UniversalUrl | null
 }
 
 export type AnimationSettings = {
@@ -52,7 +62,7 @@ export type AnimationSettings = {
   artStyle: ArtStyle
   perspective: Perspective
   loopMode: AnimationLoopMode
-  referenceFrameUrl: string | null
+  referenceFrameUrl: UniversalUrl | null
 }
 
 export type BackdropSettings = {
@@ -99,23 +109,23 @@ export type TaskError = {
 }
 
 export type TaskResultRemoveBackground = {
-  imageUrl: string
+  imageUrl: UniversalUrl
 }
 
 export type TaskResultGenerateCostume = {
-  imageUrls: string[]
+  imageUrls: UniversalUrl[]
 }
 
 export type TaskResultGenerateAnimationVideo = {
-  videoUrl: string
+  videoUrl: UniversalUrl
 }
 
 export type TaskResultExtractVideoFrames = {
-  frameUrls: string[]
+  frameUrls: UniversalUrl[]
 }
 
 export type TaskResultGenerateBackdrop = {
-  imageUrls: string[]
+  imageUrls: UniversalUrl[]
 }
 
 export type TaskResult<T extends TaskType = TaskType> = {
@@ -137,7 +147,7 @@ export type Task<T extends TaskType = TaskType> = {
 }
 
 export type TaskParamsRemoveBackground = {
-  imageUrl: string
+  imageUrl: UniversalUrl
 }
 
 export type TaskParamsGenerateCostume = {
@@ -151,7 +161,7 @@ export type TaskParamsGenerateAnimationVideo = {
 }
 
 export type TaskParamsExtractVideoFrames = {
-  videoUrl: string
+  videoUrl: UniversalUrl
   /** Duration (in milliseconds) of the segment to extract frames from. Precision is 100ms. */
   duration: number
   /** Start time (in milliseconds) from which to extract frames. Precision is 100ms. */
@@ -358,4 +368,20 @@ export async function enrichSpriteSettings(
     signal
   )) as SpriteSettings
   return result
+}
+
+export type AssetAdoptionParams = {
+  taskIds: string[]
+  asset: {
+    displayName: string
+    type: AssetType
+    description: string
+    extraSettings: AssetExtraSettings
+    filesHash?: string
+    files: FileCollection
+  }
+}
+
+export function adoptAsset(params: AssetAdoptionParams, signal?: AbortSignal) {
+  return client.post('/aigc/asset-adoption', params, { signal }) as Promise<void>
 }

--- a/spx-gui/src/components/asset/gen/backdrop/BackdropGen.vue
+++ b/spx-gui/src/components/asset/gen/backdrop/BackdropGen.vue
@@ -3,7 +3,7 @@ import { computed } from 'vue'
 import { UIButton } from '@/components/ui'
 import type { Backdrop } from '@/models/backdrop'
 import type { BackdropGen } from '@/models/gen/backdrop-gen'
-import { useMessageHandle } from '@/utils/exception'
+import { capture, useMessageHandle } from '@/utils/exception'
 import BackdropSettingInput from './BackdropSettingsInput.vue'
 import LayoutWithPreview from '../common/LayoutWithPreview.vue'
 import ImagePreview from '../common/ImagePreview.vue'
@@ -22,6 +22,9 @@ const canSubmit = computed(() => props.gen.image != null)
 const handleSubmit = useMessageHandle(
   async () => {
     const backdrop = await props.gen.finish()
+    props.gen.recordAdoption().catch((err) => {
+      capture(err, 'failed to record backdrop asset adoption')
+    })
     emit('finished', backdrop)
   },
   {

--- a/spx-gui/src/components/asset/gen/sprite/SpriteGenPhaseContent.vue
+++ b/spx-gui/src/components/asset/gen/sprite/SpriteGenPhaseContent.vue
@@ -7,7 +7,7 @@
 <script setup lang="ts">
 import { computed, shallowRef, watch } from 'vue'
 import { useI18n } from '@/utils/i18n'
-import { useMessageHandle } from '@/utils/exception'
+import { capture, useMessageHandle } from '@/utils/exception'
 import type { Sprite } from '@/models/sprite'
 import type { SpriteGen } from '@/models/gen/sprite-gen'
 import type { CostumeGen } from '@/models/gen/costume-gen'
@@ -151,6 +151,9 @@ const handleSubmit = useMessageHandle(
   async () => {
     await beforeSubmit()
     const sprite = props.gen.finish()
+    props.gen.recordAdoption().catch((err) => {
+      capture(err, 'failed to record sprite asset adoption')
+    })
     emit('finished', sprite)
   },
   {

--- a/spx-gui/src/models/common/cloud.ts
+++ b/spx-gui/src/models/common/cloud.ts
@@ -1,5 +1,5 @@
 import { createDirectUploadTask } from 'qiniu-js'
-import { usercontentBaseUrl, usercontentBucket } from '@/utils/env'
+import { usercontentBaseUrl } from '@/utils/env'
 import { filename } from '@/utils/path'
 import { humanizeFileSize, withRetry } from '@/utils/utils'
 import { mergeSignals } from '@/utils/disposable'
@@ -128,18 +128,7 @@ export function createFileWithUniversalUrl(url: UniversalUrl, name = filename(ur
   return file
 }
 
-const usercontentUrlPrefix = usercontentBaseUrl + '/'
-
 export function createFileWithWebUrl(url: WebUrl, name = filename(url)) {
-  // Kodo universal URL is preferred for files under usercontentBaseUrl.
-  // If possible, convert web URL to Kodo universal URL.
-  // TODO: consider always using (kodo) universal URL for asset files, then this conversion can be removed.
-  if (url.startsWith(usercontentUrlPrefix)) {
-    const key = url.slice(usercontentUrlPrefix.length)
-    // TODO: if there's authentication info in URL (for future version), it should be stripped here
-    const kodoUrl = stringifyKodoUrl(usercontentBucket, key)
-    return createFileWithUniversalUrl(kodoUrl, name)
-  }
   return new File(name, async (signal) => fetchFile(url, signal))
 }
 

--- a/spx-gui/src/models/gen/animation-gen.ts
+++ b/spx-gui/src/models/gen/animation-gen.ts
@@ -12,7 +12,7 @@ import type { Project } from '../project'
 import { Sprite } from '../sprite'
 import type { File } from '../common/file'
 import { validateAnimationName } from '../common/asset-name'
-import { createFileWithWebUrl, saveFileForWebUrl } from '../common/cloud'
+import { createFileWithUniversalUrl, saveFile } from '../common/cloud'
 import { Animation } from '../animation'
 import { Costume } from '../costume'
 import { getProjectSettings, getSpriteSettings, Phase, Task } from './common'
@@ -60,6 +60,10 @@ export class AnimationGen extends Disposable {
     this.extractFramesPhase = new Phase({ en: 'extract video frames', zh: '提取视频帧' })
     this.finishPhase = new Phase({ en: 'save animation', zh: '保存动画' })
     return reactive(this) as this
+  }
+
+  getTaskIds() {
+    return [this.generateVideoTask, this.extractFramesTask].map((t) => t.data?.id).filter((id) => id != null)
   }
 
   get name() {
@@ -113,11 +117,11 @@ export class AnimationGen extends Disposable {
     const video = await this.generateVideoPhase.run(async () => {
       const costume = this.referenceCostume
       if (costume == null) throw new Error('reference costume expected')
-      const referenceFrameUrl = await saveFileForWebUrl(costume.img)
+      const referenceFrameUrl = await saveFile(costume.img)
       const settings = { ...this.settings, referenceFrameUrl }
       await this.generateVideoTask.start({ settings })
       const { videoUrl } = await this.generateVideoTask.untilCompleted()
-      return createFileWithWebUrl(videoUrl)
+      return createFileWithUniversalUrl(videoUrl)
     })
     this.setVideo(video)
   }
@@ -140,10 +144,10 @@ export class AnimationGen extends Disposable {
     if (video == null) throw new Error('video not ready yet')
     if (framesConfig == null) throw new Error('frames config not set')
     return this.extractFramesPhase.run(async () => {
-      const videoUrl = await saveFileForWebUrl(video)
+      const videoUrl = await saveFile(video)
       await this.extractFramesTask.start({ videoUrl, ...framesConfig })
       const { frameUrls } = await this.extractFramesTask.untilCompleted()
-      const frames = frameUrls.map((url) => createFileWithWebUrl(url))
+      const frames = frameUrls.map((url) => createFileWithUniversalUrl(url))
       return frames
     })
   }

--- a/spx-gui/src/models/gen/backdrop-gen.ts
+++ b/spx-gui/src/models/gen/backdrop-gen.ts
@@ -2,9 +2,10 @@ import { nanoid } from 'nanoid'
 import { reactive } from 'vue'
 import { Disposable } from '@/utils/disposable'
 import { ArtStyle, BackdropCategory, Perspective } from '@/apis/common'
-import { enrichBackdropSettings, TaskType, type BackdropSettings } from '@/apis/aigc'
+import { adoptAsset, enrichBackdropSettings, TaskType, type BackdropSettings } from '@/apis/aigc'
 import type { File } from '../common/file'
-import { createFileWithWebUrl } from '../common/cloud'
+import { createFileWithUniversalUrl } from '../common/cloud'
+import { backdrop2Asset } from '../common/asset'
 import type { Project } from '../project'
 import { Backdrop } from '../backdrop'
 import { getProjectSettings, Phase, Task } from './common'
@@ -68,7 +69,7 @@ export class BackdropGen extends Disposable {
         n: 4
       })
       const { imageUrls } = await this.generateTask.untilCompleted()
-      return imageUrls.map((url) => createFileWithWebUrl(url))
+      return imageUrls.map((url) => createFileWithUniversalUrl(url))
     })
   }
 
@@ -92,6 +93,23 @@ export class BackdropGen extends Disposable {
     })
     this.result = backdrop
     return backdrop
+  }
+
+  async recordAdoption() {
+    const backdrop = this.result
+    if (backdrop == null) throw new Error('result backdrop expected')
+    const taskIds = this.generateTask.data != null ? [this.generateTask.data.id] : []
+    const assetData = await backdrop2Asset(backdrop)
+    const { name: displayName, description, ...extraSettings } = this.settings
+    return adoptAsset({
+      taskIds,
+      asset: {
+        ...assetData,
+        displayName,
+        description,
+        extraSettings
+      }
+    })
   }
 
   cancel() {

--- a/spx-gui/src/models/gen/common.ts
+++ b/spx-gui/src/models/gen/common.ts
@@ -145,7 +145,7 @@ export type TaskApis = Pick<typeof aigcApis, 'createTask' | 'cancelTask' | 'subs
 
 /** `Task` manages the lifecycle and state of an AIGC task. */
 export class Task<T extends TaskType> extends Disposable {
-  private data: TaskData<T> | null
+  data: TaskData<T> | null
 
   constructor(
     private type: T,

--- a/spx-gui/src/models/gen/costume-gen.ts
+++ b/spx-gui/src/models/gen/costume-gen.ts
@@ -5,7 +5,7 @@ import { ArtStyle, Perspective } from '@/apis/common'
 import { enrichCostumeSettings, Facing, TaskType, type CostumeSettings } from '@/apis/aigc'
 import type { File } from '../common/file'
 import { validateCostumeName } from '../common/asset-name'
-import { createFileWithWebUrl, saveFileForWebUrl } from '../common/cloud'
+import { createFileWithUniversalUrl, saveFile } from '../common/cloud'
 import type { Project } from '../project'
 import { Sprite } from '../sprite'
 import { Costume } from '../costume'
@@ -46,6 +46,11 @@ export class CostumeGen extends Disposable {
     }
     this.referenceCostumeId = this.sprite.defaultCostume?.id ?? null
     return reactive(this) as this
+  }
+
+  getTaskIds() {
+    if (this.generateTask.data == null) return []
+    return [this.generateTask.data.id]
   }
 
   get name() {
@@ -100,12 +105,12 @@ export class CostumeGen extends Disposable {
     this.setImage(null)
     const image = await this.generatePhase.run(async () => {
       const referenceCostume = this.referenceCostume
-      const referenceImageUrl = referenceCostume != null ? await saveFileForWebUrl(referenceCostume.img) : null
+      const referenceImageUrl = referenceCostume != null ? await saveFile(referenceCostume.img) : null
       const settings = { ...this.settings, referenceImageUrl }
       await this.generateTask.start({ settings, n: 1 })
       const { imageUrls } = await this.generateTask.untilCompleted()
       if (imageUrls.length < 1) throw new Error('no costume image generated')
-      return createFileWithWebUrl(imageUrls[0])
+      return createFileWithUniversalUrl(imageUrls[0])
     })
     this.setImage(image)
   }

--- a/spx-gui/src/models/gen/sprite-gen.ts
+++ b/spx-gui/src/models/gen/sprite-gen.ts
@@ -9,7 +9,8 @@ import {
   genSpriteContentSettings,
   type CostumeSettings,
   Facing,
-  TaskType
+  TaskType,
+  adoptAsset
 } from '@/apis/aigc'
 import { Project } from '../project'
 import { Sprite } from '../sprite'
@@ -18,9 +19,10 @@ import type { Animation } from '../animation'
 import { getProjectSettings, Phase, Task } from './common'
 import { CostumeGen } from './costume-gen'
 import { AnimationGen } from './animation-gen'
-import { createFileWithWebUrl } from '../common/cloud'
+import { createFileWithUniversalUrl } from '../common/cloud'
 import type { File } from '../common/file'
 import { getAnimationName, getCostumeName } from '../common/asset-name'
+import { sprite2Asset } from '../common/asset'
 
 export class SpriteGen extends Disposable {
   id: string
@@ -112,7 +114,7 @@ export class SpriteGen extends Disposable {
       const settings = this.getDefaultCostumeSettings()
       await this.genImagesTask.start({ settings, n: 4 })
       const { imageUrls } = await this.genImagesTask.untilCompleted()
-      return imageUrls.map((url) => createFileWithWebUrl(url))
+      return imageUrls.map((url) => createFileWithUniversalUrl(url))
     })
   }
 
@@ -243,6 +245,27 @@ export class SpriteGen extends Disposable {
     })
     this.result = sprite
     return sprite
+  }
+
+  async recordAdoption() {
+    const sprite = this.result
+    if (sprite == null) throw new Error('result sprite expected')
+    const taskIds = [
+      this.genImagesTask.data?.id,
+      ...this.costumes.flatMap((c) => c.getTaskIds()),
+      ...this.animations.flatMap((a) => a.getTaskIds())
+    ].filter((id) => id != null)
+    const assetData = await sprite2Asset(sprite)
+    const { name: displayName, description, ...extraSettings } = this.settings
+    return adoptAsset({
+      taskIds,
+      asset: {
+        ...assetData,
+        displayName,
+        description,
+        extraSettings
+      }
+    })
   }
 
   cancel() {


### PR DESCRIPTION
update #2652.

* **Universal URL Adoption**: Standardized AIGC task inputs and outputs to use a 'Universal URL' format (e.g., kodo://bucket/key) instead of generic web URLs (https://) across the API documentation and internal models.
* **Asset Adoption**: Implemented asset-adoption when generated asset is used.
