### PR TITLE
fix: handle case-only project rename

### DIFF
--- a/spx-gui/src/components/editor/editing.test.ts
+++ b/spx-gui/src/components/editor/editing.test.ts
@@ -392,6 +392,25 @@ describe('Editing.loadProject', () => {
     expect(project.load).toHaveBeenCalledWith(cloudData, expect.anything())
   })
 
+  it('should treat cache name with different casing as the same project', async () => {
+    const cloudData = makeSerialized('alice', 'my-project', 1)
+    const localData = makeSerialized('alice', 'My-Project', 2)
+    const cloudHelper = makeCloudHelper()
+    vi.mocked(cloudHelper.load).mockResolvedValue(cloudData)
+    const localCacheHelper = makeLocalCache(localData)
+
+    const project = makeProject({ owner: 'alice', name: 'my-project' })
+    const editing = makeEditing({ project, cloudHelper, localCacheHelper })
+
+    const helpers = makeUIHelpers()
+
+    await editing.loadProject(helpers, makeReporter(), new AbortController().signal)
+
+    expect(helpers.confirmOpenTargetWithAnotherInCache).not.toHaveBeenCalled()
+    expect(localCacheHelper.clear).not.toHaveBeenCalled()
+    expect(project.load).toHaveBeenCalledWith(localData, expect.anything())
+  })
+
   it('should open cached project and throw Cancelled when user chooses cached project over target', async () => {
     const cloudData = makeSerialized('alice', 'my-project', 1)
     const localData = makeSerialized('alice', 'cached-project', 2)

--- a/spx-gui/src/components/editor/editing.ts
+++ b/spx-gui/src/components/editor/editing.ts
@@ -221,7 +221,11 @@ export class Editing extends Disposable {
         localData = null
         this.localCacheHelper.clear().catch((e) => capture(e, 'Failed to clear local cache'))
       }
-      if (localMetadata.owner === ownerName && localMetadata.name != null && localMetadata.name !== projectName) {
+      if (
+        localMetadata.owner === ownerName &&
+        localMetadata.name != null &&
+        localMetadata.name.toLowerCase() !== projectName.toLowerCase()
+      ) {
         // If project name mismatch, ask user whether to open the cached project or not, to avoid potential data loss by clearing cache
         const stillOpenTarget = await helpers.confirmOpenTargetWithAnotherInCache(projectName, localMetadata.name)
         signal.throwIfAborted()

--- a/spx-gui/src/components/editor/navbar/EditorNavbar.vue
+++ b/spx-gui/src/components/editor/navbar/EditorNavbar.vue
@@ -166,7 +166,7 @@ import { convertScratchToXbp } from '@/apis/sb2xbp'
 import { type SpxProject } from '@/models/spx/project'
 import { getSignedInUsername, useUser } from '@/stores/user'
 import { Visibility } from '@/apis/common'
-import { getProjectEditorRoute, getProjectPageRoute } from '@/router'
+import { getProjectPageRoute } from '@/router'
 import { showTutorialsEntry } from '@/utils/env'
 import { useModifyProjectName, usePublishProject, useRemoveProject, useUnpublishProject } from '@/components/project'
 import { useLoadFromScratchModal } from '@/components/asset'
@@ -328,7 +328,15 @@ const handleModifyProjectName = useMessageHandle(
     const nextName = await modifyProjectName(project)
     if (nextName == null) return
     if (nextName !== previousName && project.owner != null) {
-      router.replace(getProjectEditorRoute(project.owner, nextName))
+      const currentRoute = router.currentRoute.value
+      router.replace({
+        params: {
+          ...currentRoute.params,
+          ownerName: project.owner,
+          projectName: nextName
+        },
+        query: currentRoute.query
+      })
     }
   },
   { en: 'Failed to modify project name', zh: '修改项目名失败' }

--- a/spx-gui/src/components/project/ProjectModifyNameModal.vue
+++ b/spx-gui/src/components/project/ProjectModifyNameModal.vue
@@ -71,7 +71,7 @@ async function validateName(name: string): Promise<FormValidationResult> {
       zh: '项目名长度超出限制（最多 100 个字符）'
     })
 
-  if (name === currentName.value) return
+  if (name.toLowerCase() === currentName.value.toLowerCase()) return
 
   const owner = props.project.owner
   if (owner == null) throw new Error('Project owner is not loaded')


### PR DESCRIPTION
Treat project names that differ only by casing as the same project during rename flows.

Allow case-only renames in `ProjectModifyNameModal`, preserve the current editor route when navigating to the renamed project, and avoid misidentifying local cache as a different project after reload.

Add coverage for the local cache restore path to keep the rename behavior stable.