### PR TITLE
Fixes sound playback failure after page refresh in the sound editor

### DIFF
--- a/spx-gui/src/components/editor/sound/waveform/WaveformPlayer.vue
+++ b/spx-gui/src/components/editor/sound/waveform/WaveformPlayer.vue
@@ -29,6 +29,14 @@ const registered = registerPlayer(stop)
 
 const play = async () => {
   if (!audioElement.value) return
+
+  // Ensure AudioContext is running to comply with browser autoplay policies,
+  // especially after a page refresh.
+  const audioContext = getAudioContext()
+  if (audioContext.state === 'suspended') {
+    await audioContext.resume()
+  }
+
   if (!Number.isFinite(audioElement.value.duration)) {
     console.warn('audio duration is invalid. Started from the beginning.')
     // This can happen when the audio is not loaded yet.


### PR DESCRIPTION
### Description
In modern browsers, the AudioContext is often created in a 'suspended' state if it happens before user interaction (which is the case after a page refresh). This PR ensures that `audioContext.resume()` is called before starting playback, complying with the browser's Autoplay Policy.

### Related Issue
Closes #2553