### PR TITLE
[Component] Feature: Add Card/Edit item component

### DIFF
--- a/ui/pages/spx/community-explore.pen
+++ b/ui/pages/spx/community-explore.pen
@@ -140,28 +140,28 @@
                 {
                   "id": "sjgux",
                   "type": "ref",
-                  "ref": "2:Jgsqa",
+                  "ref": "2:7vjfh",
                   "x": 0,
                   "y": 0
                 },
                 {
                   "id": "QFBkr",
                   "type": "ref",
-                  "ref": "2:Jgsqa",
+                  "ref": "2:7vjfh",
                   "x": 248,
                   "y": 0
                 },
                 {
                   "id": "YMmT1",
                   "type": "ref",
-                  "ref": "2:Jgsqa",
+                  "ref": "2:7vjfh",
                   "x": 496,
                   "y": 0
                 },
                 {
                   "id": "VVtVk",
                   "type": "ref",
-                  "ref": "2:Jgsqa",
+                  "ref": "2:7vjfh",
                   "x": 744,
                   "y": 0
                 }
@@ -176,28 +176,28 @@
                 {
                   "id": "RqkpQ",
                   "type": "ref",
-                  "ref": "2:Jgsqa",
+                  "ref": "2:7vjfh",
                   "x": 0,
                   "y": 0
                 },
                 {
                   "id": "izDa4",
                   "type": "ref",
-                  "ref": "2:Jgsqa",
+                  "ref": "2:7vjfh",
                   "x": 248,
                   "y": 0
                 },
                 {
                   "id": "YXNEf",
                   "type": "ref",
-                  "ref": "2:Jgsqa",
+                  "ref": "2:7vjfh",
                   "x": 496,
                   "y": 0
                 },
                 {
                   "id": "Ykxf1",
                   "type": "ref",
-                  "ref": "2:Jgsqa",
+                  "ref": "2:7vjfh",
                   "x": 744,
                   "y": 0
                 }


### PR DESCRIPTION
### Issue

- N/A

### Background

Add a reusable Card/Edit item component to the builder component library for next-ui related design work.

### Changes

- Added reusable `Card/Edit item` component in `builder-component.lib.pen`
- Updated related component library design data and exported layout structure
- Synced card/login related component sections in the component library

### Scope

- `ui/components/spx/builder-component.lib.pen`
- Card-related builder components

### Design System Impact

- [x] Yes (requires Component PR)
- [ ] No
