### PR TITLE
Add Copilot skills support

### DIFF
--- a/spx-gui/src/components/copilot/CopilotRoot.vue
+++ b/spx-gui/src/components/copilot/CopilotRoot.vue
@@ -1,37 +1,24 @@
 <script lang="ts">
 import { z } from 'zod'
-import dayjs from 'dayjs'
 import { debounce } from 'lodash'
-import { onBeforeUnmount, onMounted, onUnmounted, toValue, watch, type ComputedRef, type WatchSource } from 'vue'
+import { onBeforeUnmount, onUnmounted, toValue, watch, type WatchSource } from 'vue'
 import { useRouter, type Router } from 'vue-router'
 import { useRadar, type Radar, type RadarNodeInfo } from '@/utils/radar'
 import { useI18n, type I18n } from '@/utils/i18n'
 import { escapeHTML, unicodeSafeSlice, until } from '@/utils/utils'
 import { useIsRouteLoaded } from '@/utils/route-loading'
 import * as projectApis from '@/apis/project'
-import type { Sprite } from '@/models/spx/sprite'
-import { SpxProject } from '@/models/spx/project'
 import { useModalEvents } from '@/components/ui/modal/UIModalProvider.vue'
-import { useEditorCtxRef, type EditorCtx } from '../editor/EditorContextProvider.vue'
-import {
-  useCodeEditorRef,
-  getCodeFilePath,
-  isSelectionEmpty,
-  textDocumentId2CodeFileName,
-  type TextDocument,
-  CodeEditor
-} from '../editor/code-editor/spx-code-editor'
 import { useMessageEvents } from '../ui/message/UIMessageProvider.vue'
 import { Copilot, type ICopilotContextProvider, type SessionExported, type ToolDefinition } from './copilot'
 import * as pageLink from './custom-elements/PageLink'
 import * as highlightLink from './custom-elements/HighlightLink.vue'
 import * as codeLink from './custom-elements/CodeLink'
 import * as codeChange from './custom-elements/CodeChange.vue'
-import { codeFilePathSchema, parseProjectIdentifier, projectIdentifierSchema } from './common'
 import { useSignedInStateQuery, type SignedInState } from '@/stores/user'
 import { userSessionStorageRef } from '@/utils/user-storage'
-import { cloudHelpers, type CloudHelpers } from '@/models/common/cloud'
 import { provideCopilot } from './context'
+import { registerSkillSupport } from './skills'
 
 const listProjectsParamsSchema = z.object({
   owner: z
@@ -48,179 +35,7 @@ const listProjectsTool: ToolDefinition = {
   parameters: listProjectsParamsSchema,
   async implementation(params: z.infer<typeof listProjectsParamsSchema>) {
     const { total, data } = await projectApis.listProject(params)
-    return { total, data: data.map((p) => [p.owner, p.name].map(encodeURIComponent).join('/')) }
-  }
-}
-
-class Retriever {
-  constructor(
-    private editorCtxRef: ComputedRef<EditorCtx | undefined>,
-    private cloudHelpers: CloudHelpers
-  ) {}
-
-  async getProject(project: string | undefined, signal?: AbortSignal): Promise<SpxProject> {
-    const currentProject = this.editorCtxRef.value?.project
-    if (project == null) {
-      if (currentProject == null) throw new Error('No project specified and no current editing project available')
-      return currentProject
-    }
-    const { owner, name } = parseProjectIdentifier(project)
-    if (currentProject != null && currentProject.owner === owner && currentProject.name === name) {
-      return currentProject
-    }
-    const p = new SpxProject()
-    const serialized = await this.cloudHelpers.load(owner, name, true, signal)
-    await p.load(serialized)
-    return p
-  }
-}
-
-const getProjectMetadataParamsSchema = z.object({
-  project: projectIdentifierSchema
-})
-
-class GetProjectMetadataTool implements ToolDefinition {
-  name = 'get_project_metadata'
-  description = 'Get metadata of a project.'
-  parameters = getProjectMetadataParamsSchema
-
-  constructor(private retriever: Retriever) {}
-
-  async implementation({ project }: z.infer<typeof getProjectMetadataParamsSchema>, signal?: AbortSignal) {
-    const p = await this.retriever.getProject(project, signal)
-    const { owner: pOwner, remixedFrom, visibility, description, instructions } = p
-    return { owner: pOwner, remixedFrom, visibility, description, instructions }
-  }
-}
-
-function getProjectContent(project: SpxProject) {
-  const physics = project.stage.physics
-  return `\
-### Sprites (num: ${project.sprites.length})
-${project.sprites.map((sprite) => `- ${sprite.name}`).join('\n')}
-### Sounds (num: ${project.sounds.length})
-${project.sounds.map((sound) => `- ${sound.name}`).join('\n')}
-### Backdrops (num: ${project.stage.backdrops.length})
-${project.stage.backdrops.map((backdrop) => `- ${backdrop.name}`).join('\n')}
-### Widgets (num: ${project.stage.widgets.length})
-${project.stage.widgets.map((widget) => `- ${widget.name}`).join('\n')}
-### Physics: ${physics.enabled ? 'Enabled' : 'Disabled'}`
-}
-
-const getProjectContentParamsSchema = z.object({
-  project: projectIdentifierSchema
-})
-
-class GetProjectContentTool implements ToolDefinition {
-  name = 'get_project_content'
-  description = 'Get content of a project.'
-  parameters = getProjectContentParamsSchema
-
-  constructor(private retriever: Retriever) {}
-
-  async implementation({ project }: z.infer<typeof getProjectContentParamsSchema>, signal?: AbortSignal) {
-    const p = await this.retriever.getProject(project, signal)
-    return getProjectContent(p)
-  }
-}
-
-function getSpriteContent(sprite: Sprite) {
-  return {
-    name: sprite.name,
-    costumes: sprite.costumes.map((c) => c.name),
-    animations: sprite.animations.map((a) => a.name),
-    heading: sprite.heading,
-    x: sprite.x,
-    y: sprite.y,
-    size: sprite.size,
-    rotationStyle: sprite.rotationStyle,
-    visible: sprite.visible,
-    codeLinesNum: sprite.code.split(/\r?\n/).length
-  }
-}
-
-const getSpriteContentParamsSchema = z.object({
-  project: projectIdentifierSchema,
-  spriteName: z.string().describe('Name of the sprite')
-})
-
-class GetSpriteContentTool implements ToolDefinition {
-  name = 'get_sprite_content'
-  description = 'Get content of a sprite in a project.'
-  parameters = getSpriteContentParamsSchema
-
-  constructor(private retriever: Retriever) {}
-
-  async implementation({ project, spriteName }: z.infer<typeof getSpriteContentParamsSchema>, signal?: AbortSignal) {
-    const p = await this.retriever.getProject(project, signal)
-    const sprite = p.sprites.find((s) => s.name === spriteName)
-    if (sprite == null) throw new Error(`Sprite "${spriteName}" not found in project "${project}"`)
-    return getSpriteContent(sprite)
-  }
-}
-
-type LineRangeParams = {
-  /** 1-based */
-  lineStart?: number
-  /** 1-based */
-  lineEnd?: number
-}
-
-const lineStartSchema = z.number().default(1).describe('Line number to start from, 1-based')
-const lineEndSchema = z.number().optional().describe('Line number to end at, 1-based')
-
-/** Process code content and return in LLM-friendly format. */
-function processCode(code: string, { lineStart = 1, lineEnd }: LineRangeParams) {
-  const allLines = code.split(/\r?\n/)
-  const sampledLines = allLines.slice(lineStart - 1, lineEnd).reduce<Record<string, string>>((o, line, i) => {
-    o[i + lineStart] = line
-    return o
-  }, {})
-  return {
-    lineCount: allLines.length,
-    sampledLines
-  }
-}
-
-const getProjectCodeParamsSchema = z.object({
-  project: projectIdentifierSchema,
-  file: codeFilePathSchema,
-  lineStart: lineStartSchema,
-  lineEnd: lineEndSchema
-})
-
-class GetProjectCodeTool implements ToolDefinition {
-  name = 'get_project_code'
-  description = 'Get code content of a file in project.'
-  parameters = getProjectCodeParamsSchema
-
-  constructor(private retriever: Retriever) {}
-
-  async implementation(
-    { project, file, lineStart, lineEnd }: z.infer<typeof getProjectCodeParamsSchema>,
-    signal?: AbortSignal
-  ) {
-    const p = await this.retriever.getProject(project, signal)
-    if (p.stage.codeFilePath === file) return processCode(p.stage.code, { lineStart, lineEnd })
-    const sprite = p.sprites.find((s) => s.codeFilePath === file)
-    if (sprite == null) throw new Error(`Code file ${file} not found in project ${project}`)
-    return processCode(sprite.code, { lineStart, lineEnd })
-  }
-}
-
-const getCodeDiagnosticsParamsSchema = z.object({})
-
-class GetCodeDiagnosticsTool implements ToolDefinition {
-  name = 'get_code_diagnostics'
-  description = 'Get code diagnostics (errors or warnings) of current editing project.'
-  parameters = getCodeDiagnosticsParamsSchema
-
-  constructor(private codeEditorRef: ComputedRef<CodeEditor | null>) {}
-
-  async implementation(_: z.infer<typeof getCodeDiagnosticsParamsSchema>, signal?: AbortSignal) {
-    const codeEditor = this.codeEditorRef.value
-    if (codeEditor == null) throw new Error('Code editor is not available')
-    return codeEditor.diagnosticWorkspace(signal)
+    return { total, data: data.map((project) => [project.owner, project.name].map(encodeURIComponent).join('/')) }
   }
 }
 
@@ -237,7 +52,7 @@ class GetUINodeTextContentTool implements ToolDefinition {
 
   async implementation({ targetId }: z.infer<typeof getUINodeTextContentParamsSchema>) {
     const nodeInfo = this.radar.getNodeById(targetId)
-    if (!nodeInfo) throw new Error(`Radar node with ID ${targetId} not found.`)
+    if (nodeInfo == null) throw new Error(`Radar node with ID ${targetId} not found.`)
     const textContent = nodeInfo.getElement()?.textContent ?? ''
     return textContent.length > 500 ? unicodeSafeSlice(textContent, 0, 500) + '...' : textContent
   }
@@ -250,7 +65,6 @@ class UIContextProvider implements ICopilotContextProvider {
   ) {}
 
   private serializeNode(attrs: Record<string, string>, childrenStr: string) {
-    // TODO: use XMLSerializer?
     const attrsStr = Object.entries(attrs)
       .filter(([_, value]) => value != null && value !== '')
       .map(([key, value]) => `${key}="${escapeHTML(value)}"`)
@@ -273,8 +87,8 @@ class UIContextProvider implements ICopilotContextProvider {
     )
   }
 
-  private stringifyNodes(node: RadarNodeInfo[]): string {
-    return node.map((n) => this.stringifyNode(n)).join('')
+  private stringifyNodes(nodes: RadarNodeInfo[]): string {
+    return nodes.map((node) => this.stringifyNode(node)).join('')
   }
 
   provideContext(): string {
@@ -315,92 +129,10 @@ ${userInfo}`
 
 class LocationContextProvider implements ICopilotContextProvider {
   constructor(private router: Router) {}
+
   provideContext(): string {
     return `# Current location
 The user is now browsing page with path: \`${this.router.currentRoute.value.fullPath}\``
-  }
-}
-
-class ProjectContextProvider implements ICopilotContextProvider {
-  constructor(private editorCtxRef: ComputedRef<EditorCtx | undefined>) {}
-  provideContext(): string {
-    const project = this.editorCtxRef.value?.project
-    if (project == null) return ''
-    return `# Current project
-The user is now working on project: ${project.displayName} (${project.owner}/${project.name})
-## Project content
-${getProjectContent(project)}`
-  }
-}
-
-class SpriteContextProvider implements ICopilotContextProvider {
-  constructor(private editorCtxRef: ComputedRef<EditorCtx | undefined>) {}
-  provideContext(): string {
-    const sprite = this.editorCtxRef.value?.state.selectedSprite
-    if (sprite == null) return ''
-    return `# Current sprite content
-${JSON.stringify(getSpriteContent(sprite))}`
-  }
-}
-
-class CodeContextProvider implements ICopilotContextProvider {
-  constructor(private codeEditorRef: ComputedRef<CodeEditor | null>) {}
-
-  private sampleCode(activeTextDocument: TextDocument, line: number) {
-    const threshold = 10
-    const lineStart = Math.max(line - threshold, 1)
-    const lineEnd = lineStart + threshold * 2
-    const code = activeTextDocument.getValue()
-    return processCode(code, { lineStart, lineEnd })
-  }
-
-  provideContext(): string {
-    const codeEditorUI = this.codeEditorRef.value?.getAttachedUI()
-    if (codeEditorUI == null) return ''
-    const { activeTextDocument, cursorPosition, selection } = codeEditorUI
-    if (activeTextDocument == null) return ''
-    const codeFilePath = getCodeFilePath(activeTextDocument.id.uri)
-    const cursorPositionStr =
-      cursorPosition == null ? 'None' : `Line ${cursorPosition.line}, Column ${cursorPosition.column}`
-    const selectionStr =
-      selection == null || isSelectionEmpty(selection)
-        ? 'None'
-        : `From Line ${selection.start.line}, Column ${selection.start.column} to Line ${selection.position.line}, Column ${selection.position.column}`
-    let result = `# Current code
-The user is now viewing / editing code of file \`${codeFilePath}\`. \
-Cursor position: ${cursorPositionStr}. \
-Selection: ${selectionStr}.`
-    const code = this.sampleCode(activeTextDocument, cursorPosition?.line ?? 1)
-    result += `
-Code content of \`${codeFilePath}\`:
-${JSON.stringify(code)}`
-    return result
-  }
-}
-
-class RuntimeContextProvider implements ICopilotContextProvider {
-  constructor(private editorCtxRef: ComputedRef<EditorCtx | undefined>) {}
-
-  provideContext(): string {
-    const runtime = this.editorCtxRef.value?.state.runtime
-    if (runtime == null) return ''
-    const outputs = runtime.outputs
-    if (outputs.length === 0) return ''
-    const maxOutputs = 50
-    const recentOutputs = outputs.slice(-maxOutputs)
-    const outputsStr = recentOutputs
-      .map((output) => {
-        const time = dayjs(output.time).format('HH:mm:ss.SSS')
-        const kindStr = output.kind === 'error' ? 'ERROR' : 'LOG'
-        const sourceStr = output.source
-          ? ` [${textDocumentId2CodeFileName(output.source.textDocument).en}:${output.source.range.start.line}]`
-          : ''
-        return `[${time}] ${kindStr}${sourceStr}: ${output.message.trim()}`
-      })
-      .join('\n')
-    return `# Game runtime output
-Recent game runtime outputs (last ${recentOutputs.length} of ${outputs.length}):
-${outputsStr}`
   }
 }
 </script>
@@ -411,19 +143,26 @@ const i18n = useI18n()
 const router = useRouter()
 const modalEvents = useModalEvents()
 const messageEvents = useMessageEvents()
-const editorCtxRef = useEditorCtxRef()
-const codeEditorRef = useCodeEditorRef()
 const signedInStateQuery = useSignedInStateQuery()
-const retriever = new Retriever(editorCtxRef, cloudHelpers)
 const copilot = new Copilot()
-onUnmounted(() => copilot.dispose())
+const disposeSkillSupport = registerSkillSupport(copilot)
+const sessionStorageRef = userSessionStorageRef<SessionExported | null>('spx-gui-copilot-session', null)
+
+copilot.syncSessionWith({
+  get() {
+    return sessionStorageRef.value
+  },
+  set(value) {
+    sessionStorageRef.value = value
+  }
+})
+
+onUnmounted(() => {
+  disposeSkillSupport()
+  copilot.dispose()
+})
 
 copilot.registerTool(listProjectsTool)
-copilot.registerTool(new GetProjectMetadataTool(retriever))
-copilot.registerTool(new GetProjectContentTool(retriever))
-copilot.registerTool(new GetSpriteContentTool(retriever))
-copilot.registerTool(new GetProjectCodeTool(retriever))
-copilot.registerTool(new GetCodeDiagnosticsTool(codeEditorRef))
 copilot.registerCustomElement({
   tagName: pageLink.tagName,
   description: pageLink.detailedDescription,
@@ -452,15 +191,10 @@ copilot.registerCustomElement({
   isRaw: codeChange.isRaw,
   component: codeChange.default
 })
-
 copilot.registerTool(new GetUINodeTextContentTool(radar))
 copilot.registerContextProvider(new UIContextProvider(radar, i18n))
 copilot.registerContextProvider(new UserContextProvider(signedInStateQuery.data))
 copilot.registerContextProvider(new LocationContextProvider(router))
-copilot.registerContextProvider(new ProjectContextProvider(editorCtxRef))
-copilot.registerContextProvider(new SpriteContextProvider(editorCtxRef))
-copilot.registerContextProvider(new CodeContextProvider(codeEditorRef))
-copilot.registerContextProvider(new RuntimeContextProvider(editorCtxRef))
 
 const isRouteLoaded = useIsRouteLoaded()
 
@@ -503,34 +237,9 @@ onBeforeUnmount(
   })
 )
 
-watch(
-  () => editorCtxRef.value?.state.runtime,
-  (editorRuntime, _, onCleanup) => {
-    if (editorRuntime == null) return
-    const unlisten = editorRuntime.on('didExit', (code) => {
-      if (code !== 0) return
-      copilot.notifyUserEvent({ en: 'Game exited with code 0', zh: '游戏正常退出' }, `Game exited with code ${code}`)
-    })
-    onCleanup(unlisten)
-  },
-  { immediate: true }
-)
-
 provideCopilot(copilot)
-
-const sessionRef = userSessionStorageRef<SessionExported | null>('spx-gui-copilot-session', null)
-onMounted(() => {
-  copilot.syncSessionWith({
-    set(value) {
-      sessionRef.value = value
-    },
-    get() {
-      return sessionRef.value
-    }
-  })
-})
 </script>
 
 <template>
-  <slot></slot>
+  <slot />
 </template>

--- a/spx-gui/src/components/copilot/CopilotRoot.vue
+++ b/spx-gui/src/components/copilot/CopilotRoot.vue
@@ -13,8 +13,6 @@ import { useMessageEvents } from '../ui/message/UIMessageProvider.vue'
 import { Copilot, type ICopilotContextProvider, type SessionExported, type ToolDefinition } from './copilot'
 import * as pageLink from './custom-elements/PageLink'
 import * as highlightLink from './custom-elements/HighlightLink.vue'
-import * as codeLink from './custom-elements/CodeLink'
-import * as codeChange from './custom-elements/CodeChange.vue'
 import { useSignedInStateQuery, type SignedInState } from '@/stores/user'
 import { userSessionStorageRef } from '@/utils/user-storage'
 import { provideCopilot } from './context'
@@ -176,20 +174,6 @@ copilot.registerCustomElement({
   attributes: highlightLink.attributes,
   isRaw: highlightLink.isRaw,
   component: highlightLink.default
-})
-copilot.registerCustomElement({
-  tagName: codeLink.tagName,
-  description: codeLink.detailedDescription,
-  attributes: codeLink.attributes,
-  isRaw: codeLink.isRaw,
-  component: codeLink.default
-})
-copilot.registerCustomElement({
-  tagName: codeChange.tagName,
-  description: codeChange.detailedDescription,
-  attributes: codeChange.attributes,
-  isRaw: codeChange.isRaw,
-  component: codeChange.default
 })
 copilot.registerTool(new GetUINodeTextContentTool(radar))
 copilot.registerContextProvider(new UIContextProvider(radar, i18n))

--- a/spx-gui/src/components/copilot/copilot.test.ts
+++ b/spx-gui/src/components/copilot/copilot.test.ts
@@ -682,6 +682,8 @@ describe('Copilot', () => {
     })
 
     expect(generator.calls).toHaveLength(2)
+    const contextMessage = await copilot.getContextMessage()
+
     expect(generator.calls[1]).toEqual([
       {
         role: 'user',
@@ -719,7 +721,7 @@ describe('Copilot', () => {
         role: 'user',
         content: {
           type: 'text',
-          text: copilot.getContextMessage().content
+          text: contextMessage.content
         }
       }
     ])
@@ -870,6 +872,8 @@ describe('Copilot', () => {
     const currentRound = copilot.currentSession?.currentRound
     expect(currentRound?.state).toBe(RoundState.Completed)
     expect(generator.calls).toHaveLength(2)
+    const contextMessage = await copilot.getContextMessage()
+
     expect(generator.calls[1]).toEqual([
       {
         role: 'user',
@@ -903,7 +907,7 @@ describe('Copilot', () => {
         role: 'user',
         content: {
           type: 'text',
-          text: copilot.getContextMessage().content
+          text: contextMessage.content
         }
       }
     ])
@@ -937,6 +941,48 @@ describe('Copilot', () => {
         toolCalls: []
       }
     ])
+  })
+
+  it('should pass through string tool results without json stringification', async () => {
+    const generator = new MockBatchedMessageEventGenerator([
+      [
+        createToolCallDeltaEvent({
+          index: 0,
+          id: 'call_1',
+          function: {
+            name: 'load_skill',
+            arguments: '{"skillId":"spx-core"}'
+          }
+        }),
+        createDoneEvent('tool_calls')
+      ],
+      [createTextDeltaEvent('Loaded.'), createDoneEvent('stop')]
+    ])
+    const copilot = new Copilot(generator)
+    copilot.registerTool({
+      name: 'load_skill',
+      description: 'Load a skill document.',
+      parameters: z.object({
+        skillId: z.string()
+      }),
+      implementation: async ({ skillId }) => `<skill_content id="${skillId}">demo</skill_content>`
+    })
+    const topic = createBasicTopic('String tool result test', 'Testing plain string tool results')
+
+    await copilot.startSession(topic)
+    copilot.addUserTextMessage('Load the skill', topic)
+
+    await waitForCompletion()
+
+    expect(generator.calls).toHaveLength(2)
+    expect(generator.calls[1]?.[2]).toEqual({
+      role: 'tool',
+      toolCallId: 'call_1',
+      content: {
+        type: 'text',
+        text: '<skill_content id="spx-core">demo</skill_content>'
+      }
+    })
   })
 
   it('should preserve the current copilot tool-call block when history sampling truncates older rounds', async () => {
@@ -1017,11 +1063,13 @@ describe('Copilot', () => {
         }
       }
     ])
+    const contextMessage = await copilot.getContextMessage()
+
     expect(sampledMessages?.at(-1)).toEqual({
       role: 'user',
       content: {
         type: 'text',
-        text: copilot.getContextMessage().content
+        text: contextMessage.content
       }
     })
   })
@@ -1063,11 +1111,13 @@ describe('Copilot', () => {
     expect(generator.callOptions).toHaveLength(1)
 
     const contextMessage = generator.calls[0].at(-1)
+    const expectedContextMessage = await copilot.getContextMessage()
+
     expect(contextMessage).toEqual({
       role: 'user',
       content: {
         type: 'text',
-        text: copilot.getContextMessage().content
+        text: expectedContextMessage.content
       }
     })
     expect(contextMessage).toBeDefined()

--- a/spx-gui/src/components/copilot/copilot.ts
+++ b/spx-gui/src/components/copilot/copilot.ts
@@ -62,6 +62,7 @@ function getToolExecutionText(execution: ToolExecution): string {
     case 'executing':
       return 'Executing tool...'
     case 'completed': {
+      if (typeof execution.result === 'string') return execution.result
       const serializedResult = JSON.stringify(execution.result)
       return serializedResult == null ? 'null' : serializedResult
     }
@@ -310,7 +311,7 @@ export class Round {
   private async generateCopilotMessage() {
     try {
       const messages = this.session.rounds.flatMap((round) => [round.userMessage, ...round.resultMessages])
-      messages.push(this.copilot.getContextMessage())
+      messages.push(await this.copilot.getContextMessage())
       const apiMessages = messages.map(toApiMessage)
       // TODO: history summarization with LLM instead of truncation
       const sampledApiMessages = sampleApiMessages(apiMessages)
@@ -445,7 +446,7 @@ export interface ICopilotContextProvider {
    * Provide context information for the copilot.
    * Use plain text in English.
    */
-  provideContext(): string
+  provideContext(): string | Promise<string>
 }
 
 /** A quick input represents a UI element (typically a button) which helps the user to quickly send some message */
@@ -568,11 +569,9 @@ export class Copilot extends Disposable {
     return this.currentSessionRef.value
   }
 
-  private getContext(): string {
-    return this.contextProviders
-      .map((provider) => provider.provideContext())
-      .filter((s) => s.trim() !== '')
-      .join('\n\n')
+  private async getContext(): Promise<string> {
+    const contextParts = await Promise.all(this.contextProviders.map((provider) => provider.provideContext()))
+    return contextParts.filter((s) => s.trim() !== '').join('\n\n')
   }
 
   private getCustomElementPrompt(customElement: CustomElementDefinition) {
@@ -601,8 +600,8 @@ ${customElements.map((ce) => this.getCustomElementPrompt(ce)).join('\n\n')}`
 ${topic.description}`
   }
 
-  getContextMessage(): UserTextMessage {
-    const parts = [this.getCustomElementsPrompt(), this.getContext(), this.getTopicPrompt()]
+  async getContextMessage(): Promise<UserTextMessage> {
+    const parts = [this.getCustomElementsPrompt(), await this.getContext(), this.getTopicPrompt()]
     const content = `<context>
 ${parts.filter((p) => p.trim() !== '').join('\n\n')}
 </context>`

--- a/spx-gui/src/components/copilot/skills/bundles/spx-project/SKILL.md
+++ b/spx-gui/src/components/copilot/skills/bundles/spx-project/SKILL.md
@@ -1,0 +1,222 @@
+---
+name: spx-project
+description: Guidelines for developing spx projects (games), including file structure, code organization, and best practices. Use this skill when the task is specifically about building or modifying an spx game in XBuilder.
+---
+
+# About spx
+
+spx is a Scratch-like 2D Game Engine for STEM education. It is designed for children to learn programming by developing games. spx is developed based on XGo classfiles. In spx, there are two types of classes: `Game` classes and `Sprite` classes.
+
+The `Game` class is the "project class" that represents the whole game. In an spx project, there is only one code file (named `main.spx`) for the `Game` class. We call it code for "the stage". Variables & functions declared in the stage code can be accessed by all game objects.
+
+The `Sprite` classes are "worker classes" which are used to define game objects. In an spx project, there can be multiple code files for `Sprite` classes. Each `Sprite` class has its own code file, named after the sprite's name, e.g., `Apple.spx`, `Banana.spx`. Variables & functions declared in a sprite's code can only be accessed by that sprite.
+
+## Guidelines for Developing Games in spx
+
+You MUST follow these IMPORTANT guidelines:
+
+- **Code File Organization**: Always place in this order:
+
+  1. Variable declarations (using `var` blocks)
+  2. Function definitions
+  3. Event handlers (like `onStart`, `onClick`)
+
+- **Special API Notes**
+
+  - For physics-related API calls (e.g., `setPhysicsMode`, `setVelocity`, `setGravity`), ensure the project's physics is enabled, otherwise these calls will have no effect.
+
+- **Object-Oriented Implementation**: In spx, XGo uses classfiles instead of traditional struct-based OOP:
+
+  - Each Sprite is a distinct object type
+  - The Stage is a Game object
+  - Variable blocks become fields of the object
+  - Functions become methods of the object and please make sure to place the function definition before all event handlers (such as `onStart`, `onClick`)
+  - Sprite can directly access the Game Field because the Sprite struct embeds the Game struct
+  - The first `var` block cannot assign values since it is compiled into struct fields, but you can define variables in first `var` block and with assign values in `onStart` event handler.
+  - In particular, the clone command Make a clone of current sprite is actually copy current Sprite struct. If you want to get the cloned object, you can get the object through `onCloned => {object := this}`
+
+    Example: Stage File Structure
+
+  ```spx
+  var (
+  	score int
+  	speed int
+  )
+
+  var (
+  	fo0 = 2
+  	bar = 3
+  )
+
+  func reset() {
+  	score = 0
+  	speed = 20
+  }
+  ```
+
+  can not define to:
+
+  ```spx
+  var (
+  	fo0 = 2
+  	bar = 3
+  )
+
+  var (
+  	score int
+  	speed int
+  )
+
+  func reset() {
+  	score = 0
+  	speed = 20
+  }
+  ```
+
+  This compiles to:
+
+  ```go
+  type Game struct {
+  	spx.Game
+  	Score int
+  	Speed int
+  }
+
+  var (
+  	fo0 = 2
+  	bar = 3
+  )
+
+  func (this *Game) reset() {
+  	this.score = 0
+  	this.speed = 20
+  }
+  ```
+
+  Example: Sprite File Structure
+
+  ```spx
+  var (
+  	dir int
+  	x int
+  	y int
+  )
+
+  func reset() {
+  	dir = right
+  	x = -100
+  	y = 0
+  }
+  ```
+
+  This compiles to:
+
+  ```go
+  type Snake struct {
+  	spx.SpriteImpl
+  	*Game
+  	dir int
+  	x int
+  	y int
+  }
+
+  func (this *Snake) reset() {
+  	this.dir = right
+  	this.x = -100
+  	this.y = 0
+  }
+  ```
+
+- Put these statements at the top level of the code file:
+
+  - File-scope variable / constant definitions
+  - Event-listening statements, e.g., `onMsg "m", => { ... }`, `onKey KeyUp, => { ... }`
+
+  Put other initialization logic in the callback of `onStart`.
+
+  RIGHT:
+
+  ```spx
+  const word = "Hello"
+
+  var (
+  	count int
+  )
+
+  onStart => {
+  	println word
+  }
+
+  onClick => {
+  	count++
+  }
+  ```
+
+  WRONG:
+
+  ```spx
+  onStart => {
+  	const word = "Hello"
+  	var count int
+  	println word
+
+  	onClick => {
+  		count++
+  	}
+  }
+  ```
+
+- Access a sprite instance by name via a pre-defined global variable.
+
+  For example, if you have a sprite named `Player`, you can reference it directly from the stage or any other sprite:
+
+  ```spx
+  onStart => {
+  	// You don't need to define the variable `Player` in your code, it's done by the engine
+  	println "Position of Player: " + Player.xpos + ", " + Player.ypos
+  	Player.step 100
+  }
+  ```
+
+- Use `broadcast`/`onMsg` to decouple interactions between sprites & stage.
+
+  Though we can directly call methods on other sprites, using `broadcast` and `onMsg` promotes better separation of concerns and makes the code more maintainable. Here's an example:
+
+  ```spx
+  // Code of Sprite A
+  onClick => {
+  	broadcast "a-clicked"
+  }
+
+  // Code of Sprite B
+  onMsg "a-clicked", => {
+  	say "Sprite A was clicked"
+  }
+  ```
+
+- Prefer higher-level APIs over low-level APIs
+
+  There may be different APIs for similar purpose. For example, both `step` and `setXYpos` (or `changeXYpos`) can be used to change a sprite's position, while `step` provides higher-level abstraction as:
+
+  - it respects the sprite's heading, which is more intuitiven for character movement
+  - if there is a bound animation to state "step", it will be played
+
+  So `step` is preferred over `setXYpos` (or `changeXYpos`) in most cases. Use low-level APIs only when necessary.
+
+  The same principle applies to other APIs include `turnTo` over `setHeading`, `turn` over `changeHeading`, etc.
+
+## Some Concepts with their corresponding Chinese name
+
+- Costume 造型
+- Widget 控件
+- Monitor 监视器
+
+## APIs
+
+In document `references/apis.md`, you can find definitions for built-in APIs of spx game engine.
+
+## AI Interaction
+
+AI Interaction is a feature in XBuilder that allows games to communicate with AI during runtime. This functionality enables users to create rich interactive scenarios in games such as intelligent opponents (like AI opponents in board games), smart conversations, dynamic content generation, and adaptive gaming experiences.
+
+Read `references/ai-interaction.md` for more details and examples about how to use AI Interaction in spx games.

--- a/spx-gui/src/components/copilot/skills/bundles/spx-project/SKILL.md
+++ b/spx-gui/src/components/copilot/skills/bundles/spx-project/SKILL.md
@@ -54,7 +54,7 @@ You MUST follow these IMPORTANT guidelines:
   }
   ```
 
-  can not define to:
+  Do not define it as:
 
   ```spx
   var (
@@ -198,12 +198,12 @@ You MUST follow these IMPORTANT guidelines:
 
   There may be different APIs for similar purpose. For example, both `step` and `setXYpos` (or `changeXYpos`) can be used to change a sprite's position, while `step` provides higher-level abstraction as:
 
-  - it respects the sprite's heading, which is more intuitiven for character movement
+  - it respects the sprite's heading, which is more intuitive for character movement
   - if there is a bound animation to state "step", it will be played
 
   So `step` is preferred over `setXYpos` (or `changeXYpos`) in most cases. Use low-level APIs only when necessary.
 
-  The same principle applies to other APIs include `turnTo` over `setHeading`, `turn` over `changeHeading`, etc.
+  The same principle applies to other APIs, such as `turnTo` over `setHeading`, `turn` over `changeHeading`, etc.
 
 ## Some Concepts with their corresponding Chinese name
 

--- a/spx-gui/src/components/copilot/skills/bundles/spx-project/SKILL.md
+++ b/spx-gui/src/components/copilot/skills/bundles/spx-project/SKILL.md
@@ -33,7 +33,7 @@ You MUST follow these IMPORTANT guidelines:
   - Functions become methods of the object and please make sure to place the function definition before all event handlers (such as `onStart`, `onClick`)
   - Sprite can directly access the Game Field because the Sprite struct embeds the Game struct
   - The first `var` block cannot assign values since it is compiled into struct fields, but you can define variables in first `var` block and with assign values in `onStart` event handler.
-  - In particular, the clone command Make a clone of current sprite is actually copy current Sprite struct. If you want to get the cloned object, you can get the object through `onCloned => {object := this}`
+  - In particular, the `clone` command creates a copy of the current Sprite struct. If you want to get the cloned object, you can get the object through `onCloned => {object := this}`
 
     Example: Stage File Structure
 
@@ -44,7 +44,7 @@ You MUST follow these IMPORTANT guidelines:
   )
 
   var (
-  	fo0 = 2
+  	foo = 2
   	bar = 3
   )
 
@@ -58,7 +58,7 @@ You MUST follow these IMPORTANT guidelines:
 
   ```spx
   var (
-  	fo0 = 2
+  	foo = 2
   	bar = 3
   )
 
@@ -78,12 +78,12 @@ You MUST follow these IMPORTANT guidelines:
   ```go
   type Game struct {
   	spx.Game
-  	Score int
-  	Speed int
+  	score int
+  	speed int
   }
 
   var (
-  	fo0 = 2
+  	foo = 2
   	bar = 3
   )
 

--- a/spx-gui/src/components/copilot/skills/bundles/spx-project/references/ai-interaction.md
+++ b/spx-gui/src/components/copilot/skills/bundles/spx-project/references/ai-interaction.md
@@ -1,0 +1,367 @@
+# AI Interaction
+
+AI Interaction is a feature in XBuilder that allows games to communicate with AI during runtime. This functionality enables users to create rich interactive scenarios in games such as intelligent opponents (like AI opponents in board games), smart conversations, dynamic content generation, and adaptive gaming experiences.
+
+The AI Interaction feature is designed for children around 10 years old who are learning programming. It provides minimal APIs that allow them to easily integrate AI capabilities into their games without needing to understand complex network requests, error handling, or AI model details.
+
+## Basic Concepts
+
+### AI Interaction
+
+AI Interaction refers to the communication process between a running game and external AI. This interaction includes sending messages to AI and receiving/processing AI responses.
+
+The basic AI interaction flow is:
+
+1. The game sends a message to AI (may contain contextual information like game state)
+2. AI processes the message and generates a response
+3. The game processes the response and provides feedback
+4. AI determines subsequent actions based on the feedback
+
+This process iterates until the interaction naturally concludes or is interrupted.
+
+### AI Player
+
+An AI Player is an intelligent agent in the game that interacts with human players, capable of understanding game situations and making reasonable responses. Each AI Player is an independent interaction instance with its own memory and behavior patterns, operating without interference from others.
+
+Core characteristics of AI Players:
+
+- Identity: Clearly defined through role settings (e.g., opponent, teacher, etc.). Role definitions include:
+  - Identity description: The basic identity of the role, such as "guide", "opponent", "teacher", etc.
+  - Behavior guidelines: How the role should behave, including tone, attitude, and decision-making style
+  - Knowledge scope: What the role should or shouldn't know
+  - Goal orientation: The role's main objectives or tasks in the game
+- Interactivity: Can receive instructions and provide intelligent responses
+- Autonomy: Makes decisions based on context
+- Customizability: Behaviors and capability ranges can be freely defined
+
+Example:
+
+```go
+import "ai"
+
+// Declare Player variable (zero value is ready to use)
+var teacher ai.Player
+
+// Set the role the Player should play
+teacher.setRole "Math Teacher", { "Style": "Patient", "Difficulty": "Beginner", "Subjects": ["Addition", "Subtraction"] }
+```
+
+### AI Context
+
+AI Context is a key collection of data that helps AI understand the current game state, conversation history, and environmental information. Good context enables AI to generate more accurate and relevant responses, improving the intelligence and coherence of the gaming experience.
+
+AI Context comes in two types:
+
+- Automatically attached context: Information automatically collected and provided to AI by the system, such as conversation history and basic game environment. Users don't need to manually provide this - the system automatically attaches it during each AI interaction.
+- User-provided context: Specific information explicitly provided by developers through APIs, such as current game state or special rules. The system automatically converts this information into a format AI can understand, enabling AI to generate more intelligent responses based on the current situation.
+
+Notably, the system automatically analyzes game source code during initialization and generates a descriptive summary of the game world from the player's perspective. This summary is attached to the AI context as background knowledge, helping AI understand the game's basic design and possible player interaction methods. This allows AI to generate responses that better align with game logic and player experience.
+
+AI Context typically contains these types of information:
+
+- Game state information: Such as score, collected items, completed tasks, etc.
+- Conversation history: Previous interactions with AI, helping AI understand conversation continuity
+- Environmental information: Game world rules, available resources, time limits, etc.
+- User information: Such as the user's play style, learning progress, difficulties, etc.
+
+Good AI Context design principles:
+
+- Relevance: Only provide information relevant to the current task or conversation
+- Conciseness: Avoid redundant information, keep context data structure clear
+- Timeliness: Update context promptly to ensure AI gets the latest game state
+- Understandability: Organize information in ways AI can easily process
+
+Example:
+
+```go
+var npc ai.Player
+npc.think "What's my next move?", { "Position": [10, 20], "HP": 80, "Equipment": ["Sword", "Shield"] }
+```
+
+### AI Command
+
+AI Commands are pre-registered functions that AI can call. Through commands, AI can perform specific operations in the game, such as moving sprites, playing sounds, or changing game state.
+
+Each AI Command contains:
+
+- Command definition: Defined through struct type, including:
+  - Command name: The struct type name
+  - Command description: Can be provided by implementing struct methods to give complete descriptions. If not implemented, the system generates default descriptions.
+  - Parameter definition: Added through struct fields to define required parameters and their types
+  - Parameter description: Can be set through field tags to describe parameter purposes. If not added, the system generates default descriptions.
+- Command implementation: Concrete execution logic that receives the command definition struct as parameter and performs corresponding operations
+
+Good AI Command design principles:
+
+- Clear semantics: Command names and parameters should clearly express their functionality, understandable even without descriptions
+- Concise parameters: Avoid too many parameters to maintain usability
+
+Example:
+
+```go
+type AttackThePlayer struct {
+    Strokes int
+}
+
+var enemy ai.Player
+enemy.onCmd AttackThePlayer, (cmd) => {
+    // Execute attack logic
+}
+```
+
+### AI Message
+
+AI Messages are text content sent by the game to AI, which can contain questions, instructions, or other information. AI generates responses based on message content.
+
+AI Messages can include additional context information to help AI better understand the current game state.
+
+Example:
+
+```go
+var guide ai.Player
+guide.think "Where is the nearest treasure?", { "CurrentPosition": [35, 42], "ExploredAreas": ["East", "South"] }
+```
+
+### AI Response
+
+AI Response is AI's processing result for game messages. Each response contains:
+
+- Text response: Text content generated by AI, typically used as debug information without needing processing
+- Single AI command: The single AI command AI decides to call, automatically executed by the system
+
+After executing the command, the system provides feedback to AI for determining subsequent actions. Command execution may produce these results:
+
+- Success: Command executed correctly, game state changed as expected, AI can continue
+- Failure: Command failed due to invalid parameters or disallowed game state, with error information helping AI adjust strategy
+- Interruption: Command actively requests terminating current interaction flow
+
+Only when the AI command is legal and successfully executed is the AI response considered valid.
+
+Example:
+
+```go
+type Help struct {
+    Topic    string `desc:"Topic needing help"`
+    Priority int    `desc:"Priority, range: 1-5"`
+}
+
+var helper ai.Player
+helper.onCmd Help, (cmd) => {
+    // Execute help logic
+}
+
+helper.think "I need help" // Will automatically execute AI response command
+```
+
+## API Design
+
+All AI interaction functionality is provided through methods of the `Player` struct in the `ai` package.
+
+### setRole
+
+`setRole` is a "command" class API that sets the role AI should play during interactions. By defining clear roles, AI responses become more consistent, better suited to game scenarios, and avoid repeating role descriptions in each `think` call.
+
+```go
+Player.setRole role
+Player.setRole role, additionalContext
+```
+
+Parameters:
+
+- `role`: `string` type, describing the role AI should play, such as "guide", "opponent", "teacher", etc.
+- `additionalContext`: Optional parameter, `map[string]any` type, providing additional context information about the role
+
+For ease of use, `setRole` can be called at any point in the game to change AI's role settings. Once set, the role remains effective until replaced by new settings.
+
+Example:
+
+```go
+var guide ai.Player
+guide.setRole "Guide", { "Style": "Friendly", "Knowledge": "Game Rules" }
+```
+
+### onCmd
+
+`onCmd` is an "event" class API that registers commands AI can call. Users can predefine game operations executable by AI through it.
+
+```go
+Player.onCmd T, (command) => { return err }
+```
+
+Parameters:
+
+- `T`: Generic type representing specific AI command struct type
+- `(command) => { return err }`: Function type implementing AI command logic
+  - Its `T` type parameter `command` contains all parameter values set by AI when calling this command
+  - Its `error` type return value `err` provides feedback to AI about command execution results
+    - `nil`: Command executed successfully, AI continues
+    - `ai.Break`: Interrupt interaction
+    - Others: Error information is fed back to AI as context for strategy adjustment
+
+Command struct `T` has these characteristics:
+
+- Parameter definition: Exported fields (capitalized) in the struct automatically become configurable AI parameters, supporting basic types like `string`, `int`, `float64`, `bool` and their slices
+- Parameter description: Each field can have a `desc` tag explaining parameter purpose, e.g., `desc: "Move direction"`. These help AI correctly understand and use parameters. If not added, the system generates default descriptions.
+- Command description: Can implement `Desc() string` method to provide complete command description including functionality and usage scenarios. If not implemented, the system generates default descriptions.
+
+Example:
+
+```go
+type Move struct {
+    Direction string `desc:"Move direction, options: up, down, left, right"`
+    Steps     int    `desc:"Number of steps"`
+}
+
+var npc ai.Player
+npc.onCmd Move, (cmd) => {
+    // Execute move logic
+}
+```
+
+### think
+
+`think` is a "command" class API that sends messages to AI and optionally provides additional context information to get responses. The system automatically processes AI responses, including executing commands AI decides to call.
+
+```go
+Player.think msg
+Player.think msg, additionalContext
+```
+
+Parameters:
+
+- `msg`: `string` type, message content sent to AI
+- `additionalContext`: Optional parameter, `map[string]any` type, additional context information provided to AI
+
+For ease of use, `think` uses blocking design and returns no value. If errors occur during requests, the system automatically retries several times. If still unsuccessful after multiple attempts, it triggers error handling functions registered through `onErr`. If none registered, uses default error handling.
+
+Example:
+
+```go
+var enemy ai.Player
+enemy.think "Attack player", { "PlayerHP": 80, "Distance": 5 }
+```
+
+### onErr
+
+`onErr` is an "event" class API that registers error handling logic when AI interactions fail. By defining error handling functions, friendly prompts can be shown to users when errors occur like network request failures or invalid AI responses.
+
+```go
+Player.onErr => {}
+Player.onErr (err) => {}
+```
+
+Parameters:
+
+- `(err) => {}`: Function type representing specific error handling function, with optional `error` type parameter `err` representing specific errors (typically for debugging), obtainable through `err.Error`
+
+Example:
+
+```go
+var helper ai.Player
+helper.onErr (err) => {
+    say "AI assistant error occurred"
+    printf "ai error: %v", err // Print logs to console for debugging
+}
+```
+
+## Complete Example
+
+Here's a complete example of a Tic-Tac-Toe AI opponent:
+
+```go
+/*
+
+Assume there's already a 3x3 2D array variable board representing game state, initialized as:
+
+    [][]string{
+        {"", "", ""},
+        {"", "", ""},
+        {"", "", ""},
+    }
+
+And a function updateBoard(row, col, piece) for updating board state.
+
+*/
+
+// Define AI opponent move command
+type MakeMove struct {
+    Row    int    `desc:"Row position: -1 (no move needed), 0, 1, 2"`
+    Col    int    `desc:"Column position: -1 (no move needed), 0, 1, 2"`
+    Result string `desc:"Game result: unset (continue), X (player wins), O (AI wins), TIE (draw)"`
+}
+
+var (
+    // Declare AI opponent
+    opponent ai.Player
+)
+
+// Register AI opponent move command
+opponent.onCmd MakeMove, (cmd) => {
+    if cmd.Row != -1 && cmd.Col != -1 {
+        // Check if move position is valid
+        if cmd.Row < 0 || cmd.Row > 2 || cmd.Col < 0 || cmd.Col > 2 || board[cmd.Row][cmd.Col] != "" {
+            return errorf("Invalid move position, please choose again. Board state: %v", board)
+        }
+
+        // Update board logic
+        updateBoard(cmd.Row, cmd.Col, "O")
+    }
+
+    // Check if game ended
+    if cmd.Result == "" {
+        say "Your turn"
+    } else if cmd.Result == "TIE" {
+        say "Game over, it's a draw"
+    } else {
+        say "Game over, " + cmd.Result + " wins"
+    }
+    return ai.Break
+}
+
+// Register error handling
+opponent.onErr (err) => {
+    say "I surrender"
+    printf "AI error: %v", err
+}
+
+onStart => {
+    // Set AI opponent role
+    opponent.setRole "Tic-Tac-Toe Opponent", {
+        "Rules": "Standard Tic-Tac-Toe rules",
+        "Piece": "O",
+        "Difficulty": "Medium",
+        "Style": "Offensive",
+    }
+}
+
+onMsg "Player moved", => {
+    // Request AI opponent move
+    opponent.think "Player has moved, your turn", { "BoardState": board }
+}
+```
+
+Here's the internal logic flow of AI processing Tic-Tac-Toe game:
+
+```mermaid
+sequenceDiagram
+    participant Game
+    participant AI
+    Game->>AI: think("Player moved", BoardState)
+    AI->>AI: Analyze board to determine outcome
+    alt Player wins
+        AI-->>Game: Return "Player wins"+Break
+    else Draw
+        AI-->>Game: Return "Draw"+Break
+    else Game continues
+        AI->>AI: Choose best move position
+        AI->>AI: Simulate board after move
+        AI->>AI: Evaluate new board state
+        alt AI wins
+            AI-->>Game: MakeMove(position)+"AI wins"+Break
+        else Draw
+            AI-->>Game: MakeMove(position)+"Draw"+Break
+        else Continue
+            AI-->>Game: MakeMove(position)+"Your turn"
+        end
+    end
+```

--- a/spx-gui/src/components/copilot/skills/bundles/spx-project/references/ai-interaction.md
+++ b/spx-gui/src/components/copilot/skills/bundles/spx-project/references/ai-interaction.md
@@ -74,6 +74,8 @@ Good AI Context design principles:
 Example:
 
 ```go
+import "ai"
+
 var npc ai.Player
 npc.think "What's my next move?", { "Position": [10, 20], "HP": 80, "Equipment": ["Sword", "Shield"] }
 ```
@@ -99,6 +101,8 @@ Good AI Command design principles:
 Example:
 
 ```go
+import "ai"
+
 type AttackThePlayer struct {
     Strokes int
 }
@@ -118,6 +122,8 @@ AI Messages can include additional context information to help AI better underst
 Example:
 
 ```go
+import "ai"
+
 var guide ai.Player
 guide.think "Where is the nearest treasure?", { "CurrentPosition": [35, 42], "ExploredAreas": ["East", "South"] }
 ```
@@ -140,6 +146,8 @@ Only when the AI command is legal and successfully executed is the AI response c
 Example:
 
 ```go
+import "ai"
+
 type Help struct {
     Topic    string `desc:"Topic needing help"`
     Priority int    `desc:"Priority, range: 1-5"`
@@ -176,6 +184,8 @@ For ease of use, `setRole` can be called at any point in the game to change AI's
 Example:
 
 ```go
+import "ai"
+
 var guide ai.Player
 guide.setRole "Guide", { "Style": "Friendly", "Knowledge": "Game Rules" }
 ```
@@ -207,6 +217,8 @@ Command struct `T` has these characteristics:
 Example:
 
 ```go
+import "ai"
+
 type Move struct {
     Direction string `desc:"Move direction, options: up, down, left, right"`
     Steps     int    `desc:"Number of steps"`
@@ -237,6 +249,8 @@ For ease of use, `think` uses blocking design and returns no value. If errors oc
 Example:
 
 ```go
+import "ai"
+
 var enemy ai.Player
 enemy.think "Attack player", { "PlayerHP": 80, "Distance": 5 }
 ```
@@ -257,6 +271,8 @@ Parameters:
 Example:
 
 ```go
+import "ai"
+
 var helper ai.Player
 helper.onErr (err) => {
     say "AI assistant error occurred"
@@ -269,6 +285,8 @@ helper.onErr (err) => {
 Here's a complete example of a Tic-Tac-Toe AI opponent:
 
 ```go
+import "ai"
+
 /*
 
 Assume there's already a 3x3 2D array variable board representing game state, initialized as:

--- a/spx-gui/src/components/copilot/skills/bundles/spx-project/references/apis.md
+++ b/spx-gui/src/components/copilot/skills/bundles/spx-project/references/apis.md
@@ -1,0 +1,268 @@
+# spx APIs
+
+## Game
+
+```csv
+Name,Sample,Description
+answer,,The answer from the player
+backdropIndex,,Index of the current backdrop
+backdropName,,Name of the current backdrop
+broadcast,"broadcast ""ping""",Broadcast a message
+broadcast,"broadcast ""ping"", 1",Broadcast a message along with extra data
+broadcastAndWait,"broadcastAndWait ""ping""","Broadcast a message, with waiting for related (`onMsg`) behaviors to complete"
+broadcastAndWait,"broadcastAndWait ""ping"", 1","Broadcast a message along with extra data, with waiting for related (`onMsg`) behaviors to complete"
+Camera,,"Camera, which controls the visible area of the stage"
+ask,"ask ""What is your name?""",Ask player a question and wait for player to answer
+changeGraphicEffect,"changeGraphicEffect ColorEffect, 10","Change graphic effect of the stage. For example, if initial effect value is 100, changing by 10 will result in 110"
+changeVolume,changeVolume 10,"Change the volume for stage sounds with given volume change. For example, if initial volume is 100, changing by 10 will result in volume 110"
+clearGraphicEffects,,Clear all graphic effects of the stage
+findPath,"findPath(0, 0, 100, 100)","Find path from (fromX, fromY) to (toX, toY)"
+onAnyKey,onAnyKey key => {},Listen to any key pressed
+onBackdrop,onBackdrop backdrop => {},Listen to backdrop switching
+onBackdrop,"onBackdrop ""bg1"", => {}",Listen to switching to specific backdrop
+onClick,onClick => {},Listen to stage clicked
+onKey,"onKey KeyA, => {}",Listen to given key pressed
+onKey,"onKey [KeyA], key => {}",Listen to given keys pressed
+onMsg,"onMsg (msg, data) => {}",Listen to any message broadcasted
+onMsg,"onMsg ""ping"", => {}",Listen to specific message broadcasted
+onStart,onStart => {},Listen to game start
+onSwipe,"onSwipe Left, => {}",Listen to swipe in given direction
+pausePlaying,"pausePlaying ""s1""",Pause sound with given name
+play,"play ""s1"", true",Play sound with given name in a loop
+play,"play ""s1""",Play sound with given name
+playAndWait,"playAndWait ""s1""",Play sound with waiting
+resumePlaying,"resumePlaying ""s1""",Resume sound with given name
+setGraphicEffect,"setGraphicEffect ColorEffect, 100",Set graphic effect of the stage
+setVolume,setVolume 100,Set the volume for stage sounds
+stopPlaying,"stopPlaying ""s1""",Stop sound with given name
+volume,,The volume for stage sounds
+getWidget,"getWidget(Monitor, ""w1"")",Get the widget by given type & name
+keyPressed,keyPressed(KeyA),Check if given key is currently pressed
+mouseHitItem,,The sprite which is hit by mouse
+mousePressed,,If the mouse is currently pressed
+mouseX,,X position of the mouse
+mouseY,,Y position of the mouse
+resetTimer,,Reset the timer to zero
+setBackdrop,"setBackdrop ""bg1""",Set the current backdrop by specifying name
+setBackdrop,setBackdrop 0,Set the current backdrop by specifying index
+setBackdrop,setBackdrop Next,Switch to the Next/Prev backdrop
+setBackdropAndWait,"setBackdropAndWait ""bg1""","Set the current backdrop by specifying name, with waiting for related (`onBackdrop`) behaviors to complete"
+setBackdropAndWait,setBackdropAndWait 0,"Set the current backdrop by specifying index, with waiting for related (`onBackdrop`) behaviors to complete"
+setBackdropAndWait,setBackdropAndWait Next,"Switch to the Next/Prev backdrop, with waiting for related (`onBackdrop`) behaviors to complete"
+stopAllSounds,,Stop all playing sounds
+timer,,Current timer value
+wait,wait 1,Wait for given seconds
+```
+
+## Sprite
+
+```csv
+Name,Sample,Description
+animate,"animate ""a1""",Play animation with given name
+animate,"animate ""a1"", true",Loop the animation with given name
+animateAndWait,"animateAndWait ""a1""","Play animation with given name, with waiting for animation to complete"
+bounceOffEdge,,Bounce off if the sprite touching the edge
+changeHeading,changeHeading 90,"Change heading by given degree. For example, if initially heading at 30 degrees, changing by 90 degrees will result in heading 120 degrees"
+changeSize,changeSize 1,"Change size of the sprite. For example, if initially size is 1, changing by 1 will result in size 2"
+changeXYpos,"changeXYpos 10, 10","Change the sprite's X, Y position"
+changeXpos,changeXpos 10,Change the sprite's X position
+changeYpos,changeYpos 10,Change the sprite's Y position
+clone,,Make a clone of the sprite
+clone,clone 1,Make a clone of the sprite and pass extra data
+costumeName,,The name of the current costume
+die,,"Let the sprite die. Animation for state ""die"" will be played"
+distanceTo,distanceTo(S1),Distance from the sprite to another sprite
+distanceTo,distanceTo(Mouse),Distance from the sprite to given object
+glide,"glide 100, 100, 1",Glide to given position within given duration
+glide,"glide S1, 1",Glide to given sprite within given duration
+glide,"glide Mouse, 1",Glide to given object within given duration
+heading,,The sprite's heading direction
+hide,,Make the sprite invisible
+onCloned,onCloned data => {},Listen to sprite cloned
+onTouchStart,"onTouchStart ""S1"", sprite => {}",Listen to sprite touching another sprite with given name
+onTouchStart,"onTouchStart [""S1""], sprite => {}",Listen to sprite touching another sprite with one of given names
+say,"say ""Hi""",Say some word
+say,"say ""Hi"", 1",Say some word for given seconds
+setCostume,"setCostume ""c1""",Set the current costume by specifying name
+setHeading,setHeading Right,Set heading to given direction
+setLayer,setLayer Front,Send the sprite to front/back
+setLayer,"setLayer Forward, 1","Send the sprite forward or backward, with given layers"
+setRotationStyle,setRotationStyle LeftRight,Set the rotation style of the sprite
+setSize,setSize 2,Set size of the sprite
+setXYpos,"setXYpos 0, 0","Set the sprite's X, Y position"
+setXpos,setXpos 0,Set the sprite's X position
+setYpos,setYpos 0,Set the sprite's Y position
+show,,Make the sprite visible
+size,,"Size of the sprite. Value is relative to initial size. For example, 2 means current size is twice the initial size"
+addImpulse,"addImpulse 0, 0","Add impulse to the sprite. The impulse is an instant velocity change, i.e., the velocity will be changed by (ix, iy) instantly"
+ask,"ask ""What is your name?""",Ask player a question and wait for player to answer
+changeGraphicEffect,"changeGraphicEffect ColorEffect, 10","Change graphic effect of the sprite. For example, if initial effect value is 100, changing by 10 will result in 110"
+changeVolume,changeVolume 10,"Change the volume for sprite sounds with given volume change. For example, if initial volume is 100, changing by 10 will result in volume 110"
+clearGraphicEffects,,Clear all graphic effects of the sprite
+findPath,"findPath(0, 0, 100, 100)","Find path from (fromX, fromY) to (toX, toY)"
+stopPlaying,"stopPlaying ""s1""",Stop sound with given name
+gravity,,"The gravity for the sprite. The value is relative to the global gravity. For example, 2 means double the global gravity, 0 means no gravity"
+isOnFloor,,If the sprite is currently on the floor
+onAnyKey,onAnyKey key => {},Listen to any key pressed
+onBackdrop,onBackdrop backdrop => {},Listen to backdrop switching
+onBackdrop,"onBackdrop ""bg1"", => {}",Listen to switching to specific backdrop
+onClick,onClick => {},Listen to sprite clicked
+onKey,"onKey KeyA, => {}",Listen to given key pressed
+onKey,"onKey [KeyA], key => {}",Listen to given keys pressed
+onMsg,"onMsg (msg, data) => {}",Listen to any message broadcasted
+onMsg,"onMsg ""ping"", => {}",Listen to specific message broadcasted
+onStart,onStart => {},Listen to game start
+onSwipe,"onSwipe Left, => {}",Listen to swipe in given direction
+pausePlaying,"pausePlaying ""s1""",Pause sound with given name
+physicsMode,,The physics mode for the sprite
+play,"play ""s1"", true",Play sound with given name in a loop
+play,"play ""s1""",Play sound with given name
+playAndWait,"playAndWait ""s1""",Play sound with waiting
+resumePlaying,"resumePlaying ""s1""",Resume sound with given name
+setGraphicEffect,"setGraphicEffect ColorEffect, 100",Set graphic effect of the sprite
+setGravity,setGravity 0,Set the gravity for the sprite
+setPhysicsMode,setPhysicsMode NoPhysics,Set the physics mode for the sprite
+setVelocity,"setVelocity 0, 0",Set the velocity for the sprite
+setVolume,setVolume 100,Set the volume for sprite sounds
+velocity,,"The velocity for the sprite. It is a 2D vector represented as (vx, vy), where vx is the distance to move in x axis per second, and vy is the distance to move in y axis per second"
+volume,,The volume for sprite sounds
+step,step 100,"Step toward current heading with given distance. Animation for state ""step"" will be played"
+step,"step 100, 1","Step toward current heading with given distance and speed. Animation for state ""step"" will be played"
+step,"step 100, 1, ""a1""","Step toward current heading with given distance, speed and animation"
+stepTo,stepTo S1,"Step to given sprite. Animation for state ""step"" will be played"
+stepTo,"stepTo 100, 100","Step to given position. Animation for state ""step"" will be played"
+stepTo,stepTo Mouse,"Step to the given object. Animation for state ""step"" will be played"
+stepTo,"stepTo S1, 1","Step to given sprite and specify speed. Animation for state ""step"" will be played"
+stepTo,"stepTo 100, 100, 1","Step to given position and specify speed. Animation for state ""step"" will be played"
+stepTo,"stepTo Mouse, 1","Step to given object and specify the step speed. Animation for state ""step"" will be played"
+stepTo,"stepTo S1, 1, ""a1""",Step to given sprite and specify speed and animation
+stepTo,"stepTo 100, 100, 1, ""a1""",Step to given position and specify speed and animation
+stepTo,"stepTo Mouse, 1, ""a1""",Step to given object and specify speed and animation
+stopAnimation,"stopAnimation ""a1""",Stop animation with given name
+think,"think ""Emmm...""",Think of some word
+think,"think ""Emmm..."", 1",Think of some word for given seconds
+touching,touching(S1),if sprite touching given sprite
+touching,touching(Edge),If sprite touching given object
+touchingColor,"touchingColor(HSB(50,100,100))",If sprite touching given color
+turn,turn Right,"Turn by given direction. For example, if initially heading at 30 degrees, turning right will result in heading 120 degrees"
+turn,"turn Right, 1",Turn by given direction and specify the turn speed
+turn,"turn Right, 1, ""a1""","Turn by given direction, specify the turn speed and animation"
+turnTo,turnTo S1,Turn to given sprite
+turnTo,turnTo Right,Turn to given direction
+turnTo,turnTo Mouse,Turn to given object
+turnTo,"turnTo S1, 1","Turn to given sprite, and specify the turn speed"
+turnTo,"turnTo Right, 1","Turn to given direction, and specify the turn speed"
+turnTo,"turnTo Mouse, 1","Turn to given object, and specify the turn speed"
+turnTo,"turnTo S1, 1, ""a1""","Turn to given sprite, and specify the turn speed and animation"
+turnTo,"turnTo Right, 1, ""a1""","Turn to given direction, and specify the turn speed and animation"
+turnTo,"turnTo Mouse, 1, ""a1""","Turn to given object, and specify the turn speed and animation"
+visible,,If sprite visible
+xpos,,The sprite's X position
+ypos,,The sprite's Y position
+```
+
+## Others
+
+```csv
+Name,Sample,Description
+Back,,Back
+Backward,,Backward
+Forward,,Forward
+Front,,Front
+HSB,"HSB(50, 100, 100)",Define HSB color
+HSBA,"HSBA(50, 100, 100, 100)",Define HSBA color
+Camera.follow,Camera.follow S1,Make the camera follow the given sprite
+Camera.setXYpos,"Camera.setXYpos 0, 0",Set the X and Y position of the camera center
+Camera.setZoom,Camera.setZoom 1,Set zoom factor of the camera
+Camera.xpos,,The X position of the camera center
+Camera.ypos,,The Y position of the camera center
+Camera.zoom,,"Zoom factor of the camera. Value 1 means no zoom, greater than 1 means zoom in, and between 0 and 1 means zoom out"
+Down,,"Down direction, i.e., 180 degree"
+DynamicPhysics,,Dynamic physics effect
+Edge,,Edge of the stage
+EdgeBottom,,Bottom edge of the stage
+EdgeLeft,,Left edge of the stage
+EdgeRight,,Right edge of the stage
+EdgeTop,,Top edge of the stage
+exit,,Exit the game
+forever,forever => {},Repeat forever
+KinematicPhysics,,Kinematic physics effect
+Left,,"Left direction, i.e., -90 degree"
+LeftRight,,Left-Right
+List,,List data structure for storing multiple values
+List.append,"myList.append ""value""",Add a value to the end of the list
+List.at,myList.at 0,Get the value at a specific index
+List.contains,"myList.contains ""value""",Check if the list contains a specific value
+List.delete,myList.delete 0,Remove the item at a specific index
+List.init,"myList.init ""a"", ""b"", ""c""",Initialize the list with given values
+List.initFrom,myList.initFrom otherList,Initialize the list by copying from another list
+List.insert,"myList.insert 0, ""value""",Insert a value at a specific index
+List.len,myList.len,Get the length of the list
+List.set,"myList.set 0, ""newValue""",Set the value at a specific index
+List.string,myList.string,Get the string representation of the list
+Monitor,,Monitor widget
+Monitor.changeSize,changeSize 0.1,Change size of the widget
+Monitor.changeXYpos,"changeXYpos 10, 10",Change the widget's position
+Monitor.changeXpos,changeXpos 10,Change the widget's X position
+Monitor.changeYpos,changeYpos 10,Change the widget's Y position
+Monitor.hide,hide,Make the widget invisible
+Monitor.setSize,setSize 2,Set size of the widget
+Monitor.setXYpos,"setXYpos 0, 0","Set the widget's X, Y position"
+Monitor.setXpos,setXpos 0,Set the widget's X position
+Monitor.setYpos,setYpos 0,Set the widget's Y position
+Monitor.show,show,Make the widget visible
+Monitor.size,size,"Size of the widget. Value is relative to initial size. For example, 2 means current size is twice the initial size"
+Monitor.visible,visible,If widget visible
+Monitor.xpos,xpos,The widget's X position
+Monitor.ypos,ypos,The widget's Y position
+Mouse,,Mouse
+MovingInfo.dx,dx,Change of the X position
+MovingInfo.dy,dy,Change of the Y position
+MovingInfo.NewX,newX,The X position after moving
+MovingInfo.NewY,newY,The Y position after moving
+MovingInfo.OldX,oldX,The X position before moving
+MovingInfo.OldY,oldY,The Y position before moving
+Next,,Next item
+NoPhysics,,No physics effect
+None,,Don't Rotate
+Normal,,Normal
+Prev,,Previous item
+rand,"rand(1, 10)",Generate a random integer
+rand,"rand(1.5, 9.9)",Generate a random number
+repeat,"repeat 10, => {}",Repeat for given times
+repeatUntil,"repeatUntil false, => {}",Repeat until given condition is met
+Right,,"Right direction, i.e., 90 degree"
+Sprite,,Type for sprite
+StaticPhysics,,Static physics effect
+TurningInfo.dir,dir,The degree changed by turning
+TurningInfo.NewDir,NewDir,The heading direction after turning
+TurningInfo.OldDir,OldDir,The heading direction before turning
+Up,,"Up direction, i.e., 0 degree"
+Value,,Value type for dynamic data
+Value.equal,myValue.equal otherValue,Check if two values are equal
+Value.float,myValue.float,Convert the value to a floating-point number
+Value.int,myValue.int,Convert the value to an integer
+Value.string,myValue.string,Convert the value to a string
+waitUntil,waitUntil true,Wait until given condition is met
+Widget.changeSize,changeSize 0.1,Change size of the widget
+Widget.changeXYpos,"changeXYpos 10, 10",Change the widget's position
+Widget.changeXpos,changeXpos 10,Change the widget's X position
+Widget.changeYpos,changeYpos 10,Change the widget's Y position
+Widget.hide,hide,Make the widget invisible
+Widget.setSize,setSize 2,Set size of the widget
+Widget.setXYpos,"setXYpos 0, 0","Set the widget's X, Y position"
+Widget.setXpos,setXpos 0,Set the widget's X position
+Widget.setYpos,setYpos 0,Set the widget's Y position
+Widget.show,show,Make the widget visible
+Widget.size,size,"Size of the widget. Value is relative to initial size. For example, 2 means current size is twice the initial size"
+Widget.visible,visible,If widget visible
+Widget.xpos,xpos,The widget's X position
+Widget.ypos,ypos,The widget's Y position
+```
+
+## Keys
+
+```csv
+Name,Sample,Description
+"Key0-Key9,KeyA-KeyZ,KeyF1-KeyF12,KeyKP0-KeyKP9,KeyApostrophe,KeyBackslash,KeyBackspace,KeyCapsLock,KeyComma,KeyDelete,KeyDown,KeyEnd,KeyEnter,KeyEqual,KeyEscape,KeyGraveAccent,KeyHome,KeyInsert,KeyKPDecimal,KeyKPDivide,KeyKPEnter,KeyKPEqual,KeyKPMultiply,KeyKPSubtract,KeyLeft,KeyLeftBracket,KeyMenu,KeyMinus,KeyNumLock,KeyPageDown,KeyPageUp,KeyPause,KeyPeriod,KeyPrintScreen,KeyRight,KeyRightBracket,KeyScrollLock,KeySemicolon,KeySlash,KeySpace,KeyTab,KeyUp,KeyAlt,KeyControl,KeyShift,KeyMax,KeyAny","onKey Key1, => {}","Key definitions, used for keyboard event listening."
+```

--- a/spx-gui/src/components/copilot/skills/bundles/xgo-language/SKILL.md
+++ b/spx-gui/src/components/copilot/skills/bundles/xgo-language/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: xgo-language
+description: Handbook for XGo language features, syntax, and classfile concepts. Use this skill to understand how to read and write code in XGo.
+---
+
+# XGo Language
+
+The XGo programming language is
+
+- Superset of the Go language
+- Statically typed
+- With special features focusing on simplicity and efficiency
+
+## How XGo simplifies Go's expressions
+
+### Program structure
+
+XGo allows omitting package main and func main.
+
+```go
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("Hi")
+}
+```
+
+```xgo
+import "fmt"
+
+fmt.Println("Hi")
+```
+
+### Builtin functions
+
+XGo provides more builtin functions. It simplifies the expression of the most common tasks.
+
+```go
+fmt.Println("Hi")
+```
+
+```xgo
+println("Hi")
+```
+
+### Command-line style
+
+XGo recommends command-line style code, which is a special style for function-calls whose return values are not used:
+
+```go
+println("Hi")
+```
+
+```xgo
+println "Hi"
+```
+
+### List literals
+
+```go
+a := []int{1, 2, 3}
+```
+
+```xgo
+a := [1, 2, 3]
+```
+
+### Map literals
+
+```go
+a := map[string]int{
+	"Monday": 1,
+	"Tuesday": 2,
+}
+```
+
+```xgo
+a := {
+	"Monday": 1,
+	"Tuesday": 2,
+}
+```
+
+### Lambda expressions
+
+```go
+onStart(func() {...})
+onMsg(msg, func() {...})
+```
+
+```xgo
+onStart => {...}
+onMsg msg, => {...}
+```
+
+### Function overloading
+
+XGo allows calling multiple functions (they are defined as `Xxx__0`, `Xxx__1`, etc.) with the same name (`xxx`) in XGo but different implementations.
+
+```go
+Step__0(5.5)
+Step__1(5.5, "run")
+Step__2(10)
+```
+
+```xgo
+step 5.5
+step 5.5, "run"
+step 10
+```
+
+### Classfiles
+
+XGo classfiles provide a mechanism to abstract domain knowledge, making XGo more accessible and friendly to various user groups, especially those new to programming or unfamiliar with object-oriented programming concepts. Instead of explicitly defining classes using `type` and `struct` keywords as in Go, XGo allows defining classes using a simpler, more intuitive syntax within files called classfiles.
+
+Key Aspects of XGo Classfiles:
+
+- Simplified Syntax: Classfiles define classes using a syntax closer to sequential programming. Variables and functions are declared directly within the classfile, eliminating the need for explicit `struct` and method declarations.
+- Abstraction of Domain Knowledge: The primary purpose is to abstract domain-specific knowledge. This is achieved by defining a base class for a project and organizing related worker classes under it.
+- Project and Worker Classes: A classfile typically consists of a project class and multiple worker classes. The project class represents the main entity, while worker classes represent supporting components.
+
+Under the hood, XGo classfiles will be compiled into Go code with `struct` and method declarations, allowing seamless integration with existing Go codebases.
+
+### Syntax
+
+Load `references/syntax.md` for compact syntax examples.

--- a/spx-gui/src/components/copilot/skills/bundles/xgo-language/references/syntax.md
+++ b/spx-gui/src/components/copilot/skills/bundles/xgo-language/references/syntax.md
@@ -1,0 +1,28 @@
+# XGo Syntax Cheatsheet
+
+## Basic syntax
+
+```csv
+Package,Name,Sample,Description
+,for_iterate,for v in [] {},Iterate within given list
+,for_iterate_with_index,"for i, v in [] {}",Iterate with index within given list
+,for_loop_with_condition,for true {},Loop with condition
+,for_loop_with_range,for i in 1:5 {},Loop with range
+,func_declaration,func name(params) returnType {},"Function declaration, e.g., `func add(a int, b int) int {}`"
+,if_else_statement,if true {} else {},If else statement
+,if_statement,if true {},If statement
+,import_declaration,"import ""package""","Import package declaration, e.g., `import ""fmt""`"
+fmt,println,"println ""Hello, World!""",Print given message
+,var_declaration,var name type,"Variable declaration, e.g., `var count int`"
+```
+
+## Shorter expression styles
+
+- `println "Hello"` is a valid command-line style call in XGo
+- `[1, 2, 3]` is a list literal
+- `{ "Monday": 1 }` is a map literal
+- `onStart => {}` is a lambda-style callback form
+
+## Reminder
+
+When a syntax detail is not covered by XGo-specific sugar, follow normal Go syntax rules.

--- a/spx-gui/src/components/copilot/skills/context-provider.ts
+++ b/spx-gui/src/components/copilot/skills/context-provider.ts
@@ -1,0 +1,26 @@
+import type { ICopilotContextProvider } from '../copilot'
+import type { SkillManifestItem, SkillRegistry } from './types'
+
+function formatCatalogItems(items: SkillManifestItem[]): string {
+  return items.map((item) => `- Skill name: ${item.name}\n  Description: ${item.description}`).join('\n')
+}
+
+function formatSkillCatalog(items: SkillManifestItem[]): string {
+  if (items.length === 0) return ''
+  return `# Skills
+
+When a task matches a skill description, call \`load_skill\` with the exact skill name to read the skill.
+You can also read resources in a skill by calling \`load_skill_resource\` with the skill name and the resource path.
+
+Here are the available skills:
+
+${formatCatalogItems(items)}`
+}
+
+export class SkillCatalogContextProvider implements ICopilotContextProvider {
+  constructor(private registry: SkillRegistry) {}
+
+  async provideContext(): Promise<string> {
+    return formatSkillCatalog(await this.registry.list())
+  }
+}

--- a/spx-gui/src/components/copilot/skills/index.ts
+++ b/spx-gui/src/components/copilot/skills/index.ts
@@ -1,0 +1,48 @@
+import { fromText, type Files } from '@/models/common/file'
+import { Disposable, type Disposer } from '@/utils/disposable'
+import type { Copilot } from '../copilot'
+import { SkillCatalogContextProvider } from './context-provider'
+import { InMemorySkillRegistry } from './registry'
+import { createLoadSkillResourceTool, createLoadSkillTool } from './tools'
+import type { SkillBundle, SkillRegistry } from './types'
+
+const builtInSkills = ['spx-project', 'xgo-language']
+
+const bundleFiles = import.meta.glob(
+  './bundles/**/*.md', // For now we only bundle markdown resources from built-in skills.
+  {
+    eager: true,
+    query: '?raw',
+    import: 'default'
+  }
+) as Record<string, string>
+
+function createBuiltInSkillBundle(name: string): SkillBundle {
+  const files: Files = {}
+  const pathPrefix = `./bundles/${name}/`
+  for (const path of Object.keys(bundleFiles).sort()) {
+    if (!path.startsWith(pathPrefix)) continue
+    const filePath = path.slice(pathPrefix.length)
+    files[filePath] = fromText(filePath, bundleFiles[path])
+  }
+  return { files }
+}
+
+export function createBuiltInSkillRegistry(): SkillRegistry {
+  const registry = new InMemorySkillRegistry()
+  for (const name of builtInSkills) {
+    const bundle = createBuiltInSkillBundle(name)
+    registry.register(bundle)
+  }
+  return registry
+}
+
+/** Register built-in skill support to the given Copilot instance. */
+export function registerSkillSupport(copilot: Copilot): Disposer {
+  const disposable = new Disposable()
+  const registry = createBuiltInSkillRegistry()
+  disposable.addDisposer(copilot.registerContextProvider(new SkillCatalogContextProvider(registry)))
+  disposable.addDisposer(copilot.registerTool(createLoadSkillTool(registry)))
+  disposable.addDisposer(copilot.registerTool(createLoadSkillResourceTool(registry)))
+  return () => disposable.dispose()
+}

--- a/spx-gui/src/components/copilot/skills/parser.ts
+++ b/spx-gui/src/components/copilot/skills/parser.ts
@@ -1,0 +1,49 @@
+// Skill document format reference: https://agentskills.io/specification
+
+type ParsedSkillMetadata = {
+  name: string
+  description: string
+}
+
+export type ParsedSkillDocument = ParsedSkillMetadata & {
+  content: string
+}
+
+const frontmatterPattern = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?([\s\S]*)$/
+
+function unquote(value: string): string {
+  if (value.length < 2) return value
+  const first = value[0]
+  const last = value[value.length - 1]
+  if ((first === '"' && last === '"') || (first === "'" && last === "'")) {
+    return value.slice(1, -1)
+  }
+  return value
+}
+
+function parseFrontmatter(frontmatter: string): ParsedSkillMetadata {
+  const metadata = new Map<string, string>()
+  for (const rawLine of frontmatter.split(/\r?\n/)) {
+    const line = rawLine.trim()
+    if (line === '' || line.startsWith('#')) continue
+    const matched = line.match(/^([A-Za-z0-9_-]+):\s*(.*)$/)
+    if (matched == null) continue
+    metadata.set(matched[1], unquote(matched[2].trim()))
+  }
+
+  const name = metadata.get('name') ?? ''
+  const description = metadata.get('description') ?? ''
+  if (name === '') throw new Error('Skill frontmatter must contain a non-empty name')
+  if (description === '') throw new Error('Skill frontmatter must contain a non-empty description')
+  return { name, description }
+}
+
+export function parseSkillDocument(markdown: string): ParsedSkillDocument {
+  const matched = markdown.match(frontmatterPattern)
+  if (matched == null) throw new Error('Skill document must start with YAML frontmatter')
+  const metadata = parseFrontmatter(matched[1])
+  return {
+    ...metadata,
+    content: matched[2].trim()
+  }
+}

--- a/spx-gui/src/components/copilot/skills/registry.ts
+++ b/spx-gui/src/components/copilot/skills/registry.ts
@@ -44,7 +44,10 @@ export class InMemorySkillRegistry implements SkillRegistry {
   private getCachedRecord(bundle: SkillBundle): Promise<SkillBundleRecord> {
     let cachedRecord = this.cachedRecords.get(bundle)
     if (cachedRecord != null) return cachedRecord
-    cachedRecord = buildSkillBundleRecord(bundle)
+    cachedRecord = buildSkillBundleRecord(bundle).catch((error: unknown) => {
+      this.cachedRecords.delete(bundle)
+      throw error
+    })
     this.cachedRecords.set(bundle, cachedRecord)
     return cachedRecord
   }
@@ -80,9 +83,6 @@ export class InMemorySkillRegistry implements SkillRegistry {
   async loadResource(name: string, resourcePath: string): Promise<string> {
     const record = (await this.loadRecords()).get(name)
     if (record == null) throw new Error(`Skill not found: ${name}`)
-    if (!record.resourcePaths.includes(resourcePath)) {
-      throw new Error(`Skill resource not found: ${name}/${resourcePath}`)
-    }
     const file = record.files[resourcePath]
     if (file == null) {
       throw new Error(`Skill resource not found: ${name}/${resourcePath}`)

--- a/spx-gui/src/components/copilot/skills/registry.ts
+++ b/spx-gui/src/components/copilot/skills/registry.ts
@@ -1,0 +1,92 @@
+import { toText, type Files } from '@/models/common/file'
+import { parseSkillDocument } from './parser'
+import type { LoadedSkillDocument, SkillBundle, SkillManifestItem, SkillRegistry } from './types'
+
+type SkillBundleRecord = {
+  manifest: SkillManifestItem
+  instructions: string
+  files: Files
+  resourcePaths: string[]
+}
+
+async function buildSkillBundleRecord(bundle: SkillBundle): Promise<SkillBundleRecord> {
+  const skillFile = bundle.files['SKILL.md']
+  if (skillFile == null) throw new Error('Skill bundle does not contain SKILL.md')
+  const parsed = parseSkillDocument(await toText(skillFile))
+  const resourcePaths = Object.entries(bundle.files)
+    .filter(([path, file]) => file != null && path !== 'SKILL.md')
+    .map(([path]) => path)
+    .sort()
+
+  return {
+    manifest: {
+      name: parsed.name,
+      description: parsed.description
+    },
+    instructions: parsed.content,
+    files: bundle.files,
+    resourcePaths
+  }
+}
+
+export class InMemorySkillRegistry implements SkillRegistry {
+  private bundles = new Set<SkillBundle>()
+  private cachedRecords = new Map<SkillBundle, Promise<SkillBundleRecord>>()
+
+  register(bundle: SkillBundle) {
+    this.bundles.add(bundle)
+    return () => {
+      if (!this.bundles.delete(bundle)) return
+      this.cachedRecords.delete(bundle)
+    }
+  }
+
+  private getCachedRecord(bundle: SkillBundle): Promise<SkillBundleRecord> {
+    let cachedRecord = this.cachedRecords.get(bundle)
+    if (cachedRecord != null) return cachedRecord
+    cachedRecord = buildSkillBundleRecord(bundle)
+    this.cachedRecords.set(bundle, cachedRecord)
+    return cachedRecord
+  }
+
+  private async loadRecords(): Promise<Map<string, SkillBundleRecord>> {
+    const nextRecords = new Map<string, SkillBundleRecord>()
+    const records = await Promise.all(Array.from(this.bundles, (bundle) => this.getCachedRecord(bundle)))
+    for (const record of records.sort((left, right) => left.manifest.name.localeCompare(right.manifest.name))) {
+      if (nextRecords.has(record.manifest.name)) {
+        throw new Error(`Duplicate skill name: ${record.manifest.name}`)
+      }
+      nextRecords.set(record.manifest.name, record)
+    }
+    return nextRecords
+  }
+
+  async list(): Promise<SkillManifestItem[]> {
+    const records = await this.loadRecords()
+    return Array.from(records.values(), (record) => record.manifest)
+  }
+
+  async load(name: string): Promise<LoadedSkillDocument> {
+    const record = (await this.loadRecords()).get(name)
+    if (record == null) throw new Error(`Skill not found: ${name}`)
+    return {
+      name: record.manifest.name,
+      description: record.manifest.description,
+      instructions: record.instructions,
+      resourcePaths: record.resourcePaths
+    }
+  }
+
+  async loadResource(name: string, resourcePath: string): Promise<string> {
+    const record = (await this.loadRecords()).get(name)
+    if (record == null) throw new Error(`Skill not found: ${name}`)
+    if (!record.resourcePaths.includes(resourcePath)) {
+      throw new Error(`Skill resource not found: ${name}/${resourcePath}`)
+    }
+    const file = record.files[resourcePath]
+    if (file == null) {
+      throw new Error(`Skill resource not found: ${name}/${resourcePath}`)
+    }
+    return toText(file)
+  }
+}

--- a/spx-gui/src/components/copilot/skills/skills.test.ts
+++ b/spx-gui/src/components/copilot/skills/skills.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from 'vitest'
+
+import { SkillCatalogContextProvider } from './context-provider'
+import { createBuiltInSkillRegistry } from './index'
+import { createLoadSkillResourceTool, createLoadSkillTool } from './tools'
+import { parseSkillDocument } from './parser'
+import type { SkillRegistry } from './types'
+
+describe('parseSkillDocument', () => {
+  it('parses frontmatter metadata and markdown body', () => {
+    const parsed = parseSkillDocument(`---
+name: Demo Skill
+description: Demo description.
+---
+
+# Demo
+
+Skill body.
+`)
+
+    expect(parsed).toEqual({
+      name: 'Demo Skill',
+      description: 'Demo description.',
+      content: '# Demo\n\nSkill body.'
+    })
+  })
+
+  it('requires name and description in frontmatter', () => {
+    expect(() =>
+      parseSkillDocument(`---
+name: Demo Skill
+---
+
+Missing description.
+`)
+    ).toThrow('Skill frontmatter must contain a non-empty description')
+  })
+})
+
+describe('built-in skill registry', () => {
+  it('lists built-in skills and loads main and resource documents', async () => {
+    const registry = createBuiltInSkillRegistry()
+
+    expect(await registry.list()).toEqual([
+      {
+        name: 'spx-project',
+        description:
+          'Guidelines for developing spx projects (games), including file structure, code organization, and best practices. Use this skill when the task is specifically about building or modifying an spx game in XBuilder.'
+      },
+      {
+        name: 'xgo-language',
+        description:
+          'Handbook for XGo language features, syntax, and classfile concepts. Use this skill to understand how to read and write code in XGo.'
+      }
+    ])
+
+    expect(await registry.load('spx-project')).toEqual({
+      name: 'spx-project',
+      description:
+        'Guidelines for developing spx projects (games), including file structure, code organization, and best practices. Use this skill when the task is specifically about building or modifying an spx game in XBuilder.',
+      instructions: expect.stringContaining('# About spx'),
+      resourcePaths: ['references/ai-interaction.md', 'references/apis.md']
+    })
+    expect(await registry.loadResource('spx-project', 'references/apis.md')).toContain('# spx APIs')
+    expect(await registry.loadResource('xgo-language', 'references/syntax.md')).toContain('# XGo Syntax Cheatsheet')
+    await expect(registry.load('Missing Skill')).rejects.toThrow('Skill not found: Missing Skill')
+    await expect(registry.loadResource('spx-project', 'references/missing.md')).rejects.toThrow(
+      'Skill resource not found: spx-project/references/missing.md'
+    )
+  })
+})
+
+describe('skill catalog context', () => {
+  it('formats the catalog for normal copilot context injection', async () => {
+    const registry = createBuiltInSkillRegistry()
+    const provider = new SkillCatalogContextProvider(registry)
+    const emptyRegistry: SkillRegistry = {
+      register() {
+        return () => {}
+      },
+      async list() {
+        return []
+      },
+      async load() {
+        throw new Error('Skill not found: empty')
+      },
+      async loadResource() {
+        throw new Error('Skill resource not found: empty/resource')
+      }
+    }
+    const emptyProvider = new SkillCatalogContextProvider(emptyRegistry)
+
+    expect(await emptyProvider.provideContext()).toBe('')
+    expect(await provider.provideContext()).toContain('# Skills')
+    expect(await provider.provideContext()).toContain('call `load_skill` with the exact skill name to read the skill')
+    expect(await provider.provideContext()).toContain(
+      'You can also read resources in a skill by calling `load_skill_resource` with the skill name and the resource path'
+    )
+    expect(await provider.provideContext()).toContain('Skill name: spx-project')
+  })
+})
+
+describe('load_skill tool', () => {
+  it('loads skill documents and resources without session-specific state', async () => {
+    const registry = createBuiltInSkillRegistry()
+    const tool = createLoadSkillTool(registry)
+    const resourceTool = createLoadSkillResourceTool(registry)
+
+    const mainDocument = await tool.implementation({ skillName: 'spx-project' })
+    expect(mainDocument).toContain('<skill_content name="spx-project" path="SKILL.md">')
+    expect(mainDocument).toContain('# About spx')
+    expect(mainDocument).toContain('<skill_resources>')
+    expect(mainDocument).toContain('<file>references/ai-interaction.md</file>')
+    expect(mainDocument).toContain('<file>references/apis.md</file>')
+
+    const repeatedMainDocument = await tool.implementation({ skillName: 'spx-project' })
+    expect(repeatedMainDocument).toContain('# About spx')
+    expect(repeatedMainDocument).not.toContain('already_loaded="true"')
+
+    const resourceDocument = await resourceTool.implementation({
+      skillName: 'spx-project',
+      resourcePath: 'references/apis.md'
+    })
+    expect(resourceDocument).toContain('path="references/apis.md"')
+    expect(resourceDocument).toContain('# spx APIs')
+    expect(resourceDocument).not.toContain('<skill_resources>')
+
+    const directResourceDocument = await resourceTool.implementation({
+      skillName: 'xgo-language',
+      resourcePath: 'references/syntax.md'
+    })
+    expect(directResourceDocument).toContain('# XGo Syntax Cheatsheet')
+    expect(directResourceDocument).toContain('for_iterate')
+  })
+})

--- a/spx-gui/src/components/copilot/skills/skills.test.ts
+++ b/spx-gui/src/components/copilot/skills/skills.test.ts
@@ -113,10 +113,6 @@ describe('load_skill tool', () => {
     expect(mainDocument).toContain('<file>references/ai-interaction.md</file>')
     expect(mainDocument).toContain('<file>references/apis.md</file>')
 
-    const repeatedMainDocument = await tool.implementation({ skillName: 'spx-project' })
-    expect(repeatedMainDocument).toContain('# About spx')
-    expect(repeatedMainDocument).not.toContain('already_loaded="true"')
-
     const resourceDocument = await resourceTool.implementation({
       skillName: 'spx-project',
       resourcePath: 'references/apis.md'

--- a/spx-gui/src/components/copilot/skills/tools.ts
+++ b/spx-gui/src/components/copilot/skills/tools.ts
@@ -1,0 +1,53 @@
+import { z } from 'zod'
+import { escapeHTML } from '@/utils/utils'
+import type { ToolDefinition } from '../copilot'
+import type { SkillRegistry } from './types'
+
+function formatSkillResources(resourcePaths: string[]): string {
+  if (resourcePaths.length === 0) return ''
+  const resources = resourcePaths.map((path) => `  <file>${escapeHTML(path)}</file>`).join('\n')
+  return `\n\n<skill_resources>\n${resources}\n</skill_resources>`
+}
+
+function wrapSkillContent(name: string, path: string, content: string, resourcePaths: string[] = []): string {
+  const attrs = [`name="${escapeHTML(name)}"`, `path="${escapeHTML(path)}"`]
+  const resources = resourcePaths.length > 0 ? formatSkillResources(resourcePaths) : ''
+  return `<skill_content ${attrs.join(' ')}>
+${content}${resources}
+</skill_content>`
+}
+
+const loadSkillParamsSchema = z.object({
+  skillName: z.string().describe('Exact skill name from the available-skill catalog')
+})
+
+export function createLoadSkillTool(registry: SkillRegistry): ToolDefinition {
+  return {
+    name: 'load_skill',
+    description: `Load the main document of a skill. ` + `Use when the current task matches a skill description.`,
+    parameters: loadSkillParamsSchema,
+    async implementation({ skillName }: z.infer<typeof loadSkillParamsSchema>) {
+      const skillDocument = await registry.load(skillName)
+      return wrapSkillContent(skillDocument.name, 'SKILL.md', skillDocument.instructions, skillDocument.resourcePaths)
+    }
+  }
+}
+
+const loadSkillResourceParamsSchema = z.object({
+  skillName: z.string().describe('Exact skill name from the available-skill catalog'),
+  resourcePath: z.string().describe('Exact resource path exposed by the previously loaded skill')
+})
+
+export function createLoadSkillResourceTool(registry: SkillRegistry): ToolDefinition {
+  return {
+    name: 'load_skill_resource',
+    description:
+      `Load a resource from a skill. ` +
+      `Use this when you already know the exact resource path, typically after load_skill has listed the available resource paths.`,
+    parameters: loadSkillResourceParamsSchema,
+    async implementation({ skillName, resourcePath }: z.infer<typeof loadSkillResourceParamsSchema>) {
+      const resourceContent = await registry.loadResource(skillName, resourcePath)
+      return wrapSkillContent(skillName, resourcePath, resourceContent)
+    }
+  }
+}

--- a/spx-gui/src/components/copilot/skills/tools.ts
+++ b/spx-gui/src/components/copilot/skills/tools.ts
@@ -11,7 +11,7 @@ function formatSkillResources(resourcePaths: string[]): string {
 
 function wrapSkillContent(name: string, path: string, content: string, resourcePaths: string[] = []): string {
   const attrs = [`name="${escapeHTML(name)}"`, `path="${escapeHTML(path)}"`]
-  const resources = resourcePaths.length > 0 ? formatSkillResources(resourcePaths) : ''
+  const resources = formatSkillResources(resourcePaths)
   return `<skill_content ${attrs.join(' ')}>
 ${content}${resources}
 </skill_content>`

--- a/spx-gui/src/components/copilot/skills/types.ts
+++ b/spx-gui/src/components/copilot/skills/types.ts
@@ -1,0 +1,39 @@
+import type { Files } from '@/models/common/file'
+import type { Disposer } from '@/utils/disposable'
+
+/** A skill bundle represented as an fs-like collection of files. */
+export type SkillBundle = {
+  /** Files included in the skill bundle. See details about `Files` in `@/models/common/file.ts`. */
+  files: Files
+}
+
+/** Metadata exposed in the skill catalog and shared by loaded skill documents. */
+export type SkillManifestItem = {
+  /** Name of the skill. See details in https://agentskills.io/specification#name-field */
+  name: string
+  /** Description of the skill. See details in https://agentskills.io/specification#description-field */
+  description: string
+}
+
+/** The parsed main skill document together with its catalog metadata and available resource paths. */
+export type LoadedSkillDocument = SkillManifestItem & {
+  /** The content of the main skill document (`SKILL.md`). See details in https://agentskills.io/specification#body-content */
+  instructions: string
+  /**
+   * Relative paths of other files included in the skill bundle, excluding `SKILL.md`.
+   * Only the currently supported resource files are exposed here.
+   */
+  resourcePaths: string[]
+}
+
+/** Registry interface for skill bundle registration, discovery, and document loading. */
+export interface SkillRegistry {
+  /** Register a skill bundle to the registry. Returns a disposer to unregister the bundle. */
+  register(bundle: SkillBundle): Disposer
+  /** List all available skills in the registry. */
+  list(): Promise<SkillManifestItem[]>
+  /** Load the main skill document (`SKILL.md`) with the given skill name. */
+  load(name: string): Promise<LoadedSkillDocument>
+  /** Load a resource file with the given skill name and relative resource path. */
+  loadResource(name: string, resourcePath: string): Promise<string>
+}

--- a/spx-gui/src/components/copilot/tool-executor.ts
+++ b/spx-gui/src/components/copilot/tool-executor.ts
@@ -31,8 +31,8 @@ export class ToolExecutor {
     { id, tool: toolName, parameters: parametersStr }: ToolExecutionInput,
     signal?: AbortSignal
   ): Promise<unknown> {
-    this.executions.set(id, { state: 'executing' })
     if (this.executions.has(id)) console.warn(`Execution with ID ${id} already exists`)
+    this.executions.set(id, { state: 'executing' })
     try {
       if (typeof toolName !== 'string') throw new Error('Tool name must be a string')
       if (typeof parametersStr !== 'string') throw new Error('Parameters must be JSON string')

--- a/spx-gui/src/components/editor/ProjectEditor.vue
+++ b/spx-gui/src/components/editor/ProjectEditor.vue
@@ -45,11 +45,14 @@ import EditorPlaceholder from './common/placeholder/EditorPlaceholder.vue'
 import { useEditorCtx } from './EditorContextProvider.vue'
 import { EditMode } from './editor-state'
 import MapEditor from './map-editor/MapEditor.vue'
+import { useSpxEditorCopilot } from './copilot'
 
 const editorCtx = useEditorCtx()
 const project = computed(() => editorCtx.project)
 const selected = computed(() => editorCtx.state.selected)
 const isPreviewMode = computed(() => editorCtx.state.selectedEditMode === EditMode.Default)
+
+useSpxEditorCopilot()
 
 function handleSpriteSelect(spriteId: string | null) {
   if (spriteId == null) return

--- a/spx-gui/src/components/editor/copilot.ts
+++ b/spx-gui/src/components/editor/copilot.ts
@@ -1,0 +1,306 @@
+import dayjs from 'dayjs'
+import { z } from 'zod'
+import { onScopeDispose, watch, type ComputedRef } from 'vue'
+import { useCopilot } from '@/components/copilot/context'
+import { codeFilePathSchema, parseProjectIdentifier, projectIdentifierSchema } from '@/components/copilot/common'
+import { type ICopilotContextProvider, type ToolDefinition } from '@/components/copilot/copilot'
+import { cloudHelpers, type CloudHelpers } from '@/models/common/cloud'
+import { SpxProject } from '@/models/spx/project'
+import type { Sprite } from '@/models/spx/sprite'
+import { Disposable } from '@/utils/disposable'
+import { useEditorCtxRef, type EditorCtx } from './EditorContextProvider.vue'
+import {
+  CodeEditor,
+  getCodeFilePath,
+  isSelectionEmpty,
+  textDocumentId2CodeFileName,
+  useCodeEditorRef,
+  type TextDocument
+} from './code-editor/spx-code-editor'
+
+class Retriever {
+  constructor(
+    private editorCtxRef: ComputedRef<EditorCtx | undefined>,
+    private helpers: CloudHelpers
+  ) {}
+
+  async getProject(project: string | undefined, signal?: AbortSignal): Promise<SpxProject> {
+    const currentProject = this.editorCtxRef.value?.project
+    if (project == null) {
+      if (currentProject == null) throw new Error('No project specified and no current editing project available')
+      return currentProject
+    }
+    const { owner, name } = parseProjectIdentifier(project)
+    if (currentProject != null && currentProject.owner === owner && currentProject.name === name) {
+      return currentProject
+    }
+    const loadedProject = new SpxProject()
+    const serialized = await this.helpers.load(owner, name, true, signal)
+    await loadedProject.load(serialized)
+    return loadedProject
+  }
+}
+
+function getProjectContent(project: SpxProject) {
+  const physics = project.stage.physics
+  return `\
+### Sprites (num: ${project.sprites.length})
+${project.sprites.map((sprite) => `- ${sprite.name}`).join('\n')}
+### Sounds (num: ${project.sounds.length})
+${project.sounds.map((sound) => `- ${sound.name}`).join('\n')}
+### Backdrops (num: ${project.stage.backdrops.length})
+${project.stage.backdrops.map((backdrop) => `- ${backdrop.name}`).join('\n')}
+### Widgets (num: ${project.stage.widgets.length})
+${project.stage.widgets.map((widget) => `- ${widget.name}`).join('\n')}
+### Physics: ${physics.enabled ? 'Enabled' : 'Disabled'}`
+}
+
+function getSpriteContent(sprite: Sprite) {
+  return {
+    name: sprite.name,
+    costumes: sprite.costumes.map((costume) => costume.name),
+    animations: sprite.animations.map((animation) => animation.name),
+    heading: sprite.heading,
+    x: sprite.x,
+    y: sprite.y,
+    size: sprite.size,
+    rotationStyle: sprite.rotationStyle,
+    visible: sprite.visible,
+    codeLinesNum: sprite.code.split(/\r?\n/).length
+  }
+}
+
+type LineRangeParams = {
+  lineStart?: number
+  lineEnd?: number
+}
+
+function processCode(code: string, { lineStart = 1, lineEnd }: LineRangeParams) {
+  const allLines = code.split(/\r?\n/)
+  const sampledLines = allLines.slice(lineStart - 1, lineEnd).reduce<Record<string, string>>((result, line, index) => {
+    result[index + lineStart] = line
+    return result
+  }, {})
+  return {
+    lineCount: allLines.length,
+    sampledLines
+  }
+}
+
+const getProjectMetadataParamsSchema = z.object({
+  project: projectIdentifierSchema
+})
+
+class GetProjectMetadataTool implements ToolDefinition {
+  name = 'get_project_metadata'
+  description = 'Get metadata of a project.'
+  parameters = getProjectMetadataParamsSchema
+
+  constructor(private retriever: Retriever) {}
+
+  async implementation({ project }: z.infer<typeof getProjectMetadataParamsSchema>, signal?: AbortSignal) {
+    const loadedProject = await this.retriever.getProject(project, signal)
+    const { owner, remixedFrom, visibility, description, instructions } = loadedProject
+    return { owner, remixedFrom, visibility, description, instructions }
+  }
+}
+
+const getProjectContentParamsSchema = z.object({
+  project: projectIdentifierSchema
+})
+
+class GetProjectContentTool implements ToolDefinition {
+  name = 'get_project_content'
+  description = 'Get content of a project.'
+  parameters = getProjectContentParamsSchema
+
+  constructor(private retriever: Retriever) {}
+
+  async implementation({ project }: z.infer<typeof getProjectContentParamsSchema>, signal?: AbortSignal) {
+    const loadedProject = await this.retriever.getProject(project, signal)
+    return getProjectContent(loadedProject)
+  }
+}
+
+const getSpriteContentParamsSchema = z.object({
+  project: projectIdentifierSchema,
+  spriteName: z.string().describe('Name of the sprite')
+})
+
+class GetSpriteContentTool implements ToolDefinition {
+  name = 'get_sprite_content'
+  description = 'Get content of a sprite in a project.'
+  parameters = getSpriteContentParamsSchema
+
+  constructor(private retriever: Retriever) {}
+
+  async implementation({ project, spriteName }: z.infer<typeof getSpriteContentParamsSchema>, signal?: AbortSignal) {
+    const loadedProject = await this.retriever.getProject(project, signal)
+    const sprite = loadedProject.sprites.find((item) => item.name === spriteName)
+    if (sprite == null) throw new Error(`Sprite "${spriteName}" not found in project "${project}"`)
+    return getSpriteContent(sprite)
+  }
+}
+
+const lineStartSchema = z.number().default(1).describe('Line number to start from, 1-based')
+const lineEndSchema = z.number().optional().describe('Line number to end at, 1-based')
+
+const getProjectCodeParamsSchema = z.object({
+  project: projectIdentifierSchema,
+  file: codeFilePathSchema,
+  lineStart: lineStartSchema,
+  lineEnd: lineEndSchema
+})
+
+class GetProjectCodeTool implements ToolDefinition {
+  name = 'get_project_code'
+  description = 'Get code content of a file in project.'
+  parameters = getProjectCodeParamsSchema
+
+  constructor(private retriever: Retriever) {}
+
+  async implementation(
+    { project, file, lineStart, lineEnd }: z.infer<typeof getProjectCodeParamsSchema>,
+    signal?: AbortSignal
+  ) {
+    const loadedProject = await this.retriever.getProject(project, signal)
+    if (loadedProject.stage.codeFilePath === file) return processCode(loadedProject.stage.code, { lineStart, lineEnd })
+    const sprite = loadedProject.sprites.find((item) => item.codeFilePath === file)
+    if (sprite == null) throw new Error(`Code file ${file} not found in project ${project}`)
+    return processCode(sprite.code, { lineStart, lineEnd })
+  }
+}
+
+const getCodeDiagnosticsParamsSchema = z.object({})
+
+class GetCodeDiagnosticsTool implements ToolDefinition {
+  name = 'get_code_diagnostics'
+  description = 'Get code diagnostics (errors or warnings) of current editing project.'
+  parameters = getCodeDiagnosticsParamsSchema
+
+  constructor(private codeEditorRef: ComputedRef<CodeEditor | null>) {}
+
+  async implementation(_: z.infer<typeof getCodeDiagnosticsParamsSchema>, signal?: AbortSignal) {
+    const codeEditor = this.codeEditorRef.value
+    if (codeEditor == null) throw new Error('Code editor is not available')
+    return codeEditor.diagnosticWorkspace(signal)
+  }
+}
+
+class ProjectContextProvider implements ICopilotContextProvider {
+  constructor(private editorCtxRef: ComputedRef<EditorCtx | undefined>) {}
+
+  provideContext(): string {
+    const project = this.editorCtxRef.value?.project
+    if (project == null) return ''
+    return `# Current project
+The user is now working on project: ${project.displayName} (${project.owner}/${project.name})
+Class framework ID: spx
+## Project content
+${getProjectContent(project)}`
+  }
+}
+
+class SpriteContextProvider implements ICopilotContextProvider {
+  constructor(private editorCtxRef: ComputedRef<EditorCtx | undefined>) {}
+
+  provideContext(): string {
+    const sprite = this.editorCtxRef.value?.state.selectedSprite
+    if (sprite == null) return ''
+    return `# Current sprite content
+${JSON.stringify(getSpriteContent(sprite))}`
+  }
+}
+
+class CodeContextProvider implements ICopilotContextProvider {
+  constructor(private codeEditorRef: ComputedRef<CodeEditor | null>) {}
+
+  private sampleCode(activeTextDocument: TextDocument, line: number) {
+    const threshold = 10
+    const lineStart = Math.max(line - threshold, 1)
+    const lineEnd = lineStart + threshold * 2
+    return processCode(activeTextDocument.getValue(), { lineStart, lineEnd })
+  }
+
+  provideContext(): string {
+    const codeEditorUI = this.codeEditorRef.value?.getAttachedUI()
+    if (codeEditorUI == null) return ''
+    const { activeTextDocument, cursorPosition, selection } = codeEditorUI
+    if (activeTextDocument == null) return ''
+    const codeFilePath = getCodeFilePath(activeTextDocument.id.uri)
+    const cursorPositionStr =
+      cursorPosition == null ? 'None' : `Line ${cursorPosition.line}, Column ${cursorPosition.column}`
+    const selectionStr =
+      selection == null || isSelectionEmpty(selection)
+        ? 'None'
+        : `From Line ${selection.start.line}, Column ${selection.start.column} to Line ${selection.position.line}, Column ${selection.position.column}`
+    let result = `# Current code
+The user is now viewing / editing code of file \`${codeFilePath}\`. \
+Cursor position: ${cursorPositionStr}. \
+Selection: ${selectionStr}.`
+    const code = this.sampleCode(activeTextDocument, cursorPosition?.line ?? 1)
+    result += `
+Code content of \`${codeFilePath}\`:
+${JSON.stringify(code)}`
+    return result
+  }
+}
+
+class RuntimeContextProvider implements ICopilotContextProvider {
+  constructor(private editorCtxRef: ComputedRef<EditorCtx | undefined>) {}
+
+  provideContext(): string {
+    const runtime = this.editorCtxRef.value?.state.runtime
+    if (runtime == null) return ''
+    const outputs = runtime.outputs
+    if (outputs.length === 0) return ''
+    const recentOutputs = outputs.slice(-50)
+    const outputsStr = recentOutputs
+      .map((output) => {
+        const time = dayjs(output.time).format('HH:mm:ss.SSS')
+        const kindStr = output.kind === 'error' ? 'ERROR' : 'LOG'
+        const sourceStr = output.source
+          ? ` [${textDocumentId2CodeFileName(output.source.textDocument).en}:${output.source.range.start.line}]`
+          : ''
+        return `[${time}] ${kindStr}${sourceStr}: ${output.message.trim()}`
+      })
+      .join('\n')
+    return `# Game runtime output
+Recent game runtime outputs (last ${recentOutputs.length} of ${outputs.length}):
+${outputsStr}`
+  }
+}
+
+/** Set up Copilot for SPX Editor, including registering tools and context providers. */
+export function useSpxEditorCopilot(): void {
+  const d = new Disposable()
+  onScopeDispose(() => d.dispose())
+
+  const copilot = useCopilot()
+  const editorCtxRef = useEditorCtxRef()
+  const codeEditorRef = useCodeEditorRef()
+  const retriever = new Retriever(editorCtxRef, cloudHelpers)
+
+  d.addDisposer(copilot.registerTool(new GetProjectMetadataTool(retriever)))
+  d.addDisposer(copilot.registerTool(new GetProjectContentTool(retriever)))
+  d.addDisposer(copilot.registerTool(new GetSpriteContentTool(retriever)))
+  d.addDisposer(copilot.registerTool(new GetProjectCodeTool(retriever)))
+  d.addDisposer(copilot.registerTool(new GetCodeDiagnosticsTool(codeEditorRef)))
+  d.addDisposer(copilot.registerContextProvider(new ProjectContextProvider(editorCtxRef)))
+  d.addDisposer(copilot.registerContextProvider(new SpriteContextProvider(editorCtxRef)))
+  d.addDisposer(copilot.registerContextProvider(new CodeContextProvider(codeEditorRef)))
+  d.addDisposer(copilot.registerContextProvider(new RuntimeContextProvider(editorCtxRef)))
+
+  watch(
+    () => editorCtxRef.value?.state.runtime,
+    (editorRuntime, _, onCleanup) => {
+      if (editorRuntime == null) return
+      const unlisten = editorRuntime.on('didExit', (code) => {
+        if (code !== 0) return
+        copilot.notifyUserEvent({ en: 'Game exited with code 0', zh: '游戏正常退出' }, `Game exited with code ${code}`)
+      })
+      onCleanup(unlisten)
+    },
+    { immediate: true }
+  )
+}

--- a/spx-gui/src/components/editor/copilot.ts
+++ b/spx-gui/src/components/editor/copilot.ts
@@ -1,6 +1,6 @@
 import dayjs from 'dayjs'
 import { z } from 'zod'
-import { onScopeDispose, watch, type ComputedRef } from 'vue'
+import { onScopeDispose, watch } from 'vue'
 import { useCopilot } from '@/components/copilot/context'
 import { codeFilePathSchema, parseProjectIdentifier, projectIdentifierSchema } from '@/components/copilot/common'
 import { type ICopilotContextProvider, type ToolDefinition } from '@/components/copilot/copilot'
@@ -8,26 +8,25 @@ import { cloudHelpers, type CloudHelpers } from '@/models/common/cloud'
 import { SpxProject } from '@/models/spx/project'
 import type { Sprite } from '@/models/spx/sprite'
 import { Disposable } from '@/utils/disposable'
-import { useEditorCtxRef, type EditorCtx } from './EditorContextProvider.vue'
+import { useEditorCtx, type EditorCtx } from './EditorContextProvider.vue'
 import {
   CodeEditor,
   getCodeFilePath,
   isSelectionEmpty,
   textDocumentId2CodeFileName,
-  useCodeEditorRef,
+  useCodeEditor,
   type TextDocument
 } from './code-editor/spx-code-editor'
 
 class Retriever {
   constructor(
-    private editorCtxRef: ComputedRef<EditorCtx | undefined>,
+    private editorCtx: EditorCtx,
     private helpers: CloudHelpers
   ) {}
 
   async getProject(project: string | undefined, signal?: AbortSignal): Promise<SpxProject> {
-    const currentProject = this.editorCtxRef.value?.project
+    const currentProject = this.editorCtx.project
     if (project == null) {
-      if (currentProject == null) throw new Error('No project specified and no current editing project available')
       return currentProject
     }
     const { owner, name } = parseProjectIdentifier(project)
@@ -178,21 +177,18 @@ class GetCodeDiagnosticsTool implements ToolDefinition {
   description = 'Get code diagnostics (errors or warnings) of current editing project.'
   parameters = getCodeDiagnosticsParamsSchema
 
-  constructor(private codeEditorRef: ComputedRef<CodeEditor | null>) {}
+  constructor(private codeEditor: CodeEditor) {}
 
   async implementation(_: z.infer<typeof getCodeDiagnosticsParamsSchema>, signal?: AbortSignal) {
-    const codeEditor = this.codeEditorRef.value
-    if (codeEditor == null) throw new Error('Code editor is not available')
-    return codeEditor.diagnosticWorkspace(signal)
+    return this.codeEditor.diagnosticWorkspace(signal)
   }
 }
 
 class ProjectContextProvider implements ICopilotContextProvider {
-  constructor(private editorCtxRef: ComputedRef<EditorCtx | undefined>) {}
+  constructor(private editorCtx: EditorCtx) {}
 
   provideContext(): string {
-    const project = this.editorCtxRef.value?.project
-    if (project == null) return ''
+    const project = this.editorCtx.project
     return `# Current project
 The user is now working on project: ${project.displayName} (${project.owner}/${project.name})
 Class framework ID: spx
@@ -202,10 +198,10 @@ ${getProjectContent(project)}`
 }
 
 class SpriteContextProvider implements ICopilotContextProvider {
-  constructor(private editorCtxRef: ComputedRef<EditorCtx | undefined>) {}
+  constructor(private editorCtx: EditorCtx) {}
 
   provideContext(): string {
-    const sprite = this.editorCtxRef.value?.state.selectedSprite
+    const sprite = this.editorCtx.state.selectedSprite
     if (sprite == null) return ''
     return `# Current sprite content
 ${JSON.stringify(getSpriteContent(sprite))}`
@@ -213,7 +209,7 @@ ${JSON.stringify(getSpriteContent(sprite))}`
 }
 
 class CodeContextProvider implements ICopilotContextProvider {
-  constructor(private codeEditorRef: ComputedRef<CodeEditor | null>) {}
+  constructor(private codeEditor: CodeEditor) {}
 
   private sampleCode(activeTextDocument: TextDocument, line: number) {
     const threshold = 10
@@ -223,7 +219,7 @@ class CodeContextProvider implements ICopilotContextProvider {
   }
 
   provideContext(): string {
-    const codeEditorUI = this.codeEditorRef.value?.getAttachedUI()
+    const codeEditorUI = this.codeEditor.getAttachedUI()
     if (codeEditorUI == null) return ''
     const { activeTextDocument, cursorPosition, selection } = codeEditorUI
     if (activeTextDocument == null) return ''
@@ -247,11 +243,10 @@ ${JSON.stringify(code)}`
 }
 
 class RuntimeContextProvider implements ICopilotContextProvider {
-  constructor(private editorCtxRef: ComputedRef<EditorCtx | undefined>) {}
+  constructor(private editorCtx: EditorCtx) {}
 
   provideContext(): string {
-    const runtime = this.editorCtxRef.value?.state.runtime
-    if (runtime == null) return ''
+    const runtime = this.editorCtx.state.runtime
     const outputs = runtime.outputs
     if (outputs.length === 0) return ''
     const recentOutputs = outputs.slice(-50)
@@ -277,24 +272,23 @@ export function useSpxEditorCopilot(): void {
   onScopeDispose(() => d.dispose())
 
   const copilot = useCopilot()
-  const editorCtxRef = useEditorCtxRef()
-  const codeEditorRef = useCodeEditorRef()
-  const retriever = new Retriever(editorCtxRef, cloudHelpers)
+  const editorCtx = useEditorCtx()
+  const codeEditor = useCodeEditor()
+  const retriever = new Retriever(editorCtx, cloudHelpers)
 
   d.addDisposer(copilot.registerTool(new GetProjectMetadataTool(retriever)))
   d.addDisposer(copilot.registerTool(new GetProjectContentTool(retriever)))
   d.addDisposer(copilot.registerTool(new GetSpriteContentTool(retriever)))
   d.addDisposer(copilot.registerTool(new GetProjectCodeTool(retriever)))
-  d.addDisposer(copilot.registerTool(new GetCodeDiagnosticsTool(codeEditorRef)))
-  d.addDisposer(copilot.registerContextProvider(new ProjectContextProvider(editorCtxRef)))
-  d.addDisposer(copilot.registerContextProvider(new SpriteContextProvider(editorCtxRef)))
-  d.addDisposer(copilot.registerContextProvider(new CodeContextProvider(codeEditorRef)))
-  d.addDisposer(copilot.registerContextProvider(new RuntimeContextProvider(editorCtxRef)))
+  d.addDisposer(copilot.registerTool(new GetCodeDiagnosticsTool(codeEditor)))
+  d.addDisposer(copilot.registerContextProvider(new ProjectContextProvider(editorCtx)))
+  d.addDisposer(copilot.registerContextProvider(new SpriteContextProvider(editorCtx)))
+  d.addDisposer(copilot.registerContextProvider(new CodeContextProvider(codeEditor)))
+  d.addDisposer(copilot.registerContextProvider(new RuntimeContextProvider(editorCtx)))
 
   watch(
-    () => editorCtxRef.value?.state.runtime,
+    () => editorCtx.state.runtime,
     (editorRuntime, _, onCleanup) => {
-      if (editorRuntime == null) return
       const unlisten = editorRuntime.on('didExit', (code) => {
         if (code !== 0) return
         copilot.notifyUserEvent({ en: 'Game exited with code 0', zh: '游戏正常退出' }, `Game exited with code ${code}`)

--- a/spx-gui/src/components/editor/copilot/CodeChange.vue
+++ b/spx-gui/src/components/editor/copilot/CodeChange.vue
@@ -1,6 +1,6 @@
 <script lang="ts">
 import { z } from 'zod'
-import { codeFilePathSchema } from '../common'
+import { codeFilePathSchema } from '@/components/copilot/common'
 
 export const tagName = 'code-change'
 
@@ -37,9 +37,9 @@ import {
   type Range,
   useCodeEditorRef
 } from '@/components/editor/code-editor/spx-code-editor'
-import BlockWrapper from './common/BlockWrapper.vue'
-import BlockFooter from './common/BlockFooter.vue'
-import BlockActionBtn from './common/BlockActionBtn.vue'
+import BlockWrapper from '@/components/copilot/custom-elements/common/BlockWrapper.vue'
+import BlockFooter from '@/components/copilot/custom-elements/common/BlockFooter.vue'
+import BlockActionBtn from '@/components/copilot/custom-elements/common/BlockActionBtn.vue'
 
 const props = defineProps<{
   /** Code file path, e.g., `NiuXiaoQi.spx` */

--- a/spx-gui/src/components/editor/copilot/CodeLink.ts
+++ b/spx-gui/src/components/editor/copilot/CodeLink.ts
@@ -6,7 +6,7 @@ import {
   getTextDocumentId,
   CodeLink as RawCodeLink
 } from '@/components/editor/code-editor/spx-code-editor'
-import { codeFilePathSchema } from '../common'
+import { codeFilePathSchema } from '@/components/copilot/common'
 
 export const tagName = 'code-link'
 

--- a/spx-gui/src/components/editor/copilot/index.ts
+++ b/spx-gui/src/components/editor/copilot/index.ts
@@ -8,7 +8,7 @@ import { cloudHelpers, type CloudHelpers } from '@/models/common/cloud'
 import { SpxProject } from '@/models/spx/project'
 import type { Sprite } from '@/models/spx/sprite'
 import { Disposable } from '@/utils/disposable'
-import { useEditorCtx, type EditorCtx } from './EditorContextProvider.vue'
+import { useEditorCtx, type EditorCtx } from '../EditorContextProvider.vue'
 import {
   CodeEditor,
   getCodeFilePath,
@@ -16,7 +16,9 @@ import {
   textDocumentId2CodeFileName,
   useCodeEditor,
   type TextDocument
-} from './code-editor/spx-code-editor'
+} from '../code-editor/spx-code-editor'
+import * as codeLink from './CodeLink'
+import * as codeChange from './CodeChange.vue'
 
 class Retriever {
   constructor(
@@ -281,6 +283,24 @@ export function useSpxEditorCopilot(): void {
   d.addDisposer(copilot.registerTool(new GetSpriteContentTool(retriever)))
   d.addDisposer(copilot.registerTool(new GetProjectCodeTool(retriever)))
   d.addDisposer(copilot.registerTool(new GetCodeDiagnosticsTool(codeEditor)))
+  d.addDisposer(
+    copilot.registerCustomElement({
+      tagName: codeLink.tagName,
+      description: codeLink.detailedDescription,
+      attributes: codeLink.attributes,
+      isRaw: codeLink.isRaw,
+      component: codeLink.default
+    })
+  )
+  d.addDisposer(
+    copilot.registerCustomElement({
+      tagName: codeChange.tagName,
+      description: codeChange.detailedDescription,
+      attributes: codeChange.attributes,
+      isRaw: codeChange.isRaw,
+      component: codeChange.default
+    })
+  )
   d.addDisposer(copilot.registerContextProvider(new ProjectContextProvider(editorCtx)))
   d.addDisposer(copilot.registerContextProvider(new SpriteContextProvider(editorCtx)))
   d.addDisposer(copilot.registerContextProvider(new CodeContextProvider(codeEditor)))


### PR DESCRIPTION
Refs #2808

Relies on https://github.com/goplus/builder-backend/pull/193.

## Summary

- add generic skill support to the Copilot runtime, including skill catalog context and `load_skill` / `load_skill_resource` tools
- move project-specific Copilot integration out of `CopilotRoot` and register it from the project editor side
- add built-in SPX and XGo skill bundles with expanded reference content for project structure, APIs, AI interaction, and syntax
- add and update tests for the Copilot skill registry, tools, and integration flow

## Notes

- the develop doc change was removed from this PR and is handled separately
- verified with `npm run type-check && npm run lint && npm test`
