### PR TITLE
fix(spx-gui): defer dropdown outside click binding

### DIFF
--- a/spx-gui/src/components/ui/UIDropdown.test.ts
+++ b/spx-gui/src/components/ui/UIDropdown.test.ts
@@ -237,7 +237,7 @@ describe('UIDropdown', () => {
     await flushDropdown()
     expect(popupContainer.text()).toContain('Dropdown content')
 
-    await wrapper.get('[data-test-id="outside"]').trigger('click')
+    await wrapper.get('[data-test-id="outside"]').trigger('mouseup')
     await flushDropdown()
 
     expect(dropdown.emitted('clickOutside')).toHaveLength(1)
@@ -340,7 +340,7 @@ describe('UIDropdown', () => {
     expect(popupContainer.text()).toContain('Parent content')
     expect(popupContainer.text()).toContain('Child content')
 
-    await wrapper.get('[data-test-id="parent-content"]').trigger('click')
+    await wrapper.get('[data-test-id="parent-content"]').trigger('mouseup')
     await flushDropdown()
 
     expect(childDropdown.emitted('update:visible')).toEqual([[false]])

--- a/spx-gui/src/components/ui/UIDropdown.test.ts
+++ b/spx-gui/src/components/ui/UIDropdown.test.ts
@@ -23,6 +23,7 @@ vi.mock('@floating-ui/dom', () => ({
 
 async function flushDropdown() {
   await nextTick()
+  await vi.advanceTimersByTimeAsync(0)
   await Promise.resolve()
   await nextTick()
 }
@@ -237,12 +238,63 @@ describe('UIDropdown', () => {
     await flushDropdown()
     expect(popupContainer.text()).toContain('Dropdown content')
 
-    await wrapper.get('[data-test-id="outside"]').trigger('mouseup')
+    await wrapper.get('[data-test-id="outside"]').trigger('click')
     await flushDropdown()
 
     expect(dropdown.emitted('clickOutside')).toHaveLength(1)
     expect(dropdown.emitted('update:visible')).toEqual([[true], [false]])
     expect(popupContainer.text()).not.toContain('Dropdown content')
+  })
+
+  it('does not immediately close when manual control opens it on mouseup', async () => {
+    const wrapper = mount(
+      defineComponent({
+        setup() {
+          const visible = ref(false)
+
+          return () =>
+            h(PopupProvider, null, {
+              default: () => [
+                h(
+                  UIDropdown,
+                  {
+                    trigger: 'manual',
+                    visible: visible.value,
+                    'onUpdate:visible': (nextVisible: boolean) => (visible.value = nextVisible)
+                  },
+                  {
+                    trigger: () => h('button', { 'data-test-id': 'trigger' }, 'Trigger'),
+                    default: () => h('div', 'Dropdown content')
+                  }
+                ),
+                h(
+                  'button',
+                  {
+                    'data-test-id': 'opener',
+                    onMouseup: () => {
+                      visible.value = true
+                    }
+                  },
+                  'Open'
+                )
+              ]
+            })
+        }
+      }),
+      { attachTo: document.body }
+    )
+
+    const dropdown = wrapper.getComponent(UIDropdown)
+    const popupContainer = wrapper.get('[data-test-id="popup-container"]')
+    const openerEl = wrapper.get('[data-test-id="opener"]').element
+
+    openerEl.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }))
+    openerEl.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushDropdown()
+
+    expect(dropdown.emitted('clickOutside')).toBeUndefined()
+    expect(dropdown.emitted('update:visible')).toBeUndefined()
+    expect(popupContainer.text()).toContain('Dropdown content')
   })
 
   it('keeps the internal trigger ref working even when the trigger slot node also defines a ref', async () => {
@@ -340,7 +392,7 @@ describe('UIDropdown', () => {
     expect(popupContainer.text()).toContain('Parent content')
     expect(popupContainer.text()).toContain('Child content')
 
-    await wrapper.get('[data-test-id="parent-content"]').trigger('mouseup')
+    await wrapper.get('[data-test-id="parent-content"]').trigger('click')
     await flushDropdown()
 
     expect(childDropdown.emitted('update:visible')).toEqual([[false]])

--- a/spx-gui/src/components/ui/UIDropdown.vue
+++ b/spx-gui/src/components/ui/UIDropdown.vue
@@ -44,6 +44,8 @@ export type Props = {
 
 <script setup lang="ts">
 import { computed, onScopeDispose, provide, ref, useSlots, watch, watchEffect, type CSSProperties } from 'vue'
+import { timeout } from '@/utils/utils'
+import { getCleanupSignal } from '@/utils/disposable'
 import { cn } from './utils'
 import {
   PopupRenderTrigger,
@@ -202,15 +204,11 @@ watch(
   { immediate: true }
 )
 
-watchEffect((onCleanup) => {
+watchEffect(async (onCleanup) => {
   if (!visibleComputed.value || !popup.isTopmost.value) return
 
   // Close the dropdown when user clicks outside of it.
-  // We listen to event `mouseup` instead `click` here. This avoids a
-  // timing issue with manual control: a caller may open the dropdown on
-  // `mouseup`, and a later document `click` event from the same click interaction would
-  // immediately close it again.
-  function handleDocumentMouseup(e: MouseEvent) {
+  function handleDocumentClick(e: MouseEvent) {
     // Ignore clicks that belong to the current trigger/content pair. Nested
     // dropdowns register separately, so their own stack entry handles itself.
     if (isEventInsideCurrentDropdown(e, triggerRef.value, contentRef.value)) return
@@ -226,12 +224,15 @@ watchEffect((onCleanup) => {
     setVisible(false)
   }
 
-  document.addEventListener('mouseup', handleDocumentMouseup, true)
-  window.addEventListener('keydown', handleDocumentKeydown)
-  onCleanup(() => {
-    document.removeEventListener('mouseup', handleDocumentMouseup, true)
-    window.removeEventListener('keydown', handleDocumentKeydown)
-  })
+  const signal = getCleanupSignal(onCleanup)
+  window.addEventListener('keydown', handleDocumentKeydown, { signal })
+
+  // Delay the outside-click listener to the next macro task.
+  // This avoids a timing issue with manual control: a caller may open the dropdown on
+  // event `mouseup`, and the document `click` event from the same click interaction would
+  // trigger `handleDocumentClick` here and immediately close the dropdown again.
+  await timeout(0)
+  if (!signal.aborted) document.addEventListener('click', handleDocumentClick, { capture: true, signal })
 })
 
 const exposed: PopupTriggerHandle & { setVisible(visible: boolean): void } = {

--- a/spx-gui/src/components/ui/UIDropdown.vue
+++ b/spx-gui/src/components/ui/UIDropdown.vue
@@ -205,7 +205,12 @@ watch(
 watchEffect((onCleanup) => {
   if (!visibleComputed.value || !popup.isTopmost.value) return
 
-  function handleDocumentClick(e: MouseEvent) {
+  // Close the dropdown when user clicks outside of it.
+  // We listen to event `mouseup` instead `click` here. This avoids a
+  // timing issue with manual control: a caller may open the dropdown on
+  // `mouseup`, and a later document `click` event from the same click interaction would
+  // immediately close it again.
+  function handleDocumentMouseup(e: MouseEvent) {
     // Ignore clicks that belong to the current trigger/content pair. Nested
     // dropdowns register separately, so their own stack entry handles itself.
     if (isEventInsideCurrentDropdown(e, triggerRef.value, contentRef.value)) return
@@ -213,6 +218,7 @@ watchEffect((onCleanup) => {
     emit('clickOutside', e)
   }
 
+  // Close the dropdown when user presses ESC.
   function handleDocumentKeydown(e: KeyboardEvent) {
     if (e.key !== 'Escape') return
     // Only the topmost open dropdown installs this listener, so ESC peels off
@@ -220,10 +226,10 @@ watchEffect((onCleanup) => {
     setVisible(false)
   }
 
-  document.addEventListener('click', handleDocumentClick, true)
+  document.addEventListener('mouseup', handleDocumentMouseup, true)
   window.addEventListener('keydown', handleDocumentKeydown)
   onCleanup(() => {
-    document.removeEventListener('click', handleDocumentClick, true)
+    document.removeEventListener('mouseup', handleDocumentMouseup, true)
     window.removeEventListener('keydown', handleDocumentKeydown)
   })
 })


### PR DESCRIPTION
## Summary
- keep dropdown outside-close behavior on document `click`
- delay outside-click listener binding with `timeout(0)` so the opening interaction is not treated as an outside click
- use `getCleanupSignal(onCleanup)` to avoid binding listeners after the effect is cleaned up
- restore `click`-based outside-close tests and add a regression test for manual `mouseup` open

## Validation
- npm run type-check
- npm run lint
- npm test
- npx vitest --run src/components/ui/UIDropdown.test.ts
