### PR TITLE
chore(ci): remove Docker layer cache and add tools/ispx to Go cache paths

### DIFF
--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -24,8 +24,6 @@ jobs:
             NODE_ENV=staging
           provenance: false
           sbom: false
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
           push: ${{ github.event_name == 'push' && github.ref_name == 'dev' }}
           tags: |
             ghcr.io/${{github.repository}}:dev

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -52,6 +52,7 @@ jobs:
           cache: true
           cache-dependency-path: |
             tools/spxls/go.sum
+            tools/ispx/go.sum
             tools/ai/go.sum
 
       - name: Build WASM


### PR DESCRIPTION
- Remove GHA cache for Docker builds in `publish-docker-image.yml` as exporting layers slows down overall build time
- Add `tools/ispx/go.sum` to Go module cache paths in `validate.yml` since `build-wasm.sh` now builds ispx alongside spxls