### PR TITLE
Fix missing history entry for DnD or APIReferenceItem-click in code editor

### DIFF
--- a/spx-gui/src/components/editor/code-editor/code-editor.ts
+++ b/spx-gui/src/components/editor/code-editor/code-editor.ts
@@ -973,7 +973,9 @@ export class CodeEditor extends Disposable {
 
       this.getAttachedUI()?.open(targetDoc.id)
 
-      targetDoc.setValue(code)
+      await this.history.doAction({ name: { en: 'Write code file', zh: '写入代码文件' } }, () =>
+        targetDoc.setValue(code)
+      )
 
       const diagnostics = await this.getDiagnostics({ file })
       const files = await this.listFiles()

--- a/spx-gui/src/components/editor/code-editor/text-document.ts
+++ b/spx-gui/src/components/editor/code-editor/text-document.ts
@@ -18,6 +18,30 @@ import {
 import { toMonacoPosition, toMonacoRange, fromMonacoPosition, fromMonacoRange } from './ui/common'
 import type { Monaco, monaco } from './monaco'
 
+/**
+ * Indicates the origin of a text change in `TextDocument`.
+ *
+ * When Monaco's model content changes (via `onDidChangeContent`), we need to know
+ * who initiated the change to decide whether `TextDocument` should record it in history:
+ *
+ * - `User`: The change comes from direct user interaction with the Monaco editor
+ *   (typing, pasting via browser, etc.). In this case, `TextDocument` (via `CodeOwner`)
+ *   is responsible for calling `history.doAction` to record the change.
+ *
+ * - `Program`: The change comes from application code calling `TextDocument` methods
+ *   like `pushEdits` or `setValue`. In this case, `TextDocument` does NOT record history.
+ *   The **caller** (direct or indirect) is responsible for wrapping the call in
+ *   `history.doAction` if the change should be undoable.
+ *
+ * NOTE: This design has a known limitation. Some callers of `pushEdits` are essentially
+ * alternative input methods (e.g., completion, input helper) and should behave like `User`
+ * changes (mergeable "Update xxx code" history), while others (e.g., format, apply copilot
+ * code change) need distinct, non-mergeable history actions. Currently all `pushEdits` /
+ * `setValue` calls use `Program`, forcing every caller to handle history explicitly.
+ * A planned improvement (see [#2881](https://github.com/goplus/builder/issues/2881)) will
+ * allow callers to control history behavior via a parameter, so that "alternative input" callers
+ * get automatic User-like history by default.
+ */
 enum CodeChangeKind {
   /** User interaction with monaco editor */
   User,
@@ -158,10 +182,22 @@ export class TextDocument
     this.monacoTextModel.setValue(newCode)
   }, 100)
 
-  /** Kind of the current change */
+  /**
+   * Kind of the current change. Defaults to `User` so that changes from
+   * direct Monaco interactions (typing, etc.) are automatically recorded
+   * in history by `CodeOwner.setCode`. Methods like `pushEdits` and
+   * `setValue` temporarily switch this to `Program` via
+   * `withChangeKindProgram`, delegating history responsibility to the caller.
+   */
   private changeKind = CodeChangeKind.User
 
-  /** Set the change kind to programmatic */
+  /**
+   * Temporarily set `changeKind` to `Program` while executing `fn`.
+   * Any Monaco model change triggered within `fn` will be treated as a
+   * programmatic change, so `CodeOwner.setCode` will skip `history.doAction`.
+   * The caller of the public method (e.g., `pushEdits`, `setValue`) is
+   * responsible for wrapping the call in `history.doAction` if needed.
+   */
   private withChangeKindProgram(fn: () => void) {
     const original = this.changeKind
     this.changeKind = CodeChangeKind.Program
@@ -176,6 +212,11 @@ export class TextDocument
     return this.monacoTextModel.getValue()
   }
 
+  /**
+   * Replace the entire text model value programmatically.
+   * History is NOT recorded here — the caller is responsible for wrapping
+   * this call in `history.doAction` if the change should be undoable.
+   */
   setValue(newValue: string) {
     this.withChangeKindProgram(() => {
       this.monacoTextModel.setValue(newValue)
@@ -215,6 +256,11 @@ export class TextDocument
     return fromMonacoRange(this.monacoTextModel.getFullModelRange())
   }
 
+  /**
+   * Apply edits to the Monaco text model programmatically.
+   * History is NOT recorded here — the caller is responsible for wrapping
+   * this call in `history.doAction` if the edits should be undoable.
+   */
   pushEdits(edits: TextEdit[]): void {
     this.withChangeKindProgram(() => {
       this.monacoTextModel.pushEditOperations(

--- a/spx-gui/src/components/editor/code-editor/ui/CodeEditorUI.vue
+++ b/spx-gui/src/components/editor/code-editor/ui/CodeEditorUI.vue
@@ -170,7 +170,7 @@ function handleMonacoEditorDragLeave(e: DragEvent) {
   handleMonacoEditorDrag(null)
 }
 
-function handleMonacoEditorDrop(e: DragEvent) {
+async function handleMonacoEditorDrop(e: DragEvent) {
   e.preventDefault()
 
   const ui = uiRef.value
@@ -184,12 +184,16 @@ function handleMonacoEditorDrop(e: DragEvent) {
   const range = { start: position, end: position }
   const ddi = getDdiDragData(e.dataTransfer)
   if (ddi != null) {
-    ui.insertDefinition(ddi, range)
+    await editorCtx.state.history.doAction({ name: { en: 'Insert code', zh: '插入代码' } }, () =>
+      ui.insertDefinition(ddi, range)
+    )
     return
   }
   const dataTextPlain = e.dataTransfer.getData('text/plain')
   if (dataTextPlain !== '') {
-    ui.insertText(dataTextPlain, range)
+    await editorCtx.state.history.doAction({ name: { en: 'Insert code', zh: '插入代码' } }, () =>
+      ui.insertText(dataTextPlain, range)
+    )
     return
   }
 }

--- a/spx-gui/src/components/editor/code-editor/ui/api-reference/APIReferenceItem.vue
+++ b/spx-gui/src/components/editor/code-editor/ui/api-reference/APIReferenceItem.vue
@@ -4,6 +4,7 @@ import * as lsp from 'vscode-languageserver-protocol'
 import { useMessageHandle } from '@/utils/exception'
 import { UIDropdown } from '@/components/ui'
 import { type Action, setDdiDragData } from '../../common'
+import { useEditorCtx } from '@/components/editor/EditorContextProvider.vue'
 import DefinitionOverviewWrapper from '../definition/DefinitionOverviewWrapper.vue'
 import DefinitionDetailWrapper from '../definition/DefinitionDetailWrapper.vue'
 import MarkdownView from '../markdown/MarkdownView.vue'
@@ -18,12 +19,19 @@ const props = defineProps<{
   interactionDisabled: boolean
 }>()
 
+const editorCtx = useEditorCtx()
 const codeEditorUICtx = useCodeEditorUICtx()
 
-const handleInsert = useMessageHandle(() => codeEditorUICtx.ui.insertDefinition(props.item), {
-  en: 'Failed to insert',
-  zh: '插入失败'
-}).fn
+const handleInsert = useMessageHandle(
+  () =>
+    editorCtx.state.history.doAction({ name: { en: 'Insert code', zh: '插入代码' } }, () =>
+      codeEditorUICtx.ui.insertDefinition(props.item)
+    ),
+  {
+    en: 'Failed to insert',
+    zh: '插入失败'
+  }
+).fn
 
 const parsed = computed(() => {
   const parsed = codeEditorUICtx.ui.parseSnippet(props.item.insertSnippet)

--- a/spx-gui/src/components/editor/code-editor/ui/code-editor-ui.ts
+++ b/spx-gui/src/components/editor/code-editor/ui/code-editor-ui.ts
@@ -470,8 +470,8 @@ export class CodeEditorUI extends Disposable implements ICodeEditorUI {
     // The "TabStop / Placeholder" of snippet is not helpful and introduces confusion,
     // so we transform snippet to text and insert it directly.
     const text = parsed.toString()
-    if (isBlockDefinitionKind(ddi.kind)) this.insertBlockText(text, range)
-    else this.insertInlineText(text, range)
+    if (isBlockDefinitionKind(ddi.kind)) return this.insertBlockText(text, range)
+    else return this.insertInlineText(text, range)
   }
 
   private cursorPositionRef = shallowRef<Position | null>(null)


### PR DESCRIPTION
Closes #2864

## What

Fix several call sites in the code editor that perform programmatic text insertions without recording a history entry, making the undo button remain disabled after the action.

## Root cause

`TextDocument.pushEdits` / `setValue` run under `changeKind = Program`, so `CodeOwner.setCode` skips `history.doAction`. The convention is that callers are responsible for wrapping the call in `history.doAction`. The following call sites were missing that wrapper:

- Drag-and-drop a DDI (API reference item) onto the editor (`handleMonacoEditorDrop` in `CodeEditorUI.vue`)
- Drag-and-drop plain text onto the editor (same handler)
- Click "Insert" on an API reference item (`APIReferenceItem.vue`)
- AI copilot `writeToFile` MCP tool (`code-editor.ts`)

## Changes

- **`CodeEditorUI.vue`** — wrap both DDI and plain-text drop insertions in `history.doAction`
- **`APIReferenceItem.vue`** — wrap `insertDefinition` call in `history.doAction`
- **`code-editor.ts`** — wrap `targetDoc.setValue(code)` in `writeToFile` with `history.doAction`
- **`text-document.ts`** — add comments explaining the `CodeChangeKind` convention and reference the follow-up refactor tracked in #2881

Note: `CompletionController.applyCompletionItem` (PlainText path) and `InputHelperUI.handleInputUpdate` also lack `history.doAction`, but those are intentionally left for the refactor in #2881, which will give `pushEdits` / `setValue` a caller-controlled history mode so those "alternative input" callers get automatic history by default.
