### PR TITLE
fix: remove non-scoped deep selector from UIFormItem

### DIFF
--- a/spx-gui/src/components/ui/form/UIFormItem.vue
+++ b/spx-gui/src/components/ui/form/UIFormItem.vue
@@ -77,11 +77,11 @@ const handleContentInput = debounce(() => {
     margin-top: 24px;
   }
 
-  .ui-form-item :deep(.n-form-item-feedback-wrapper) {
+  .ui-form-item .n-form-item-feedback-wrapper {
     line-height: 1.57143;
   }
 
-  .ui-form-item :deep(.n-form-item-feedback-wrapper):empty {
+  .ui-form-item .n-form-item-feedback-wrapper:empty {
     display: none;
   }
 }


### PR DESCRIPTION
## Summary

- remove invalid `:deep(...)` usage from the non-scoped style block in `UIFormItem`
- keep the feedback wrapper rules effective after the Tailwind migration
- confirm there are no other components in `spx-gui` using Vue `:deep` inside non-scoped `<style>` blocks

## Testing

- checked [spx-gui/src/components/ui/form/UIFormItem.vue](spx-gui/src/components/ui/form/UIFormItem.vue) for diagnostics
- scanned all `.vue` components in `spx-gui` for `:deep` usage and verified all real usages are inside `<style scoped>` blocks
