### PR TITLE
Improve hover display behavior

### DIFF
--- a/spx-gui/src/components/editor/code-editor/spx-code-editor/ui/resource/SpxResourceItem.vue
+++ b/spx-gui/src/components/editor/code-editor/spx-code-editor/ui/resource/SpxResourceItem.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed } from 'vue'
+import { capture } from '@/utils/exception'
 import { Animation } from '@/models/spx/animation'
 import { Backdrop } from '@/models/spx/backdrop'
 import { Costume } from '@/models/spx/costume'
@@ -14,7 +15,7 @@ import SpriteItem from '@/components/editor/sprite/SpriteItem.vue'
 import BackdropItem from '@/components/editor/stage/backdrop/BackdropItem.vue'
 import WidgetItem from '@/components/editor/stage/widget/WidgetItem.vue'
 import type { ResourceIdentifier } from '../../../xgo-code-editor'
-import { getResourceModel } from '../../common'
+import { getResourceModel, getResourceNameWithType } from '../../common'
 
 const props = withDefaults(
   defineProps<{
@@ -30,6 +31,14 @@ const props = withDefaults(
 
 const editorCtx = useEditorCtx()
 const model = computed(() => getResourceModel(editorCtx.project, props.resource))
+const name = computed(() => {
+  try {
+    return getResourceNameWithType(props.resource.uri).name
+  } catch (err) {
+    capture(err, `Failed to resolve resource URI: ${props.resource.uri}`)
+    return props.resource.uri
+  }
+})
 </script>
 
 <template>
@@ -51,6 +60,7 @@ const model = computed(() => getResourceModel(editorCtx.project, props.resource)
     :autoplay="autoplay"
   />
   <WidgetItem v-else-if="model != null && isWidget(model)" :widget="model" :selectable="selectable" color="primary" />
+  <div v-else>{{ $t({ zh: `未知资源（${name}）`, en: `Unknown resource (${name})` }) }}</div>
 </template>
 
 <style lang="scss" scoped></style>

--- a/spx-gui/src/components/editor/code-editor/xgo-code-editor/ui/hover/HoverCard.vue
+++ b/spx-gui/src/components/editor/code-editor/xgo-code-editor/ui/hover/HoverCard.vue
@@ -59,7 +59,6 @@ const handleAction = useMessageHandle(
 .body {
   display: flex;
   flex-direction: column;
-  gap: 8px;
   min-width: 250px;
   max-width: 328px;
   min-height: 0;

--- a/spx-gui/src/components/editor/code-editor/xgo-code-editor/ui/hover/HoverUI.vue
+++ b/spx-gui/src/components/editor/code-editor/xgo-code-editor/ui/hover/HoverUI.vue
@@ -70,7 +70,6 @@ useDecorations(() => {
   >
     <HoverCard
       v-if="controller.hover != null"
-      :contents="controller.hover.contents"
       :actions="controller.hover.actions"
       @mouseenter="controller.emit('cardMouseEnter')"
       @mouseleave="controller.emit('cardMouseLeave')"

--- a/spx-gui/src/components/editor/code-editor/xgo-code-editor/ui/hover/index.ts
+++ b/spx-gui/src/components/editor/code-editor/xgo-code-editor/ui/hover/index.ts
@@ -64,8 +64,6 @@ export class HoverController extends Emitter<{
     if (textDocument == null) return null
 
     const diagnosticsHover = this.getDiagnosticsHover(textDocument, position)
-    if (diagnosticsHover != null) return diagnosticsHover
-
     const providedHover = await this.provider.provideHover({ textDocument, signal }, position)
     let providedInternalHover: InternalHover | null = null
     if (providedHover != null) {
@@ -76,15 +74,15 @@ export class HoverController extends Emitter<{
     const inputHelperHover = this.getInputHelperHover(position)
 
     let hover: InternalHover | null = null
-    ;[
+    for (const hoverItem of [
       // These three items from high priority to low priority are checked in order:
       // * Contents from higher-priority item will be used
       // * Actions from all items (with the same range) will be merged
       inputHelperHover,
       resourceReferenceHover,
       providedInternalHover
-    ].forEach((hoverItem) => {
-      if (hoverItem == null) return
+    ]) {
+      if (hoverItem == null) continue
       if (hover == null) {
         hover = {
           contents: [],
@@ -92,10 +90,17 @@ export class HoverController extends Emitter<{
           actions: []
         }
       }
-      if (!rangeEq(hoverItem.range, hover.range)) return
-      if (hover.contents.length === 0) hover.contents = hoverItem.contents
+      if (!rangeEq(hoverItem.range, hover.range)) continue
+      if (hover.contents.length === 0) hover.contents = [...hoverItem.contents]
       hover.actions.push(...hoverItem.actions)
-    })
+    }
+
+    if (diagnosticsHover != null) {
+      if (hover == null) return diagnosticsHover
+      // Show diagnostics after the main hover content, but keep its action first as it is usually higher priority.
+      hover.contents.push(...diagnosticsHover.contents)
+      hover.actions.unshift(...diagnosticsHover.actions)
+    }
 
     return hover
   })

--- a/spx-gui/src/components/editor/code-editor/xgo-code-editor/ui/markdown/DiagnosticItem.vue
+++ b/spx-gui/src/components/editor/code-editor/xgo-code-editor/ui/markdown/DiagnosticItem.vue
@@ -8,7 +8,7 @@ defineProps<{
 </script>
 
 <template>
-  <div class="diagnostic-item">
+  <div class="diagnostic-item" :class="`severity-${severity}`">
     <UIIcon class="icon" :type="severity" />
     <div class="body">
       <slot></slot>
@@ -18,10 +18,19 @@ defineProps<{
 
 <style lang="scss" scoped>
 .diagnostic-item {
+  padding: 6px 8px;
   display: flex;
   align-items: flex-start;
   gap: 8px;
   align-self: stretch;
+  border-radius: 8px;
+
+  &.severity-warning {
+    background-color: var(--ui-color-yellow-200);
+  }
+  &.severity-error {
+    background-color: var(--ui-color-red-100);
+  }
 }
 
 .icon {
@@ -30,6 +39,5 @@ defineProps<{
 
 .body {
   flex: 1;
-  color: var(--ui-color-grey-1000);
 }
 </style>


### PR DESCRIPTION
Closes #2978

## Summary

This PR improves hover content display in the code editor.

When diagnostics and other hover sources such as input helper or resource reference are available at the same position, the hover now shows both instead of showing only diagnostics.

## Notes

The exact UI presentation details can still be refined later. This PR focuses on landing the current behavior improvement first.

This PR relies on the corresponding language server change that has already landed in goplus/xgolsw:
- https://github.com/goplus/xgolsw/commit/e55c3441db54dedaeafda0119a852c93cdfe85a3

The hover trigger fix has been split into a separate PR and is no longer part of this PR.

## Validation

- Checked file-level diagnostics for the modified hover-related frontend files
- Verified the PR scope only covers the hover content display changes
