### PR TITLE
Fix occasional missed hover trigger

### DIFF
--- a/spx-gui/src/components/editor/code-editor/xgo-code-editor/ui/hover/index.ts
+++ b/spx-gui/src/components/editor/code-editor/xgo-code-editor/ui/hover/index.ts
@@ -222,8 +222,8 @@ export class HoverController extends Emitter<{
           handleMouseEnter({ type: 'other' })
           return
         }
-        if (e.target.range.isEmpty()) {
-          // target with type `CONTENT_TEXT` & empty range stands for special contents, like decorations
+        if (e.target.detail.mightBeForeignElement) {
+          // `mightBeForeignElement` indicates injected or foreign content like inlay hint decorations.
           handleMouseEnter({ type: 'other' })
           return
         }


### PR DESCRIPTION
Refs #2978

## Summary

This PR only fixes the hover trigger issue in the code editor.

When the pointer is near the middle between two characters, Monaco may still report a `CONTENT_TEXT` target while the previous `range.isEmpty()` check can classify the target in a way that causes the hover popup to be skipped unexpectedly.

This change switches that guard to `mightBeForeignElement`, which is a better fit for filtering injected or foreign content such as inlay-hint-like decorations while still allowing normal text hover to trigger reliably.

## Scope

This PR intentionally includes only the hover trigger fix.

The separate hover content display changes remain in:
- https://github.com/goplus/builder/pull/3004

## Validation

- Checked file-level diagnostics for the modified hover controller file
- Verified the diff only changes the hover trigger guard in `hover/index.ts`
