### PR TITLE
refactor: migrate update API calls from `PUT` to `PATCH`

### DIFF
--- a/spx-gui/src/apis/aigc.ts
+++ b/spx-gui/src/apis/aigc.ts
@@ -182,19 +182,15 @@ export type TaskParams<T extends TaskType = TaskType> = {
   [TaskType.GenerateBackdrop]: TaskParamsGenerateBackdrop
 }[T]
 
-export async function createTask<T extends TaskType>(
-  type: T,
-  params: TaskParams<T>,
-  signal?: AbortSignal
-): Promise<Task<T>> {
+export function createTask<T extends TaskType>(type: T, params: TaskParams<T>, signal?: AbortSignal): Promise<Task<T>> {
   return client.post('/aigc/task', { type, parameters: params }, { signal }) as Promise<Task<T>>
 }
 
-export async function getTask(taskID: string, signal?: AbortSignal): Promise<Task> {
+export function getTask(taskID: string, signal?: AbortSignal): Promise<Task> {
   return client.get(`/aigc/task/${encodeURIComponent(taskID)}`, undefined, { signal }) as Promise<Task>
 }
 
-export async function cancelTask(taskID: string, signal?: AbortSignal): Promise<Task> {
+export function cancelTask(taskID: string, signal?: AbortSignal): Promise<Task> {
   return client.post(`/aigc/task/${encodeURIComponent(taskID)}/cancellation`, undefined, { signal }) as Promise<Task>
 }
 
@@ -266,7 +262,7 @@ export type EnrichAssetSettingsParams = {
 
 export type EnrichAssetSettingsResult = SpriteSettings | CostumeSettings | AnimationSettings | BackdropSettings
 
-export async function enrichAssetSettings(
+export function enrichAssetSettings(
   params: EnrichAssetSettingsParams,
   signal?: AbortSignal
 ): Promise<EnrichAssetSettingsResult> {
@@ -282,7 +278,7 @@ export type SpriteContentSettings = {
   animationBindings: Partial<Record<State, string>>
 }
 
-export async function genSpriteContentSettings(
+export function genSpriteContentSettings(
   settings: SpriteSettings,
   signal?: AbortSignal
 ): Promise<SpriteContentSettings> {
@@ -293,13 +289,13 @@ export async function genSpriteContentSettings(
   ) as Promise<SpriteContentSettings>
 }
 
-export async function enrichBackdropSettings(
+export function enrichBackdropSettings(
   input: string,
   settings?: BackdropSettings,
   projectSettings?: ProjectSettings,
   signal?: AbortSignal
 ): Promise<BackdropSettings> {
-  const result = (await enrichAssetSettings(
+  return enrichAssetSettings(
     {
       assetType: AIGCAssetType.Backdrop,
       input,
@@ -307,18 +303,17 @@ export async function enrichBackdropSettings(
       projectSettings
     },
     signal
-  )) as BackdropSettings
-  return result
+  ) as Promise<BackdropSettings>
 }
 
-export async function enrichCostumeSettings(
+export function enrichCostumeSettings(
   input: string,
   settings?: CostumeSettings,
   spriteSettings?: SpriteSettings,
   projectSettings?: ProjectSettings,
   signal?: AbortSignal
 ): Promise<CostumeSettings> {
-  const result = (await enrichAssetSettings(
+  return enrichAssetSettings(
     {
       assetType: AIGCAssetType.Costume,
       input,
@@ -327,18 +322,17 @@ export async function enrichCostumeSettings(
       projectSettings
     },
     signal
-  )) as CostumeSettings
-  return result
+  ) as Promise<CostumeSettings>
 }
 
-export async function enrichAnimationSettings(
+export function enrichAnimationSettings(
   input: string,
   settings?: AnimationSettings,
   spriteSettings?: SpriteSettings,
   projectSettings?: ProjectSettings,
   signal?: AbortSignal
 ): Promise<AnimationSettings> {
-  const result = (await enrichAssetSettings(
+  return enrichAssetSettings(
     {
       assetType: AIGCAssetType.Animation,
       input,
@@ -347,17 +341,16 @@ export async function enrichAnimationSettings(
       projectSettings
     },
     signal
-  )) as AnimationSettings
-  return result
+  ) as Promise<AnimationSettings>
 }
 
-export async function enrichSpriteSettings(
+export function enrichSpriteSettings(
   input: string,
   settings?: SpriteSettings,
   projectSettings?: ProjectSettings,
   signal?: AbortSignal
 ): Promise<SpriteSettings> {
-  const result = (await enrichAssetSettings(
+  return enrichAssetSettings(
     {
       assetType: AIGCAssetType.Sprite,
       input,
@@ -365,8 +358,7 @@ export async function enrichSpriteSettings(
       projectSettings
     },
     signal
-  )) as SpriteSettings
-  return result
+  ) as Promise<SpriteSettings>
 }
 
 export type AssetAdoptionParams = {

--- a/spx-gui/src/apis/asset.ts
+++ b/spx-gui/src/apis/asset.ts
@@ -74,7 +74,7 @@ export function addAsset(params: AddAssetParams) {
 export type UpdateAssetParams = AddAssetParams
 
 export function updateAsset(id: string, params: UpdateAssetParams) {
-  return client.put(`/asset/${encodeURIComponent(id)}`, params) as Promise<AssetData>
+  return client.patch(`/asset/${encodeURIComponent(id)}`, params) as Promise<AssetData>
 }
 
 export function deleteAsset(id: string) {

--- a/spx-gui/src/apis/common/client.ts
+++ b/spx-gui/src/apis/common/client.ts
@@ -164,10 +164,6 @@ export class Client {
     return this.requestBinary(path, payload, { ...options, method: 'POST' })
   }
 
-  put(path: string, payload?: unknown, options?: Omit<RequestOptions, 'method'>) {
-    return this.requestJSON(path, payload, { ...options, method: 'PUT' })
-  }
-
   patch(path: string, payload?: unknown, options?: Omit<RequestOptions, 'method'>) {
     return this.requestJSON(path, payload, { ...options, method: 'PATCH' })
   }

--- a/spx-gui/src/apis/copilot.ts
+++ b/spx-gui/src/apis/copilot.ts
@@ -38,12 +38,12 @@ export type GenerateMessageOptions = {
 
 const timeout = 15 * 1000
 
-export async function generateMessage(scope: CopilotScope, messages: Message[], options?: GenerateMessageOptions) {
-  return (await client.post(
+export function generateMessage(scope: CopilotScope, messages: Message[], options?: GenerateMessageOptions) {
+  return client.post(
     '/copilot/message',
     { scope, messages },
     { timeout: timeout, signal: options?.signal }
-  )) as Message
+  ) as Promise<Message>
 }
 
 export async function* generateStreamMessage(

--- a/spx-gui/src/apis/course-series.ts
+++ b/spx-gui/src/apis/course-series.ts
@@ -18,7 +18,7 @@ export type CourseSeries = {
 }
 
 /** Get a course series by ID */
-export async function getCourseSeries(id: string, signal?: AbortSignal) {
+export function getCourseSeries(id: string, signal?: AbortSignal) {
   return client.get(`/course-series/${encodeURIComponent(id)}`, undefined, { signal }) as Promise<CourseSeries>
 }
 
@@ -28,17 +28,17 @@ export type AddUpdateCourseSeriesParams = Pick<
 >
 
 /** Add a new course series */
-export async function addCourseSeries(params: AddUpdateCourseSeriesParams, signal?: AbortSignal) {
+export function addCourseSeries(params: AddUpdateCourseSeriesParams, signal?: AbortSignal) {
   return client.post('/course-series', params, { signal }) as Promise<CourseSeries>
 }
 
 /** Update an existing course series */
-export async function updateCourseSeries(id: string, params: AddUpdateCourseSeriesParams, signal?: AbortSignal) {
-  return client.put(`/course-series/${encodeURIComponent(id)}`, params, { signal }) as Promise<CourseSeries>
+export function updateCourseSeries(id: string, params: AddUpdateCourseSeriesParams, signal?: AbortSignal) {
+  return client.patch(`/course-series/${encodeURIComponent(id)}`, params, { signal }) as Promise<CourseSeries>
 }
 
 /** Delete a course series */
-export async function deleteCourseSeries(id: string) {
+export function deleteCourseSeries(id: string) {
   return client.delete(`/course-series/${encodeURIComponent(id)}`) as Promise<void>
 }
 
@@ -51,7 +51,7 @@ export type ListCourseSeriesParams = PaginationParams & {
   owner?: string
 }
 
-export async function listCourseSeries(params?: ListCourseSeriesParams, signal?: AbortSignal) {
+export function listCourseSeries(params?: ListCourseSeriesParams, signal?: AbortSignal) {
   return client.get('/course-serieses/list', params, { signal }) as Promise<ByPage<CourseSeries>>
 }
 

--- a/spx-gui/src/apis/course.ts
+++ b/spx-gui/src/apis/course.ts
@@ -26,24 +26,24 @@ export type Course = {
 }
 
 /** Get a course by ID */
-export async function getCourse(id: string, signal?: AbortSignal) {
+export function getCourse(id: string, signal?: AbortSignal) {
   return client.get(`/course/${encodeURIComponent(id)}`, undefined, { signal }) as Promise<Course>
 }
 
 export type AddUpdateCourseParams = Pick<Course, 'title' | 'thumbnail' | 'entrypoint' | 'references' | 'prompt'>
 
 /** Add a new course */
-export async function addCourse(params: AddUpdateCourseParams, signal?: AbortSignal) {
+export function addCourse(params: AddUpdateCourseParams, signal?: AbortSignal) {
   return client.post('/course', params, { signal }) as Promise<Course>
 }
 
 /** Update an existing course */
-export async function updateCourse(id: string, params: AddUpdateCourseParams, signal?: AbortSignal) {
-  return client.put(`/course/${encodeURIComponent(id)}`, params, { signal }) as Promise<Course>
+export function updateCourse(id: string, params: AddUpdateCourseParams, signal?: AbortSignal) {
+  return client.patch(`/course/${encodeURIComponent(id)}`, params, { signal }) as Promise<Course>
 }
 
 /** Delete a course */
-export async function deleteCourse(id: string) {
+export function deleteCourse(id: string) {
   return client.delete(`/course/${encodeURIComponent(id)}`) as Promise<void>
 }
 
@@ -61,7 +61,7 @@ export type ListCourseParams = PaginationParams & {
   sortOrder?: 'asc' | 'desc'
 }
 
-export async function listCourse(params: ListCourseParams, signal?: AbortSignal) {
+export function listCourse(params: ListCourseParams, signal?: AbortSignal) {
   return client.get('/courses/list', params, { signal }) as Promise<ByPage<Course>>
 }
 

--- a/spx-gui/src/apis/project.ts
+++ b/spx-gui/src/apis/project.ts
@@ -87,7 +87,7 @@ export type AddProjectParams = Prettify<
   Pick<ProjectData, 'name' | 'files' | 'visibility' | 'thumbnail'> & Partial<Pick<ProjectData, 'displayName'>>
 >
 
-export async function addProject(params: AddProjectParams | AddProjectByRemixParams, signal?: AbortSignal) {
+export function addProject(params: AddProjectParams | AddProjectByRemixParams, signal?: AbortSignal) {
   return client.post('/project', params, { signal }) as Promise<ProjectData>
 }
 
@@ -100,7 +100,7 @@ export type UpdateProjectParams = Prettify<
   >
 >
 
-export async function updateProject(owner: string, name: string, params: UpdateProjectParams, signal?: AbortSignal) {
+export function updateProject(owner: string, name: string, params: UpdateProjectParams, signal?: AbortSignal) {
   return client.patch(`/project/${encodeURIComponent(owner)}/${encodeURIComponent(name)}`, params, {
     signal
   }) as Promise<ProjectData>
@@ -138,11 +138,11 @@ export type ListProjectParams = PaginationParams & {
   sortOrder?: 'asc' | 'desc'
 }
 
-export async function listProject(params?: ListProjectParams) {
+export function listProject(params?: ListProjectParams) {
   return client.get('/projects/list', params) as Promise<ByPage<ProjectData>>
 }
 
-export async function getProject(owner: string, name: string, signal?: AbortSignal) {
+export function getProject(owner: string, name: string, signal?: AbortSignal) {
   return client.get(`/project/${encodeURIComponent(owner)}/${encodeURIComponent(name)}`, undefined, {
     signal
   }) as Promise<ProjectData>
@@ -192,7 +192,7 @@ export async function exploreProjects({ order, count }: ExploreParams) {
 }
 
 /** Record a view for the given project */
-export async function recordProjectView(owner: string, name: string) {
+export function recordProjectView(owner: string, name: string) {
   return client.post(`/project/${encodeURIComponent(owner)}/${encodeURIComponent(name)}/view`) as Promise<void>
 }
 
@@ -216,11 +216,11 @@ export async function isLiking(owner: string, name: string) {
   }
 }
 
-export async function likeProject(owner: string, name: string) {
+export function likeProject(owner: string, name: string) {
   return client.post(`/project/${encodeURIComponent(owner)}/${encodeURIComponent(name)}/liking`) as Promise<void>
 }
 
-export async function unlikeProject(owner: string, name: string) {
+export function unlikeProject(owner: string, name: string) {
   return client.delete(`/project/${encodeURIComponent(owner)}/${encodeURIComponent(name)}/liking`) as Promise<void>
 }
 

--- a/spx-gui/src/apis/sb2xbp.ts
+++ b/spx-gui/src/apis/sb2xbp.ts
@@ -22,5 +22,5 @@ export async function convertScratchToXbp(file: File, signal?: AbortSignal) {
   form.append('file', file, file.name)
 
   const blob = await client.postBinary('/util/sb2xbp', form, { signal })
-  return blob
+  return blob as Blob
 }

--- a/spx-gui/src/apis/user.ts
+++ b/spx-gui/src/apis/user.ts
@@ -34,18 +34,18 @@ export type UserCapabilities = {
   canUsePremiumLLM: boolean
 }
 
-export async function getUser(name: string): Promise<User> {
-  return await (client.get(`/user/${encodeURIComponent(name)}`) as Promise<User>)
+export function getUser(name: string): Promise<User> {
+  return client.get(`/user/${encodeURIComponent(name)}`) as Promise<User>
 }
 
-export async function getSignedInUser(): Promise<SignedInUser> {
-  return await (client.get(`/user`) as Promise<SignedInUser>)
+export function getSignedInUser(): Promise<SignedInUser> {
+  return client.get(`/user`) as Promise<SignedInUser>
 }
 
 export type UpdateSignedInUserParams = Partial<Pick<User, 'displayName' | 'description'>>
 
-export async function updateSignedInUser(params: UpdateSignedInUserParams) {
-  return await (client.put(`/user`, params) as Promise<SignedInUser>)
+export function updateSignedInUser(params: UpdateSignedInUserParams) {
+  return client.patch(`/user`, params) as Promise<SignedInUser>
 }
 
 export type ListUserParams = PaginationParams & {
@@ -59,8 +59,8 @@ export type ListUserParams = PaginationParams & {
   sortOrder?: 'asc' | 'desc'
 }
 
-export async function listUsers(params: ListUserParams) {
-  return await (client.get('/users/list', params) as Promise<ByPage<User>>)
+export function listUsers(params: ListUserParams) {
+  return client.get('/users/list', params) as Promise<ByPage<User>>
 }
 
 /**
@@ -83,10 +83,10 @@ export async function isFollowing(username: string) {
   }
 }
 
-export async function follow(username: string) {
-  await client.post(`/user/${encodeURIComponent(username)}/following`)
+export function follow(username: string) {
+  return client.post(`/user/${encodeURIComponent(username)}/following`) as Promise<void>
 }
 
-export async function unfollow(username: string) {
-  await client.delete(`/user/${encodeURIComponent(username)}/following`)
+export function unfollow(username: string) {
+  return client.delete(`/user/${encodeURIComponent(username)}/following`) as Promise<void>
 }


### PR DESCRIPTION
- Add `client.patch` and remove obsolete `client.put`
- Update user, project, asset, course, and course-series update calls

Updates #2892