### PR TITLE
Fix incomplete rendering for project name

### DIFF
--- a/spx-gui/src/components/editor/navbar/EditorProjectDisplayName.vue
+++ b/spx-gui/src/components/editor/navbar/EditorProjectDisplayName.vue
@@ -204,7 +204,6 @@ function handleSubmitProjectDisplayName() {
   white-space: nowrap;
   text-overflow: ellipsis;
   font-size: 16px;
-  line-height: 1;
 }
 
 .name-text {


### PR DESCRIPTION
The owner / project name is not rendered completely:

<img width="209" height="52" alt="image" src="https://github.com/user-attachments/assets/e2da0299-e76d-4df8-9506-f3bd35e3fa02" />

Here we fix it by removing the `line-height: 1`