### PR TITLE
Fix SPX play overload documentation

### DIFF
--- a/spx-gui/src/components/editor/code-editor/spx-code-editor/document-base/index.ts
+++ b/spx-gui/src/components/editor/code-editor/spx-code-editor/document-base/index.ts
@@ -1837,12 +1837,12 @@ export const gamePlay0: DefinitionDocumentationItem = {
     name: 'Game.play',
     overloadId: '0'
   },
-  insertSnippet: 'play ${1:"${BUILDER_FIRST_SOUND_NAME:s1}"}, ${2:true}',
-  insertSnippetParameterHints: ['sound', 'loop'],
-  overview: 'play sound, loop',
+  insertSnippet: 'play ${1:"${BUILDER_FIRST_SOUND_NAME:s1}"}',
+  insertSnippetParameterHints: ['sound'],
+  overview: 'play sound',
   detail: makeBasicMarkdownString({
-    en: 'Play sound with given name in a loop',
-    zh: '循环播放声音（指定名字）'
+    en: 'Play sound with given name',
+    zh: '播放声音（指定名字）'
   })
 }
 
@@ -1854,12 +1854,12 @@ export const gamePlay1: DefinitionDocumentationItem = {
     name: 'Game.play',
     overloadId: '1'
   },
-  insertSnippet: 'play ${1:"${BUILDER_FIRST_SOUND_NAME:s1}"}',
-  insertSnippetParameterHints: ['sound'],
-  overview: 'play sound',
+  insertSnippet: 'play ${1:"${BUILDER_FIRST_SOUND_NAME:s1}"}, ${2:true}',
+  insertSnippetParameterHints: ['sound', 'loop'],
+  overview: 'play sound, loop',
   detail: makeBasicMarkdownString({
-    en: 'Play sound with given name',
-    zh: '播放声音（指定名字）'
+    en: 'Play sound with given name in a loop',
+    zh: '循环播放声音（指定名字）'
   })
 }
 


### PR DESCRIPTION
Fix the SPX code editor documentation mapping for `Game.play` and `Sprite.play` overloads.

Closes #3082

## Summary

- Correct `Game.play` overload `0` to document the non-looping `play sound` form.
- Correct `Game.play` overload `1` to document the looping `play sound, loop` form.
- Keep `Sprite.play` inheriting the same corrected definitions.

## Tests

- `npm run type-check`