### PR TITLE
fix(spx-gui): code editor HoverCard disappearing immediately when the mouse stays still

### DIFF
--- a/spx-gui/src/components/editor/code-editor/xgo-code-editor/ui/hover/HoverUI.vue
+++ b/spx-gui/src/components/editor/code-editor/xgo-code-editor/ui/hover/HoverUI.vue
@@ -71,8 +71,8 @@ useDecorations(() => {
     <HoverCard
       v-if="controller.hover != null"
       :actions="controller.hover.actions"
-      @mouseenter="controller.emit('cardMouseEnter')"
-      @mouseleave="controller.emit('cardMouseLeave')"
+      @mouseenter="controller.emit('cardMouseEnter', $event)"
+      @mouseleave="controller.emit('cardMouseLeave', $event)"
       @action="controller.hideHover()"
     >
       <HoverCardContent v-for="(content, i) in controller.hover.contents" :key="i">

--- a/spx-gui/src/components/editor/code-editor/xgo-code-editor/ui/hover/index.ts
+++ b/spx-gui/src/components/editor/code-editor/xgo-code-editor/ui/hover/index.ts
@@ -46,8 +46,8 @@ type HoverTarget =
     }
 
 export class HoverController extends Emitter<{
-  cardMouseEnter: void
-  cardMouseLeave: void
+  cardMouseEnter: MouseEvent
+  cardMouseLeave: MouseEvent
 }> {
   private provider: IHoverProvider | null = null
 
@@ -255,8 +255,10 @@ export class HoverController extends Emitter<{
         lastMouseClientPoint = { x: e.event.posx, y: e.event.posy }
         // Keep the current hover alive when Monaco still maps this event back
         // to the active hover range, even if the target was briefly reclassified.
+        const isTextLikeTarget =
+          e.target.type === monaco.editor.MouseTargetType.CONTENT_TEXT || isForeignMouseTarget(e.target)
         const targetPosition = resolveMouseTargetPosition(e.target)
-        if (targetPosition != null && isPositionInsideCurrentHover(targetPosition)) {
+        if (isTextLikeTarget && targetPosition != null && isPositionInsideCurrentHover(targetPosition)) {
           handleMouseEnter({ type: 'text', position: targetPosition })
           return
         }
@@ -286,18 +288,26 @@ export class HoverController extends Emitter<{
       })
     )
 
-    // Use DOM `mouseleave` insteadOf `editor.OnMouseLeave` so we can inspect `relatedTarget` before deciding to hide.
+    // Use DOM `mouseleave` instead of `editor.OnMouseLeave` so we can inspect `relatedTarget` before deciding to hide.
     editorEl.addEventListener(
       'mouseleave',
       (e) => {
+        lastMouseClientPoint = { x: e.clientX, y: e.clientY }
         if (shouldKeepHoverOpen(e.relatedTarget)) return
         handleMouseEnter({ type: 'other' })
       },
       { signal: this.getSignal() }
     )
 
-    this.on('cardMouseEnter', () => handleMouseEnter({ type: 'hover-card' }))
-    this.on('cardMouseLeave', () => handleMouseEnter({ type: 'other' }))
+    this.on('cardMouseEnter', (e) => {
+      lastMouseClientPoint = { x: e.clientX, y: e.clientY }
+      handleMouseEnter({ type: 'hover-card' })
+    })
+    this.on('cardMouseLeave', (e) => {
+      lastMouseClientPoint = { x: e.clientX, y: e.clientY }
+      if (shouldKeepHoverOpen(e.relatedTarget)) return
+      handleMouseEnter({ type: 'other' })
+    })
 
     this.addDisposable(editor.onKeyDown(() => this.hideHover()))
     this.addDisposable(editor.onMouseDown(() => this.hideHover()))
@@ -322,7 +332,13 @@ function isPointerInsidePopup(point: { x: number; y: number } | null) {
   return isInPopup(resolveEventHTMLElement(el))
 }
 
-export function resolveMouseTargetPosition(target: monaco.editor.IEditorMouseEvent['target']): Position | null {
+// Monaco's mouse-target union doesn't expose `detail.mightBeForeignElement`
+// as a common field, so use a narrow structural read just for this optional flag.
+function isForeignMouseTarget(target: monaco.editor.IEditorMouseEvent['target']) {
+  return (target as { detail?: { mightBeForeignElement?: boolean } | null }).detail?.mightBeForeignElement === true
+}
+
+function resolveMouseTargetPosition(target: monaco.editor.IEditorMouseEvent['target']): Position | null {
   const range = target.range
   if (range != null) {
     return fromMonacoPosition({

--- a/spx-gui/src/components/editor/code-editor/xgo-code-editor/ui/hover/index.ts
+++ b/spx-gui/src/components/editor/code-editor/xgo-code-editor/ui/hover/index.ts
@@ -25,6 +25,7 @@ import {
   builtInCommandRenameResource,
   builtInCommandInvokeInputHelper
 } from '../code-editor-ui'
+import { isInPopup } from '@/components/ui'
 import { fromMonacoPosition } from '../common'
 import { hasPreviewForInputType } from '../markdown/InputValuePreview.vue'
 
@@ -193,6 +194,11 @@ export class HoverController extends Emitter<{
 
   init() {
     const { monaco, editor, resourceReferenceController } = this.ui
+    const editorEl = editor.getDomNode()
+    if (editorEl == null) throw new Error('No editor dom node')
+    // Track the latest mouse position so we can re-check the live Monaco/popup
+    // hit target when a stationary hover is briefly disturbed by decoration or popup mount.
+    let lastMouseClientPoint: { x: number; y: number } | null = null
 
     const hideHoverWithDebounce = debounce(() => this.hideHover(), 100)
 
@@ -203,8 +209,31 @@ export class HoverController extends Emitter<{
       }
     })
 
+    const isPositionInsideCurrentHover = (position: Position) => {
+      const currentHover = this.hover
+      return currentHover != null && containsPosition(currentHover.range, position)
+    }
+
+    const shouldKeepHoverOpen = (relatedTarget: EventTarget | null) => {
+      // Treat transient Monaco target reclassification and moves into popup
+      // content as still-hovering states. This keeps a stationary hover from
+      // collapsing while decorations/popup DOM are being mounted.
+      if (lastMouseClientPoint != null) {
+        const liveTarget = editor.getTargetAtClientPoint(lastMouseClientPoint.x, lastMouseClientPoint.y)
+        if (liveTarget != null) {
+          const targetPosition = resolveMouseTargetPosition(liveTarget)
+          if (targetPosition != null && isPositionInsideCurrentHover(targetPosition)) return true
+        }
+      }
+      if (isInPopup(resolveEventHTMLElement(relatedTarget))) return true
+      return isPointerInsidePopup(lastMouseClientPoint)
+    }
+
     const handleMouseEnter = debounce((target: HoverTarget) => {
       if (target.type === 'other') {
+        // Popup mount/decorations can briefly reclassify a stationary pointer.
+        // Keep the hover open while the cursor still maps to the current range or popup.
+        if (shouldKeepHoverOpen(null)) return
         hideHoverWithDebounce()
         return
       }
@@ -223,6 +252,14 @@ export class HoverController extends Emitter<{
 
     this.addDisposable(
       editor.onMouseMove((e: monaco.editor.IEditorMouseEvent) => {
+        lastMouseClientPoint = { x: e.event.posx, y: e.event.posy }
+        // Keep the current hover alive when Monaco still maps this event back
+        // to the active hover range, even if the target was briefly reclassified.
+        const targetPosition = resolveMouseTargetPosition(e.target)
+        if (targetPosition != null && isPositionInsideCurrentHover(targetPosition)) {
+          handleMouseEnter({ type: 'text', position: targetPosition })
+          return
+        }
         if (e.target.type !== monaco.editor.MouseTargetType.CONTENT_TEXT) {
           handleMouseEnter({ type: 'other' })
           return
@@ -249,7 +286,15 @@ export class HoverController extends Emitter<{
       })
     )
 
-    this.addDisposable(editor.onMouseLeave(() => handleMouseEnter({ type: 'other' })))
+    // Use DOM `mouseleave` insteadOf `editor.OnMouseLeave` so we can inspect `relatedTarget` before deciding to hide.
+    editorEl.addEventListener(
+      'mouseleave',
+      (e) => {
+        if (shouldKeepHoverOpen(e.relatedTarget)) return
+        handleMouseEnter({ type: 'other' })
+      },
+      { signal: this.getSignal() }
+    )
 
     this.on('cardMouseEnter', () => handleMouseEnter({ type: 'hover-card' }))
     this.on('cardMouseLeave', () => handleMouseEnter({ type: 'other' }))
@@ -263,4 +308,31 @@ export class HoverController extends Emitter<{
       })
     )
   }
+}
+
+function resolveEventHTMLElement(target: EventTarget | null) {
+  if (target instanceof HTMLElement) return target
+  if (target instanceof Node) return target.parentElement
+  return null
+}
+
+function isPointerInsidePopup(point: { x: number; y: number } | null) {
+  if (point == null) return false
+  const el = document.elementFromPoint(point.x, point.y)
+  return isInPopup(resolveEventHTMLElement(el))
+}
+
+export function resolveMouseTargetPosition(target: monaco.editor.IEditorMouseEvent['target']): Position | null {
+  const range = (target as { range?: { startLineNumber: number; startColumn: number } | null }).range
+  if (range != null) {
+    return fromMonacoPosition({
+      lineNumber: range.startLineNumber,
+      column: range.startColumn
+    })
+  }
+  const position = (target as { position?: { lineNumber: number; column: number } | null }).position
+  if (position != null) {
+    return fromMonacoPosition(position)
+  }
+  return null
 }

--- a/spx-gui/src/components/editor/code-editor/xgo-code-editor/ui/hover/index.ts
+++ b/spx-gui/src/components/editor/code-editor/xgo-code-editor/ui/hover/index.ts
@@ -323,14 +323,14 @@ function isPointerInsidePopup(point: { x: number; y: number } | null) {
 }
 
 export function resolveMouseTargetPosition(target: monaco.editor.IEditorMouseEvent['target']): Position | null {
-  const range = (target as { range?: { startLineNumber: number; startColumn: number } | null }).range
+  const range = target.range
   if (range != null) {
     return fromMonacoPosition({
       lineNumber: range.startLineNumber,
       column: range.startColumn
     })
   }
-  const position = (target as { position?: { lineNumber: number; column: number } | null }).position
+  const position = target.position
   if (position != null) {
     return fromMonacoPosition(position)
   }


### PR DESCRIPTION
## Problem Solved

After replacing `naive-ui` with the custom `UIDropdown`, hover behavior in the code editor regressed:

- Hovering over text could cause the `HoverCard` to flash and disappear immediately
- If the mouse kept moving slightly, the `HoverCard` often stayed open
- Moving from the editor text into the hover popup could also be misinterpreted as leaving the hover area

The root cause was a combination of two effects:

1. After the hover popup/decorations were mounted, Monaco could temporarily reclassify the current stationary pointer target as a non-text / foreign target
2. Popup mount / hit-testing changes could also trigger a transient leave-like signal while the pointer was still effectively on the same hovered text or had already moved into popup content

The old hover state logic treated these transient signals as a real hover exit and closed the popup too early.

## What Changed

This PR keeps the fix inside the editor hover controller rather than pushing Monaco-specific behavior down into `UIDropdown`.

### 1. Keep the current hover alive when Monaco still maps the event back to the active hover range

In `editor.onMouseMove(...)`, if Monaco reports a transiently reclassified target but that target still resolves to a position inside the current hover range, the hover is preserved instead of being closed.

### 2. Use DOM `mouseleave` instead of Monaco `onMouseLeave`

The controller now listens to the editor DOM `mouseleave` event so it can inspect `relatedTarget` and distinguish between:

- actually leaving the hover interaction
- moving into popup content

### 3. Add a unified “should keep hover open” check

A shared guard determines whether hover should stay open by checking:

- whether the live Monaco target under the latest mouse position still belongs to the current hover range
- whether the pointer moved into popup content
- whether the current mouse point already resolves into popup content

This prevents transient mount / classification effects from collapsing a valid hover.

### 4. Preserve existing closing behavior

The following behaviors remain unchanged:

- close on `Escape`
- close on editor `mousedown`
- close when resource modification starts

## Result

After this change:

- HoverCard remains visible when the mouse stays still on hovered text
- HoverCard no longer closes incorrectly when moving from editor text into popup content
- Normal closing behavior still works as expected

## Scope

- Affects only code-editor hover state handling
- Does not change generic `UIDropdown` semantics
- Keeps Monaco/editor-specific logic inside the hover controller where it belongs
