### PR TITLE
docs(api-spec): add `name` field to `PUT /project/{owner}/{name}` request body

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -402,6 +402,9 @@ paths:
                 - files
                 - visibility
               properties:
+                name:
+                  description: New name of the project. If provided, the project will be renamed.
+                  $ref: "#/components/schemas/Project/properties/name"
                 files:
                   $ref: "#/components/schemas/Project/properties/files"
                 visibility:


### PR DESCRIPTION
Allow renaming a project by providing a new `name` in the update request body.