### PR TITLE
refactor(spx-gui): improve component definition typing

### DIFF
--- a/spx-gui/src/components/ui/modal/UIModalProvider.vue
+++ b/spx-gui/src/components/ui/modal/UIModalProvider.vue
@@ -20,7 +20,7 @@
  * delayed removal, events, and the provider-level `active` prop.
  */
 import { type InjectionKey, inject, provide, shallowReactive, nextTick, type Component, ref } from 'vue'
-import type { ComponentDefinition, PruneProps } from '@/utils/types'
+import type { ComponentDefinition, EmitsForComponent, PropsForComponent, Prettify } from '@/utils/types'
 import { Cancelled } from '@/utils/exception'
 import Emitter from '@/utils/emitter'
 import { provideModalContainer } from '../utils'
@@ -65,13 +65,19 @@ type ModalContext = {
   add(modalInfo: Omit<ModalInfo, 'id' | 'visible'>): void
 }
 
+export type ModalComponentDefinition = ComponentDefinition<ModalComponentProps, ModalComponentEmits<any>>
+
+type ResolvedValue<E> = E extends { resolved: infer Args extends any[] } ? Args[0] : never
+
+type ExtraProps<C extends ModalComponentDefinition> = Prettify<Omit<PropsForComponent<C>, keyof ModalComponentProps>>
+
 const modalContextInjectKey: InjectionKey<ModalContext> = Symbol('modal-context')
 
-export function useModal<P extends ModalComponentProps, R>(component: ComponentDefinition<P, ModalComponentEmits<R>>) {
+export function useModal<C extends ModalComponentDefinition>(component: C) {
   const ctx = inject(modalContextInjectKey)
   if (ctx == null) throw new Error('useModal should be called inside of ModalProvider')
-  return function invokeModal(extraProps: Omit<PruneProps<P, ModalComponentEmits<R>>, keyof ModalComponentProps>) {
-    return new Promise<R>((resolve, reject) => {
+  return function invokeModal(extraProps: ExtraProps<C>) {
+    return new Promise<ResolvedValue<EmitsForComponent<C>>>((resolve, reject) => {
       const handlers = { resolve, reject }
       ctx.add({ component, props: extraProps, handlers })
     })

--- a/spx-gui/src/utils/types.ts
+++ b/spx-gui/src/utils/types.ts
@@ -1,33 +1,93 @@
-import { type AllowedComponentProps, type ObjectEmitsOptions, type VNodeProps } from 'vue'
+import { type AllowedComponentProps, type EmitFn, type VNodeProps } from 'vue'
 
-// copied from vue source code
 type UnionToIntersection<U> = (U extends any ? (k: U) => void : never) extends (k: infer I) => void ? I : never
 
-// copied from vue source code
-type EmitFn<Options = ObjectEmitsOptions, Event extends keyof Options = keyof Options> =
-  Options extends Array<infer V>
-    ? (event: V, ...args: any[]) => void
-    : {} extends Options
-      ? (event: string, ...args: any[]) => void
-      : UnionToIntersection<
-          {
-            [key in Event]: Options[key] extends (...args: infer Args) => any
-              ? (event: key, ...args: Args) => void
-              : Options[key] extends any[]
-                ? (event: key, ...args: Options[key]) => void
-                : (event: key, ...args: any[]) => void
-          }[Event]
-        >
+// At most 8 overloads (event names) are supported, which should be enough for most use cases.
+// TypeScript doesn't support infinite overloads, and supporting too many overloads can cause performance issues.
+type OverloadedParameters<T> = T extends {
+  (...args: infer A1): any
+  (...args: infer A2): any
+  (...args: infer A3): any
+  (...args: infer A4): any
+  (...args: infer A5): any
+  (...args: infer A6): any
+  (...args: infer A7): any
+  (...args: infer A8): any
+}
+  ? A1 | A2 | A3 | A4 | A5 | A6 | A7 | A8
+  : T extends {
+        (...args: infer A1): any
+        (...args: infer A2): any
+        (...args: infer A3): any
+        (...args: infer A4): any
+        (...args: infer A5): any
+        (...args: infer A6): any
+        (...args: infer A7): any
+      }
+    ? A1 | A2 | A3 | A4 | A5 | A6 | A7
+    : T extends {
+          (...args: infer A1): any
+          (...args: infer A2): any
+          (...args: infer A3): any
+          (...args: infer A4): any
+          (...args: infer A5): any
+          (...args: infer A6): any
+        }
+      ? A1 | A2 | A3 | A4 | A5 | A6
+      : T extends {
+            (...args: infer A1): any
+            (...args: infer A2): any
+            (...args: infer A3): any
+            (...args: infer A4): any
+            (...args: infer A5): any
+          }
+        ? A1 | A2 | A3 | A4 | A5
+        : T extends {
+              (...args: infer A1): any
+              (...args: infer A2): any
+              (...args: infer A3): any
+              (...args: infer A4): any
+            }
+          ? A1 | A2 | A3 | A4
+          : T extends {
+                (...args: infer A1): any
+                (...args: infer A2): any
+                (...args: infer A3): any
+              }
+            ? A1 | A2 | A3
+            : T extends {
+                  (...args: infer A1): any
+                  (...args: infer A2): any
+                }
+              ? A1 | A2
+              : T extends (...args: infer A) => any
+                ? A
+                : never
+
+type EmitParamsToEmits<Params> = Params extends [infer Event, ...infer Args]
+  ? Event extends PropertyKey
+    ? string extends Event
+      ? never
+      : number extends Event
+        ? never
+        : symbol extends Event
+          ? never
+          : { [K in Event]: Args }
+    : never
+  : never
+
+/** Convert an Emit function type to an emits object type. Inverse operation of `EmitFn`. */
+type EmitFnToEmitsObject<T> = Prettify<UnionToIntersection<EmitParamsToEmits<OverloadedParameters<T>>>>
 
 /** Vue Component type with given props type & emits type */
-export type ComponentDefinition<Props, Emits extends Record<string, any[]>> = {
+export type ComponentDefinition<Props, Emits> = {
   new (): {
     $props: Props
     $emit: EmitFn<Emits>
   }
 }
 
-type ShortEmitsToProps<Emits extends Record<string, any[]>> = {
+type ShortEmitsToProps<Emits extends Record<string, any>> = {
   [K in `on${Capitalize<string & keyof Emits>}`]?: K extends `on${infer C}`
     ? (
         ...args: Emits[Uncapitalize<C>] extends (...args: infer P) => any
@@ -45,10 +105,17 @@ type ShortEmitsToProps<Emits extends Record<string, any[]>> = {
  * - Props from Vue internal, like `class`, `style`
  * - Props of VNode, like `key`, `ref`
  */
-export type PruneProps<Props, Emits extends Record<string, any[]>> = Omit<
-  Props,
-  keyof ShortEmitsToProps<Emits> | keyof VNodeProps | keyof AllowedComponentProps
+export type PruneProps<Props, Emits extends Record<string, any>> = Prettify<
+  Omit<Props, keyof ShortEmitsToProps<Emits> | keyof VNodeProps | keyof AllowedComponentProps>
 >
+
+/** Get the emits (object) type of a Vue component. */
+export type EmitsForComponent<C> = C extends { new (): { $emit: infer Emit } } ? EmitFnToEmitsObject<Emit> : never
+
+/** Get the props type of a Vue component, excluding emits-generated props and internal props. */
+export type PropsForComponent<C> = C extends { new (): { $props: infer Props; $emit: infer Emit } }
+  ? PruneProps<Props, EmitFnToEmitsObject<Emit>>
+  : never
 
 /** Prettify a type to make it more readable in IDEs */
 export type Prettify<T> = { [K in keyof T]: T[K] } & {}


### PR DESCRIPTION
This extracts the component definition typing improvements into a separate, focused change.

Changes:
- infer emits object types from component `$emit` overloads
- expose reusable component prop/emits extraction helpers in `src/utils/types.ts`
- tighten `useModal()` typing based on component definitions so its type checking is more accurate and avoids the incorrect results that the previous implementation often produced

Validation:
- verified touched files have no editor diagnostics
- attempted `vue-tsc --noEmit -p tsconfig.app.json` in the isolated worktree using shared dependencies; validation is currently blocked by an unrelated existing TS2742 error in `src/components/ui/popup/use-floating-popup.ts`
