### PR TITLE
Use localized numbered default resource names

### DIFF
--- a/spx-gui/src/components/asset/index.ts
+++ b/spx-gui/src/components/asset/index.ts
@@ -6,6 +6,7 @@ import { stripExt } from '@/utils/path'
 import { useI18n } from '@/utils/i18n'
 import { useNetwork } from '@/utils/network'
 import { humanizeAssetType, type AssetGenModel, type AssetModel } from '@/models/spx/common/asset'
+import { resourceAnimationName, resourceSpriteName, resourceWidgetName } from '@/models/spx/common/resource'
 import { fromNativeFile } from '@/models/common/file'
 import { type SpxProject } from '@/models/spx/project'
 import { Backdrop } from '@/models/spx/backdrop'
@@ -98,13 +99,14 @@ export function useLoadFromScratchModal() {
 
 export function useAddSpriteFromLocalFile() {
   const editorCtx = useEditorCtx()
+  const i18n = useI18n()
   const preprocess = useModal(PreprocessModal)
   return async function addSpriteFromLocalFile(project: SpxProject) {
     const actionMessage = { en: 'Add sprite', zh: '添加精灵' }
     const nativeFiles = await selectFilesWithUploadLimit({ accept: imgExts })
     const files = nativeFiles.map((f) => fromNativeFile(f))
-    const spriteName = files.length > 1 ? '' : stripExt(files[0].name)
-    const sprite = Sprite.create(spriteName)
+    const spriteNameBase = files.length > 1 ? i18n.t(resourceSpriteName) + '1' : stripExt(files[0].name)
+    const sprite = Sprite.create(spriteNameBase)
     const costumes = await preprocess({
       files,
       title: actionMessage,
@@ -192,13 +194,14 @@ export function useAddBackdropFromLocalFile() {
 
 export function useAddAnimationByGroupingCostumes() {
   const editorCtx = useEditorCtx()
+  const i18n = useI18n()
   const invokeGroupCostumesModal = useModal(GroupCostumesModal)
   return async function addAnimationByGroupingCostumes(project: SpxProject, sprite: Sprite) {
     const { selectedCostumes, removeCostumes } = await invokeGroupCostumesModal({ sprite })
     const action = { name: { en: 'Group costumes as animation', zh: '合并造型为动画' } }
     return editorCtx.state.history.doAction(action, () => {
       const costumes = selectedCostumes.map((costume) => costume.clone())
-      const animation = Animation.create('', costumes)
+      const animation = Animation.create(i18n.t(resourceAnimationName) + '1', costumes)
       sprite.addAnimation(animation)
       if (removeCostumes) {
         for (let i = selectedCostumes.length - 1; i >= 0; i--) {
@@ -214,8 +217,9 @@ export function useAddAnimationByGroupingCostumes() {
 
 export function useAddMonitor() {
   const editorCtx = useEditorCtx()
+  const i18n = useI18n()
   return async function addMonitor(project: SpxProject) {
-    const monitor = await Monitor.create()
+    const monitor = await Monitor.create(i18n.t(resourceWidgetName) + '1')
     const action = { name: { en: 'Add widget', zh: '添加控件' } }
     await editorCtx.state.history.doAction(action, () => {
       project.stage.addWidget(monitor)

--- a/spx-gui/src/components/asset/index.ts
+++ b/spx-gui/src/components/asset/index.ts
@@ -6,7 +6,7 @@ import { stripExt } from '@/utils/path'
 import { useI18n } from '@/utils/i18n'
 import { useNetwork } from '@/utils/network'
 import { humanizeAssetType, type AssetGenModel, type AssetModel } from '@/models/spx/common/asset'
-import { resourceAnimationName, resourceSpriteName, resourceWidgetName } from '@/models/spx/common/resource'
+import { resourceAnimationName, resourceMonitorName, resourceSpriteName } from '@/models/spx/common/resource'
 import { fromNativeFile } from '@/models/common/file'
 import { type SpxProject } from '@/models/spx/project'
 import { Backdrop } from '@/models/spx/backdrop'
@@ -219,8 +219,8 @@ export function useAddMonitor() {
   const editorCtx = useEditorCtx()
   const i18n = useI18n()
   return async function addMonitor(project: SpxProject) {
-    const monitor = await Monitor.create(i18n.t(resourceWidgetName) + '1')
-    const action = { name: { en: 'Add widget', zh: '添加控件' } }
+    const monitor = await Monitor.create(i18n.t(resourceMonitorName) + '1')
+    const action = { name: { en: 'Add monitor', zh: '添加监视器' } }
     await editorCtx.state.history.doAction(action, () => {
       project.stage.addWidget(monitor)
     })

--- a/spx-gui/src/models/spx/common/asset-name.test.ts
+++ b/spx-gui/src/models/spx/common/asset-name.test.ts
@@ -29,10 +29,10 @@ describe('normalizeAssetName', () => {
 describe('getSpriteName', () => {
   it('should work well', () => {
     const project = new SpxProject()
-    expect(getSpriteName(project)).toBe('MySprite')
-    project.addSprite(new Sprite('MySprite'))
-    project.addSprite(new Sprite('MySprite3'))
-    expect(getSpriteName(project)).toBe('MySprite2')
+    expect(getSpriteName(project, 'sprite')).toBe('Sprite')
+    project.addSprite(new Sprite('Sprite'))
+    project.addSprite(new Sprite('Sprite3'))
+    expect(getSpriteName(project, 'sprite')).toBe('Sprite2')
   })
 
   it('should work well with base', () => {
@@ -44,15 +44,29 @@ describe('getSpriteName', () => {
     expect(getSpriteName(project, 'fooBar')).toBe('FooBar3')
     expect(getSpriteName(project, 'Foo  bar')).toBe('FooBar3')
   })
+
+  it('should increment numeric suffix instead of appending to it', () => {
+    const project = new SpxProject()
+    project.addSprite(new Sprite('Sprite2'))
+    project.addSprite(new Sprite('Sprite4'))
+    expect(getSpriteName(project, 'sprite2')).toBe('Sprite3')
+  })
+
+  it('should fall back to english default name for empty base', () => {
+    const project = new SpxProject()
+    expect(getSpriteName(project, '')).toBe('Sprite1')
+    project.addSprite(new Sprite('Sprite1'))
+    expect(getSpriteName(project, '')).toBe('Sprite2')
+  })
 })
 
 describe('getSoundName', () => {
   it('should work well', () => {
     const project = new SpxProject()
-    expect(getSoundName(project)).toBe('sound')
+    expect(getSoundName(project, 'sound')).toBe('sound')
     project.addSound(new Sound('sound', mockFile()))
     project.addSound(new Sound('sound3', mockFile()))
-    expect(getSoundName(project)).toBe('sound2')
+    expect(getSoundName(project, 'sound')).toBe('sound2')
   })
 
   it('should work well with base', () => {
@@ -63,6 +77,20 @@ describe('getSoundName', () => {
     expect(getSoundName(project, 'foo_bar')).toBe('foo_bar3')
     expect(getSoundName(project, 'fooBar')).toBe('fooBar')
     expect(getSoundName(project, 'Foo  bar')).toBe('foo  bar')
+  })
+
+  it('should increment numeric suffix instead of appending to it', () => {
+    const project = new SpxProject()
+    project.addSound(new Sound('sound2', mockFile()))
+    project.addSound(new Sound('sound4', mockFile()))
+    expect(getSoundName(project, 'sound2')).toBe('sound3')
+  })
+
+  it('should fall back to english default name for empty base', () => {
+    const project = new SpxProject()
+    expect(getSoundName(project, '')).toBe('sound1')
+    project.addSound(new Sound('sound1', mockFile()))
+    expect(getSoundName(project, '')).toBe('sound2')
   })
 })
 

--- a/spx-gui/src/models/spx/common/asset-name.ts
+++ b/spx-gui/src/models/spx/common/asset-name.ts
@@ -10,6 +10,8 @@ import {
   resourceWidgetName
 } from './resource'
 
+const numericSuffixRE = /^(.*?)(\d+)$/
+
 function validateAssetName(name: string) {
   if (name === '') return { en: 'The name must not be blank', zh: '名字不可为空' }
   if (name.length > 100)
@@ -168,12 +170,12 @@ export function normalizeAssetName(src: string, cas: 'camel' | 'pascal') {
 }
 
 function splitNumericSuffix(base: string) {
-  const match = base.match(/^(.*?)(\d+)$/)
+  const match = base.match(numericSuffixRE)
   if (match == null) return null
   return {
-    prefix: match[1],
-    suffix: Number(match[2]),
-    width: match[2].length
+    base: match[1],
+    num: parseInt(match[2], 10),
+    numWidth: match[2].length
   }
 }
 
@@ -188,10 +190,10 @@ function getValidName(base: string, isValid: (name: string) => boolean) {
 
   const numericSuffix = splitNumericSuffix(base)
   if (numericSuffix != null) {
-    for (let i = numericSuffix.suffix + 1; ; i++) {
-      const name = formatNumericSuffix(numericSuffix.prefix, i, numericSuffix.width)
+    for (let i = numericSuffix.num + 1; ; i++) {
+      const name = formatNumericSuffix(numericSuffix.base, i, numericSuffix.numWidth)
       if (isValid(name)) return name
-      if (i - numericSuffix.suffix > 10000) {
+      if (i - numericSuffix.num > 10000) {
         throw new Error(`unexpected infinite loop with base ${base}`)
       }
     }

--- a/spx-gui/src/models/spx/common/asset-name.ts
+++ b/spx-gui/src/models/spx/common/asset-name.ts
@@ -10,8 +10,6 @@ import {
   resourceWidgetName
 } from './resource'
 
-const numericSuffixRE = /^(.*?)(\d+)$/
-
 function validateAssetName(name: string) {
   if (name === '') return { en: 'The name must not be blank', zh: '名字不可为空' }
   if (name.length > 100)
@@ -169,8 +167,10 @@ export function normalizeAssetName(src: string, cas: 'camel' | 'pascal') {
   return unicodeSafeSlice(result, 0, 50)
 }
 
-function splitNumericSuffix(base: string) {
-  const match = base.match(numericSuffixRE)
+const numericSuffixRE = /^(.*?)(\d+)$/
+
+function splitNumericSuffix(name: string) {
+  const match = name.match(numericSuffixRE)
   if (match == null) return null
   return {
     base: match[1],
@@ -179,30 +179,27 @@ function splitNumericSuffix(base: string) {
   }
 }
 
-function formatNumericSuffix(prefix: string, suffix: number, width: number) {
-  const normalizedSuffix = width > 1 ? String(suffix).padStart(width, '0') : String(suffix)
-  return prefix + normalizedSuffix
+function formatNumericSuffix(base: string, num: number, numWidth: number) {
+  const suffix = numWidth > 1 ? String(num).padStart(numWidth, '0') : String(num)
+  return base + suffix
 }
 
-function getValidName(base: string, isValid: (name: string) => boolean) {
-  if (base === '') throw new Error('name base must not be blank')
-  if (isValid(base)) return base
+function getValidName(initialName: string, isValid: (name: string) => boolean) {
+  if (initialName === '') throw new Error('name must not be blank')
+  if (isValid(initialName)) return initialName
 
-  const numericSuffix = splitNumericSuffix(base)
-  if (numericSuffix != null) {
-    for (let i = numericSuffix.num + 1; ; i++) {
-      const name = formatNumericSuffix(numericSuffix.base, i, numericSuffix.numWidth)
-      if (isValid(name)) return name
-      if (i - numericSuffix.num > 10000) {
-        throw new Error(`unexpected infinite loop with base ${base}`)
-      }
-    }
-  }
+  // Try to add/increment numeric suffix to find a valid name
+  const splitted = splitNumericSuffix(initialName)
+  const base = splitted == null ? initialName : splitted.base
+  const initialNum = splitted == null ? 1 : splitted.num
+  const numWidth = splitted == null ? 1 : splitted.numWidth
 
-  for (let i = 2; ; i++) {
-    const name = base + i
+  for (let i = initialNum + 1; ; i++) {
+    const name = formatNumericSuffix(base, i, numWidth)
     if (isValid(name)) return name
-    if (i > 10000) throw new Error(`unexpected infinite loop with base ${base}`) // for debug purpose
+    if (i - initialNum > 10000) {
+      throw new Error(`unexpected infinite loop with base ${initialName}`)
+    }
   }
 }
 

--- a/spx-gui/src/models/spx/common/asset-name.ts
+++ b/spx-gui/src/models/spx/common/asset-name.ts
@@ -1,6 +1,14 @@
-import { lowFirst, unicodeSafeSlice, upFirst } from '@/utils/utils'
 import type { LocaleMessage } from '@/utils/i18n'
+import { lowFirst, unicodeSafeSlice, upFirst } from '@/utils/utils'
 import { getXGoIdentifierNameTip, normalizeXGoIdentifierAssetName, validateXGoIdentifierName } from '@/utils/xgo'
+import {
+  resourceAnimationName,
+  resourceBackdropName,
+  resourceCostumeName,
+  resourceSoundName,
+  resourceSpriteName,
+  resourceWidgetName
+} from './resource'
 
 function validateAssetName(name: string) {
   if (name === '') return { en: 'The name must not be blank', zh: '名字不可为空' }
@@ -45,7 +53,7 @@ function getXGoIdentifierAssetNameTip(asset: LocaleMessage) {
   return getXGoIdentifierNameTip(asset)
 }
 
-export const spriteNameTip = getXGoIdentifierAssetNameTip({ en: 'sprite', zh: '精灵' })
+export const spriteNameTip = getXGoIdentifierAssetNameTip(resourceSpriteName)
 
 export interface SpriteLike {
   name: string
@@ -65,7 +73,7 @@ export function validateSpriteName(name: string, parent: SpriteLikeParent | null
     return { en: `Sprite with name ${name} already exists`, zh: '存在同名的精灵' }
 }
 
-export const costumeNameTip = getAssetNameTip({ en: 'costume', zh: '造型' })
+export const costumeNameTip = getAssetNameTip(resourceCostumeName)
 
 export interface CostumeLike {
   name: string
@@ -82,7 +90,7 @@ export function validateCostumeName(name: string, parent: CostumeLikeParent | nu
     return { en: `Costume with name ${name} already exists`, zh: '存在同名的造型' }
 }
 
-export const animationNameTip = getAssetNameTip({ en: 'animation', zh: '动画' })
+export const animationNameTip = getAssetNameTip(resourceAnimationName)
 
 export interface AnimationLike {
   name: string
@@ -99,7 +107,7 @@ export function validateAnimationName(name: string, parent: AnimationLikeParent 
     return { en: `Animation with name ${name} already exists`, zh: '存在同名的动画' }
 }
 
-export const soundNameTip = getAssetNameTip({ en: 'sound', zh: '声音' })
+export const soundNameTip = getAssetNameTip(resourceSoundName)
 
 export interface SoundLike {
   name: string
@@ -116,7 +124,7 @@ export function validateSoundName(name: string, parent: SoundLikeParent | null) 
     return { en: `Sound with name ${name} already exists`, zh: '存在同名的声音' }
 }
 
-export const backdropNameTip = getAssetNameTip({ en: 'backdrop', zh: '背景' })
+export const backdropNameTip = getAssetNameTip(resourceBackdropName)
 
 export interface BackdropLike {
   name: string
@@ -133,7 +141,7 @@ export function validateBackdropName(name: string, parent: BackdropLikeParent | 
     return { en: `Backdrop with name ${name} already exists`, zh: '存在同名的背景' }
 }
 
-export const widgetNameTip = getAssetNameTip({ en: 'widget', zh: '控件' })
+export const widgetNameTip = getAssetNameTip(resourceWidgetName)
 
 export interface WidgetLike {
   name: string
@@ -159,17 +167,45 @@ export function normalizeAssetName(src: string, cas: 'camel' | 'pascal') {
   return unicodeSafeSlice(result, 0, 50)
 }
 
+function splitNumericSuffix(base: string) {
+  const match = base.match(/^(.*?)(\d+)$/)
+  if (match == null) return null
+  return {
+    prefix: match[1],
+    suffix: Number(match[2]),
+    width: match[2].length
+  }
+}
+
+function formatNumericSuffix(prefix: string, suffix: number, width: number) {
+  const normalizedSuffix = width > 1 ? String(suffix).padStart(width, '0') : String(suffix)
+  return prefix + normalizedSuffix
+}
+
 function getValidName(base: string, isValid: (name: string) => boolean) {
-  let name: string
-  for (let i = 1; ; i++) {
-    name = i === 1 ? base : base + i
+  if (base === '') throw new Error('name base must not be blank')
+  if (isValid(base)) return base
+
+  const numericSuffix = splitNumericSuffix(base)
+  if (numericSuffix != null) {
+    for (let i = numericSuffix.suffix + 1; ; i++) {
+      const name = formatNumericSuffix(numericSuffix.prefix, i, numericSuffix.width)
+      if (isValid(name)) return name
+      if (i - numericSuffix.suffix > 10000) {
+        throw new Error(`unexpected infinite loop with base ${base}`)
+      }
+    }
+  }
+
+  for (let i = 2; ; i++) {
+    const name = base + i
     if (isValid(name)) return name
     if (i > 10000) throw new Error(`unexpected infinite loop with base ${base}`) // for debug purpose
   }
 }
 
-export function getSpriteName(parent: SpriteLikeParent | null, base = '') {
-  base = normalizeXGoIdentifierAssetName(base, 'pascal') || 'MySprite'
+export function getSpriteName(parent: SpriteLikeParent | null, base: string) {
+  base = normalizeXGoIdentifierAssetName(base, 'pascal') || 'Sprite1'
   return getValidName(base, (n) => validateSpriteName(n, parent) == null)
 }
 
@@ -178,8 +214,8 @@ export function ensureValidSpriteName(name: string, parent: SpriteLikeParent | n
   return getSpriteName(parent, name)
 }
 
-export function getCostumeName(parent: CostumeLikeParent | null, base = '') {
-  base = normalizeAssetName(base, 'camel') || 'costume'
+export function getCostumeName(parent: CostumeLikeParent | null, base: string) {
+  base = normalizeAssetName(base, 'camel') || 'costume1'
   return getValidName(base, (n) => validateCostumeName(n, parent) == null)
 }
 
@@ -188,8 +224,8 @@ export function ensureValidCostumeName(name: string, parent: CostumeLikeParent |
   return getCostumeName(parent, name)
 }
 
-export function getAnimationName(parent: AnimationLikeParent | null, base = '') {
-  base = normalizeAssetName(base, 'camel') || 'animation'
+export function getAnimationName(parent: AnimationLikeParent | null, base: string) {
+  base = normalizeAssetName(base, 'camel') || 'animation1'
   return getValidName(base, (n) => validateAnimationName(n, parent) == null)
 }
 
@@ -198,8 +234,8 @@ export function ensureValidAnimationName(name: string, parent: AnimationLikePare
   return getAnimationName(parent, name)
 }
 
-export function getSoundName(parent: SoundLikeParent | null, base = '') {
-  base = normalizeAssetName(base, 'camel') || 'sound'
+export function getSoundName(parent: SoundLikeParent | null, base: string) {
+  base = normalizeAssetName(base, 'camel') || 'sound1'
   return getValidName(base, (n) => validateSoundName(n, parent) == null)
 }
 
@@ -208,8 +244,8 @@ export function ensureValidSoundName(name: string, parent: SoundLikeParent | nul
   return getSoundName(parent, name)
 }
 
-export function getBackdropName(parent: BackdropLikeParent | null, base = '') {
-  base = normalizeAssetName(base, 'camel') || 'backdrop'
+export function getBackdropName(parent: BackdropLikeParent | null, base: string) {
+  base = normalizeAssetName(base, 'camel') || 'backdrop1'
   return getValidName(base, (n) => validateBackdropName(n, parent) == null)
 }
 
@@ -218,8 +254,8 @@ export function ensureValidBackdropName(name: string, parent: BackdropLikeParent
   return getBackdropName(parent, name)
 }
 
-export function getWidgetName(parent: WidgetLikeParent | null, base = '') {
-  base = normalizeAssetName(base, 'camel') || 'widget'
+export function getWidgetName(parent: WidgetLikeParent | null, base: string) {
+  base = normalizeAssetName(base, 'camel') || 'widget1'
   return getValidName(base, (n) => validateWidgetName(n, parent) == null)
 }
 

--- a/spx-gui/src/models/spx/common/asset.ts
+++ b/spx-gui/src/models/spx/common/asset.ts
@@ -9,6 +9,7 @@ import type { SpriteGen } from '../gen/sprite-gen'
 import type { BackdropGen } from '../gen/backdrop-gen'
 import { fromBlob, fromConfig, toConfig } from '../../common/file'
 import { getFiles, saveFiles } from '../../common/cloud'
+import { resourceBackdropName, resourceSoundName, resourceSpriteName } from './resource'
 
 export type AssetMetadata = Partial<Omit<AssetData, 'files'>>
 
@@ -34,9 +35,9 @@ export type AssetGenModel<T extends AssetType = AssetType> = T extends AssetType
     : never
 
 const assetTypeMessages = {
-  [AssetType.Backdrop]: { en: 'backdrop', zh: '背景' },
-  [AssetType.Sprite]: { en: 'sprite', zh: '精灵' },
-  [AssetType.Sound]: { en: 'sound', zh: '声音' }
+  [AssetType.Backdrop]: resourceBackdropName,
+  [AssetType.Sprite]: resourceSpriteName,
+  [AssetType.Sound]: resourceSoundName
 }
 
 export function humanizeAssetType(type: AssetType): LocaleMessage {

--- a/spx-gui/src/models/spx/common/resource.ts
+++ b/spx-gui/src/models/spx/common/resource.ts
@@ -11,22 +11,30 @@ export type ResourceModel = Stage | Sound | Sprite | Backdrop | Widget | Animati
 
 export type ResourceType = 'stage' | 'sound' | 'sprite' | 'backdrop' | 'widget' | 'animation' | 'costume'
 
+export const resourceStageName = { en: 'stage', zh: '舞台' }
+export const resourceSoundName = { en: 'sound', zh: '声音' }
+export const resourceSpriteName = { en: 'sprite', zh: '精灵' }
+export const resourceBackdropName = { en: 'backdrop', zh: '背景' }
+export const resourceWidgetName = { en: 'widget', zh: '控件' }
+export const resourceAnimationName = { en: 'animation', zh: '动画' }
+export const resourceCostumeName = { en: 'costume', zh: '造型' }
+
 export function humanizeResourceType(type: ResourceType): LocaleMessage {
   switch (type) {
     case 'stage':
-      return { en: 'stage', zh: '舞台' }
+      return resourceStageName
     case 'sound':
-      return { en: 'sound', zh: '声音' }
+      return resourceSoundName
     case 'sprite':
-      return { en: 'sprite', zh: '精灵' }
+      return resourceSpriteName
     case 'backdrop':
-      return { en: 'backdrop', zh: '背景' }
+      return resourceBackdropName
     case 'widget':
-      return { en: 'widget', zh: '控件' }
+      return resourceWidgetName
     case 'animation':
-      return { en: 'animation', zh: '动画' }
+      return resourceAnimationName
     case 'costume':
-      return { en: 'costume', zh: '造型' }
+      return resourceCostumeName
     default:
       throw new Error(`Invalid resource type: ${type}`)
   }

--- a/spx-gui/src/models/spx/common/resource.ts
+++ b/spx-gui/src/models/spx/common/resource.ts
@@ -16,6 +16,7 @@ export const resourceSoundName = { en: 'sound', zh: '声音' }
 export const resourceSpriteName = { en: 'sprite', zh: '精灵' }
 export const resourceBackdropName = { en: 'backdrop', zh: '背景' }
 export const resourceWidgetName = { en: 'widget', zh: '控件' }
+export const resourceMonitorName = { en: 'monitor', zh: '监视器' }
 export const resourceAnimationName = { en: 'animation', zh: '动画' }
 export const resourceCostumeName = { en: 'costume', zh: '造型' }
 

--- a/spx-gui/src/models/spx/gen/sprite-gen.ts
+++ b/spx-gui/src/models/spx/gen/sprite-gen.ts
@@ -33,6 +33,7 @@ import {
   validateSpriteName,
   type SpriteLikeParent
 } from '../common/asset-name'
+import { resourceAnimationName, resourceCostumeName } from '../common/resource'
 import { sprite2Asset } from '../common/asset'
 
 /** User selected item in sprite gen */
@@ -351,7 +352,7 @@ export class SpriteGen extends Disposable {
     return this.costumes[0]
   }
   addCostume() {
-    const name = getCostumeName(this)
+    const name = getCostumeName(this, this.i18n.t(resourceCostumeName) + '1')
     const defaultCostumeGen = this.defaultCostume
     if (defaultCostumeGen == null) throw new Error('default costume expected')
     const costumeGen = new CostumeGen(this.i18n, this, this.project, {
@@ -384,7 +385,7 @@ export class SpriteGen extends Disposable {
   /** Animations gen */
   animations: AnimationGen[]
   addAnimation() {
-    const name = getAnimationName(this)
+    const name = getAnimationName(this, this.i18n.t(resourceAnimationName) + '1')
     const defaultCostumeGen = this.defaultCostume
     if (defaultCostumeGen == null) throw new Error('default costume expected')
     const animationGen = new AnimationGen(this.i18n, this, this.project, {

--- a/spx-gui/src/models/spx/widget/monitor.ts
+++ b/spx-gui/src/models/spx/widget/monitor.ts
@@ -59,7 +59,7 @@ export class Monitor extends BaseWidget {
    * Create instance with default inits
    * NOTE: the "default" means default behavior for builder, not the default behavior of spx
    */
-  static async create(nameBase: string = 'monitor', inits?: MonitorInits) {
+  static async create(nameBase: string, inits?: MonitorInits) {
     return new Monitor(getWidgetName(null, nameBase), {
       // Default position: the left-top corner with margin 10
       // TODO: calculate initial position based on current stage size & existed widgets


### PR DESCRIPTION
Closes #3029

## Summary
- use numbered localized default names when creating new resources from editor flows
- keep low-level asset naming helpers simple, with English fallback for rare empty-name cases
- share resource name locale messages via common constants to avoid duplicated definitions

## Validation
- `npm run type-check`
- `npm run lint`
- `npm run test -- --run`
