### PR TITLE
Prevent editor stalls on invalid images

### DIFF
--- a/spx-gui/src/apis/common/client.ts
+++ b/spx-gui/src/apis/common/client.ts
@@ -5,8 +5,7 @@
 import * as Sentry from '@sentry/vue'
 import dayjs from 'dayjs'
 import { apiBaseUrl } from '@/utils/env'
-import { TimeoutException } from '@/utils/exception/base'
-import { mergeSignals } from '@/utils/disposable'
+import { getTimeoutSignal, mergeSignals } from '@/utils/disposable'
 import { ApiException, ApiExceptionCode, type MovedResourceCanonical, type QuotaExceededMeta } from './exception'
 import { parseSSE, type SSEEvent } from './sse'
 
@@ -107,10 +106,9 @@ export class Client {
   /** Perform request object and handle errors */
   private async doRequest(req: Request, options?: RequestOptions): Promise<Response> {
     const timeout = options?.timeout ?? this.defaultTimeout
-    const timeoutCtrl = new AbortController()
-    const timeoutTimer = setTimeout(() => timeoutCtrl.abort(new TimeoutException()), timeout)
-    const signal = mergeSignals(options?.signal, timeoutCtrl.signal)
-    const resp = await this.fetchFn(req, { signal }).finally(() => clearTimeout(timeoutTimer))
+    const [timeoutSignal, cancelTimeout] = getTimeoutSignal(timeout)
+    const signal = mergeSignals(timeoutSignal, options?.signal)
+    const resp = await this.fetchFn(req, { signal }).finally(cancelTimeout)
     if (!resp.ok) {
       let payload: ApiExceptionPayload | undefined
       try {

--- a/spx-gui/src/components/editor/common/viewer/SpriteNode.vue
+++ b/spx-gui/src/components/editor/common/viewer/SpriteNode.vue
@@ -44,7 +44,7 @@ const emit = defineEmits<{
 const nodeRef = ref<KonvaNodeInstance<Image>>()
 const costume = computed(() => props.localConfig.defaultCostume)
 const bitmapResolution = computed(() => costume.value?.bitmapResolution ?? 1)
-const [image] = useFileImg(() => costume.value?.img)
+const [image, imageLoading] = useFileImg(() => costume.value?.img)
 const rawSize = useAsyncComputedLegacy(async () => costume.value?.getRawSize() ?? null)
 
 const nodeId = computed(() => getNodeId(props.localConfig))
@@ -56,7 +56,7 @@ const configGetter = computed(() => {
 })
 
 watchEffect((onCleanup) => {
-  props.nodeReadyMap.set(nodeId.value, image.value != null)
+  props.nodeReadyMap.set(nodeId.value, !imageLoading.value)
   onCleanup(() => props.nodeReadyMap.delete(nodeId.value))
 })
 

--- a/spx-gui/src/models/spx/project.test.ts
+++ b/spx-gui/src/models/spx/project.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
+import { TimeoutException } from '@/utils/exception'
 import { ProjectType } from '@/apis/project'
 import { Sprite } from './sprite'
 import { Animation } from './animation'
@@ -113,6 +114,41 @@ describe('Project', () => {
     const { metadata } = await project.export()
     expect(metadata.type).toBe(ProjectType.Game)
     expect(metadata.thumbnail).toBe(thumbnail)
+  })
+
+  it('should stop waiting for screenshot after timeout when exporting', async () => {
+    vi.useFakeTimers()
+    const project = makeProject(null)
+    const signalPromise = new Promise<AbortSignal>((resolve) => {
+      project.bindScreenshotTaker((_name, signal) => {
+        if (signal == null) throw new Error('abort signal expected')
+        resolve(signal)
+        return new Promise((_, reject) => {
+          signal.addEventListener('abort', () => reject(signal.reason))
+        })
+      })
+    })
+
+    let settled = false
+    const exportPromise = project.export().then((result) => {
+      settled = true
+      return result
+    })
+
+    const signal = await signalPromise
+    expect(settled).toBe(false)
+
+    await vi.advanceTimersByTimeAsync(2999)
+    expect(settled).toBe(false)
+
+    await vi.advanceTimersByTimeAsync(100)
+    expect(settled).toBe(true)
+
+    const { metadata } = await exportPromise
+    expect(signal.aborted).toBe(true)
+    expect(signal.reason).toBeInstanceOf(TimeoutException)
+    expect(metadata.thumbnail).toBeUndefined()
+    vi.useRealTimers()
   })
 
   it('should move sprites correctly', async () => {

--- a/spx-gui/src/models/spx/project.ts
+++ b/spx-gui/src/models/spx/project.ts
@@ -7,9 +7,9 @@ import { computed, reactive, watch, type ComputedRef, toValue, effectScope } fro
 
 import { join } from '@/utils/path'
 import { debounce } from 'lodash'
-import { Disposable, getCleanupSignal } from '@/utils/disposable'
+import { Disposable, getCleanupSignal, getTimeoutSignal, mergeSignals, promiseForSignal } from '@/utils/disposable'
 import Mutex from '@/utils/mutex'
-import { Cancelled } from '@/utils/exception'
+import { Cancelled, capture } from '@/utils/exception'
 import { getSpxProjectKnowledge } from '@/utils/spx'
 import { ProjectType, Visibility, type ProjectExtraSettings } from '@/apis/project'
 import { generateAIDescription } from '@/apis/ai-description'
@@ -41,6 +41,9 @@ const mainFileMaxLength = 60_000
 const spriteFileMaxLength = 20_000
 const projectConfigMaxLength = 15_000
 const spriteConfigMaxLength = 5_000
+
+// The maximum time to wait for screenshot taking before giving up, in milliseconds
+const screenshotTimeout = 3000
 
 type RawRunConfig = {
   width?: number
@@ -320,10 +323,13 @@ export class SpxProject extends Disposable implements IProject {
     try {
       const reactiveThis = reactive(this) as this
       if (reactiveThis.screenshotTaker == null) return
-      reactiveThis.thumbnail = await reactiveThis.screenshotTaker('thumbnail', signal)
+      const [timeoutSignal, cancelTimeout] = getTimeoutSignal(screenshotTimeout)
+      reactiveThis.thumbnail = await Promise.race([
+        reactiveThis.screenshotTaker('thumbnail', mergeSignals(timeoutSignal, signal)),
+        promiseForSignal(timeoutSignal)
+      ]).finally(cancelTimeout)
     } catch (e) {
-      if (e instanceof Cancelled) return
-      console.warn('failed to update thumbnail', e)
+      capture(e, 'failed to update thumbnail')
     }
   }, 300)
 

--- a/spx-gui/src/utils/disposable.ts
+++ b/spx-gui/src/utils/disposable.ts
@@ -3,7 +3,7 @@
  */
 
 import { markRaw } from 'vue'
-import { Cancelled } from './exception/base'
+import { Cancelled, TimeoutException } from './exception/base'
 
 export type Disposer = () => void
 
@@ -60,9 +60,27 @@ export function getCleanupSignal(onCleanup: OnCleanup) {
   return ctrl.signal
 }
 
+/** Merge multiple signals into one. The merged signal will be aborted when any of the input signals is aborted. */
+export function mergeSignals(signal: AbortSignal, ...others: Array<AbortSignal | null | undefined>): AbortSignal
+export function mergeSignals(...signals: Array<AbortSignal | null | undefined>): AbortSignal | null
 export function mergeSignals(...signals: Array<AbortSignal | null | undefined>): AbortSignal | null {
   const nonEmptySignals = signals.filter((s) => s != null) as AbortSignal[]
   if (nonEmptySignals.length === 0) return null
   if (nonEmptySignals.length === 1) return nonEmptySignals[0]
   return AbortSignal.any(nonEmptySignals)
+}
+
+/** Create a signal which will be aborted after given timeout. The signal will be aborted with `TimeoutException`. */
+export function getTimeoutSignal(timeout: number): [AbortSignal, Disposer] {
+  const ctrl = new AbortController()
+  const timer = setTimeout(() => ctrl.abort(new TimeoutException()), timeout)
+  return [ctrl.signal, () => clearTimeout(timer)]
+}
+
+/** Create a promise which will be rejected when given signal is aborted. The promise will be rejected with the abort reason. */
+export function promiseForSignal(signal: AbortSignal): Promise<never> {
+  if (signal.aborted) return Promise.reject(signal.reason)
+  return new Promise<never>((_, reject) => {
+    signal.addEventListener('abort', () => reject(signal.reason), { once: true })
+  })
 }


### PR DESCRIPTION
Closes #3135

## Summary

- stop SpriteNode from reporting invalid-image failures as still loading
- add a timeout to project-export thumbnail screenshots so export cannot block on broken image handling
- cover the screenshot timeout behavior with a focused project test

## Validation

- npm run type-check
- npm run lint
- npx vitest --run
