### PR TITLE
Support project type in models & apis

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -207,6 +207,12 @@ paths:
                 displayName:
                   description: Defaults to `name` if not provided.
                   $ref: "#/components/schemas/Project/properties/displayName"
+                type:
+                  description: |
+                    Project type.
+
+                    If omitted, the request defaults to `game` for backward compatibility.
+                  $ref: "#/components/schemas/Project/properties/type"
                 files:
                   description: |
                     File paths and their corresponding universal URLs associated with the project.
@@ -287,6 +293,11 @@ paths:
           in: query
           schema:
             $ref: "#/components/schemas/Project/properties/visibility"
+        - name: type
+          description: Filter projects by project type.
+          in: query
+          schema:
+            $ref: "#/components/schemas/Project/properties/type"
         - name: liker
           description: Filter projects liked by the specified user.
           in: query
@@ -2607,6 +2618,14 @@ components:
           type: string
           examples:
             - NiuXiaoQi
+        type:
+          description: |
+            Type of the project.
+
+            When omitted in legacy data, it should be interpreted as `game` for backward compatibility.
+          type: string
+          examples:
+            - game
         displayName:
           description: Display name of the project.
           type: string

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -2624,6 +2624,8 @@ components:
 
             When omitted in legacy data, it should be interpreted as `game` for backward compatibility.
           type: string
+          enum:
+            - game
           examples:
             - game
         displayName:

--- a/spx-gui/src/apis/project.ts
+++ b/spx-gui/src/apis/project.ts
@@ -13,6 +13,15 @@ export enum ProjectDataType {
   Sound = 2
 }
 
+export enum ProjectType {
+  /** 2D game project based on spx. */
+  Game = 'game'
+}
+
+export function isSupportedProjectType(type: string | null | undefined): type is ProjectType.Game {
+  return type == null || type === ProjectType.Game
+}
+
 /** Source of extra settings of the project. */
 export const enum ProjectExtraSettingsSource {
   /** Settings generated automatically by the system (e.g., via AI analysis). */
@@ -49,6 +58,8 @@ export type ProjectData = {
   latestRelease: ProjectRelease | null
   /** Unique name of the project */
   name: string
+  /** Type of the project */
+  type: ProjectType
   /** Display name of the project */
   displayName: string
   /** Version number of the project */
@@ -76,7 +87,7 @@ export type ProjectData = {
 }
 
 export type AddProjectByRemixParams = Prettify<
-  Pick<ProjectData, 'name' | 'visibility'> &
+  Pick<ProjectData, 'name' | 'visibility' | 'type'> &
     Partial<Pick<ProjectData, 'displayName'>> & {
       /** Full name of the project or project release to remix from. */
       remixSource: string
@@ -84,7 +95,7 @@ export type AddProjectByRemixParams = Prettify<
 >
 
 export type AddProjectParams = Prettify<
-  Pick<ProjectData, 'name' | 'files' | 'visibility' | 'thumbnail'> & Partial<Pick<ProjectData, 'displayName'>>
+  Pick<ProjectData, 'name' | 'files' | 'visibility' | 'thumbnail' | 'type'> & Partial<Pick<ProjectData, 'displayName'>>
 >
 
 export function addProject(params: AddProjectParams | AddProjectByRemixParams, signal?: AbortSignal) {
@@ -122,6 +133,8 @@ export type ListProjectParams = PaginationParams & {
   keyword?: string
   /** Filter projects by visibility */
   visibility?: Visibility
+  /** Filter projects by type */
+  type?: ProjectType
   /** Filter projects liked by the specified user */
   liker?: string
   /** Filter projects that were created after this timestamp */
@@ -157,15 +170,17 @@ export enum ExploreOrder {
 export type ExploreParams = {
   order: ExploreOrder
   count: number
+  type: ProjectType
 }
 
 /** Get project list for explore purpose */
-export async function exploreProjects({ order, count }: ExploreParams) {
+export async function exploreProjects({ order, count, type }: ExploreParams) {
   // count within the last 6 months
   const countAfter = timeStringify(dayjs().subtract(6, 'month').valueOf())
   const p: ListProjectParams = {
     visibility: Visibility.Public,
     owner: ownerAll,
+    type,
     pageSize: count,
     pageIndex: 1
   }

--- a/spx-gui/src/apis/project.ts
+++ b/spx-gui/src/apis/project.ts
@@ -18,8 +18,8 @@ export enum ProjectType {
   Game = 'game'
 }
 
-export function isSupportedProjectType(type: string | null | undefined): type is ProjectType.Game {
-  return type == null || type === ProjectType.Game
+export function isSupportedProjectType(type: string | null | undefined): boolean {
+  return type === ProjectType.Game
 }
 
 /** Source of extra settings of the project. */

--- a/spx-gui/src/components/editor/editing.test.ts
+++ b/spx-gui/src/components/editor/editing.test.ts
@@ -5,7 +5,7 @@ import { timeout } from '@/utils/utils'
 import { Cancelled } from '@/utils/exception'
 import { ProgressReporter } from '@/utils/progress'
 import type { QueryRet } from '@/utils/query'
-import { Visibility, type ProjectData } from '@/apis/project'
+import { ProjectType, Visibility, type ProjectData } from '@/apis/project'
 import { type Files } from '@/models/common/file'
 import type { CloudHelpers, PreferPublishedContent } from '@/models/common/cloud'
 import { mockFile, MockProject } from '@/models/common/test'
@@ -43,6 +43,7 @@ function makeCloudSerialized(owner: string, name: string, version: number = 1): 
       owner,
       remixedFrom: null,
       name,
+      type: ProjectType.Game,
       displayName: name,
       version,
       visibility: Visibility.Private,

--- a/spx-gui/src/components/project/ProjectCreateModal.vue
+++ b/spx-gui/src/components/project/ProjectCreateModal.vue
@@ -48,7 +48,7 @@ import {
   useForm,
   type FormValidationResult
 } from '@/components/ui'
-import { getProject, addProject, Visibility, parseRemixSource } from '@/apis/project'
+import { getProject, addProject, ProjectType, Visibility, parseRemixSource } from '@/apis/project'
 import { useI18n } from '@/utils/i18n'
 import { useMessageHandle } from '@/utils/exception'
 import { untilLoaded } from '@/utils/query'
@@ -93,6 +93,8 @@ const handleSubmit = useMessageHandle(
       await addProject({
         name: projectName,
         displayName: projectName,
+        // This modal will own project type selection in a later design.
+        type: ProjectType.Game,
         visibility: Visibility.Private,
         remixSource: props.remixSource
       })

--- a/spx-gui/src/components/project/ProjectOpenModal.vue
+++ b/spx-gui/src/components/project/ProjectOpenModal.vue
@@ -4,7 +4,7 @@ import ListResultWrapper from '@/components/common/ListResultWrapper.vue'
 import ProjectItem from '@/components/project/ProjectItem.vue'
 import { computed, shallowRef } from 'vue'
 import { useQuery } from '@/utils/query'
-import { listProject } from '@/apis/project'
+import { listProject, ProjectType } from '@/apis/project'
 
 const props = defineProps<{
   visible: boolean
@@ -22,6 +22,8 @@ const pageTotal = computed(() => Math.ceil((queryRet.data.value?.total ?? 0) / p
 const queryRet = useQuery(
   () =>
     listProject({
+      // This modal will list projects across types in a later design.
+      type: ProjectType.Game,
       orderBy: 'updatedAt',
       sortOrder: 'desc',
       pageIndex: page.value,

--- a/spx-gui/src/models/common/cloud.ts
+++ b/spx-gui/src/models/common/cloud.ts
@@ -7,7 +7,14 @@ import { ConcurrencyLimitController } from '@/utils/concurrency-limit'
 import { selectFile, selectFiles, type FileSelectOptions } from '@/utils/file'
 import type { WebUrl, UniversalUrl, FileCollection, UniversalToWebUrlMap } from '@/apis/common'
 import type { ProjectData } from '@/apis/project'
-import { Visibility, addProject, getProject, type UpdateProjectParams, updateProject } from '@/apis/project'
+import {
+  isSupportedProjectType,
+  Visibility,
+  addProject,
+  getProject,
+  type UpdateProjectParams,
+  updateProject
+} from '@/apis/project'
 import { getUpInfo, makeObjectUrls, type UpInfo as RawUpInfo } from '@/apis/util'
 import { DefaultException, TimeoutException } from '@/utils/exception'
 import { getUphostsByRegion } from '@/utils/kodo'
@@ -55,6 +62,12 @@ async function load(
       }
     }
   }
+  if (!isSupportedProjectType(projectData.type)) {
+    throw new DefaultException({
+      en: `The project type "${projectData.type}" is not supported.`,
+      zh: `该项目类型暂不支持：${projectData.type}。`
+    })
+  }
   return parseProjectData(projectData)
 }
 
@@ -65,10 +78,11 @@ export function getPublishedContent(project: ProjectData) {
 }
 
 async function save(metadata: PartialMetadata, files: Files, signal?: AbortSignal) {
-  const { owner, name, displayName, id } = metadata
+  const { owner, name, displayName, id, type } = metadata
   if (owner == null) throw new Error('owner expected')
   if (!name) throw new DefaultException({ en: 'project name not specified', zh: '未指定项目名' })
   if (!displayName) throw new DefaultException({ en: 'project display name not specified', zh: '未指定项目显示名' })
+  if (type == null) throw new DefaultException({ en: 'project type not specified', zh: '未指定项目类型' })
 
   const aiDescriptionFiles = createAIDescriptionFiles(metadata)
   const filesToSave = { ...files, ...aiDescriptionFiles }
@@ -96,7 +110,17 @@ async function save(metadata: PartialMetadata, files: Files, signal?: AbortSigna
         }
         return updateProject(owner, name, updateParams, signal)
       })()
-    : addProject({ name, displayName, visibility, thumbnail: thumbnailUniversalUrl, files: fileCollection }, signal))
+    : addProject(
+        {
+          name,
+          displayName,
+          visibility,
+          thumbnail: thumbnailUniversalUrl,
+          files: fileCollection,
+          type
+        },
+        signal
+      ))
   signal?.throwIfAborted()
 
   metadata = { ...savedMetadata, thumbnail: metadata.thumbnail }

--- a/spx-gui/src/models/common/local.ts
+++ b/spx-gui/src/models/common/local.ts
@@ -1,4 +1,5 @@
 import localforage from 'localforage'
+import { ProjectType } from '@/apis/project'
 import type { PartialMetadata, ProjectSerialized } from '../project'
 import { File, type Files, type Metadata as FileMetadata } from './file'
 
@@ -94,6 +95,7 @@ async function load(key: string, signal?: AbortSignal) {
   signal?.throwIfAborted()
   if (metadataEx == null) return null
   const { files: fileList, thumbnail: rawThumbnail, ...metadata } = metadataEx
+  if (metadata.type == null) metadata.type = ProjectType.Game // Default to Game type for backward compatibility
   const files: Files = {}
   await Promise.all(
     fileList.map(async (path) => {

--- a/spx-gui/src/models/common/local.ts
+++ b/spx-gui/src/models/common/local.ts
@@ -1,5 +1,6 @@
 import localforage from 'localforage'
-import { ProjectType } from '@/apis/project'
+import { isSupportedProjectType, ProjectType } from '@/apis/project'
+import { DefaultException } from '@/utils/exception'
 import type { PartialMetadata, ProjectSerialized } from '../project'
 import { File, type Files, type Metadata as FileMetadata } from './file'
 
@@ -96,6 +97,12 @@ async function load(key: string, signal?: AbortSignal) {
   if (metadataEx == null) return null
   const { files: fileList, thumbnail: rawThumbnail, ...metadata } = metadataEx
   if (metadata.type == null) metadata.type = ProjectType.Game // Default to Game type for backward compatibility
+  if (!isSupportedProjectType(metadata.type)) {
+    throw new DefaultException({
+      en: `The project type "${metadata.type}" is not supported.`,
+      zh: `该项目类型暂不支持：${metadata.type}。`
+    })
+  }
   const files: Files = {}
   await Promise.all(
     fileList.map(async (path) => {

--- a/spx-gui/src/models/common/xbp.test.ts
+++ b/spx-gui/src/models/common/xbp.test.ts
@@ -5,6 +5,7 @@ import { Sound } from '../spx/sound'
 import { Costume } from '../spx/costume'
 import { fromText, toText } from './file'
 import { SpxProject } from '../spx/project'
+import { ProjectType } from '@/apis/project'
 import { load, save } from './xbp'
 
 vi.mock('@/apis/ai-description', () => ({
@@ -64,6 +65,7 @@ describe('save & load', () => {
     const project2 = new SpxProject(undefined, 'test2')
     await project2.load(loaded)
     expect(project2.name).toBe('test2')
+    expect(project2.type).toBe(ProjectType.Game)
     expect(project2.displayName).toBe('Test Project')
     expect(project2.description).toBe('test description')
     expect(project2.instructions).toBe('test instructions')

--- a/spx-gui/src/models/common/xbp.test.ts
+++ b/spx-gui/src/models/common/xbp.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi } from 'vitest'
+import { DefaultException } from '@/utils/exception'
 import { Sprite } from '../spx/sprite'
 import { Animation } from '../spx/animation'
 import { Sound } from '../spx/sound'
@@ -7,6 +8,7 @@ import { fromText, toText } from './file'
 import { SpxProject } from '../spx/project'
 import { ProjectType } from '@/apis/project'
 import { load, save } from './xbp'
+import { unzip, zip } from '@/utils/zip'
 
 vi.mock('@/apis/ai-description', () => ({
   generateAIDescription: vi.fn().mockResolvedValue('Mocked AI description for testing')
@@ -30,6 +32,21 @@ function makeProject(name?: string, screenshotTaker = async () => mockFile()) {
   project.addSprite(sprite)
   project.bindScreenshotTaker(screenshotTaker)
   return project
+}
+
+async function rewriteBuilderMetadata(
+  projectFile: File,
+  rewrite: (metadata: Record<string, unknown>) => Record<string, unknown>
+) {
+  const arrayBuffer = await projectFile.arrayBuffer()
+  const unzipped = await unzip(new Uint8Array(arrayBuffer))
+  const metadataFileName = 'builder-meta.json'
+  const metadataBytes = unzipped[metadataFileName]
+  expect(metadataBytes).toBeDefined()
+  const metadata = JSON.parse(new TextDecoder().decode(metadataBytes)) as Record<string, unknown>
+  unzipped[metadataFileName] = new TextEncoder().encode(JSON.stringify(rewrite(metadata)))
+  const zipped = await zip(unzipped)
+  return new File([zipped], projectFile.name, { type: projectFile.type })
 }
 
 describe('save', () => {
@@ -69,6 +86,40 @@ describe('save & load', () => {
     expect(project2.displayName).toBe('Test Project')
     expect(project2.description).toBe('test description')
     expect(project2.instructions).toBe('test instructions')
+  })
+
+  it('should default missing metadata type to game when loading', async () => {
+    const project = makeProject('test')
+    const { metadata, files } = await project.export()
+    const projectFile = await save(metadata, files)
+    const legacyProjectFile = await rewriteBuilderMetadata(projectFile, (builderMetadata) => {
+      const { type: _type, ...rest } = builderMetadata
+      return rest
+    })
+
+    const loaded = await load(legacyProjectFile)
+    const project2 = new SpxProject(undefined, 'test2')
+    await project2.load(loaded)
+
+    expect(project2.type).toBe(ProjectType.Game)
+  })
+
+  it('should reject unsupported metadata type when loading', async () => {
+    const project = makeProject('test')
+    const { metadata, files } = await project.export()
+    const projectFile = await save(metadata, files)
+    const invalidProjectFile = await rewriteBuilderMetadata(projectFile, (builderMetadata) => ({
+      ...builderMetadata,
+      type: 'unknown'
+    }))
+
+    await expect(load(invalidProjectFile)).rejects.toBeInstanceOf(DefaultException)
+    await expect(load(invalidProjectFile)).rejects.toMatchObject({
+      userMessage: {
+        en: 'The project type "unknown" is not supported.',
+        zh: '该项目类型暂不支持：unknown。'
+      }
+    })
   })
 
   it('should save & load project with thumbnail correctly', async () => {

--- a/spx-gui/src/models/common/xbp.ts
+++ b/spx-gui/src/models/common/xbp.ts
@@ -9,6 +9,8 @@
 import { zip, unzip, type Zippable } from '@/utils/zip'
 import { filename, stripExt } from '@/utils/path'
 import { getExtFromMime } from '@/utils/file'
+import { DefaultException } from '@/utils/exception'
+import { isSupportedProjectType, ProjectType } from '@/apis/project'
 import { File as LazyFile, toConfig, type Files as LazyFiles } from './file'
 import type { PartialMetadata, ProjectSerialized } from '../project'
 import { createAIDescriptionFiles, extractAIDescription } from './'
@@ -38,7 +40,14 @@ export async function load(xbpFile: File) {
       const uint8Array = unzipped[path]
       const file = new LazyFile(filename(path), () => Promise.resolve(uint8Array.buffer))
       if (path === metadataFileName) {
-        const m = await toConfig(file)
+        const m = (await toConfig(file)) as PartialMetadata
+        if (m.type == null) m.type = ProjectType.Game // Default to Game type for backward compatibility
+        if (!isSupportedProjectType(m.type)) {
+          throw new DefaultException({
+            en: `The project type "${m.type}" is not supported.`,
+            zh: `该项目类型暂不支持：${m.type}。`
+          })
+        }
         Object.assign(metadata, m)
         return
       }
@@ -61,6 +70,7 @@ export async function save(metadata: PartialMetadata, files: LazyFiles, signal?:
   const zippable: Zippable = {}
 
   const metadataJson = JSON.stringify({
+    type: metadata.type,
     displayName: metadata.displayName,
     description: metadata.description,
     instructions: metadata.instructions,

--- a/spx-gui/src/models/spx/project.test.ts
+++ b/spx-gui/src/models/spx/project.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest'
+import { ProjectType } from '@/apis/project'
 import { Sprite } from './sprite'
 import { Animation } from './animation'
 import { Sound } from './sound'
@@ -110,6 +111,7 @@ describe('Project', () => {
     unbindScreenshotTaker()
 
     const { metadata } = await project.export()
+    expect(metadata.type).toBe(ProjectType.Game)
     expect(metadata.thumbnail).toBe(thumbnail)
   })
 

--- a/spx-gui/src/models/spx/project.ts
+++ b/spx-gui/src/models/spx/project.ts
@@ -10,7 +10,7 @@ import { debounce } from 'lodash'
 import { Disposable, getCleanupSignal } from '@/utils/disposable'
 import Mutex from '@/utils/mutex'
 import { Cancelled } from '@/utils/exception'
-import { Visibility, type ProjectExtraSettings } from '@/apis/project'
+import { ProjectType, Visibility, type ProjectExtraSettings } from '@/apis/project'
 import { toConfig, type Files, fromConfig, File, toText, getImageSize } from '../common/file'
 import { assign } from '../common'
 import { ensureValidSpriteName, ensureValidSoundName } from './common/asset-name'
@@ -103,6 +103,7 @@ export class SpxProject extends Disposable implements IProject {
   owner?: string
   remixedFrom?: string | null
   name?: string
+  type = ProjectType.Game
   displayName = ''
   version = 0
   visibility?: Visibility
@@ -387,6 +388,7 @@ export class SpxProject extends Disposable implements IProject {
       updatedAt: this.updatedAt,
       owner: this.owner,
       name: this.name,
+      type: this.type,
       displayName: this.displayName,
       version: this.version,
       visibility: this.visibility,

--- a/spx-gui/src/pages/community/explore.vue
+++ b/spx-gui/src/pages/community/explore.vue
@@ -28,7 +28,7 @@
 import { useQuery } from '@/utils/query'
 import { useRouteQueryParamStrEnum } from '@/utils/route'
 import { usePageTitle } from '@/utils/utils'
-import { exploreProjects, ExploreOrder as Order } from '@/apis/project'
+import { exploreProjects, ExploreOrder as Order, ProjectType } from '@/apis/project'
 import { UIChipRadioGroup, UIChipRadio } from '@/components/ui'
 import ListResultWrapper from '@/components/common/ListResultWrapper.vue'
 import CenteredWrapper from '@/components/community/CenteredWrapper.vue'
@@ -55,7 +55,8 @@ const queryRet = useQuery(
     if (order.value === Order.FollowingCreated) await ensureSignedIn()
     return exploreProjects({
       order: order.value,
-      count: maxCount
+      count: maxCount,
+      type: ProjectType.Game
     })
   },
   {

--- a/spx-gui/src/pages/community/home.vue
+++ b/spx-gui/src/pages/community/home.vue
@@ -119,7 +119,7 @@
 import { computed } from 'vue'
 import { useQuery } from '@/utils/query'
 import { usePageTitle } from '@/utils/utils'
-import { ExploreOrder, exploreProjects, listProject } from '@/apis/project'
+import { ExploreOrder, ProjectType, exploreProjects, listProject } from '@/apis/project'
 import { getExploreRoute, getUserPageRoute } from '@/router'
 import { isSignedIn, useSignedInUser } from '@/stores/user'
 import { useResponsive } from '@/components/ui'
@@ -144,6 +144,7 @@ const myProjects = useQuery(
   async () => {
     if (!isSignedIn()) return []
     const { data: projects } = await listProject({
+      type: ProjectType.Game,
       pageIndex: 1,
       pageSize: numInRow.value,
       orderBy: 'updatedAt',
@@ -157,14 +158,14 @@ const myProjects = useQuery(
 const communityLikingRoute = getExploreRoute(ExploreOrder.MostLikes)
 
 const communityLikingProjects = useQuery(
-  () => exploreProjects({ order: ExploreOrder.MostLikes, count: numInRow.value }),
+  () => exploreProjects({ type: ProjectType.Game, order: ExploreOrder.MostLikes, count: numInRow.value }),
   { en: 'Failed to load projects', zh: '加载失败' }
 )
 
 const communityRemixingRoute = getExploreRoute(ExploreOrder.MostRemixes)
 
 const communityRemixingProjects = useQuery(
-  () => exploreProjects({ order: ExploreOrder.MostRemixes, count: numInRow.value }),
+  () => exploreProjects({ type: ProjectType.Game, order: ExploreOrder.MostRemixes, count: numInRow.value }),
   { en: 'Failed to load projects', zh: '加载失败' }
 )
 
@@ -173,7 +174,7 @@ const followingCreatedRoute = computed(() => getExploreRoute(ExploreOrder.Follow
 const followingCreatedProjects = useQuery(
   async () => {
     if (!isSignedIn()) return []
-    return exploreProjects({ order: ExploreOrder.FollowingCreated, count: numInRow.value })
+    return exploreProjects({ type: ProjectType.Game, order: ExploreOrder.FollowingCreated, count: numInRow.value })
   },
   { en: 'Failed to load projects', zh: '加载失败' }
 )

--- a/spx-gui/src/pages/community/project.vue
+++ b/spx-gui/src/pages/community/project.vue
@@ -8,7 +8,14 @@ import { humanizeCount, humanizeExactCount, untilNotNull } from '@/utils/utils'
 import { useEnsureSignedIn } from '@/utils/user'
 import { isSignInRequiredForProject } from '@/utils/project'
 import { usePageTitle } from '@/utils/utils'
-import { ownerAll, recordProjectView, stringifyProjectFullName, stringifyRemixSource, Visibility } from '@/apis/project'
+import {
+  ProjectType,
+  ownerAll,
+  recordProjectView,
+  stringifyProjectFullName,
+  stringifyRemixSource,
+  Visibility
+} from '@/apis/project'
 import { listProject } from '@/apis/project'
 import { listReleases } from '@/apis/project-release'
 import { SpxProject, type CloudProject } from '@/models/spx/project'
@@ -308,6 +315,7 @@ const remixNumInRow = computed(() => (isDesktopLarge.value ? 6 : 5))
 const remixesRet = useQuery(
   async () => {
     const { data: projects } = await listProject({
+      type: ProjectType.Game,
       visibility: Visibility.Public,
       owner: ownerAll,
       remixedFrom: stringifyRemixSource(props.ownerInput, props.nameInput),

--- a/spx-gui/src/pages/community/search.vue
+++ b/spx-gui/src/pages/community/search.vue
@@ -65,7 +65,7 @@ export const searchKeywordQueryParamName = 'q'
 import { computed } from 'vue'
 import { useRouteQueryParamInt, useRouteQueryParamStr, useRouteQueryParamStrEnum } from '@/utils/route'
 import { useQuery } from '@/utils/query'
-import { Visibility, listProject, ownerAll, type ListProjectParams } from '@/apis/project'
+import { ProjectType, Visibility, listProject, ownerAll, type ListProjectParams } from '@/apis/project'
 import { usePageTitle } from '@/utils/utils'
 import { UISelect, UISelectOption, UIPagination, useResponsive } from '@/components/ui'
 import ListResultWrapper from '@/components/common/ListResultWrapper.vue'
@@ -99,6 +99,7 @@ const pageTotal = computed(() => Math.ceil((queryRet.data.value?.total ?? 0) / p
 
 const listParams = computed<ListProjectParams>(() => {
   const p: ListProjectParams = {
+    type: ProjectType.Game,
     visibility: Visibility.Public,
     owner: ownerAll,
     pageSize: pageSize.value,

--- a/spx-gui/src/pages/community/user/likes.vue
+++ b/spx-gui/src/pages/community/user/likes.vue
@@ -3,7 +3,7 @@ import { computed } from 'vue'
 import { useRouteQueryParamInt } from '@/utils/route'
 import { useQuery } from '@/utils/query'
 import { usePageTitle } from '@/utils/utils'
-import { Visibility, listProject, ownerAll } from '@/apis/project'
+import { ProjectType, Visibility, listProject, ownerAll } from '@/apis/project'
 import { useUser } from '@/stores/user'
 import { UIPagination, useResponsive } from '@/components/ui'
 import ListResultWrapper from '@/components/common/ListResultWrapper.vue'
@@ -32,6 +32,7 @@ const pageTotal = computed(() => Math.ceil((queryRet.data.value?.total ?? 0) / p
 const queryRet = useQuery(
   () =>
     listProject({
+      type: ProjectType.Game,
       visibility: Visibility.Public,
       owner: ownerAll,
       liker: props.nameInput,

--- a/spx-gui/src/pages/community/user/overview.vue
+++ b/spx-gui/src/pages/community/user/overview.vue
@@ -3,7 +3,7 @@ import { computed } from 'vue'
 import { getUserPageRoute } from '@/router'
 import { useQuery } from '@/utils/query'
 import { usePageTitle } from '@/utils/utils'
-import { Visibility, listProject, ownerAll } from '@/apis/project'
+import { ProjectType, Visibility, listProject, ownerAll } from '@/apis/project'
 import { useSignedInUser, useUser } from '@/stores/user'
 import { useResponsive } from '@/components/ui'
 import CommunityCard from '@/components/community/CommunityCard.vue'
@@ -38,6 +38,7 @@ const projectsRoute = computed(() => {
 const projectsRet = useQuery(
   async () => {
     const { data: projects } = await listProject({
+      type: ProjectType.Game,
       owner: props.nameInput,
       pageIndex: 1,
       pageSize: numInRow.value,
@@ -56,6 +57,7 @@ const likesRoute = computed(() => {
 const likesRet = useQuery(
   async () => {
     const { data: likes } = await listProject({
+      type: ProjectType.Game,
       visibility: Visibility.Public,
       owner: ownerAll,
       liker: props.nameInput,

--- a/spx-gui/src/pages/community/user/projects.vue
+++ b/spx-gui/src/pages/community/user/projects.vue
@@ -6,7 +6,7 @@ import { useMessageHandle } from '@/utils/exception'
 import { useQuery } from '@/utils/query'
 import { usePageTitle } from '@/utils/utils'
 import { useEnsureSignedIn } from '@/utils/user'
-import { Visibility, listProject, type ListProjectParams } from '@/apis/project'
+import { ProjectType, Visibility, listProject, type ListProjectParams } from '@/apis/project'
 import { getOwnProjectEditorRoute } from '@/router'
 import { useSignedInUser, useUser } from '@/stores/user'
 import { UISelect, UISelectOption, UIPagination, UIButton, useResponsive } from '@/components/ui'
@@ -48,6 +48,7 @@ const order = useRouteQueryParamStrEnum('o', Order, Order.RecentlyUpdated, (kvs)
 
 const listParams = computed<ListProjectParams>(() => {
   const p: ListProjectParams = {
+    type: ProjectType.Game,
     owner: props.nameInput,
     pageSize: pageSize.value,
     pageIndex: page.value


### PR DESCRIPTION
Update #2802.

## Scope

This PR only adds project type support in the models and APIs layers.

The UI layer, including routing and user-facing flows, still assumes `type: game` for now. Broader multi-project-type UI support will be handled in a separate change.

## Dependency

This PR depends on goplus/builder-backend#182 being merged first.
