### PR TITLE
Improved settings inference

### DIFF
--- a/spx-gui/src/models/gen/animation-gen.ts
+++ b/spx-gui/src/models/gen/animation-gen.ts
@@ -1,5 +1,6 @@
 import { nanoid } from 'nanoid'
 import { reactive } from 'vue'
+import type { Prettify } from '@/utils/types'
 import { Disposable } from '@/utils/disposable'
 import { AnimationLoopMode, ArtStyle, Perspective } from '@/apis/common'
 import {
@@ -11,7 +12,7 @@ import {
 import type { Project } from '../project'
 import { Sprite } from '../sprite'
 import type { File } from '../common/file'
-import { validateAnimationName } from '../common/asset-name'
+import { ensureValidAnimationName, validateAnimationName } from '../common/asset-name'
 import { createFileWithUniversalUrl, saveFile } from '../common/cloud'
 import { Animation } from '../animation'
 import { Costume } from '../costume'
@@ -19,6 +20,14 @@ import { getProjectSettings, getSpriteSettings, Phase, Task } from './common'
 import type { SpriteGen } from './sprite-gen'
 
 export type FramesConfig = Omit<TaskParamsExtractVideoFrames, 'videoUrl'>
+
+export type AnimationGenInits = Prettify<
+  Partial<
+    Omit<AnimationSettings, 'referenceFrameUrl'> & {
+      referenceCostumeId: string | null
+    }
+  >
+>
 
 export class AnimationGen extends Disposable {
   id: string
@@ -36,7 +45,11 @@ export class AnimationGen extends Disposable {
   private extractFramesPhase: Phase<File[]>
   private finishPhase: Phase<Animation>
 
-  constructor(parent: Sprite | SpriteGen, project: Project, settings: Partial<AnimationSettings>) {
+  constructor(
+    parent: Sprite | SpriteGen,
+    project: Project,
+    { referenceCostumeId = null, ...settings }: AnimationGenInits
+  ) {
     super()
     this.id = nanoid()
     this.parent = parent
@@ -50,7 +63,7 @@ export class AnimationGen extends Disposable {
       referenceFrameUrl: null,
       ...settings
     }
-    this.referenceCostumeId = this.sprite.defaultCostume?.id ?? null
+    this.referenceCostumeId = referenceCostumeId
     this.enrichPhase = new Phase({ en: 'enrich animation settings', zh: '丰富动画设置' })
     this.generateVideoTask = new Task(TaskType.GenerateAnimationVideo)
     this.generateVideoPhase = new Phase({ en: 'generate animation video', zh: '生成动画视频' })
@@ -70,7 +83,7 @@ export class AnimationGen extends Disposable {
     return this.settings.name
   }
   setName(name: string) {
-    const err = validateAnimationName(name, this.sprite)
+    const err = validateAnimationName(name, this.parent)
     if (err != null) throw new Error(`invalid name ${name}: ${err.en}`)
     this.settings.name = name
     this.result?.setName(name)
@@ -80,7 +93,7 @@ export class AnimationGen extends Disposable {
     return this.enrichPhase.state
   }
   async enrich() {
-    const draft = await this.enrichPhase.track(
+    const enriched = await this.enrichPhase.track(
       enrichAnimationSettings(
         this.settings.description,
         this.settings,
@@ -88,14 +101,19 @@ export class AnimationGen extends Disposable {
         getProjectSettings(this.project)
       )
     )
-    this.setSettings({
-      ...draft,
-      referenceFrameUrl: null // TODO: use default costume as reference frame
-    })
+    this.setSettings(enriched)
   }
 
   settings: AnimationSettings
+  /**
+   * Update multiple settings at once.
+   * NOTE: the name in updates may be altered to avoid conflict
+   */
   setSettings(updates: Partial<AnimationSettings>) {
+    if (updates.name != null && updates.name !== this.settings.name) {
+      const newName = ensureValidAnimationName(updates.name, this.parent)
+      updates = { ...updates, name: newName }
+    }
     Object.assign(this.settings, updates)
   }
 

--- a/spx-gui/src/models/gen/backdrop-gen.ts
+++ b/spx-gui/src/models/gen/backdrop-gen.ts
@@ -5,6 +5,7 @@ import { ArtStyle, BackdropCategory, Perspective } from '@/apis/common'
 import { adoptAsset, enrichBackdropSettings, TaskType, type BackdropSettings } from '@/apis/aigc'
 import type { File } from '../common/file'
 import { createFileWithUniversalUrl } from '../common/cloud'
+import { validateBackdropName } from '../common/asset-name'
 import { backdrop2Asset } from '../common/asset'
 import type { Project } from '../project'
 import { Backdrop } from '../backdrop'
@@ -40,7 +41,8 @@ export class BackdropGen extends Disposable {
     return this.settings.name
   }
   setName(name: string) {
-    // TODO: check name validity
+    const err = validateBackdropName(name, this.project.stage)
+    if (err != null) throw new Error(`invalid name ${name}: ${err.en}`)
     this.settings.name = name
   }
 

--- a/spx-gui/src/models/gen/common.test.ts
+++ b/spx-gui/src/models/gen/common.test.ts
@@ -9,7 +9,7 @@ import {
   type TaskResult
 } from '@/apis/aigc'
 import { Cancelled } from '@/utils/exception'
-import { Task, TaskException } from './common'
+import { majorityOf, Task, TaskException } from './common'
 
 function makeTaskData<T extends TaskType>(type: T, status: TaskStatus, id = 'task-1'): TaskData<T> {
   return {
@@ -248,5 +248,24 @@ describe('Task', () => {
     await expect(task.untilCompleted()).resolves.toEqual({ imageUrls: ['http://example.com/2.png'] })
 
     expect(apis.subscribeTaskEvents).toHaveBeenCalledTimes(2)
+  })
+})
+
+describe('majorityOf', () => {
+  it('returns majority value when count exceeds half', () => {
+    expect(majorityOf([1])).toBe(1)
+    expect(majorityOf([1, 2, 2])).toBe(2)
+    expect(majorityOf([1, 2, 2, 2, 3])).toBe(2)
+    expect(majorityOf(['a', 'b', 'a', 'a'])).toBe('a')
+  })
+
+  it('returns null when no majority exists', () => {
+    expect(majorityOf([1, 2])).toBeNull()
+    expect(majorityOf([1, 1, 2, 2])).toBeNull()
+    expect(majorityOf(['a', 'b', 'c'])).toBeNull()
+  })
+
+  it('returns null for empty array', () => {
+    expect(majorityOf([])).toBeNull()
   })
 })

--- a/spx-gui/src/models/gen/common.ts
+++ b/spx-gui/src/models/gen/common.ts
@@ -21,19 +21,36 @@ import type { Sprite } from '../sprite'
 
 export function getProjectSettings(project: Project): ProjectSettings {
   return {
-    name: project.name ?? 'TODO',
-    description: project.description ?? 'TODO',
-    artStyle: project.extraSettings?.artStyle ?? ArtStyle.Unspecified,
-    perspective: project.extraSettings?.perspective ?? Perspective.Unspecified
+    name: project.name ?? '',
+    description: project.description ?? '',
+    // TODO: consider saving inferred settings to project extraSettings?
+    artStyle: project.extraSettings?.artStyle ?? inferProjectArtStyle(project),
+    perspective: project.extraSettings?.perspective ?? inferProjectPerspective(project)
   }
+}
+
+/** Infers the project's art style by finding the majority art style among all sprites and backdrops. */
+function inferProjectArtStyle(project: Project): ArtStyle {
+  const assetArtStyles = [...project.sprites, ...project.stage.backdrops]
+    .map((a) => a.assetMetadata?.extraSettings?.artStyle)
+    .filter((as) => as != null)
+  return majorityOf(assetArtStyles) ?? ArtStyle.Unspecified
+}
+
+/** Infers the project's perspective by finding the majority perspective among all sprites and backdrops. */
+function inferProjectPerspective(project: Project): Perspective {
+  const assetPerspectives = [...project.sprites, ...project.stage.backdrops]
+    .map((a) => a.assetMetadata?.extraSettings?.perspective)
+    .filter((p) => p != null)
+  return majorityOf(assetPerspectives) ?? Perspective.Unspecified
 }
 
 export function getSpriteSettings(sprite: Sprite): SpriteSettings {
   const extraSettings = sprite.assetMetadata?.extraSettings ?? null
   return {
-    name: sprite.name ?? 'TODO',
+    name: sprite.name ?? '',
     category: (extraSettings?.category as SpriteCategory | undefined) ?? SpriteCategory.Unspecified,
-    description: sprite.assetMetadata?.description ?? 'TODO',
+    description: sprite.assetMetadata?.description ?? '',
     artStyle: extraSettings?.artStyle ?? ArtStyle.Unspecified,
     perspective: extraSettings?.perspective ?? Perspective.Unspecified
   }
@@ -208,4 +225,19 @@ export class Task<T extends TaskType> extends Disposable {
     if (this.data == null || isTerminalTaskStatus(this.data.status)) return
     return this.apis.cancelTask(this.data.id, this.getSignal())
   }
+}
+
+/** Returns the majority value (appears more than half) in the array, or null if none exists. */
+export function majorityOf<T>(values: T[]): T | null {
+  const counts = new Map<T, number>()
+  for (const v of values) {
+    counts.set(v, (counts.get(v) ?? 0) + 1)
+  }
+  const majorityCount = Math.floor(values.length / 2) + 1
+  for (const [v, count] of counts) {
+    if (count >= majorityCount) {
+      return v
+    }
+  }
+  return null
 }

--- a/spx-gui/src/models/gen/costume-gen.ts
+++ b/spx-gui/src/models/gen/costume-gen.ts
@@ -1,16 +1,25 @@
 import { nanoid } from 'nanoid'
 import { reactive } from 'vue'
+import type { Prettify } from '@/utils/types'
 import { Disposable } from '@/utils/disposable'
 import { ArtStyle, Perspective } from '@/apis/common'
 import { enrichCostumeSettings, Facing, TaskType, type CostumeSettings } from '@/apis/aigc'
 import type { File } from '../common/file'
-import { validateCostumeName } from '../common/asset-name'
+import { ensureValidCostumeName, validateCostumeName } from '../common/asset-name'
 import { createFileWithUniversalUrl, saveFile } from '../common/cloud'
 import type { Project } from '../project'
 import { Sprite } from '../sprite'
 import { Costume } from '../costume'
 import { getProjectSettings, getSpriteSettings, Phase, Task } from './common'
 import { SpriteGen } from './sprite-gen'
+
+export type CostumeGenInits = Prettify<
+  Partial<
+    Omit<CostumeSettings, 'referenceImageUrl'> & {
+      referenceCostumeId: string | null
+    }
+  >
+>
 
 /** `CostumeGen` tracks the generation process of a costume. */
 export class CostumeGen extends Disposable {
@@ -26,7 +35,11 @@ export class CostumeGen extends Disposable {
   private generatePhase: Phase<File>
   private finishPhase: Phase<Costume>
 
-  constructor(parent: Sprite | SpriteGen, project: Project, settings: Partial<CostumeSettings>) {
+  constructor(
+    parent: Sprite | SpriteGen,
+    project: Project,
+    { referenceCostumeId = null, ...settings }: CostumeGenInits
+  ) {
     super()
     this.id = nanoid()
     this.parent = parent
@@ -38,13 +51,13 @@ export class CostumeGen extends Disposable {
     this.settings = {
       name: '',
       description: '',
-      facing: Facing.Front,
+      facing: Facing.Unspecified,
       artStyle: ArtStyle.Unspecified,
       perspective: Perspective.Unspecified,
       referenceImageUrl: null,
       ...settings
     }
-    this.referenceCostumeId = this.sprite.defaultCostume?.id ?? null
+    this.referenceCostumeId = referenceCostumeId
     return reactive(this) as this
   }
 
@@ -57,7 +70,7 @@ export class CostumeGen extends Disposable {
     return this.settings.name
   }
   setName(name: string) {
-    const err = validateCostumeName(name, this.sprite)
+    const err = validateCostumeName(name, this.parent)
     if (err != null) throw new Error(`invalid name ${name}: ${err.en}`)
     this.settings.name = name
     this.result?.setName(name)
@@ -67,7 +80,7 @@ export class CostumeGen extends Disposable {
     return this.enrichPhase.state
   }
   async enrich() {
-    const draft = await this.enrichPhase.track(
+    const enriched = await this.enrichPhase.track(
       enrichCostumeSettings(
         this.settings.description,
         this.settings,
@@ -75,11 +88,19 @@ export class CostumeGen extends Disposable {
         getProjectSettings(this.project)
       )
     )
-    this.setSettings(draft)
+    this.setSettings(enriched)
   }
 
   settings: CostumeSettings
+  /**
+   * Update multiple settings at once.
+   * NOTE: the name in updates may be altered to avoid conflict
+   */
   setSettings(updates: Partial<CostumeSettings>) {
+    if (updates.name != null && updates.name !== this.settings.name) {
+      const newName = ensureValidCostumeName(updates.name, this.parent)
+      updates = { ...updates, name: newName }
+    }
     Object.assign(this.settings, updates)
   }
 

--- a/spx-gui/src/models/gen/sprite-gen.test.ts
+++ b/spx-gui/src/models/gen/sprite-gen.test.ts
@@ -4,7 +4,6 @@ import * as aigcApis from '@/apis/aigc'
 import * as spxUtils from '@/utils/spx'
 import { createI18n } from '@/utils/i18n'
 import * as fileHelpers from '@/models/common/file'
-import * as cloudHelpers from '@/models/common/cloud'
 import { makeProject } from '../common/test'
 import { SpriteGen } from './sprite-gen'
 import type { CostumeGen } from './costume-gen'
@@ -14,7 +13,6 @@ import type { AnimationGen } from './animation-gen'
 vi.mock('@/apis/aigc', { spy: true })
 vi.spyOn(spxUtils, 'adaptImg').mockImplementation((file) => Promise.resolve(file))
 vi.spyOn(fileHelpers, 'getImageSize').mockReturnValue(Promise.resolve({ width: 100, height: 100 }))
-vi.spyOn(cloudHelpers, 'saveFileForWebUrl').mockImplementation(() => Promise.resolve('TODO'))
 
 function enrichSettings(input: string) {
   return Promise.resolve({

--- a/spx-gui/src/models/gen/sprite-gen.ts
+++ b/spx-gui/src/models/gen/sprite-gen.ts
@@ -21,7 +21,7 @@ import { CostumeGen } from './costume-gen'
 import { AnimationGen } from './animation-gen'
 import { createFileWithUniversalUrl } from '../common/cloud'
 import type { File } from '../common/file'
-import { getAnimationName, getCostumeName } from '../common/asset-name'
+import { getAnimationName, getCostumeName, validateSpriteName } from '../common/asset-name'
 import { sprite2Asset } from '../common/asset'
 
 export class SpriteGen extends Disposable {
@@ -67,7 +67,8 @@ export class SpriteGen extends Disposable {
     return this.settings.name
   }
   setName(name: string) {
-    // TODO: check name validity
+    const err = validateSpriteName(name, this.project)
+    if (err != null) throw new Error(`invalid name ${name}: ${err.en}`)
     this.settings.name = name
   }
 
@@ -194,13 +195,17 @@ export class SpriteGen extends Disposable {
       // Generate default costume
       const defaultCostumeGen = new CostumeGen(this, project, this.getDefaultCostumeSettings())
       defaultCostumeGen.setImage(image)
-      await defaultCostumeGen.finish()
+      const defaultCostume = await defaultCostumeGen.finish()
       this.costumes.push(defaultCostumeGen)
 
       // Generate additional costumes & animations
       const settings = await genSpriteContentSettings(this.settings)
-      this.costumes.push(...settings.costumes.map((s) => new CostumeGen(this, project, s)))
-      this.animations = settings.animations.map((s) => new AnimationGen(this, project, s))
+      this.costumes.push(
+        ...settings.costumes.map((s) => new CostumeGen(this, project, { ...s, referenceCostumeId: defaultCostume.id }))
+      )
+      this.animations = settings.animations.map(
+        (s) => new AnimationGen(this, project, { ...s, referenceCostumeId: defaultCostume.id })
+      )
     })
   }
 
@@ -212,7 +217,15 @@ export class SpriteGen extends Disposable {
   }
   addCostume() {
     const name = getCostumeName(this)
-    const costumeGen = new CostumeGen(this, this.project, { name })
+    const defaultCostumeGen = this.defaultCostume
+    if (defaultCostumeGen == null) throw new Error('default costume expected')
+    const costumeGen = new CostumeGen(this, this.project, {
+      name,
+      artStyle: this.settings.artStyle,
+      perspective: this.settings.perspective,
+      facing: defaultCostumeGen.settings.facing,
+      referenceCostumeId: defaultCostumeGen.result?.id
+    })
     this.costumes.push(costumeGen)
     return costumeGen
   }
@@ -228,7 +241,14 @@ export class SpriteGen extends Disposable {
   animations: AnimationGen[]
   addAnimation() {
     const name = getAnimationName(this)
-    const animationGen = new AnimationGen(this, this.project, { name })
+    const defaultCostumeGen = this.defaultCostume
+    if (defaultCostumeGen == null) throw new Error('default costume expected')
+    const animationGen = new AnimationGen(this, this.project, {
+      name,
+      artStyle: this.settings.artStyle,
+      perspective: this.settings.perspective,
+      referenceCostumeId: defaultCostumeGen.result?.id
+    })
     this.animations.push(animationGen)
     return animationGen
   }


### PR DESCRIPTION
close #2745.

* Infers project settings from existing content during enrichment.
* Updates default settings for new costume and animation generations in sprite generation.
* Prevents naming conflicts in costumes/animations caused by enrichment.