### PR TITLE
refactor(spx-gui): simplify modal transform-origin handling & fix select trigger background

### DIFF
--- a/spx-gui/src/components/ui/modal/UIModal.test.ts
+++ b/spx-gui/src/components/ui/modal/UIModal.test.ts
@@ -339,13 +339,14 @@ describe('UIModal', () => {
 
       const surface = getLatestElement('.ui-modal-surface') as HTMLElement
 
-      expect(surface.style.transformOrigin).toBe('40px 70px')
+      expect(surface.style.transformOrigin).toBe('var(--ui-modal-transform-origin, center)')
+      expect(surface.style.getPropertyValue('--ui-modal-transform-origin')).toBe('40px 70px')
       ;(wrapper.vm as unknown as { modalRef: InstanceType<typeof UIModal> | null }).modalRef?.setTransformOrigin({
         x: 80,
         y: 120
       })
       await flushModal()
-      expect(surface.style.transformOrigin).toBe('70px 100px')
+      expect(surface.style.getPropertyValue('--ui-modal-transform-origin')).toBe('70px 100px')
     })
   })
 

--- a/spx-gui/src/components/ui/modal/UIModal.vue
+++ b/spx-gui/src/components/ui/modal/UIModal.vue
@@ -208,7 +208,11 @@ watch(
 watch(
   [containerRef, transformOrigin],
   ([contentEl, origin]) => {
-    if (contentEl == null || !contentEl.isConnected || origin == null) return
+    if (contentEl == null || !contentEl.isConnected) return
+    if (origin == null) {
+      contentEl.style.removeProperty('--ui-modal-transform-origin')
+      return
+    }
     contentEl.style.setProperty(
       '--ui-modal-transform-origin',
       // Use layout offsets here instead of getBoundingClientRect(): the modal surface is

--- a/spx-gui/src/components/ui/modal/UIModal.vue
+++ b/spx-gui/src/components/ui/modal/UIModal.vue
@@ -15,7 +15,7 @@
               tabindex="-1"
               class="ui-modal-surface"
               :class="surfaceClass"
-              :style="transformStyle"
+              :style="{ transformOrigin: 'var(--ui-modal-transform-origin, center)' }"
               @click.stop
             >
               <slot></slot>
@@ -37,7 +37,7 @@ export type ModalTransformOrigin = {
 </script>
 
 <script setup lang="ts">
-import { computed, mergeProps, nextTick, ref, useAttrs, watch, type CSSProperties } from 'vue'
+import { computed, mergeProps, ref, useAttrs, watch } from 'vue'
 import type { RadarNodeMeta } from '@/utils/radar'
 import { getCleanupSignal } from '@/utils/disposable'
 import { untilNotNull } from '@/utils/utils'
@@ -181,76 +181,47 @@ function isEscTargetWithinModalScope(modalContainer: HTMLElement, target: EventT
   return modalContainer.contains(target)
 }
 
-// Imperative transform-origin override requested by external callers for the
-// current modal cycle (for example, collapse-back-to-trigger flows).
-const explicitTransformOrigin = ref<ModalTransformOrigin | null>(null)
-// The final animation origin for the current modal cycle, resolved from the open
-// position and any later explicit override.
 const transformOrigin = ref<ModalTransformOrigin | null>(null)
-// Inline style applied to the teleported modal surface after the final origin has
-// been converted into surface-local coordinates.
-const transformStyle = ref<CSSProperties | null>(null)
 
-function setExplicitTransformOrigin(origin: ModalTransformOrigin | null) {
-  explicitTransformOrigin.value = origin
-  // If a caller overrides the origin while the modal is already open, switch the
-  // current cycle to that explicit origin immediately.
-  if (props.visible && origin != null) {
-    transformOrigin.value = origin
-  }
+function setTransformOrigin(origin: ModalTransformOrigin | null) {
+  transformOrigin.value = origin
 }
 
+// When a new open cycle starts, capture the last click point as origin.
 const lastClickEvent = useLastClickEvent()
-
-// When a new open cycle starts, capture the origin once: prefer an explicit
-// override if one is already present, otherwise fall back to the last click point.
 watch(
   () => props.visible,
   (show) => {
-    if (show) {
-      transformOrigin.value = explicitTransformOrigin.value ?? resolveClickOrigin(lastClickEvent.value)
+    if (!show) return
+    if (lastClickEvent.value == null) {
+      setTransformOrigin(null)
+    } else {
+      setTransformOrigin({
+        x: lastClickEvent.value.clientX,
+        y: lastClickEvent.value.clientY
+      })
     }
   },
   { immediate: true }
 )
 
-// Recompute the inline transform-origin whenever visibility, surface mounting, or
-// the resolved origin changes.
 watch(
-  [() => props.visible, containerRef, transformOrigin],
-  async ([show, contentEl, origin], _, onCleanup) => {
-    const signal = getCleanupSignal(onCleanup)
-    if (!show || contentEl == null || !contentEl.isConnected || origin == null) {
-      transformStyle.value = null
-      return
-    }
-    // Wait until the teleported surface has settled into its final layout before measuring.
-    await nextTick()
-    if (signal.aborted || !contentEl.isConnected) return
-    transformStyle.value = {
-      transformOrigin: transformOriginToStyle(contentEl, origin)
-    }
+  [containerRef, transformOrigin],
+  ([contentEl, origin]) => {
+    if (contentEl == null || !contentEl.isConnected || origin == null) return
+    contentEl.style.setProperty(
+      '--ui-modal-transform-origin',
+      // Use layout offsets here instead of getBoundingClientRect(): the modal surface is
+      // scaled during enter/leave transitions, while offsetLeft/offsetTop stay anchored to
+      // the untransformed layout position we want for this approximate transform origin.
+      `${origin.x - contentEl.offsetLeft}px ${origin.y - contentEl.offsetTop}px`
+    )
   },
-  { immediate: true, flush: 'post' }
+  { immediate: true }
 )
 
-function resolveClickOrigin(clickEvent: MouseEvent | null): ModalTransformOrigin | null {
-  if (clickEvent == null) return null
-  return {
-    x: clickEvent.clientX,
-    y: clickEvent.clientY
-  }
-}
-
-function transformOriginToStyle(contentEl: HTMLElement, origin: ModalTransformOrigin) {
-  // Use layout offsets here instead of getBoundingClientRect(): the modal surface is
-  // scaled during enter/leave transitions, while offsetLeft/offsetTop stay anchored to
-  // the untransformed layout position we want for this approximate transform origin.
-  return `${origin.x - contentEl.offsetLeft}px ${origin.y - contentEl.offsetTop}px`
-}
-
 defineExpose({
-  setTransformOrigin: setExplicitTransformOrigin
+  setTransformOrigin
 })
 </script>
 

--- a/spx-gui/src/components/ui/modal/UIModalProvider.vue
+++ b/spx-gui/src/components/ui/modal/UIModalProvider.vue
@@ -95,11 +95,11 @@ export function useModalEvents(): ModalEvents {
 const modalContainer = ref<HTMLElement>()
 const currentModals = shallowReactive<ModalInfo[]>([])
 const emitter: ModalEvents = new Emitter()
-let nextModalId = 0
+let nextModalId = 1
 
 async function add({ component, props, handlers }: Omit<ModalInfo, 'id' | 'visible'>) {
-  nextModalId += 1
   const id = nextModalId
+  nextModalId += 1
   const currentModal = shallowReactive({ id, component, props, handlers, visible: false })
   currentModals.push(currentModal)
   // The modal entry needs to exist in the tree before it can transition from hidden to visible.

--- a/spx-gui/src/components/ui/select/UISelect.vue
+++ b/spx-gui/src/components/ui/select/UISelect.vue
@@ -122,6 +122,17 @@ onBeforeUnmount(() => {
     background: var(--ui-color-grey-400);
   }
 
+  .ui-select:has(:active) {
+    color: var(--ui-color-grey-1000);
+    background: var(--ui-color-grey-500);
+  }
+
+  .ui-select:has(:focus) {
+    color: var(--ui-color-grey-1000);
+    background: var(--ui-color-grey-400);
+    box-shadow: inset 0 0 0 1px var(--ui-color-primary-500);
+  }
+
   .ui-select[data-disabled='true'] {
     background: var(--ui-color-disabled-bg);
     color: var(--ui-color-disabled-text);
@@ -132,12 +143,6 @@ onBeforeUnmount(() => {
     cursor: not-allowed;
   }
 
-  .ui-select:has(:focus) {
-    color: var(--ui-color-grey-1000);
-    background: var(--ui-color-grey-400);
-    box-shadow: inset 0 0 0 1px var(--ui-color-primary-500);
-  }
-
   .ui-select[data-ui-state='success'] {
     box-shadow: inset 0 0 0 1px var(--ui-color-success-main);
   }
@@ -146,9 +151,8 @@ onBeforeUnmount(() => {
     box-shadow: inset 0 0 0 1px var(--ui-color-danger-main);
   }
 
-  .ui-select:has(:active) {
-    color: var(--ui-color-grey-1000);
-    background: var(--ui-color-grey-500);
+  .ui-select:is([data-ui-state='success'], [data-ui-state='error']):not(:hover) {
+    background: var(--ui-color-grey-100);
   }
 }
 </style>

--- a/spx-gui/src/components/ui/select/UISelect.vue
+++ b/spx-gui/src/components/ui/select/UISelect.vue
@@ -117,6 +117,10 @@ onBeforeUnmount(() => {
     transition: 0.3s;
   }
 
+  .ui-select:is([data-ui-state='success'], [data-ui-state='error']) {
+    background: var(--ui-color-grey-100);
+  }
+
   .ui-select:hover {
     color: var(--ui-color-grey-800);
     background: var(--ui-color-grey-400);
@@ -144,10 +148,6 @@ onBeforeUnmount(() => {
 
   .ui-select[data-ui-state='error'] {
     box-shadow: inset 0 0 0 1px var(--ui-color-danger-main);
-  }
-
-  .ui-select:is([data-ui-state='success'], [data-ui-state='error']):not(:hover) {
-    background: var(--ui-color-grey-100);
   }
 
   .ui-select:has(:active) {

--- a/spx-gui/src/components/ui/select/UISelect.vue
+++ b/spx-gui/src/components/ui/select/UISelect.vue
@@ -122,17 +122,6 @@ onBeforeUnmount(() => {
     background: var(--ui-color-grey-400);
   }
 
-  .ui-select:has(:active) {
-    color: var(--ui-color-grey-1000);
-    background: var(--ui-color-grey-500);
-  }
-
-  .ui-select:has(:focus) {
-    color: var(--ui-color-grey-1000);
-    background: var(--ui-color-grey-400);
-    box-shadow: inset 0 0 0 1px var(--ui-color-primary-500);
-  }
-
   .ui-select[data-disabled='true'] {
     background: var(--ui-color-disabled-bg);
     color: var(--ui-color-disabled-text);
@@ -141,6 +130,12 @@ onBeforeUnmount(() => {
 
   .ui-select[data-disabled='true'] select {
     cursor: not-allowed;
+  }
+
+  .ui-select:has(:focus) {
+    color: var(--ui-color-grey-1000);
+    background: var(--ui-color-grey-400);
+    box-shadow: inset 0 0 0 1px var(--ui-color-primary-500);
   }
 
   .ui-select[data-ui-state='success'] {
@@ -153,6 +148,11 @@ onBeforeUnmount(() => {
 
   .ui-select:is([data-ui-state='success'], [data-ui-state='error']):not(:hover) {
     background: var(--ui-color-grey-100);
+  }
+
+  .ui-select:has(:active) {
+    color: var(--ui-color-grey-1000);
+    background: var(--ui-color-grey-500);
   }
 }
 </style>

--- a/spx-gui/src/components/ui/utils/layer-stack.ts
+++ b/spx-gui/src/components/ui/utils/layer-stack.ts
@@ -42,7 +42,7 @@ export type LayerStack = {
  */
 export function createLayerStack(): LayerStack {
   const entries = shallowReactive<LayerEntry[]>([])
-  let nextId = 0
+  let nextId = 1
 
   function getEntry(id: number) {
     return entries.find((entry) => entry.id === id) ?? null
@@ -59,8 +59,8 @@ export function createLayerStack(): LayerStack {
   const topmostId = computed(() => getTopmostOpenEntry()?.id)
 
   function register(open: Readonly<Ref<boolean>>) {
-    nextId += 1
     const entry = shallowReactive<LayerEntry>({ id: nextId, open })
+    nextId += 1
     entries.push(entry)
 
     function unregister() {


### PR DESCRIPTION
### Changes
* simplify modal transform-origin handling, solve the comment:  https://github.com/goplus/builder/pull/3037#pullrequestreview-4202219527
* align modal and layer-stack id counters with next-id semantics, solve the comment: https://github.com/goplus/builder/pull/3037#discussion_r3192789257
* fix select trigger background with validation state border 