### PR TITLE
refactor(tools/ispx): migrate AI bridge API to namespaced exports

### DIFF
--- a/spx-gui/src/components/project/runner/ProjectRunner.vue
+++ b/spx-gui/src/components/project/runner/ProjectRunner.vue
@@ -42,9 +42,9 @@ type RunnerFiles = {
 }
 
 interface RunnerIframeWindow extends Window {
-  setAIInteractionAPIEndpoint: (endpoint: string) => void
-  setAIInteractionAPITokenProvider: (provider: () => Promise<string>) => void
-  setAIDescription: (description: string) => void
+  xbuilder_set_ai_interaction_api_endpoint: (endpoint: string) => void
+  xbuilder_set_ai_interaction_api_token_provider: (provider: () => Promise<string>) => void
+  xbuilder_set_ai_description: (description: string) => void
   /** Init the engine. Can be called early; project-agnostic. */
   initEngine(assetURLs: Record<string, string>, config?: EngineConfig): Promise<void>
   /** Init the game with project files. Should be called after `initEngine`, before `startGame` or earlier (when files change, etc.). */
@@ -250,9 +250,9 @@ async function prepareAIInteraction(
   const aiDescription = await project.ensureAIDescription(false, signal)
   if (engineInitPromise == null) throw new Error('engineInitPromise expected')
   await engineInitPromise
-  iframeWindow.setAIDescription(aiDescription)
-  iframeWindow.setAIInteractionAPIEndpoint(apiBaseUrl + '/ai/interaction')
-  iframeWindow.setAIInteractionAPITokenProvider(async () => (await ensureAccessToken()) ?? '')
+  iframeWindow.xbuilder_set_ai_description(aiDescription)
+  iframeWindow.xbuilder_set_ai_interaction_api_endpoint(apiBaseUrl + '/ai/interaction')
+  iframeWindow.xbuilder_set_ai_interaction_api_token_provider(async () => (await ensureAccessToken()) ?? '')
   reporter.report(1)
   return
 }

--- a/tools/ai/backoff.go
+++ b/tools/ai/backoff.go
@@ -31,10 +31,8 @@ func backoffSleep(base, cap time.Duration, attempt int) time.Duration {
 func backoffAttempts(ctx context.Context, maxAttempts int, base, cap time.Duration) iter.Seq[int] {
 	return func(yield func(int) bool) {
 		for attempt := range maxAttempts {
-			select {
-			case <-ctx.Done():
+			if ctx.Err() != nil {
 				return
-			default:
 			}
 
 			if !yield(attempt) {

--- a/tools/ispx/ai.go
+++ b/tools/ispx/ai.go
@@ -17,13 +17,6 @@ func init() {
 	js.Global().Set("xbuilder_set_ai_description", js.FuncOf(setAIDescription))
 	js.Global().Set("xbuilder_set_ai_interaction_api_endpoint", js.FuncOf(setAIInteractionAPIEndpoint))
 	js.Global().Set("xbuilder_set_ai_interaction_api_token_provider", js.FuncOf(setAIInteractionAPITokenProvider))
-
-	// Deprecated: Use the "xbuilder_" prefixed versions instead.
-	//
-	// FIXME: Remove these aliases in future releases.
-	js.Global().Set("setAIDescription", js.FuncOf(setAIDescription))
-	js.Global().Set("setAIInteractionAPIEndpoint", js.FuncOf(setAIInteractionAPIEndpoint))
-	js.Global().Set("setAIInteractionAPITokenProvider", js.FuncOf(setAIInteractionAPITokenProvider))
 }
 
 // initAI initializes AI integration for the ispx interpreter.

--- a/tools/ispx/build.sh
+++ b/tools/ispx/build.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -e
 
-GOOS=js GOARCH=wasm go build -tags canvas -trimpath -ldflags "-s -w -checklinkname=0" -o ispx.wasm
+GOOS=js GOARCH=wasm go build -trimpath -ldflags "-s -w -checklinkname=0" -o ispx.wasm


### PR DESCRIPTION
- Update `ProjectRunner` to call `xbuilder_` AI bridge methods
- Remove deprecated unprefixed AI globals and keep only namespaced exports in ispx
- Simplify `backoffAttempts` cancellation by checking `ctx.Err()` directly
- Remove explicit `-tags canvas` from the ispx Wasm build command