### PR TITLE
fix: encode resource names in spx resource URIs

### DIFF
--- a/spx-gui/src/components/editor/code-editor/spx-code-editor/common.test.ts
+++ b/spx-gui/src/components/editor/code-editor/spx-code-editor/common.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from 'vitest'
-import { parseResourceURI, parseResourceContextURI } from './common'
+import { Animation } from '@/models/spx/animation'
+import { Backdrop } from '@/models/spx/backdrop'
+import { Costume } from '@/models/spx/costume'
+import { Sound } from '@/models/spx/sound'
+import { Sprite } from '@/models/spx/sprite'
+import { Monitor } from '@/models/spx/widget/monitor'
+import { mockFile } from '@/models/common/test'
+import { getResourceURI, parseResourceURI, parseResourceContextURI } from './common'
 
 describe('parseResourceURI', () => {
   it('should parse resource uri correctly', () => {
@@ -15,6 +22,10 @@ describe('parseResourceURI', () => {
     expect(parseResourceURI('spx://resources/sounds/Bar')).toEqual([{ type: 'sound', name: 'Bar' }])
     expect(parseResourceURI('spx://resources/backdrops/space')).toEqual([{ type: 'backdrop', name: 'space' }])
     expect(parseResourceURI('spx://resources/widgets/%E5%88%86%E6%95%B0')).toEqual([{ type: 'widget', name: '分数' }])
+    expect(parseResourceURI('spx://resources/sprites/Foo%2FBar/costumes/hello%20world')).toEqual([
+      { type: 'sprite', name: 'Foo/Bar' },
+      { type: 'costume', name: 'hello world' }
+    ])
     expect(parseResourceURI('spx://resources/stage')).toEqual([{ type: 'stage', name: undefined }])
   })
 })
@@ -23,6 +34,7 @@ describe('parseResourceContextURI', () => {
   it('should parse resource context uri correctly', () => {
     expect(parseResourceContextURI('spx://resources/sprites')).toEqual({ parent: [], type: 'sprite' })
     expect(parseResourceContextURI('spx://resources/sounds')).toEqual({ parent: [], type: 'sound' })
+    expect(parseResourceContextURI('spx://resources/widgets')).toEqual({ parent: [], type: 'widget' })
     expect(parseResourceContextURI('spx://resources/sprites/Foo/costumes')).toEqual({
       parent: [{ type: 'sprite', name: 'Foo' }],
       type: 'costume'
@@ -38,5 +50,34 @@ describe('parseResourceContextURI', () => {
       ],
       type: 'costume'
     })
+    expect(parseResourceContextURI('spx://resources/sprites/Foo%2FBar/costumes')).toEqual({
+      parent: [{ type: 'sprite', name: 'Foo/Bar' }],
+      type: 'costume'
+    })
+  })
+})
+
+describe('getResourceURI', () => {
+  it('should encode resource names in generated uris', () => {
+    const sprite = new Sprite('Foo/Bar')
+    const sound = new Sound('Boom #1', mockFile())
+    const backdrop = new Backdrop('Sky & Sea', mockFile())
+    const costume = new Costume('hello world', mockFile())
+    sprite.addCostume(costume)
+    const animation = new Animation('run/fast')
+    sprite.addAnimation(animation)
+    const widget = new Monitor('Score #1', {
+      x: 10,
+      y: 20,
+      label: 'Score',
+      variableName: 'score'
+    })
+
+    expect(getResourceURI(sprite)).toBe('spx://resources/sprites/Foo%2FBar')
+    expect(getResourceURI(sound)).toBe('spx://resources/sounds/Boom%20%231')
+    expect(getResourceURI(backdrop)).toBe('spx://resources/backdrops/Sky%20%26%20Sea')
+    expect(getResourceURI(costume)).toBe('spx://resources/sprites/Foo%2FBar/costumes/hello%20world')
+    expect(getResourceURI(animation)).toBe('spx://resources/sprites/Foo%2FBar/animations/run%2Ffast')
+    expect(getResourceURI(widget)).toBe('spx://resources/widgets/Score%20%231')
   })
 })

--- a/spx-gui/src/components/editor/code-editor/spx-code-editor/common.ts
+++ b/spx-gui/src/components/editor/code-editor/spx-code-editor/common.ts
@@ -52,18 +52,6 @@ export type ResourceNameWithType = {
   name: string
 }
 
-/**
- * We should encode resource name in URI because it may contain special characters (e.g., `/`),
- * but now the language server doesn't do the encoding when constructing the URI, which causes problems.
- * We temporarily disable encoding to keep things working, but we should fix the language server
- * to do the encoding and re-enable this in the future.
- */
-const shouldEncodeResourceName = false
-
-export function encodeResourceName(name: string): string {
-  return shouldEncodeResourceName ? encodeURIComponent(name) : name
-}
-
 export function parseResourceURI(uri: ResourceURI): ResourceNameWithType[] {
   if (!isResourceUri(uri)) throw new Error(`Invalid resource URI: ${uri}`)
   const parts = uri.slice(resourceURIPrefix.length).split('/').map(decodeURIComponent)
@@ -140,21 +128,21 @@ export function getResourceModel(project: SpxProject, resourceId: ResourceIdenti
 }
 
 export function getResourceURI(resource: ResourceModel): string {
-  if (resource instanceof Sprite) return `${resourceURIPrefix}sprites/${encodeResourceName(resource.name)}`
-  if (resource instanceof Sound) return `${resourceURIPrefix}sounds/${encodeResourceName(resource.name)}`
-  if (resource instanceof Backdrop) return `${resourceURIPrefix}backdrops/${encodeResourceName(resource.name)}`
+  if (resource instanceof Sprite) return `${resourceURIPrefix}sprites/${encodeURIComponent(resource.name)}`
+  if (resource instanceof Sound) return `${resourceURIPrefix}sounds/${encodeURIComponent(resource.name)}`
+  if (resource instanceof Backdrop) return `${resourceURIPrefix}backdrops/${encodeURIComponent(resource.name)}`
   if (resource instanceof Costume) {
     const parent = resource.parent
     if (parent == null) throw new Error(`Costume ${resource.name} has no sprite`)
     if (!(parent instanceof Sprite)) throw new Error(`Invalid parent type: ${parent}`)
-    return `${resourceURIPrefix}sprites/${encodeResourceName(parent.name)}/costumes/${encodeResourceName(resource.name)}`
+    return `${resourceURIPrefix}sprites/${encodeURIComponent(parent.name)}/costumes/${encodeURIComponent(resource.name)}`
   }
   if (resource instanceof Animation) {
     const sprite = resource.sprite
     if (sprite == null) throw new Error(`Animation ${resource.name} has no sprite`)
-    return `${resourceURIPrefix}sprites/${encodeResourceName(sprite.name)}/animations/${encodeResourceName(resource.name)}`
+    return `${resourceURIPrefix}sprites/${encodeURIComponent(sprite.name)}/animations/${encodeURIComponent(resource.name)}`
   }
-  if (isWidget(resource)) return `${resourceURIPrefix}widgets/${encodeResourceName(resource.name)}`
+  if (isWidget(resource)) return `${resourceURIPrefix}widgets/${encodeURIComponent(resource.name)}`
   if (resource instanceof Stage) return `${resourceURIPrefix}stage`
   throw new Error(`Unsupported resource type: ${resource}`)
 }


### PR DESCRIPTION
## Summary
- encode resource names when generating spx resource URIs
- add parsing coverage for encoded resource names
- add tests for encoded URIs generated from resource models

## Testing
- npm test

## Related
- https://github.com/goplus/xgolsw/pull/279