### PR TITLE
chore(tools): add linker flags to strip symbols from WASM builds

### DIFF
--- a/tools/ispx/build.sh
+++ b/tools/ispx/build.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -e
 
-GOOS=js GOARCH=wasm go build -tags canvas -ldflags -checklinkname=0 -trimpath -o ispx.wasm
+GOOS=js GOARCH=wasm go build -tags canvas -trimpath -ldflags "-s -w -checklinkname=0" -o ispx.wasm

--- a/tools/spxls/build.sh
+++ b/tools/spxls/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
 
-GOOS=js GOARCH=wasm go build -trimpath -o spxls.wasm github.com/goplus/xgolsw
+GOOS=js GOARCH=wasm go build -trimpath -ldflags "-s -w" -o spxls.wasm github.com/goplus/xgolsw
 
 go tool pkgdatagen -no-std -o spxls-pkgdata.zip github.com/goplus/builder/tools/ai


### PR DESCRIPTION
Add `-s -w` flags to `ldflags` in both `spxls` and `ispx` build scripts to strip symbol table and DWARF debug information from WASM binaries. This reduces file sizes by approximately 2-3% (about 1.6 MB combined).