### PR TITLE
Fix Shiki hang on inline struct type highlighting

### DIFF
--- a/spx-gui/src/utils/xgo/gop-tm-language.json
+++ b/spx-gui/src/utils/xgo/gop-tm-language.json
@@ -1931,36 +1931,27 @@
 				},
 				{
 					"comment": "one line with semicolon(;) without formatting gofmt - single type | property variables and types",
-					"match": "(?:(?<=\\{)((?:\\s*(?:(?:(?:\\w+\\,\\s*)+)?(?:\\w+\\s+))?(?:(?:(?:\\s*(?:[\\*\\[\\]]+)?(?:\\<\\-\\s*)?\\bchan\\b(?:\\s*\\<\\-)?\\s*)+)?(?:[\\S]+)(?:\\;)?))+)\\s*(?=\\}))",
+					"match": "(?:((?:(?:\\w+\\,\\s*)+)?(?:\\w+\\s+))?([^;`\\\"\\/}]+)(?:\\;|(?=\\})))",
 					"captures": {
 						"1": {
 							"patterns": [
 								{
-									"match": "(?:((?:(?:\\w+\\,\\s*)+)?(?:\\w+\\s+))?((?:(?:\\s*(?:[\\*\\[\\]]+)?(?:\\<\\-\\s*)?\\bchan\\b(?:\\s*\\<\\-)?\\s*)+)?(?:[\\S]+)(?:\\;)?))",
-									"captures": {
-										"1": {
-											"patterns": [
-												{
-													"include": "#type-declarations"
-												},
-												{
-													"match": "(?:\\w+)",
-													"name": "variable.other.property.gop"
-												}
-											]
-										},
-										"2": {
-											"patterns": [
-												{
-													"include": "#type-declarations"
-												},
-												{
-													"match": "(?:\\w+)",
-													"name": "entity.name.type.gop"
-												}
-											]
-										}
-									}
+									"include": "#type-declarations"
+								},
+								{
+									"match": "(?:\\w+)",
+									"name": "variable.other.property.gop"
+								}
+							]
+						},
+						"2": {
+							"patterns": [
+								{
+									"include": "#type-declarations"
+								},
+								{
+									"match": "(?:\\w+)",
+									"name": "entity.name.type.gop"
 								}
 							]
 						}

--- a/spx-gui/src/utils/xgo/gop-tm-language.json
+++ b/spx-gui/src/utils/xgo/gop-tm-language.json
@@ -1930,8 +1930,8 @@
 					}
 				},
 				{
-					"comment": "one line with semicolon(;) without formatting gofmt - single type | property variables and types",
-					"match": "(?:((?:(?:\\w+\\,\\s*)+)?(?:\\w+\\s+))?([^;`\\\"\\/}]+)(?:\\;|(?=\\})))",
+					"comment": "one field per match - semicolon-terminated or ending before } - handles inline struct fields with optional variable names",
+					"match": "(?:\\s*((?:\\w+\\s*,\\s*)*\\w+\\s+)?([^\\s;`\\\"\\/}\\r\\n][^;`\\\"\\/}\\r\\n]*)(?:\\;|(?=\\})))",
 					"captures": {
 						"1": {
 							"patterns": [


### PR DESCRIPTION
## Summary
- narrow the inline struct semicolon field rule in the xgo TextMate grammar
- avoid catastrophic regex behavior when Shiki tokenizes nested function types with inline struct parameters
- preserve normal highlighting for representative semicolon-separated struct fields

## Testing
- verified the updated grammar file parses without errors
- reproduced the original pathological input in an isolated Shiki harness and confirmed `codeToTokens` and `codeToHtml` complete successfully after the grammar change
- verified a representative `type T struct{X_0 int; X_1 float64}` sample still produces highlighted HTML

Closes #2932
