### PR TITLE
fix(spx-gui): tooltip side-placement alignment bug

### DIFF
--- a/spx-gui/src/components/ui/UITooltip.test.ts
+++ b/spx-gui/src/components/ui/UITooltip.test.ts
@@ -2,7 +2,7 @@ import { mount } from '@vue/test-utils'
 import { defineComponent, h, nextTick, ref } from 'vue'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import UITooltip from './UITooltip.vue'
-import { providePopupStack } from './popup'
+import { POPUP_ARROW_SIZE, providePopupStack } from './popup'
 import { providePopupContainer } from './utils'
 
 const floatingMocks = vi.hoisted(() => {
@@ -279,11 +279,12 @@ describe('UITooltip', () => {
     await flushTooltip()
 
     const options = floatingMocks.computePosition.mock.calls[0]?.[2]
+    const offsetMiddleware = options?.middleware.find((middleware: { name?: string }) => middleware.name === 'offset')
     expect(options?.placement).toBe('right')
-    expect(options?.middleware[0]).toMatchObject({
+    expect(offsetMiddleware).toMatchObject({
       name: 'offset',
       value: {
-        mainAxis: 8,
+        mainAxis: POPUP_ARROW_SIZE,
         crossAxis: 0
       }
     })
@@ -315,11 +316,12 @@ describe('UITooltip', () => {
     await flushTooltip()
 
     const options = floatingMocks.computePosition.mock.calls[0]?.[2]
+    const offsetMiddleware = options?.middleware.find((middleware: { name?: string }) => middleware.name === 'offset')
     expect(options?.placement).toBe('top-end')
-    expect(options?.middleware[0]).toMatchObject({
+    expect(offsetMiddleware).toMatchObject({
       name: 'offset',
       value: {
-        mainAxis: 8,
+        mainAxis: POPUP_ARROW_SIZE,
         crossAxis: 0
       }
     })

--- a/spx-gui/src/components/ui/UITooltip.test.ts
+++ b/spx-gui/src/components/ui/UITooltip.test.ts
@@ -252,4 +252,76 @@ describe('UITooltip', () => {
     expect(tooltip.emitted('update:visible')).toEqual([[true], [false]])
     expect(popupContainer.text()).not.toContain('Tooltip content')
   })
+
+  it('uses a main-axis gap for right placement instead of shifting the tooltip downward', async () => {
+    const wrapper = mount(
+      defineComponent({
+        setup() {
+          return () =>
+            h(PopupProvider, null, {
+              default: () =>
+                h(
+                  UITooltip,
+                  { delay: 0, placement: 'right' },
+                  {
+                    trigger: () => h('button', { 'data-test-id': 'trigger' }, 'Hover me'),
+                    default: () => h('div', 'Tooltip content')
+                  }
+                )
+            })
+        }
+      }),
+      { attachTo: document.body }
+    )
+
+    await wrapper.get('[data-test-id="trigger"]').trigger('mouseenter')
+    await vi.advanceTimersByTimeAsync(0)
+    await flushTooltip()
+
+    const options = floatingMocks.computePosition.mock.calls[0]?.[2]
+    expect(options?.placement).toBe('right')
+    expect(options?.middleware[0]).toMatchObject({
+      name: 'offset',
+      value: {
+        mainAxis: 8,
+        crossAxis: 0
+      }
+    })
+  })
+
+  it('keeps top-end placement using a vertical gap and no horizontal shift', async () => {
+    const wrapper = mount(
+      defineComponent({
+        setup() {
+          return () =>
+            h(PopupProvider, null, {
+              default: () =>
+                h(
+                  UITooltip,
+                  { delay: 0, placement: 'top-end' },
+                  {
+                    trigger: () => h('button', { 'data-test-id': 'trigger' }, 'Hover me'),
+                    default: () => h('div', 'Tooltip content')
+                  }
+                )
+            })
+        }
+      }),
+      { attachTo: document.body }
+    )
+
+    await wrapper.get('[data-test-id="trigger"]').trigger('mouseenter')
+    await vi.advanceTimersByTimeAsync(0)
+    await flushTooltip()
+
+    const options = floatingMocks.computePosition.mock.calls[0]?.[2]
+    expect(options?.placement).toBe('top-end')
+    expect(options?.middleware[0]).toMatchObject({
+      name: 'offset',
+      value: {
+        mainAxis: 8,
+        crossAxis: 0
+      }
+    })
+  })
 })

--- a/spx-gui/src/components/ui/UITooltip.vue
+++ b/spx-gui/src/components/ui/UITooltip.vue
@@ -60,7 +60,6 @@ const {
 } = useFloatingPopup({
   visible: visibleComputed,
   placement: computed(() => props.placement),
-  offset: computed(() => ({ x: 0, y: 8 })),
   showArrow: true
 })
 const popupStyle = computed(

--- a/spx-gui/src/components/ui/popup/use-floating-popup.test.ts
+++ b/spx-gui/src/components/ui/popup/use-floating-popup.test.ts
@@ -20,6 +20,7 @@ vi.mock('@floating-ui/dom', () => ({
 
 import {
   POPUP_ARROW_SIZE,
+  resolveDefaultPopupOffset,
   resolveFloatingOffset,
   resolvePopupTransformOrigin,
   useFloatingPopup
@@ -57,6 +58,17 @@ describe('resolveFloatingOffset', () => {
       mainAxis: 6,
       crossAxis: 10
     })
+  })
+})
+
+describe('resolveDefaultPopupOffset', () => {
+  it('uses one arrow-size gap along the main axis when arrows are enabled', () => {
+    expect(resolveDefaultPopupOffset('top-end', true)).toEqual({ x: 0, y: POPUP_ARROW_SIZE })
+    expect(resolveDefaultPopupOffset('right', true)).toEqual({ x: POPUP_ARROW_SIZE, y: 0 })
+  })
+
+  it('keeps the default gap at zero when arrows are disabled', () => {
+    expect(resolveDefaultPopupOffset('bottom', false)).toEqual({ x: 0, y: 0 })
   })
 })
 
@@ -155,6 +167,14 @@ describe('useFloatingPopup', () => {
     popup.arrowRef.value = document.createElement('div')
     await flushFloatingEffects()
 
+    const options = floatingMocks.computePosition.mock.calls[0]?.[2]
+    expect(options?.middleware[0]).toMatchObject({
+      name: 'offset',
+      value: {
+        mainAxis: POPUP_ARROW_SIZE,
+        crossAxis: 0
+      }
+    })
     expect(popup.arrowStyle.value).toMatchObject({
       width: `${POPUP_ARROW_SIZE}px`,
       height: `${POPUP_ARROW_SIZE}px`,

--- a/spx-gui/src/components/ui/popup/use-floating-popup.test.ts
+++ b/spx-gui/src/components/ui/popup/use-floating-popup.test.ts
@@ -168,7 +168,8 @@ describe('useFloatingPopup', () => {
     await flushFloatingEffects()
 
     const options = floatingMocks.computePosition.mock.calls[0]?.[2]
-    expect(options?.middleware[0]).toMatchObject({
+    const offsetMiddleware = options?.middleware.find((middleware: { name?: string }) => middleware.name === 'offset')
+    expect(offsetMiddleware).toMatchObject({
       name: 'offset',
       value: {
         mainAxis: POPUP_ARROW_SIZE,

--- a/spx-gui/src/components/ui/popup/use-floating-popup.ts
+++ b/spx-gui/src/components/ui/popup/use-floating-popup.ts
@@ -153,9 +153,9 @@ function resolvePopupState(
 export function resolveDefaultPopupOffset(placement: PopupPlacement, showArrow: boolean): PopupOffset {
   if (!showArrow) return { x: 0, y: 0 }
   const side = placement.split('-')[0]
-  // When an arrow is shown, keep the popup separated from the trigger by one
-  // arrow size along the placement's main axis so the arrow has room to sit
-  // between the popup surface and the trigger edge.
+  // When an arrow is shown, offset the popup by one arrow-size from the trigger
+  // along the placement's main axis, leaving room for the arrow tip to sit in
+  // the gap between the popup surface and the trigger edge.
   if (side === 'left' || side === 'right') {
     return { x: POPUP_ARROW_SIZE, y: 0 }
   }

--- a/spx-gui/src/components/ui/popup/use-floating-popup.ts
+++ b/spx-gui/src/components/ui/popup/use-floating-popup.ts
@@ -136,6 +136,7 @@ function resolvePopupState(
 ): ResolvedPopupState {
   const virtualAnchor = options.virtualAnchor == null ? null : toValue(options.virtualAnchor)
   const showArrow = options.showArrow ?? false
+  const placement = options.placement == null ? 'bottom' : toValue(options.placement)
   return {
     visible: toValue(options.visible),
     // Dropdowns can be anchored either to a real trigger element or to an
@@ -143,10 +144,22 @@ function resolvePopupState(
     reference: resolveReferenceElement(referenceEl, virtualAnchor),
     floatingEl,
     arrowEl: showArrow ? arrowEl : null,
-    placement: options.placement == null ? 'bottom' : toValue(options.placement),
-    popupOffset: options.offset == null ? { x: 0, y: 0 } : toValue(options.offset),
+    placement,
+    popupOffset: options.offset == null ? resolveDefaultPopupOffset(placement, showArrow) : toValue(options.offset),
     showArrow
   }
+}
+
+export function resolveDefaultPopupOffset(placement: PopupPlacement, showArrow: boolean): PopupOffset {
+  if (!showArrow) return { x: 0, y: 0 }
+  const side = placement.split('-')[0]
+  // When an arrow is shown, keep the popup separated from the trigger by one
+  // arrow size along the placement's main axis so the arrow has room to sit
+  // between the popup surface and the trigger edge.
+  if (side === 'left' || side === 'right') {
+    return { x: POPUP_ARROW_SIZE, y: 0 }
+  }
+  return { x: 0, y: POPUP_ARROW_SIZE }
 }
 
 export function resolveFloatingOffset(placement: PopupPlacement, offset: PopupOffset) {

--- a/spx-gui/src/pages/docs/ui-design/index.vue
+++ b/spx-gui/src/pages/docs/ui-design/index.vue
@@ -395,6 +395,94 @@
         </div>
       </section>
 
+      <section id="ui-tooltip" :class="sectionClass">
+        <div :class="sectionHeaderClass">
+          <h2 :class="sectionTitleClass">UITooltip</h2>
+          <p :class="sectionDescriptionClass">
+            {{
+              $t({
+                en: 'Hover tooltip examples for checking placement, disabled state, and content behavior.',
+                zh: '用于检查不同方向、禁用态的 tooltip 示例。'
+              })
+            }}
+          </p>
+        </div>
+
+        <div :class="showcaseGridClass">
+          <div :class="surfaceCardClass">
+            <div :class="groupLabelClass">Placements</div>
+            <div :class="wrapRowClass">
+              <UITooltip v-for="placement in tooltipPlacements" :key="placement" :placement="placement">
+                <template #trigger>
+                  <UIButton type="white">{{ placement }}</UIButton>
+                </template>
+                {{ `Tooltip: ${placement}` }}
+              </UITooltip>
+              <UITooltip disabled>
+                <template #trigger>
+                  <UIButton type="neutral">disabled</UIButton>
+                </template>
+                {{ 'YOU SHOULD NOT SEE ME' }}
+              </UITooltip>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section id="ui-dropdown" :class="sectionClass">
+        <div :class="sectionHeaderClass">
+          <h2 :class="sectionTitleClass">UIDropdown</h2>
+          <p :class="sectionDescriptionClass">
+            {{
+              $t({
+                en: 'Dropdown examples for placement, trigger mode, disabled state.',
+                zh: '用于检查不同方向、触发方式和禁用态行为的 dropdown 示例。'
+              })
+            }}
+          </p>
+        </div>
+
+        <div class="flex flex-col gap-4">
+          <div :class="surfaceCardClass">
+            <div :class="controlRowClass">
+              <label :class="[controlFieldClass, compactFieldClass]">
+                <span>tigger: </span>
+                <UIRadioGroup v-model:value="dropdownTriggerType">
+                  <UIRadio value="hover">Hover</UIRadio>
+                  <UIRadio value="click">Click</UIRadio>
+                </UIRadioGroup>
+              </label>
+            </div>
+            <div :class="groupLabelClass">Placements</div>
+            <div :class="wrapRowClass">
+              <UIDropdown
+                v-for="placement in dropdownPlacements"
+                :key="placement"
+                :placement="placement"
+                :trigger="dropdownTriggerType"
+              >
+                <template #trigger>
+                  <UIButton type="white">{{ placement }}</UIButton>
+                </template>
+                <UIMenu>
+                  <UIMenuItem>Action one</UIMenuItem>
+                  <UIMenuItem>Action two</UIMenuItem>
+                  <UIMenuItem>Action three</UIMenuItem>
+                </UIMenu>
+              </UIDropdown>
+              <UIDropdown disabled :trigger="dropdownTriggerType">
+                <template #trigger>
+                  <UIButton type="neutral">disabled</UIButton>
+                </template>
+                <UIMenu>
+                  <UIMenuItem>YOU SHOULD NOT SEE ME</UIMenuItem>
+                </UIMenu>
+              </UIDropdown>
+            </div>
+          </div>
+        </div>
+      </section>
+
       <section id="ui-block-items" :class="sectionClass">
         <div :class="sectionHeaderClass">
           <h2 :class="sectionTitleClass">UIBlockItem Wrappers</h2>
@@ -782,6 +870,7 @@ import {
   UICardHeader,
   UICheckbox,
   UICheckboxGroup,
+  UIDropdown,
   UIEditorBackdropItem,
   UIEditorSoundItem,
   UIEditorSpriteItem,
@@ -803,7 +892,10 @@ import {
   UITab,
   UITabs,
   UITag,
+  UITooltip,
   UITextInput,
+  UIMenu,
+  UIMenuItem,
   useMessage
 } from '@/components/ui'
 import GenLoading from '@/components/asset/gen/common/GenLoading.vue'
@@ -869,6 +961,8 @@ const directoryItems = [
   { id: 'ui-choices', label: 'Choices' },
   { id: 'ui-tabs', label: 'UITabs' },
   { id: 'ui-card', label: 'UICard' },
+  { id: 'ui-tooltip', label: 'UITooltip' },
+  { id: 'ui-dropdown', label: 'UIDropdown' },
   { id: 'ui-block-items', label: 'UIBlockItem Wrappers' },
   { id: 'gen-item', label: 'GenItem' },
   { id: 'ui-tag', label: 'UITag' },
@@ -878,6 +972,17 @@ const directoryItems = [
 
 const buttonTypes = ['primary', 'secondary', 'neutral', 'white', 'red', 'green', 'blue', 'purple'] as const
 const tagDirections = ['up', 'right', 'down', 'left'] as const
+const tooltipPlacements = [
+  'top',
+  'top-start',
+  'top-end',
+  'left',
+  'right',
+  'bottom',
+  'bottom-start',
+  'bottom-end'
+] as const
+const dropdownPlacements = ['top', 'top-start', 'top-end', 'bottom', 'bottom-start', 'bottom-end'] as const
 
 const buttonShape = ref<'circle' | 'square'>('circle')
 const buttonSize = ref<'small' | 'medium' | 'large'>('medium')
@@ -931,6 +1036,8 @@ const assetItemsVisibleLabel = computed(() => {
 })
 
 async function handleSoundDemoPlay() {}
+
+const dropdownTriggerType = ref<'hover' | 'click'>('click')
 
 const tagVariant = ref<'stroke' | 'none'>('stroke')
 const message = useMessage()


### PR DESCRIPTION
Fix tooltip side-placement offset handling and centralize arrow-based default popup gaps in `useFloatingPopup`. 

Previously `UITooltip` always passed a vertical `{ x: 0, y: 8 }` gap, which is only correct for top/bottom placements; for `right` it incorrectly shifted the popup downward. 

The default gap is now derived from placement and `POPUP_ARROW_SIZE` inside `useFloatingPopup`, so arrow-enabled popups keep a consistent gap without duplicating magic numbers in individual consumers.