### PR TITLE
fix(code-editor): trigger completion for unicode identifiers

### DIFF
--- a/spx-gui/src/components/editor/code-editor/xgo-code-editor/ui/completion/index.ts
+++ b/spx-gui/src/components/editor/code-editor/xgo-code-editor/ui/completion/index.ts
@@ -208,7 +208,7 @@ export class CompletionController extends Emitter<{
 }
 
 function shouldTriggerCompletion(char: string) {
-  return /[\w."]/.test(char)
+  return /[\p{L}\p{Nd}_."]/u.test(char)
 }
 
 function compareItems(a: InternalCompletionItem, b: InternalCompletionItem) {


### PR DESCRIPTION
Allow completion to start when the typed character is a Go identifier letter or decimal digit outside ASCII. This lets resource names such as Chinese sprite names request suggestions after IME input.