### PR TITLE
docs(openapi): make product APIs resource-oriented

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -12,87 +12,9 @@ security:
   - bearerAuth: []
 
 paths:
-  /users/list:
-    get:
-      tags:
-        - Users
-      summary: List users
-      description: Retrieve a paginated list of users with optional filtering and ordering.
-      security: []
-      parameters:
-        - name: follower
-          description: |
-            Filter users who are being followed by the specified user.
-
-            Historical usernames are accepted and transparently normalized to the canonical username.
-          in: query
-          schema:
-            $ref: "#/components/schemas/User/properties/username"
-        - name: followee
-          description: |
-            Filter users who are following the specified user.
-
-            Historical usernames are accepted and transparently normalized to the canonical username.
-          in: query
-          schema:
-            $ref: "#/components/schemas/User/properties/username"
-        - name: orderBy
-          description: Field by which to order the results.
-          in: query
-          schema:
-            type: string
-            enum:
-              - createdAt
-              - updatedAt
-              - followedAt
-            default: createdAt
-            examples:
-              - createdAt
-        - $ref: "#/components/parameters/SortOrder"
-        - $ref: "#/components/parameters/PageIndex"
-        - $ref: "#/components/parameters/PageSize"
-      responses:
-        "200":
-          description: Successful response.
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  total:
-                    $ref: "#/components/schemas/ByPage/properties/total"
-                  data:
-                    description: Array of user objects.
-                    type: array
-                    items:
-                      $ref: "#/components/schemas/User"
-
-  /user/{username}:
-    get:
-      tags:
-        - Users
-      summary: Get a user
-      description: Retrieve details of a specific user.
-      security: []
-      parameters:
-        - name: username
-          description: Username of the user to get.
-          in: path
-          required: true
-          schema:
-            $ref: "#/components/schemas/User/properties/username"
-      responses:
-        "200":
-          description: Successful response.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/User"
-        "301":
-          $ref: "#/components/responses/MovedPermanently"
-
   /user:
     get:
+      operationId: getAuthenticatedUser
       tags:
         - Users
       summary: Get the authenticated user
@@ -103,8 +25,11 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/User"
+                $ref: "#/components/schemas/AuthenticatedUser"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
     patch:
+      operationId: updateAuthenticatedUser
       tags:
         - Users
       summary: Update the authenticated user
@@ -123,7 +48,13 @@ paths:
                 displayName:
                   $ref: "#/components/schemas/User/properties/displayName"
                 avatar:
-                  $ref: "#/components/schemas/User/properties/avatar"
+                  description: New avatar Kodo universal URL of the authenticated user.
+                  allOf:
+                    - $ref: "#/components/schemas/User/properties/avatar"
+                    - minLength: 1
+                      pattern: "^kodo://[^/?#@:]+/[^?#]+$"
+                      examples:
+                        - kodo://xbuilder-usercontent-test/files/FvYyHLNrtx8qFHSwnLjEe57UA2fF-2824936
                 description:
                   $ref: "#/components/schemas/User/properties/description"
       responses:
@@ -132,31 +63,103 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/User"
+                $ref: "#/components/schemas/AuthenticatedUser"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
 
-  /user/{username}/following:
-    post:
-      tags:
-        - Users
-      summary: Follow a user
-      description: Follow the specified user as the authenticated user.
-      parameters:
-        - name: username
-          description: Username of the user to follow.
-          in: path
-          required: true
-          schema:
-            $ref: "#/components/schemas/User/properties/username"
-      responses:
-        "204":
-          description: Successfully followed the user.
-        "409":
-          $ref: "#/components/responses/ResourceMoved"
+  /user/followers:
     get:
+      operationId: listAuthenticatedUserFollowers
       tags:
         - Users
-      summary: Check if a user is followed by the authenticated user
-      description: Determine if the authenticated user is following the specified user.
+      summary: List followers of the authenticated user
+      description: Retrieve users who follow the authenticated user.
+      parameters:
+        - name: orderBy
+          description: Field by which to order the results.
+          in: query
+          schema:
+            type: string
+            enum:
+              - createdAt
+              - updatedAt
+              - followedAt
+            default: followedAt
+            examples:
+              - followedAt
+        - $ref: "#/components/parameters/SortOrder"
+        - $ref: "#/components/parameters/PageIndex"
+        - $ref: "#/components/parameters/PageSize"
+      responses:
+        "200":
+          description: Successful response.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - total
+                  - data
+                properties:
+                  total:
+                    $ref: "#/components/schemas/ByPage/properties/total"
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/User"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+
+  /user/following:
+    get:
+      operationId: listAuthenticatedUserFollowing
+      tags:
+        - Users
+      summary: List users followed by the authenticated user
+      description: Retrieve users followed by the authenticated user.
+      parameters:
+        - name: orderBy
+          description: Field by which to order the results.
+          in: query
+          schema:
+            type: string
+            enum:
+              - createdAt
+              - updatedAt
+              - followedAt
+            default: followedAt
+            examples:
+              - followedAt
+        - $ref: "#/components/parameters/SortOrder"
+        - $ref: "#/components/parameters/PageIndex"
+        - $ref: "#/components/parameters/PageSize"
+      responses:
+        "200":
+          description: Successful response.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - total
+                  - data
+                properties:
+                  total:
+                    $ref: "#/components/schemas/ByPage/properties/total"
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/User"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+
+  /user/following/{username}:
+    get:
+      operationId: checkAuthenticatedUserFollowing
+      tags:
+        - Users
+      summary: Check whether the authenticated user follows a user
+      description: Determine if the authenticated user follows the specified user.
       parameters:
         - name: username
           description: Username of the user to check.
@@ -166,16 +169,39 @@ paths:
             $ref: "#/components/schemas/User/properties/username"
       responses:
         "204":
-          description: The user is followed by the authenticated user.
-        "404":
-          description: The user is not followed by the authenticated user.
+          description: The authenticated user follows the specified user.
         "301":
           $ref: "#/components/responses/MovedPermanently"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          description: The target user does not exist, or the authenticated user does not follow the target user.
+    put:
+      operationId: followUser
+      tags:
+        - Users
+      summary: Follow a user
+      description: Add the specified user to the authenticated user's following collection.
+      parameters:
+        - name: username
+          description: Username of the user to follow.
+          in: path
+          required: true
+          schema:
+            $ref: "#/components/schemas/User/properties/username"
+      responses:
+        "204":
+          description: Successfully followed the user, or the relationship already existed.
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "409":
+          $ref: "#/components/responses/ResourceMoved"
     delete:
+      operationId: unfollowUser
       tags:
         - Users
       summary: Unfollow a user
-      description: Unfollow the specified user as the authenticated user.
+      description: Remove the specified user from the authenticated user's following collection.
       parameters:
         - name: username
           description: Username of the user to unfollow.
@@ -185,129 +211,25 @@ paths:
             $ref: "#/components/schemas/User/properties/username"
       responses:
         "204":
-          description: Successfully unfollowed the user.
+          description: Successfully unfollowed the user, or the relationship did not exist.
+        "401":
+          $ref: "#/components/responses/Unauthorized"
         "409":
           $ref: "#/components/responses/ResourceMoved"
 
-  /project:
-    post:
-      tags:
-        - Projects
-      summary: Create a project
-      description: |
-        Create a new project.
-
-        If `remixSource` is provided, the new project will be a remix of an existing project.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              required:
-                - name
-                - visibility
-              properties:
-                remixSource:
-                  description: |
-                    Full name of the project or project release to remix from.
-
-                    **Using the project's full name means remixing the latest release sourced from that project.**
-
-                    Historical project or project release routes return `40901` with a `canonical` payload.
-                  oneOf:
-                    - $ref: "#/components/schemas/ProjectFullName"
-                    - $ref: "#/components/schemas/ProjectReleaseFullName"
-                name:
-                  $ref: "#/components/schemas/Project/properties/name"
-                displayName:
-                  description: Defaults to `name` if not provided.
-                  $ref: "#/components/schemas/Project/properties/displayName"
-                type:
-                  description: |
-                    Project type.
-
-                    If omitted, the request defaults to `game` for backward compatibility.
-                  $ref: "#/components/schemas/Project/properties/type"
-                files:
-                  description: |
-                    File paths and their corresponding universal URLs associated with the project.
-
-                    **Required if `remixSource` is not provided.**
-                  $ref: "#/components/schemas/Project/properties/files"
-                visibility:
-                  $ref: "#/components/schemas/Project/properties/visibility"
-                description:
-                  $ref: "#/components/schemas/Project/properties/description"
-                instructions:
-                  $ref: "#/components/schemas/Project/properties/instructions"
-                thumbnail:
-                  $ref: "#/components/schemas/Project/properties/thumbnail"
-      responses:
-        "201":
-          description: Successfully created the project.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Project"
-        "409":
-          description: |
-            Returned when `remixSource` references a historical project or project release route.
-
-            The response includes a `canonical` payload for the route-derived fields in `remixSource`.
-
-            Clients may update the request and resubmit it explicitly.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/MovedResourceError"
-
-  /projects/list:
+  /user/projects:
     get:
+      operationId: listAuthenticatedUserProjects
       tags:
         - Projects
-      summary: List projects
-      description: |
-        Retrieve a paginated list of projects with optional filtering and ordering.
-
-        #### Visibility rules
-
-        | Authenticated (as alice) | Owner | Visibility | Access |
-        |--------------------------|-------|------------|--------|
-        | false | * | | All users' public projects (force `visibility=public`) |
-        | false | * | public | All users' public projects |
-        | false | * | private | `401 Unauthorized` |
-        | false | alice | | Alice's public projects (force `visibility=public`) |
-        | false | alice | public | Alice's public projects |
-        | false | alice | private | `401 Unauthorized` |
-        | true | * | | All alice's projects + others' public projects |
-        | true | * | public | All users' public projects |
-        | true | * | private | Alice's private projects |
-        | true | alice | | All alice's projects |
-        | true | alice | public | Alice's public projects |
-        | true | alice | private | Alice's private projects |
-        | true | bob | | Bob's public projects (force `visibility=public`) |
-        | true | bob | public | Bob's public projects |
-        | true | bob | private | `401 Unauthorized` |
-      security:
-        - {}
-        - bearerAuth: []
+      summary: List projects owned by the authenticated user
+      description: Retrieve a paginated list of projects owned by the authenticated user.
       parameters:
-        - name: owner
-          description: |
-            Filter projects by the owner's username.
-
-            Defaults to the authenticated user if not specified. Use `*` to include projects from all users.
-            Historical usernames are accepted and transparently normalized to the canonical username.
-          in: query
-          schema:
-            $ref: "#/components/schemas/Project/properties/owner"
         - name: remixedFrom
           description: |
             Filter remixed projects by the full name of the source project or project release.
 
-            Historical project or project release routes are accepted and transparently normalized to the canonical
-            route.
+            Moved project or project release names are transparently normalized to canonical values.
           in: query
           schema:
             oneOf:
@@ -330,14 +252,6 @@ paths:
           in: query
           schema:
             $ref: "#/components/schemas/Project/properties/type"
-        - name: liker
-          description: |
-            Filter projects liked by the specified user.
-
-            Historical usernames are accepted and transparently normalized to the canonical username.
-          in: query
-          schema:
-            $ref: "#/components/schemas/User/properties/username"
         - name: createdAfter
           description: Filter projects created after this timestamp.
           in: query
@@ -356,12 +270,179 @@ paths:
           schema:
             type: string
             format: date-time
-        - name: fromFollowees
-          description: When true, include projects created by the authenticated user's followees.
+        - name: orderBy
+          description: Field by which to order the results.
           in: query
           schema:
-            type: boolean
-            default: false
+            type: string
+            enum:
+              - createdAt
+              - updatedAt
+              - likeCount
+              - remixCount
+              - recentLikeCount
+              - recentRemixCount
+            default: createdAt
+            examples:
+              - createdAt
+        - $ref: "#/components/parameters/SortOrder"
+        - $ref: "#/components/parameters/PageIndex"
+        - $ref: "#/components/parameters/PageSize"
+      responses:
+        "200":
+          description: Successful response.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - total
+                  - data
+                properties:
+                  total:
+                    $ref: "#/components/schemas/ByPage/properties/total"
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/Project"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+    post:
+      operationId: createProject
+      tags:
+        - Projects
+      summary: Create a project
+      description: |
+        Create a new project owned by the authenticated user.
+
+        If `remixSource` is provided, the new project will be a remix of an existing project.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - name
+                - visibility
+              properties:
+                remixSource:
+                  description: |
+                    Full name of the project or project release to remix from.
+
+                    Using the project's full name means remixing the latest release sourced from that project.
+
+                    Moved project or project release names return `40901` with a `canonical` payload.
+                  oneOf:
+                    - $ref: "#/components/schemas/ProjectFullName"
+                    - $ref: "#/components/schemas/ProjectReleaseFullName"
+                name:
+                  $ref: "#/components/schemas/Project/properties/name"
+                displayName:
+                  description: Defaults to `name` if not provided.
+                  $ref: "#/components/schemas/Project/properties/displayName"
+                type:
+                  description: Defaults to `game` if not provided.
+                  $ref: "#/components/schemas/Project/properties/type"
+                files:
+                  description: |
+                    File paths and their corresponding universal URLs associated with the project.
+
+                    Required if `remixSource` is not provided.
+                  $ref: "#/components/schemas/Project/properties/files"
+                visibility:
+                  $ref: "#/components/schemas/Project/properties/visibility"
+                description:
+                  $ref: "#/components/schemas/Project/properties/description"
+                instructions:
+                  $ref: "#/components/schemas/Project/properties/instructions"
+                extraSettings:
+                  $ref: "#/components/schemas/Project/properties/extraSettings"
+                thumbnail:
+                  $ref: "#/components/schemas/Project/properties/thumbnail"
+      responses:
+        "201":
+          description: Successfully created the project.
+          headers:
+            Location:
+              description: Canonical route of the created project.
+              schema:
+                type: string
+                format: uri-reference
+                minLength: 1
+                examples:
+                  - /projects/john/NiuXiaoQi
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Project"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "409":
+          description: |
+            Returned when `remixSource` references a moved project or project release.
+
+            The response includes a `canonical` payload for the route-derived fields in `remixSource`.
+
+            Clients may update the request and resubmit it explicitly.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MovedResourceError"
+
+  /user/liked-projects:
+    get:
+      operationId: listAuthenticatedUserLikedProjects
+      tags:
+        - Projects
+      summary: List projects liked by the authenticated user
+      description: Retrieve projects liked by the authenticated user.
+      parameters:
+        - name: remixedFrom
+          description: |
+            Filter remixed projects by the full name of the source project or project release.
+
+            Moved project or project release names are transparently normalized to canonical values.
+          in: query
+          schema:
+            oneOf:
+              - $ref: "#/components/schemas/ProjectFullName"
+              - $ref: "#/components/schemas/ProjectReleaseFullName"
+        - name: keyword
+          description: Filter projects by display name or name pattern.
+          in: query
+          schema:
+            type: string
+            examples:
+              - Niu Xiao Qi
+        - name: visibility
+          description: Filter projects by visibility.
+          in: query
+          schema:
+            $ref: "#/components/schemas/Project/properties/visibility"
+        - name: type
+          description: Filter projects by project type.
+          in: query
+          schema:
+            $ref: "#/components/schemas/Project/properties/type"
+        - name: createdAfter
+          description: Filter projects created after this timestamp.
+          in: query
+          schema:
+            type: string
+            format: date-time
+        - name: likesReceivedAfter
+          description: Filter projects that gained new likes after this timestamp.
+          in: query
+          schema:
+            type: string
+            format: date-time
+        - name: remixesReceivedAfter
+          description: Filter projects that were remixed after this timestamp.
+          in: query
+          schema:
+            type: string
+            format: date-time
         - name: orderBy
           description: Field by which to order the results.
           in: query
@@ -375,9 +456,9 @@ paths:
               - recentLikeCount
               - recentRemixCount
               - likedAt
-            default: createdAt
+            default: likedAt
             examples:
-              - createdAt
+              - likedAt
         - $ref: "#/components/parameters/SortOrder"
         - $ref: "#/components/parameters/PageIndex"
         - $ref: "#/components/parameters/PageSize"
@@ -388,6 +469,9 @@ paths:
             application/json:
               schema:
                 type: object
+                required:
+                  - total
+                  - data
                 properties:
                   total:
                     $ref: "#/components/schemas/ByPage/properties/total"
@@ -395,167 +479,15 @@ paths:
                     type: array
                     items:
                       $ref: "#/components/schemas/Project"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
 
-  /project/{owner}/{name}:
+  /user/liked-projects/{owner}/{project}:
     get:
+      operationId: checkAuthenticatedUserLikedProject
       tags:
         - Projects
-      summary: Get a project
-      description: Retrieve details of a specific project.
-      security:
-        - {}
-        - bearerAuth: []
-      parameters:
-        - name: owner
-          description: Username of the project's owner.
-          in: path
-          required: true
-          schema:
-            $ref: "#/components/schemas/Project/properties/owner"
-        - name: name
-          description: Name of the project to get.
-          in: path
-          required: true
-          schema:
-            $ref: "#/components/schemas/Project/properties/name"
-      responses:
-        "200":
-          description: Successful response.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Project"
-        "301":
-          $ref: "#/components/responses/MovedPermanently"
-    patch:
-      tags:
-        - Projects
-      summary: Update a project
-      description: Update the details of a specific project.
-      parameters:
-        - name: owner
-          description: Username of the project's owner.
-          in: path
-          required: true
-          schema:
-            $ref: "#/components/schemas/Project/properties/owner"
-        - name: name
-          description: Name of the project to update.
-          in: path
-          required: true
-          schema:
-            $ref: "#/components/schemas/Project/properties/name"
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              minProperties: 1
-              properties:
-                name:
-                  description: New name of the project. If provided, the project will be renamed.
-                  $ref: "#/components/schemas/Project/properties/name"
-                files:
-                  $ref: "#/components/schemas/Project/properties/files"
-                visibility:
-                  $ref: "#/components/schemas/Project/properties/visibility"
-                displayName:
-                  $ref: "#/components/schemas/Project/properties/displayName"
-                description:
-                  $ref: "#/components/schemas/Project/properties/description"
-                instructions:
-                  $ref: "#/components/schemas/Project/properties/instructions"
-                extraSettings:
-                  $ref: "#/components/schemas/Project/properties/extraSettings"
-                thumbnail:
-                  $ref: "#/components/schemas/Project/properties/thumbnail"
-      responses:
-        "200":
-          description: Successfully updated the project.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Project"
-        "409":
-          $ref: "#/components/responses/ResourceMoved"
-    delete:
-      tags:
-        - Projects
-      summary: Delete a project
-      description: Permanently delete a specific project by its owner and name.
-      parameters:
-        - name: owner
-          description: Username of the project's owner.
-          in: path
-          required: true
-          schema:
-            $ref: "#/components/schemas/Project/properties/owner"
-        - name: name
-          description: Name of the project to delete.
-          in: path
-          required: true
-          schema:
-            $ref: "#/components/schemas/Project/properties/name"
-      responses:
-        "204":
-          description: Successfully deleted the project.
-        "409":
-          $ref: "#/components/responses/ResourceMoved"
-
-  /project/{owner}/{name}/view:
-    post:
-      tags:
-        - Projects
-      summary: Record a project view
-      description: Record a view for the specified project as the authenticated user.
-      parameters:
-        - name: owner
-          description: Username of the project's owner.
-          in: path
-          required: true
-          schema:
-            $ref: "#/components/schemas/Project/properties/owner"
-        - name: name
-          description: Name of the project to record a view for.
-          in: path
-          required: true
-          schema:
-            $ref: "#/components/schemas/Project/properties/name"
-      responses:
-        "204":
-          description: Successfully recorded the project view.
-        "409":
-          $ref: "#/components/responses/ResourceMoved"
-
-  /project/{owner}/{name}/liking:
-    post:
-      tags:
-        - Projects
-      summary: Like a project
-      description: Like the specified project as the authenticated user.
-      parameters:
-        - name: owner
-          description: Username of the project's owner.
-          in: path
-          required: true
-          schema:
-            $ref: "#/components/schemas/Project/properties/owner"
-        - name: name
-          description: Name of the project to like.
-          in: path
-          required: true
-          schema:
-            $ref: "#/components/schemas/Project/properties/name"
-      responses:
-        "204":
-          description: Successfully liked the project.
-        "409":
-          $ref: "#/components/responses/ResourceMoved"
-    get:
-      tags:
-        - Projects
-      summary: Check if a project is liked by the authenticated user
+      summary: Check whether the authenticated user liked a project
       description: Determine if the authenticated user has liked the specified project.
       parameters:
         - name: owner
@@ -564,7 +496,7 @@ paths:
           required: true
           schema:
             $ref: "#/components/schemas/Project/properties/owner"
-        - name: name
+        - name: project
           description: Name of the project to check.
           in: path
           required: true
@@ -573,15 +505,18 @@ paths:
       responses:
         "204":
           description: The project is liked by the authenticated user.
-        "404":
-          description: The project is not liked by the authenticated user.
         "301":
           $ref: "#/components/responses/MovedPermanently"
-    delete:
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          description: The project does not exist, or the authenticated user has not liked the project.
+    put:
+      operationId: likeProject
       tags:
         - Projects
-      summary: Unlike a project
-      description: Unlike the specified project as the authenticated user.
+      summary: Like a project
+      description: Add the project to the authenticated user's liked-projects collection.
       parameters:
         - name: owner
           description: Username of the project's owner.
@@ -589,7 +524,33 @@ paths:
           required: true
           schema:
             $ref: "#/components/schemas/Project/properties/owner"
-        - name: name
+        - name: project
+          description: Name of the project to like.
+          in: path
+          required: true
+          schema:
+            $ref: "#/components/schemas/Project/properties/name"
+      responses:
+        "204":
+          description: Successfully liked the project, or the relationship already existed.
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "409":
+          $ref: "#/components/responses/ResourceMoved"
+    delete:
+      operationId: unlikeProject
+      tags:
+        - Projects
+      summary: Unlike a project
+      description: Remove the project from the authenticated user's liked-projects collection.
+      parameters:
+        - name: owner
+          description: Username of the project's owner.
+          in: path
+          required: true
+          schema:
+            $ref: "#/components/schemas/Project/properties/owner"
+        - name: project
           description: Name of the project to unlike.
           in: path
           required: true
@@ -597,71 +558,45 @@ paths:
             $ref: "#/components/schemas/Project/properties/name"
       responses:
         "204":
-          description: Successfully unliked the project.
+          description: Successfully unliked the project, or the relationship did not exist.
+        "401":
+          $ref: "#/components/responses/Unauthorized"
         "409":
           $ref: "#/components/responses/ResourceMoved"
 
-  /project-release:
-    post:
-      tags:
-        - Project Releases
-      summary: Create a project release
-      description: Create a new release for a specific project.
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-              required:
-                - projectFullName
-                - name
-                - description
-              properties:
-                projectFullName:
-                  description: |
-                    Historical project routes return `40901` with a `canonical` payload.
-                  $ref: "#/components/schemas/ProjectRelease/properties/projectFullName"
-                name:
-                  $ref: "#/components/schemas/ProjectRelease/properties/name"
-                description:
-                  $ref: "#/components/schemas/ProjectRelease/properties/description"
-                thumbnail:
-                  $ref: "#/components/schemas/ProjectRelease/properties/thumbnail"
-      responses:
-        "201":
-          description: Successfully created the project release.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ProjectRelease"
-        "409":
-          description: |
-            Returned when `projectFullName` references a historical project route.
-
-            The response includes a `canonical` payload for `projectFullName`.
-
-            Clients may update the request and resubmit it explicitly.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/MovedResourceError"
-
-  /project-releases/list:
+  /user/assets:
     get:
+      operationId: listAuthenticatedUserAssets
       tags:
-        - Project Releases
-      summary: List project releases
-      description: Retrieve a paginated list of project releases with optional filtering and ordering.
-      security: []
+        - Assets
+      summary: List assets owned by the authenticated user
+      description: Retrieve a paginated list of assets owned by the authenticated user.
       parameters:
-        - name: projectFullName
-          description: |
-            Filter releases by the full name of the associated project.
-
-            Historical project routes are accepted and transparently normalized to the canonical route.
+        - name: keyword
+          description: Filter assets by display name pattern.
           in: query
           schema:
-            $ref: "#/components/schemas/ProjectRelease/properties/projectFullName"
+            $ref: "#/components/schemas/Asset/properties/displayName"
+        - name: type
+          description: Filter assets by type.
+          in: query
+          schema:
+            $ref: "#/components/schemas/Asset/properties/type"
+        - name: category
+          description: Filter assets by category.
+          in: query
+          schema:
+            $ref: "#/components/schemas/Asset/properties/category"
+        - name: filesHash
+          description: Filter assets by files hash.
+          in: query
+          schema:
+            $ref: "#/components/schemas/Asset/properties/filesHash"
+        - name: visibility
+          description: Filter assets by visibility.
+          in: query
+          schema:
+            $ref: "#/components/schemas/Asset/properties/visibility"
         - name: orderBy
           description: Field by which to order the results.
           in: query
@@ -670,7 +605,7 @@ paths:
             enum:
               - createdAt
               - updatedAt
-              - remixCount
+              - displayName
             default: createdAt
             examples:
               - createdAt
@@ -684,60 +619,27 @@ paths:
             application/json:
               schema:
                 type: object
+                required:
+                  - total
+                  - data
                 properties:
                   total:
                     $ref: "#/components/schemas/ByPage/properties/total"
                   data:
-                    description: Array of project release objects.
                     type: array
                     items:
-                      $ref: "#/components/schemas/ProjectRelease"
-
-  /project-release/{owner}/{project}/{release}:
-    get:
-      tags:
-        - Project Releases
-      summary: Get a project release
-      description: Retrieve details of a specific project release.
-      security: []
-      parameters:
-        - name: owner
-          description: Username of the project's owner.
-          in: path
-          required: true
-          schema:
-            $ref: "#/components/schemas/Project/properties/owner"
-        - name: project
-          description: Name of the project.
-          in: path
-          required: true
-          schema:
-            $ref: "#/components/schemas/Project/properties/name"
-        - name: release
-          description: Name of the project release to get.
-          in: path
-          required: true
-          schema:
-            $ref: "#/components/schemas/ProjectRelease/properties/name"
-      responses:
-        "200":
-          description: Successful response.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ProjectRelease"
-        "301":
-          $ref: "#/components/responses/MovedPermanently"
-
-  /asset:
+                      $ref: "#/components/schemas/Asset"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
     post:
+      operationId: createAsset
       tags:
         - Assets
       summary: Create an asset
       description: |
-        Create a new asset with the necessary details.
+        Create a new asset owned by the authenticated user.
 
-        #### Permission requirements
+        Permission requirements:
 
         - Only users with the `assetAdmin` role can create public assets.
         - Regular users can only create private assets.
@@ -776,40 +678,1178 @@ paths:
       responses:
         "201":
           description: Successfully created the asset.
+          headers:
+            Location:
+              description: Canonical route of the created asset.
+              schema:
+                type: string
+                format: uri-reference
+                minLength: 1
+                examples:
+                  - /assets/1
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/Asset"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
         "403":
           description: Insufficient permissions to perform this operation.
 
-  /assets/list:
+  /user/courses:
     get:
+      operationId: listAuthenticatedUserCourses
+      tags:
+        - Courses
+      summary: List courses owned by the authenticated user
+      description: Retrieve courses owned by the authenticated user.
+      parameters:
+        - name: courseSeriesID
+          description: Filter courses by the course series ID.
+          in: query
+          schema:
+            $ref: "#/components/schemas/Model/properties/id"
+        - name: orderBy
+          description: Field by which to order the results.
+          in: query
+          schema:
+            type: string
+            enum:
+              - createdAt
+              - updatedAt
+              - sequenceInCourseSeries
+            default: createdAt
+            examples:
+              - createdAt
+        - $ref: "#/components/parameters/SortOrder"
+        - $ref: "#/components/parameters/PageIndex"
+        - $ref: "#/components/parameters/PageSize"
+      responses:
+        "200":
+          description: Successful response.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - total
+                  - data
+                properties:
+                  total:
+                    $ref: "#/components/schemas/ByPage/properties/total"
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/Course"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+    post:
+      operationId: createCourse
+      tags:
+        - Courses
+      summary: Create a course
+      description: |
+        Create a new course owned by the authenticated user.
+
+        Permission requirements:
+
+        - Only users with the `courseAdmin` role can create courses.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - title
+                - thumbnail
+                - entrypoint
+                - references
+                - prompt
+              properties:
+                title:
+                  $ref: "#/components/schemas/Course/properties/title"
+                thumbnail:
+                  $ref: "#/components/schemas/Course/properties/thumbnail"
+                entrypoint:
+                  $ref: "#/components/schemas/Course/properties/entrypoint"
+                references:
+                  $ref: "#/components/schemas/Course/properties/references"
+                prompt:
+                  $ref: "#/components/schemas/Course/properties/prompt"
+      responses:
+        "201":
+          description: Successfully created the course.
+          headers:
+            Location:
+              description: Canonical route of the created course.
+              schema:
+                type: string
+                format: uri-reference
+                minLength: 1
+                examples:
+                  - /courses/1
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Course"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          description: Insufficient permissions to perform this operation.
+
+  /user/course-series:
+    get:
+      operationId: listAuthenticatedUserCourseSeries
+      tags:
+        - Course Series
+      summary: List course series owned by the authenticated user
+      description: Retrieve course series owned by the authenticated user.
+      parameters:
+        - name: orderBy
+          description: Field by which to order the results.
+          in: query
+          schema:
+            type: string
+            enum:
+              - createdAt
+              - updatedAt
+              - order
+            default: order
+            examples:
+              - order
+        - $ref: "#/components/parameters/SortOrder"
+        - $ref: "#/components/parameters/PageIndex"
+        - $ref: "#/components/parameters/PageSize"
+      responses:
+        "200":
+          description: Successful response.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - total
+                  - data
+                properties:
+                  total:
+                    $ref: "#/components/schemas/ByPage/properties/total"
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/CourseSeries"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+    post:
+      operationId: createCourseSeries
+      tags:
+        - Course Series
+      summary: Create a course series
+      description: |
+        Create a new course series owned by the authenticated user.
+
+        Permission requirements:
+
+        - Only users with the `courseAdmin` role can create course series.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - title
+                - courseIDs
+                - order
+              properties:
+                title:
+                  $ref: "#/components/schemas/CourseSeries/properties/title"
+                thumbnail:
+                  $ref: "#/components/schemas/CourseSeries/properties/thumbnail"
+                description:
+                  $ref: "#/components/schemas/CourseSeries/properties/description"
+                courseIDs:
+                  $ref: "#/components/schemas/CourseSeries/properties/courseIDs"
+                order:
+                  $ref: "#/components/schemas/CourseSeries/properties/order"
+      responses:
+        "201":
+          description: Successfully created the course series.
+          headers:
+            Location:
+              description: Canonical route of the created course series.
+              schema:
+                type: string
+                format: uri-reference
+                minLength: 1
+                examples:
+                  - /course-series/1
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CourseSeries"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          description: Insufficient permissions to perform this operation.
+
+  /users:
+    get:
+      operationId: listUsers
+      tags:
+        - Users
+      summary: List users
+      description: Retrieve a paginated list of users.
+      security: []
+      parameters:
+        - name: orderBy
+          description: Field by which to order the results.
+          in: query
+          schema:
+            type: string
+            enum:
+              - createdAt
+              - updatedAt
+            default: createdAt
+            examples:
+              - createdAt
+        - $ref: "#/components/parameters/SortOrder"
+        - $ref: "#/components/parameters/PageIndex"
+        - $ref: "#/components/parameters/PageSize"
+      responses:
+        "200":
+          description: Successful response.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - total
+                  - data
+                properties:
+                  total:
+                    $ref: "#/components/schemas/ByPage/properties/total"
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/User"
+
+  /users/{username}:
+    get:
+      operationId: getUser
+      tags:
+        - Users
+      summary: Get a user
+      description: Retrieve details of a specific user.
+      security: []
+      parameters:
+        - name: username
+          description: Username of the user to get.
+          in: path
+          required: true
+          schema:
+            $ref: "#/components/schemas/User/properties/username"
+      responses:
+        "200":
+          description: Successful response.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/User"
+        "301":
+          $ref: "#/components/responses/MovedPermanently"
+
+  /users/{username}/followers:
+    get:
+      operationId: listUserFollowers
+      tags:
+        - Users
+      summary: List followers of a user
+      description: Retrieve users who follow the specified user.
+      security: []
+      parameters:
+        - name: username
+          description: Username of the user whose followers are listed.
+          in: path
+          required: true
+          schema:
+            $ref: "#/components/schemas/User/properties/username"
+        - name: orderBy
+          description: Field by which to order the results.
+          in: query
+          schema:
+            type: string
+            enum:
+              - createdAt
+              - updatedAt
+              - followedAt
+            default: followedAt
+            examples:
+              - followedAt
+        - $ref: "#/components/parameters/SortOrder"
+        - $ref: "#/components/parameters/PageIndex"
+        - $ref: "#/components/parameters/PageSize"
+      responses:
+        "200":
+          description: Successful response.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - total
+                  - data
+                properties:
+                  total:
+                    $ref: "#/components/schemas/ByPage/properties/total"
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/User"
+        "301":
+          $ref: "#/components/responses/MovedPermanently"
+
+  /users/{username}/following:
+    get:
+      operationId: listUserFollowing
+      tags:
+        - Users
+      summary: List users followed by a user
+      description: Retrieve users followed by the specified user.
+      security: []
+      parameters:
+        - name: username
+          description: Username of the user whose following collection is listed.
+          in: path
+          required: true
+          schema:
+            $ref: "#/components/schemas/User/properties/username"
+        - name: orderBy
+          description: Field by which to order the results.
+          in: query
+          schema:
+            type: string
+            enum:
+              - createdAt
+              - updatedAt
+              - followedAt
+            default: followedAt
+            examples:
+              - followedAt
+        - $ref: "#/components/parameters/SortOrder"
+        - $ref: "#/components/parameters/PageIndex"
+        - $ref: "#/components/parameters/PageSize"
+      responses:
+        "200":
+          description: Successful response.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - total
+                  - data
+                properties:
+                  total:
+                    $ref: "#/components/schemas/ByPage/properties/total"
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/User"
+        "301":
+          $ref: "#/components/responses/MovedPermanently"
+
+  /users/{username}/projects:
+    get:
+      operationId: listUserProjects
+      tags:
+        - Projects
+      summary: List public projects owned by a user
+      description: Retrieve public projects owned by the specified user.
+      security: []
+      parameters:
+        - name: username
+          description: Username of the project owner.
+          in: path
+          required: true
+          schema:
+            $ref: "#/components/schemas/User/properties/username"
+        - name: remixedFrom
+          description: |
+            Filter remixed projects by the full name of the source project or project release.
+
+            Moved project or project release names are transparently normalized to canonical values.
+          in: query
+          schema:
+            oneOf:
+              - $ref: "#/components/schemas/ProjectFullName"
+              - $ref: "#/components/schemas/ProjectReleaseFullName"
+        - name: keyword
+          description: Filter projects by display name or name pattern.
+          in: query
+          schema:
+            type: string
+            examples:
+              - Niu Xiao Qi
+        - name: type
+          description: Filter projects by project type.
+          in: query
+          schema:
+            $ref: "#/components/schemas/Project/properties/type"
+        - name: createdAfter
+          description: Filter projects created after this timestamp.
+          in: query
+          schema:
+            type: string
+            format: date-time
+        - name: likesReceivedAfter
+          description: Filter projects that gained new likes after this timestamp.
+          in: query
+          schema:
+            type: string
+            format: date-time
+        - name: remixesReceivedAfter
+          description: Filter projects that were remixed after this timestamp.
+          in: query
+          schema:
+            type: string
+            format: date-time
+        - name: orderBy
+          description: Field by which to order the results.
+          in: query
+          schema:
+            type: string
+            enum:
+              - createdAt
+              - updatedAt
+              - likeCount
+              - remixCount
+              - recentLikeCount
+              - recentRemixCount
+            default: createdAt
+            examples:
+              - createdAt
+        - $ref: "#/components/parameters/SortOrder"
+        - $ref: "#/components/parameters/PageIndex"
+        - $ref: "#/components/parameters/PageSize"
+      responses:
+        "200":
+          description: Successful response.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - total
+                  - data
+                properties:
+                  total:
+                    $ref: "#/components/schemas/ByPage/properties/total"
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/Project"
+        "301":
+          $ref: "#/components/responses/MovedPermanently"
+
+  /users/{username}/liked-projects:
+    get:
+      operationId: listUserLikedProjects
+      tags:
+        - Projects
+      summary: List projects liked by a user
+      description: Retrieve public projects liked by the specified user.
+      security: []
+      parameters:
+        - name: username
+          description: Username of the user whose liked projects are listed.
+          in: path
+          required: true
+          schema:
+            $ref: "#/components/schemas/User/properties/username"
+        - name: remixedFrom
+          description: |
+            Filter remixed projects by the full name of the source project or project release.
+
+            Moved project or project release names are transparently normalized to canonical values.
+          in: query
+          schema:
+            oneOf:
+              - $ref: "#/components/schemas/ProjectFullName"
+              - $ref: "#/components/schemas/ProjectReleaseFullName"
+        - name: keyword
+          description: Filter projects by display name or name pattern.
+          in: query
+          schema:
+            type: string
+            examples:
+              - Niu Xiao Qi
+        - name: type
+          description: Filter projects by project type.
+          in: query
+          schema:
+            $ref: "#/components/schemas/Project/properties/type"
+        - name: createdAfter
+          description: Filter projects created after this timestamp.
+          in: query
+          schema:
+            type: string
+            format: date-time
+        - name: likesReceivedAfter
+          description: Filter projects that gained new likes after this timestamp.
+          in: query
+          schema:
+            type: string
+            format: date-time
+        - name: remixesReceivedAfter
+          description: Filter projects that were remixed after this timestamp.
+          in: query
+          schema:
+            type: string
+            format: date-time
+        - name: orderBy
+          description: Field by which to order the results.
+          in: query
+          schema:
+            type: string
+            enum:
+              - createdAt
+              - updatedAt
+              - likeCount
+              - remixCount
+              - recentLikeCount
+              - recentRemixCount
+              - likedAt
+            default: likedAt
+            examples:
+              - likedAt
+        - $ref: "#/components/parameters/SortOrder"
+        - $ref: "#/components/parameters/PageIndex"
+        - $ref: "#/components/parameters/PageSize"
+      responses:
+        "200":
+          description: Successful response.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - total
+                  - data
+                properties:
+                  total:
+                    $ref: "#/components/schemas/ByPage/properties/total"
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/Project"
+        "301":
+          $ref: "#/components/responses/MovedPermanently"
+
+  /users/{username}/assets:
+    get:
+      operationId: listUserAssets
+      tags:
+        - Assets
+      summary: List public assets owned by a user
+      description: Retrieve public assets owned by the specified user.
+      security: []
+      parameters:
+        - name: username
+          description: Username of the asset owner.
+          in: path
+          required: true
+          schema:
+            $ref: "#/components/schemas/User/properties/username"
+        - name: keyword
+          description: Filter assets by display name pattern.
+          in: query
+          schema:
+            $ref: "#/components/schemas/Asset/properties/displayName"
+        - name: type
+          description: Filter assets by type.
+          in: query
+          schema:
+            $ref: "#/components/schemas/Asset/properties/type"
+        - name: category
+          description: Filter assets by category.
+          in: query
+          schema:
+            $ref: "#/components/schemas/Asset/properties/category"
+        - name: filesHash
+          description: Filter assets by files hash.
+          in: query
+          schema:
+            $ref: "#/components/schemas/Asset/properties/filesHash"
+        - name: orderBy
+          description: Field by which to order the results.
+          in: query
+          schema:
+            type: string
+            enum:
+              - createdAt
+              - updatedAt
+              - displayName
+            default: createdAt
+            examples:
+              - createdAt
+        - $ref: "#/components/parameters/SortOrder"
+        - $ref: "#/components/parameters/PageIndex"
+        - $ref: "#/components/parameters/PageSize"
+      responses:
+        "200":
+          description: Successful response.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - total
+                  - data
+                properties:
+                  total:
+                    $ref: "#/components/schemas/ByPage/properties/total"
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/Asset"
+        "301":
+          $ref: "#/components/responses/MovedPermanently"
+
+  /users/{username}/courses:
+    get:
+      operationId: listUserCourses
+      tags:
+        - Courses
+      summary: List courses owned by a user
+      description: Retrieve courses owned by the specified user.
+      security: []
+      parameters:
+        - name: username
+          description: Username of the course owner.
+          in: path
+          required: true
+          schema:
+            $ref: "#/components/schemas/User/properties/username"
+        - name: courseSeriesID
+          description: Filter courses by the course series ID.
+          in: query
+          schema:
+            $ref: "#/components/schemas/Model/properties/id"
+        - name: orderBy
+          description: Field by which to order the results.
+          in: query
+          schema:
+            type: string
+            enum:
+              - createdAt
+              - updatedAt
+              - sequenceInCourseSeries
+            default: createdAt
+            examples:
+              - createdAt
+        - $ref: "#/components/parameters/SortOrder"
+        - $ref: "#/components/parameters/PageIndex"
+        - $ref: "#/components/parameters/PageSize"
+      responses:
+        "200":
+          description: Successful response.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - total
+                  - data
+                properties:
+                  total:
+                    $ref: "#/components/schemas/ByPage/properties/total"
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/Course"
+        "301":
+          $ref: "#/components/responses/MovedPermanently"
+
+  /users/{username}/course-series:
+    get:
+      operationId: listUserCourseSeries
+      tags:
+        - Course Series
+      summary: List course series owned by a user
+      description: Retrieve course series owned by the specified user.
+      security: []
+      parameters:
+        - name: username
+          description: Username of the course series owner.
+          in: path
+          required: true
+          schema:
+            $ref: "#/components/schemas/User/properties/username"
+        - name: orderBy
+          description: Field by which to order the results.
+          in: query
+          schema:
+            type: string
+            enum:
+              - createdAt
+              - updatedAt
+              - order
+            default: order
+            examples:
+              - order
+        - $ref: "#/components/parameters/SortOrder"
+        - $ref: "#/components/parameters/PageIndex"
+        - $ref: "#/components/parameters/PageSize"
+      responses:
+        "200":
+          description: Successful response.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - total
+                  - data
+                properties:
+                  total:
+                    $ref: "#/components/schemas/ByPage/properties/total"
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/CourseSeries"
+        "301":
+          $ref: "#/components/responses/MovedPermanently"
+
+  /projects:
+    get:
+      operationId: listProjects
+      tags:
+        - Projects
+      summary: List projects
+      description: |
+        Retrieve a paginated list of projects visible to the request.
+
+        Anonymous requests return public projects. Authenticated requests return public projects and the authenticated
+        user's own projects when no visibility filter is provided. A non-public visibility filter requires
+        authentication and is scoped to the authenticated user's own projects.
+      security:
+        - {}
+        - bearerAuth: []
+      parameters:
+        - name: remixedFrom
+          description: |
+            Filter remixed projects by the full name of the source project or project release.
+
+            Moved project or project release names are transparently normalized to canonical values.
+          in: query
+          schema:
+            oneOf:
+              - $ref: "#/components/schemas/ProjectFullName"
+              - $ref: "#/components/schemas/ProjectReleaseFullName"
+        - name: keyword
+          description: Filter projects by display name or name pattern.
+          in: query
+          schema:
+            type: string
+            examples:
+              - Niu Xiao Qi
+        - name: visibility
+          description: Filter projects by visibility.
+          in: query
+          schema:
+            $ref: "#/components/schemas/Project/properties/visibility"
+        - name: type
+          description: Filter projects by project type.
+          in: query
+          schema:
+            $ref: "#/components/schemas/Project/properties/type"
+        - name: createdAfter
+          description: Filter projects created after this timestamp.
+          in: query
+          schema:
+            type: string
+            format: date-time
+        - name: likesReceivedAfter
+          description: Filter projects that gained new likes after this timestamp.
+          in: query
+          schema:
+            type: string
+            format: date-time
+        - name: remixesReceivedAfter
+          description: Filter projects that were remixed after this timestamp.
+          in: query
+          schema:
+            type: string
+            format: date-time
+        - name: fromFollowees
+          description: |
+            When true, filter to projects created by the authenticated user's followees.
+
+            Supplying `true` without authentication returns `401 Unauthorized`.
+          in: query
+          schema:
+            type: boolean
+            default: false
+        - name: orderBy
+          description: Field by which to order the results.
+          in: query
+          schema:
+            type: string
+            enum:
+              - createdAt
+              - updatedAt
+              - likeCount
+              - remixCount
+              - recentLikeCount
+              - recentRemixCount
+            default: createdAt
+            examples:
+              - createdAt
+        - $ref: "#/components/parameters/SortOrder"
+        - $ref: "#/components/parameters/PageIndex"
+        - $ref: "#/components/parameters/PageSize"
+      responses:
+        "200":
+          description: Successful response.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - total
+                  - data
+                properties:
+                  total:
+                    $ref: "#/components/schemas/ByPage/properties/total"
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/Project"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+
+  /projects/{owner}/{project}:
+    get:
+      operationId: getProject
+      tags:
+        - Projects
+      summary: Get a project
+      description: Retrieve details of a specific project.
+      security:
+        - {}
+        - bearerAuth: []
+      parameters:
+        - name: owner
+          description: Username of the project's owner.
+          in: path
+          required: true
+          schema:
+            $ref: "#/components/schemas/Project/properties/owner"
+        - name: project
+          description: Name of the project to get.
+          in: path
+          required: true
+          schema:
+            $ref: "#/components/schemas/Project/properties/name"
+      responses:
+        "200":
+          description: Successful response.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Project"
+        "301":
+          $ref: "#/components/responses/MovedPermanently"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+    patch:
+      operationId: updateProject
+      tags:
+        - Projects
+      summary: Update a project
+      description: Update the details of a specific project.
+      parameters:
+        - name: owner
+          description: Username of the project's owner.
+          in: path
+          required: true
+          schema:
+            $ref: "#/components/schemas/Project/properties/owner"
+        - name: project
+          description: Name of the project to update.
+          in: path
+          required: true
+          schema:
+            $ref: "#/components/schemas/Project/properties/name"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              minProperties: 1
+              properties:
+                name:
+                  description: New name of the project. If provided, the project will be renamed.
+                  $ref: "#/components/schemas/Project/properties/name"
+                files:
+                  $ref: "#/components/schemas/Project/properties/files"
+                visibility:
+                  $ref: "#/components/schemas/Project/properties/visibility"
+                displayName:
+                  $ref: "#/components/schemas/Project/properties/displayName"
+                description:
+                  $ref: "#/components/schemas/Project/properties/description"
+                instructions:
+                  $ref: "#/components/schemas/Project/properties/instructions"
+                extraSettings:
+                  $ref: "#/components/schemas/Project/properties/extraSettings"
+                thumbnail:
+                  $ref: "#/components/schemas/Project/properties/thumbnail"
+      responses:
+        "200":
+          description: Successfully updated the project.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Project"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "409":
+          $ref: "#/components/responses/ResourceMoved"
+    delete:
+      operationId: deleteProject
+      tags:
+        - Projects
+      summary: Delete a project
+      description: Permanently delete a specific project.
+      parameters:
+        - name: owner
+          description: Username of the project's owner.
+          in: path
+          required: true
+          schema:
+            $ref: "#/components/schemas/Project/properties/owner"
+        - name: project
+          description: Name of the project to delete.
+          in: path
+          required: true
+          schema:
+            $ref: "#/components/schemas/Project/properties/name"
+      responses:
+        "204":
+          description: Successfully deleted the project.
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "409":
+          $ref: "#/components/responses/ResourceMoved"
+
+  /projects/{owner}/{project}/views:
+    post:
+      operationId: recordProjectView
+      tags:
+        - Projects
+      summary: Record a project view
+      description: Record a view for the specified project as the authenticated user.
+      parameters:
+        - name: owner
+          description: Username of the project's owner.
+          in: path
+          required: true
+          schema:
+            $ref: "#/components/schemas/Project/properties/owner"
+        - name: project
+          description: Name of the project to record a view for.
+          in: path
+          required: true
+          schema:
+            $ref: "#/components/schemas/Project/properties/name"
+      responses:
+        "204":
+          description: Successfully recorded the project view.
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "409":
+          $ref: "#/components/responses/ResourceMoved"
+
+  /projects/{owner}/{project}/releases:
+    get:
+      operationId: listProjectReleases
+      tags:
+        - Project Releases
+      summary: List project releases
+      description: Retrieve a paginated list of releases for a project.
+      security:
+        - {}
+        - bearerAuth: []
+      parameters:
+        - name: owner
+          description: Username of the project's owner.
+          in: path
+          required: true
+          schema:
+            $ref: "#/components/schemas/Project/properties/owner"
+        - name: project
+          description: Name of the project.
+          in: path
+          required: true
+          schema:
+            $ref: "#/components/schemas/Project/properties/name"
+        - name: orderBy
+          description: Field by which to order the results.
+          in: query
+          schema:
+            type: string
+            enum:
+              - createdAt
+              - updatedAt
+              - remixCount
+            default: createdAt
+            examples:
+              - createdAt
+        - $ref: "#/components/parameters/SortOrder"
+        - $ref: "#/components/parameters/PageIndex"
+        - $ref: "#/components/parameters/PageSize"
+      responses:
+        "200":
+          description: Successful response.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - total
+                  - data
+                properties:
+                  total:
+                    $ref: "#/components/schemas/ByPage/properties/total"
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/ProjectRelease"
+        "301":
+          $ref: "#/components/responses/MovedPermanently"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+    post:
+      operationId: createProjectRelease
+      tags:
+        - Project Releases
+      summary: Create a project release
+      description: Create a new release for a specific project.
+      parameters:
+        - name: owner
+          description: Username of the project's owner.
+          in: path
+          required: true
+          schema:
+            $ref: "#/components/schemas/Project/properties/owner"
+        - name: project
+          description: Name of the project.
+          in: path
+          required: true
+          schema:
+            $ref: "#/components/schemas/Project/properties/name"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - name
+                - description
+              properties:
+                name:
+                  $ref: "#/components/schemas/ProjectRelease/properties/name"
+                description:
+                  $ref: "#/components/schemas/ProjectRelease/properties/description"
+                thumbnail:
+                  $ref: "#/components/schemas/ProjectRelease/properties/thumbnail"
+      responses:
+        "201":
+          description: Successfully created the project release.
+          headers:
+            Location:
+              description: Canonical route of the created project release.
+              schema:
+                type: string
+                format: uri-reference
+                minLength: 1
+                examples:
+                  - /projects/john/NiuXiaoQi/releases/v1.2.3
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProjectRelease"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "409":
+          description: |
+            Returned when the project path references a moved project.
+
+            The response includes a `canonical` payload for the project route.
+
+            Clients may update the request and resubmit it explicitly.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MovedResourceError"
+
+  /projects/{owner}/{project}/releases/{release}:
+    get:
+      operationId: getProjectRelease
+      tags:
+        - Project Releases
+      summary: Get a project release
+      description: Retrieve details of a specific project release.
+      security:
+        - {}
+        - bearerAuth: []
+      parameters:
+        - name: owner
+          description: Username of the project's owner.
+          in: path
+          required: true
+          schema:
+            $ref: "#/components/schemas/Project/properties/owner"
+        - name: project
+          description: Name of the project.
+          in: path
+          required: true
+          schema:
+            $ref: "#/components/schemas/Project/properties/name"
+        - name: release
+          description: Name of the project release to get.
+          in: path
+          required: true
+          schema:
+            $ref: "#/components/schemas/ProjectRelease/properties/name"
+      responses:
+        "200":
+          description: Successful response.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProjectRelease"
+        "301":
+          $ref: "#/components/responses/MovedPermanently"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+
+  /assets:
+    get:
+      operationId: listAssets
       tags:
         - Assets
       summary: List assets
       description: |
-        Retrieve a paginated list of assets with optional filtering and ordering.
+        Retrieve a paginated list of assets visible to the request.
 
-        #### Visibility rules
-
-        | Authenticated (as alice) | Owner | Visibility | Access |
-        |--------------------------|-------|------------|--------|
-        | false | * | | All users' public assets (force `visibility=public`) |
-        | false | * | public | All users' public assets |
-        | false | * | private | `401 Unauthorized` |
-        | false | alice | | Alice's public assets (force `visibility=public`) |
-        | false | alice | public | Alice's public assets |
-        | false | alice | private | `401 Unauthorized` |
-        | true | * | | All alice's assets + others' public assets |
-        | true | * | public | All users' public assets |
-        | true | * | private | Alice's private assets |
-        | true | alice | | All alice's assets |
-        | true | alice | public | Alice's public assets |
-        | true | alice | private | Alice's private assets |
-        | true | bob | | Bob's public assets (force `visibility=public`) |
-        | true | bob | public | Bob's public assets |
-        | true | bob | private | `401 Unauthorized` |
+        Anonymous requests return public assets. Authenticated requests return public assets and the authenticated
+        user's own assets when no visibility filter is provided. A non-public visibility filter requires authentication
+        and is scoped to the authenticated user's own assets.
       security:
         - {}
         - bearerAuth: []
@@ -819,15 +1859,6 @@ paths:
           in: query
           schema:
             $ref: "#/components/schemas/Asset/properties/displayName"
-        - name: owner
-          description: |
-            Filter assets by owner's username.
-
-            Defaults to the authenticated user if not specified. Use `*` to include assets from all users.
-            Historical usernames are accepted and transparently normalized to the canonical username.
-          in: query
-          schema:
-            $ref: "#/components/schemas/User/properties/username"
         - name: type
           description: Filter assets by type.
           in: query
@@ -856,6 +1887,8 @@ paths:
             enum:
               - createdAt
               - updatedAt
+              - displayName
+            default: createdAt
             examples:
               - createdAt
         - $ref: "#/components/parameters/SortOrder"
@@ -868,17 +1901,22 @@ paths:
             application/json:
               schema:
                 type: object
+                required:
+                  - total
+                  - data
                 properties:
                   total:
                     $ref: "#/components/schemas/ByPage/properties/total"
                   data:
-                    description: Array of asset objects.
                     type: array
                     items:
                       $ref: "#/components/schemas/Asset"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
 
-  /asset/{id}:
+  /assets/{assetID}:
     get:
+      operationId: getAsset
       tags:
         - Assets
       summary: Get an asset
@@ -887,7 +1925,7 @@ paths:
         - {}
         - bearerAuth: []
       parameters:
-        - name: id
+        - name: assetID
           description: ID of the asset to get.
           in: path
           required: true
@@ -900,19 +1938,22 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Asset"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
     patch:
+      operationId: updateAsset
       tags:
         - Assets
       summary: Update an asset
       description: |
         Update the details of a specific asset.
 
-        #### Permission requirements
+        Permission requirements:
 
         - Only users with the `assetAdmin` role can update assets to public visibility.
         - Asset owners can update their private assets.
       parameters:
-        - name: id
+        - name: assetID
           description: ID of the asset to update.
           in: path
           required: true
@@ -949,15 +1990,18 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Asset"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
         "403":
           description: Insufficient permissions to perform this operation.
     delete:
+      operationId: deleteAsset
       tags:
         - Assets
       summary: Delete an asset
-      description: Permanently delete a specific asset by its ID.
+      description: Permanently delete a specific asset.
       parameters:
-        - name: id
+        - name: assetID
           description: ID of the asset to delete.
           in: path
           required: true
@@ -966,27 +2010,1150 @@ paths:
       responses:
         "204":
           description: Successfully deleted the asset.
+        "401":
+          $ref: "#/components/responses/Unauthorized"
 
-  /aigc/asset/description:
+  /courses:
+    get:
+      operationId: listCourses
+      tags:
+        - Courses
+      summary: List courses
+      description: Retrieve a paginated list of courses visible to the request.
+      security:
+        - {}
+        - bearerAuth: []
+      parameters:
+        - name: courseSeriesID
+          description: Filter courses by the course series ID.
+          in: query
+          schema:
+            $ref: "#/components/schemas/Model/properties/id"
+        - name: orderBy
+          description: Field by which to order the results.
+          in: query
+          schema:
+            type: string
+            enum:
+              - createdAt
+              - updatedAt
+              - sequenceInCourseSeries
+            default: createdAt
+            examples:
+              - createdAt
+        - $ref: "#/components/parameters/SortOrder"
+        - $ref: "#/components/parameters/PageIndex"
+        - $ref: "#/components/parameters/PageSize"
+      responses:
+        "200":
+          description: Successful response.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - total
+                  - data
+                properties:
+                  total:
+                    $ref: "#/components/schemas/ByPage/properties/total"
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/Course"
+
+  /courses/{courseID}:
+    get:
+      operationId: getCourse
+      tags:
+        - Courses
+      summary: Get a course
+      description: Retrieve details of a specific course.
+      security:
+        - {}
+        - bearerAuth: []
+      parameters:
+        - name: courseID
+          description: ID of the course to get.
+          in: path
+          required: true
+          schema:
+            $ref: "#/components/schemas/Model/properties/id"
+      responses:
+        "200":
+          description: Successful response.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Course"
+    patch:
+      operationId: updateCourse
+      tags:
+        - Courses
+      summary: Update a course
+      description: |
+        Update the details of a specific course.
+
+        Permission requirements:
+
+        - Only users with the `courseAdmin` role can update courses.
+      parameters:
+        - name: courseID
+          description: ID of the course to update.
+          in: path
+          required: true
+          schema:
+            $ref: "#/components/schemas/Model/properties/id"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              minProperties: 1
+              properties:
+                title:
+                  $ref: "#/components/schemas/Course/properties/title"
+                thumbnail:
+                  $ref: "#/components/schemas/Course/properties/thumbnail"
+                entrypoint:
+                  $ref: "#/components/schemas/Course/properties/entrypoint"
+                references:
+                  $ref: "#/components/schemas/Course/properties/references"
+                prompt:
+                  $ref: "#/components/schemas/Course/properties/prompt"
+      responses:
+        "200":
+          description: Successfully updated the course.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Course"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          description: Insufficient permissions to perform this operation.
+    delete:
+      operationId: deleteCourse
+      tags:
+        - Courses
+      summary: Delete a course
+      description: |
+        Permanently delete a specific course.
+
+        Permission requirements:
+
+        - Only users with the `courseAdmin` role can delete courses.
+      parameters:
+        - name: courseID
+          description: ID of the course to delete.
+          in: path
+          required: true
+          schema:
+            $ref: "#/components/schemas/Model/properties/id"
+      responses:
+        "204":
+          description: Successfully deleted the course.
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          description: Insufficient permissions to perform this operation.
+
+  /course-series:
+    get:
+      operationId: listCourseSeries
+      tags:
+        - Course Series
+      summary: List course series
+      description: Retrieve a paginated list of course series visible to the request.
+      security:
+        - {}
+        - bearerAuth: []
+      parameters:
+        - name: orderBy
+          description: Field by which to order the results.
+          in: query
+          schema:
+            type: string
+            enum:
+              - createdAt
+              - updatedAt
+              - order
+            default: order
+            examples:
+              - order
+        - $ref: "#/components/parameters/SortOrder"
+        - $ref: "#/components/parameters/PageIndex"
+        - $ref: "#/components/parameters/PageSize"
+      responses:
+        "200":
+          description: Successful response.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - total
+                  - data
+                properties:
+                  total:
+                    $ref: "#/components/schemas/ByPage/properties/total"
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/CourseSeries"
+
+  /course-series/{courseSeriesID}:
+    get:
+      operationId: getCourseSeries
+      tags:
+        - Course Series
+      summary: Get a course series
+      description: Retrieve details of a specific course series.
+      security:
+        - {}
+        - bearerAuth: []
+      parameters:
+        - name: courseSeriesID
+          description: ID of the course series to get.
+          in: path
+          required: true
+          schema:
+            $ref: "#/components/schemas/Model/properties/id"
+      responses:
+        "200":
+          description: Successful response.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CourseSeries"
+    patch:
+      operationId: updateCourseSeries
+      tags:
+        - Course Series
+      summary: Update a course series
+      description: |
+        Update the details of a specific course series.
+
+        Permission requirements:
+
+        - Only users with the `courseAdmin` role can update course series.
+      parameters:
+        - name: courseSeriesID
+          description: ID of the course series to update.
+          in: path
+          required: true
+          schema:
+            $ref: "#/components/schemas/Model/properties/id"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              minProperties: 1
+              properties:
+                title:
+                  $ref: "#/components/schemas/CourseSeries/properties/title"
+                thumbnail:
+                  $ref: "#/components/schemas/CourseSeries/properties/thumbnail"
+                description:
+                  $ref: "#/components/schemas/CourseSeries/properties/description"
+                courseIDs:
+                  $ref: "#/components/schemas/CourseSeries/properties/courseIDs"
+                order:
+                  $ref: "#/components/schemas/CourseSeries/properties/order"
+      responses:
+        "200":
+          description: Successfully updated the course series.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CourseSeries"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          description: Insufficient permissions to perform this operation.
+    delete:
+      operationId: deleteCourseSeries
+      tags:
+        - Course Series
+      summary: Delete a course series
+      description: |
+        Permanently delete a specific course series.
+
+        Permission requirements:
+
+        - Only users with the `courseAdmin` role can delete course series.
+      parameters:
+        - name: courseSeriesID
+          description: ID of the course series to delete.
+          in: path
+          required: true
+          schema:
+            $ref: "#/components/schemas/Model/properties/id"
+      responses:
+        "204":
+          description: Successfully deleted the course series.
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          description: Insufficient permissions to perform this operation.
+
+  /copilot/messages:
     post:
+      operationId: createCopilotMessage
+      tags:
+        - Copilot
+      summary: Generate a structured SSE stream message
+      description: |
+        Generate a structured SSE stream message by sending a list of input messages.
+
+        The response is a Server-Sent Events stream where each `data:` line contains a single JSON object.
+
+        Event semantics:
+
+        | Event | Data schema | Semantics |
+        |-------|-------------|-----------|
+        | `text_delta` | `CopilotSSETextDeltaEvent` | Incremental assistant text fragment. Concatenate `text` values in order to reconstruct `content.text`. |
+        | `tool_call_delta` | `CopilotSSEToolCallDeltaEvent` | Incremental fragment for one assistant tool call. Merge fragments by `index`; `id`, `function.name`, and `function.arguments` are omitted when a fragment does not update them. |
+        | `done` | `CopilotSSEDoneEvent` | Terminal success event. Emitted after all prior deltas. `finishReason` is the provider finish reason such as `stop` or `tool_calls`. |
+        | `error` | `CopilotSSEErrorEvent` | Terminal failure event emitted if streaming fails after the HTTP response has started. No `done` event follows `error`. |
+
+        A successful stream may contain any number of `text_delta` and `tool_call_delta` events before the final `done`
+        event. Assistant responses may be text-only, tool-call-only, or contain both.
+
+        Quota and rate limits:
+
+        - Each message consumes 1 quota from the authenticated user's allowance.
+        - Per-user short-window rate limits also apply to prevent bursts. Hitting them returns 429 with `Retry-After`.
+        - Long-window quota limits vary based on the authenticated user's plan.
+        - When the long-window quota limit is reached, the 403 response includes a `Retry-After` header with the wait time in seconds.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CopilotMessageRequest"
+      responses:
+        "200":
+          description: |
+            Structured SSE stream established.
+
+            Parse the stream as SSE frames and then decode each event's JSON `data` payload according to the event type.
+          content:
+            text/event-stream:
+              schema:
+                type: string
+                description: Server-Sent Events stream containing `text_delta`, `tool_call_delta`, `done`, and `error` events.
+              examples:
+                textOnly:
+                  summary: Text-only assistant response
+                  value: |
+                    event: text_delta
+                    data: {"text":"Hello"}
+
+                    event: text_delta
+                    data: {"text":"!"}
+
+                    event: done
+                    data: {"finishReason":"stop"}
+                textAndToolCall:
+                  summary: Assistant text followed by a tool call
+                  value: |
+                    event: text_delta
+                    data: {"text":"Let me check that for you."}
+
+                    event: tool_call_delta
+                    data: {"index":0,"id":"call_1","function":{"name":"list_projects","arguments":"{\"query\":\"demo\"}"}}
+
+                    event: done
+                    data: {"finishReason":"tool_calls"}
+                providerError:
+                  summary: Stream failure after the response has started
+                  value: |
+                    event: error
+                    data: {"reason":"streamFailed","message":"stream failed"}
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          description: Insufficient permissions or quota to perform this operation.
+          headers:
+            Retry-After:
+              description: Seconds to wait before retrying after hitting the long-window quota limit.
+              schema:
+                type: integer
+        "429":
+          description: Too many requests to perform this operation.
+          headers:
+            Retry-After:
+              description: Seconds to wait before retrying after hitting the short-window rate limit.
+              schema:
+                type: integer
+
+  /ai-interaction/turns:
+    post:
+      operationId: createAIInteractionTurn
+      tags:
+        - AI Interaction
+      summary: Perform an AI interaction turn
+      description: |
+        Send a message and context to the AI, receive a response including text and an optional command.
+
+        Quota and rate limits:
+
+        - Each turn consumes 1 quota from the authenticated user's AI interaction turn allowance.
+        - Per-user short-window rate limits also apply to prevent bursts. Hitting them returns 429 with `Retry-After`.
+        - Long-window quota limits vary based on the authenticated user's plan.
+        - When the long-window quota limit is reached, the 403 response includes a `Retry-After` header with the wait time in seconds.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - commandSpecs
+              allOf:
+                - if:
+                    properties:
+                      continuationTurn:
+                        const: 0
+                  then:
+                    required:
+                      - content
+                    properties:
+                      content:
+                        minLength: 1
+                - if:
+                    required:
+                      - continuationTurn
+                    properties:
+                      continuationTurn:
+                        minimum: 1
+                  then:
+                    required:
+                      - history
+                    properties:
+                      history:
+                        minItems: 1
+              properties:
+                content:
+                  description: The core user input message.
+                  type: string
+                  maxLength: 280
+                  examples:
+                    - What should I do next?
+                context:
+                  description: Specific context for the current user input.
+                  type: object
+                  additionalProperties: true
+                  examples:
+                    - position: [10, 20]
+                      health: 80
+                role:
+                  description: Persona the AI should adopt.
+                  type: string
+                  examples:
+                    - Guide
+                roleContext:
+                  description: Additional context specific to the role.
+                  type: object
+                  additionalProperties: true
+                  examples:
+                    - style: friendly
+                      knowledgeScope: game rules
+                knowledgeBase:
+                  description: Background knowledge provided to the AI.
+                  type: object
+                  additionalProperties: true
+                  examples:
+                    - worldName: TestWorld
+                      gravity: 9.8
+                commandSpecs:
+                  description: Commands the AI is allowed to call.
+                  type: array
+                  minItems: 1
+                  items:
+                    type: object
+                    required:
+                      - name
+                    properties:
+                      name:
+                        description: Unique identifier for the command.
+                        type: string
+                        minLength: 1
+                        examples:
+                          - Move
+                      description:
+                        description: Explanation of what the command does.
+                        type: string
+                        examples:
+                          - Move the character
+                      parameters:
+                        description: Parameters the command accepts.
+                        type: array
+                        items:
+                          type: object
+                          required:
+                            - name
+                            - type
+                          properties:
+                            name:
+                              description: Parameter name.
+                              type: string
+                              minLength: 1
+                              examples:
+                                - Direction
+                            type:
+                              description: Go type name of the parameter.
+                              type: string
+                              minLength: 1
+                              examples:
+                                - string
+                            description:
+                              description: Purpose of the parameter.
+                              type: string
+                              examples:
+                                - "Direction to move: up, down, left, right"
+                history:
+                  description: Record of previous interactions in this session.
+                  type: array
+                  items:
+                    $ref: "#/components/schemas/AIInteractionTurn"
+                archivedHistory:
+                  description: Content of archived historical interactions.
+                  type: string
+                  examples:
+                    - "Previous conversation summary..."
+                continuationTurn:
+                  description: |
+                    Current turn number in a multi-turn interaction sequence.
+
+                    A value of 0 means this is the initial turn from user input. Values greater than 0 indicate
+                    continuation turns where the AI continues the current interaction sequence based on command outcomes.
+                  type: integer
+                  format: int32
+                  minimum: 0
+                  default: 0
+                  examples:
+                    - 0
+      responses:
+        "200":
+          description: Successful AI interaction.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - text
+                properties:
+                  text:
+                    description: Textual part of the AI's response.
+                    type: string
+                    examples:
+                      - Okay, I suggest moving to (1, 1).
+                  commandName:
+                    description: Name of the command the AI wants to execute.
+                    type: string
+                    examples:
+                      - MakeMove
+                  commandArgs:
+                    description: Arguments for the command to be executed.
+                    type: object
+                    additionalProperties: true
+                    examples:
+                      - Row: 1
+                        Col: 1
+                        Result: ""
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          description: Insufficient permissions or quota to perform this operation.
+          headers:
+            Retry-After:
+              description: Seconds to wait before retrying after hitting the long-window quota limit.
+              schema:
+                type: integer
+        "429":
+          description: Too many requests to perform this operation.
+          headers:
+            Retry-After:
+              description: Seconds to wait before retrying after hitting the short-window rate limit.
+              schema:
+                type: integer
+
+  /ai-interaction/archives:
+    post:
+      operationId: createAIInteractionArchive
+      tags:
+        - AI Interaction
+      summary: Archive AI interaction history
+      description: |
+        Archive a batch of interaction turns into a condensed summary for future context.
+
+        Quota and rate limits:
+
+        - Each archive request consumes 1 quota from the authenticated user's AI interaction archive allowance.
+        - Per-user short-window rate limits also apply to prevent bursts. Hitting them returns 429 with `Retry-After`.
+        - Long-window quota limits vary based on the authenticated user's plan.
+        - When the long-window quota limit is reached, the 403 response includes a `Retry-After` header with the wait time in seconds.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - turns
+              properties:
+                turns:
+                  description: Interaction turns to be archived.
+                  type: array
+                  minItems: 1
+                  maxItems: 50
+                  items:
+                    $ref: "#/components/schemas/AIInteractionTurn"
+                existingArchive:
+                  description: Existing archived content to be merged with new turns.
+                  type:
+                    - string
+                    - "null"
+                  examples:
+                    - "Previous conversation summary..."
+      responses:
+        "200":
+          description: Successfully archived interaction history.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - content
+                properties:
+                  content:
+                    description: The consolidated archive content.
+                    type: string
+                    examples:
+                      - "Complete conversation summary including new turns..."
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          description: Insufficient permissions or quota to perform this operation.
+          headers:
+            Retry-After:
+              description: Seconds to wait before retrying after hitting the long-window quota limit.
+              schema:
+                type: integer
+        "429":
+          description: Too many requests to perform this operation.
+          headers:
+            Retry-After:
+              description: Seconds to wait before retrying after hitting the short-window rate limit.
+              schema:
+                type: integer
+
+  /aigc/tasks:
+    post:
+      operationId: createAIGCTask
+      tags:
+        - AIGC
+      summary: Create an AIGC task
+      description: |
+        Create an asynchronous AIGC task for resource-intensive generation and media-processing operations such as image
+        generation, video generation, background removal, and video frame extraction.
+
+        Task-based generation and media-processing operations are processed asynchronously. Use the returned task ID to
+        poll for status via `GET /aigc/tasks/{taskID}` or subscribe to real-time updates via
+        `GET /aigc/tasks/{taskID}/events`.
+
+        Supported task types:
+
+        | Type | Description |
+        |------|-------------|
+        | `removeBackground` | Remove image background |
+        | `generateCostume` | Generate costume image |
+        | `generateAnimationVideo` | Generate animation video |
+        | `extractVideoFrames` | Extract frames from video |
+        | `generateBackdrop` | Generate backdrop image |
+
+        Quota and rate limits:
+
+        - Each task consumes quota from the authenticated user's AIGC allowance based on the task type.
+        - Per-user short-window rate limits apply. Hitting them returns 429 with `Retry-After`.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              oneOf:
+                - title: removeBackground
+                  type: object
+                  required:
+                    - type
+                    - parameters
+                  properties:
+                    type:
+                      type: string
+                      enum:
+                        - removeBackground
+                    parameters:
+                      description: Parameters for background removal.
+                      type: object
+                      required:
+                        - imageUrl
+                      properties:
+                        imageUrl:
+                          description: Universal URL of the image to remove background from, such as kodo://bucket/key.
+                          type: string
+                          format: uri
+                          minLength: 1
+                          examples:
+                            - kodo://bucket/character.png
+                - title: generateCostume
+                  type: object
+                  required:
+                    - type
+                    - parameters
+                  properties:
+                    type:
+                      type: string
+                      enum:
+                        - generateCostume
+                    parameters:
+                      description: Parameters for costume generation.
+                      type: object
+                      required:
+                        - settings
+                      properties:
+                        settings:
+                          $ref: "#/components/schemas/AIGCCostumeSettings"
+                        n:
+                          description: Number of costume images to generate.
+                          type: integer
+                          minimum: 1
+                          maximum: 4
+                          default: 1
+                          examples:
+                            - 4
+                - title: generateAnimationVideo
+                  type: object
+                  required:
+                    - type
+                    - parameters
+                  properties:
+                    type:
+                      type: string
+                      enum:
+                        - generateAnimationVideo
+                    parameters:
+                      description: Parameters for animation video generation.
+                      type: object
+                      required:
+                        - settings
+                      properties:
+                        settings:
+                          $ref: "#/components/schemas/AIGCAnimationSettings"
+                - title: extractVideoFrames
+                  type: object
+                  required:
+                    - type
+                    - parameters
+                  properties:
+                    type:
+                      type: string
+                      enum:
+                        - extractVideoFrames
+                    parameters:
+                      description: Parameters for video frame extraction.
+                      type: object
+                      required:
+                        - videoUrl
+                        - duration
+                      properties:
+                        videoUrl:
+                          description: Universal URL of the video to extract frames from, such as kodo://bucket/key.
+                          type: string
+                          format: uri
+                          minLength: 1
+                          examples:
+                            - kodo://bucket/animation.mp4
+                        startTime:
+                          description: Start time in milliseconds from which to extract frames. Precision is 100ms.
+                          type: integer
+                          minimum: 0
+                          multipleOf: 100
+                          default: 0
+                          examples:
+                            - 0
+                            - 1500
+                        duration:
+                          description: Duration in milliseconds of the segment to extract frames from. Precision is 100ms.
+                          type: integer
+                          minimum: 0
+                          multipleOf: 100
+                          maximum: 60000
+                          examples:
+                            - 3000
+                            - 10000
+                        interval:
+                          description: Interval between frames in milliseconds. Precision is 100ms.
+                          type: integer
+                          minimum: 100
+                          multipleOf: 100
+                          maximum: 1000
+                          default: 100
+                          examples:
+                            - 100
+                - title: generateBackdrop
+                  type: object
+                  required:
+                    - type
+                    - parameters
+                  properties:
+                    type:
+                      type: string
+                      enum:
+                        - generateBackdrop
+                    parameters:
+                      description: Parameters for backdrop generation.
+                      type: object
+                      required:
+                        - settings
+                      properties:
+                        settings:
+                          $ref: "#/components/schemas/AIGCBackdropSettings"
+                        n:
+                          description: Number of backdrop images to generate.
+                          type: integer
+                          minimum: 1
+                          maximum: 4
+                          default: 1
+                          examples:
+                            - 4
+      responses:
+        "202":
+          description: Task accepted and queued for processing.
+          headers:
+            Location:
+              description: Canonical route of the created AIGC task.
+              schema:
+                type: string
+                format: uri-reference
+                minLength: 1
+                examples:
+                  - /aigc/tasks/1
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AIGCTask"
+        "400":
+          description: Invalid task type or parameters.
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          description: Insufficient permissions or quota.
+          headers:
+            Retry-After:
+              description: Seconds to wait before retrying after hitting the long-window quota limit.
+              schema:
+                type: integer
+        "429":
+          description: Too many requests.
+          headers:
+            Retry-After:
+              description: Seconds to wait before retrying after hitting the short-window rate limit.
+              schema:
+                type: integer
+
+  /aigc/tasks/{taskID}:
+    get:
+      operationId: getAIGCTask
+      tags:
+        - AIGC
+      summary: Get AIGC task status
+      description: |
+        Get the current status of an AIGC task.
+
+        Poll this endpoint to check if the task is complete. For real-time updates, use the SSE endpoint
+        `GET /aigc/tasks/{taskID}/events` instead.
+      parameters:
+        - name: taskID
+          description: The task ID to get.
+          in: path
+          required: true
+          schema:
+            $ref: "#/components/schemas/Model/properties/id"
+      responses:
+        "200":
+          description: Task status retrieved.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AIGCTask"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          description: Task not found.
+
+  /aigc/tasks/{taskID}/events:
+    get:
+      operationId: subscribeAIGCTaskEvents
+      tags:
+        - AIGC
+      summary: Subscribe to AIGC task events
+      description: |
+        Subscribe to real-time task status updates via Server-Sent Events.
+
+        The first event is always a `snapshot` containing the current task state. This eliminates the need to call
+        `GET /aigc/tasks/{taskID}` separately and avoids race conditions between fetching current state and subscribing
+        to updates.
+
+        The connection remains open until the task completes, is cancelled, or fails. If the task is already in a
+        terminal state when connecting, the `snapshot` event will contain the final state and the connection will close
+        immediately.
+
+        Event types:
+
+        | Event | Data | Description |
+        |-------|------|-------------|
+        | `snapshot` | Full `AIGCTask` object | Initial state, always sent first |
+        | `cancelling` | `{}` | Task cancellation in progress |
+        | `completed` | `{"result": {...}}` | Task completed successfully |
+        | `cancelled` | `{}` | Task was cancelled |
+        | `failed` | `{"error": {"reason": "...", "message": "..."}}` | Task failed |
+
+        Example: task in progress
+
+        ```
+        GET /aigc/tasks/123/events
+
+        event: snapshot
+        data: {"id": "123", "status": "processing"}
+
+        event: completed
+        data: {"result": {"imageUrls": ["kodo://bucket/path/to/file.png"]}}
+        ```
+
+        Example: task already completed
+
+        ```
+        GET /aigc/tasks/456/events
+
+        event: snapshot
+        data: {"id": "456", "status": "completed", "result": {"imageUrls": ["kodo://bucket/path/to/file.png"]}}
+
+        (connection closed)
+        ```
+
+        Example: task pending
+
+        ```
+        GET /aigc/tasks/789/events
+
+        event: snapshot
+        data: {"id": "789", "status": "pending"}
+
+        event: completed
+        data: {"result": {"imageUrls": ["kodo://bucket/path/to/file.png"]}}
+        ```
+
+        Example: task cancelled
+
+        ```
+        GET /aigc/tasks/123/events
+
+        event: snapshot
+        data: {"id": "123", "status": "processing"}
+
+        event: cancelling
+        data: {}
+
+        event: cancelled
+        data: {}
+
+        (connection closed)
+        ```
+      parameters:
+        - name: taskID
+          description: The task ID to subscribe to.
+          in: path
+          required: true
+          schema:
+            $ref: "#/components/schemas/Model/properties/id"
+      responses:
+        "200":
+          description: SSE stream established.
+          content:
+            text/event-stream:
+              schema:
+                type: string
+                description: Server-Sent Events stream.
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          description: Task not found.
+
+  /aigc/tasks/{taskID}/cancellation:
+    put:
+      operationId: cancelAIGCTask
+      tags:
+        - AIGC
+      summary: Cancel an AIGC task
+      description: |
+        Cancel a pending or processing AIGC task.
+
+        If subscribed via `GET /aigc/tasks/{taskID}/events`, a `cancelling` event will be emitted when cancellation
+        begins, followed by a `cancelled` event when complete.
+
+        Cancellation rules:
+
+        | Current Status | Result |
+        |----------------|--------|
+        | `pending` | Immediately `cancelled`, quota refunded |
+        | `processing` | Transitions to `cancelling`, then `cancelled` |
+        | `cancelling` | No-op, returns current state |
+        | `completed` | `409 Conflict` |
+        | `cancelled` | No-op, idempotent, returns current state |
+        | `failed` | `409 Conflict` |
+
+        Quota refund:
+
+        - Tasks cancelled from `pending` status receive a full quota refund.
+        - Tasks cancelled from `processing` status do not receive a refund because resources are already consumed.
+      parameters:
+        - name: taskID
+          description: The task ID to cancel.
+          in: path
+          required: true
+          schema:
+            $ref: "#/components/schemas/Model/properties/id"
+      responses:
+        "202":
+          description: Cancellation request accepted.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AIGCTask"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          description: Task not found.
+        "409":
+          description: Task cannot be cancelled because it has already completed or failed.
+
+  /aigc/project-descriptions:
+    post:
+      operationId: generateProjectDescription
+      tags:
+        - AIGC
+      summary: Generate project description
+      description: |
+        Generate an AI-powered descriptive summary of a game from the player's perspective based on provided game content
+        such as spx source code and project structure.
+
+        Quota and rate limits:
+
+        - Each request consumes 1 quota from the authenticated user's AI description allowance.
+        - Per-user short-window rate limits also apply to prevent bursts. Hitting them returns 429 with `Retry-After`.
+        - Quota limits vary based on the authenticated user's plan.
+        - When the long-window quota limit is reached, the 403 response includes a `Retry-After` header with the wait time in seconds.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - content
+              properties:
+                content:
+                  description: The game content to generate a description for, such as spx source code or project structure.
+                  type: string
+                  minLength: 1
+                  maxLength: 150000
+                  examples:
+                    - |
+                      Game: TicTacToe
+                      Description: A classic Tic-Tac-Toe game.
+
+                      === File: main.spx ===
+                      var (
+                          // board is the main Tic-Tac-Toe board, where 1 represents "X" and 2 represents "O".
+                          board [3][3]int
+                      )
+
+                      // onStart handles the game start event.
+                      onStart => {
+                        // ...
+                      }
+                knowledge:
+                  description: Optional background knowledge used to ground project description generation.
+                  type: string
+                  maxLength: 120000
+                  examples:
+                    - |
+                      # About spx
+
+                      spx is a Scratch-like 2D Game Engine for STEM education.
+      responses:
+        "200":
+          description: Successfully generated project description.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - description
+                properties:
+                  description:
+                    description: AI-generated descriptive summary of the game world from the player's perspective.
+                    type: string
+                    examples:
+                      - |
+                        This is a Tic-Tac-Toe game played on a 3x3 grid. The player uses `X` marks while the AI opponent
+                        uses `O` marks. Players take turns placing their marks in empty squares, with the goal of getting
+                        three marks in a row horizontally, vertically, or diagonally. The game supports mouse click
+                        interaction. Click on an empty square to place your mark. The game ends when either player
+                        achieves three in a row or the board is completely filled.
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          description: Insufficient permissions or quota to perform this operation.
+          headers:
+            Retry-After:
+              description: Seconds to wait before retrying after hitting the long-window quota limit.
+              schema:
+                type: integer
+        "429":
+          description: Too many requests to perform this operation.
+          headers:
+            Retry-After:
+              description: Seconds to wait before retrying after hitting the short-window rate limit.
+              schema:
+                type: integer
+
+  /aigc/asset-descriptions:
+    post:
+      operationId: generateAssetDescription
       tags:
         - AIGC
       summary: Generate asset description
       description: |
         Generate a description for an asset using AI based on the provided text prompt and image input.
 
-        This endpoint accepts multimodal input (text and image) to generate a contextual description
-        suitable for embedding and search operations. The text prompt typically includes the asset's
-        display name and additional context about how the description will be used.
+        This endpoint accepts multimodal input to generate a contextual description suitable for embedding and search
+        operations. The text prompt typically includes the asset's display name and additional context about how the
+        description will be used.
 
-        #### Image requirements
+        Image requirements:
 
         - Format: PNG only (`image/png`)
-        - Maximum image size: 5 MB (after decoding the base64 content)
+        - Maximum image size: 5 MB after decoding the base64 content
         - Images must be provided as base64-encoded data URLs
-        - Other formats (SVG, JPEG, WebP) must be converted to PNG before sending
+        - Other formats must be converted to PNG before sending
 
-        #### Quota & rate limits
+        Quota and rate limits:
 
         - Each request consumes 1 quota from the authenticated user's AIGC allowance.
         - Per-user short-window rate limits apply. Hitting them returns 429 with `Retry-After`.
@@ -1040,7 +3207,7 @@ paths:
         "400":
           description: Invalid request parameters.
         "401":
-          description: Unauthorized - authentication required.
+          $ref: "#/components/responses/Unauthorized"
         "403":
           description: Insufficient permissions or quota to perform this operation.
           headers:
@@ -1056,1091 +3223,9 @@ paths:
               schema:
                 type: integer
 
-  /course:
+  /aigc/asset-adoptions:
     post:
-      tags:
-        - Courses
-      summary: Create a course
-      description: |
-        Create a new course with the necessary details.
-
-        #### Permission requirements
-
-        - Only users with the `courseAdmin` role can create courses.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              required:
-                - title
-                - thumbnail
-                - entrypoint
-                - references
-                - prompt
-              properties:
-                title:
-                  $ref: "#/components/schemas/Course/properties/title"
-                thumbnail:
-                  $ref: "#/components/schemas/Course/properties/thumbnail"
-                entrypoint:
-                  $ref: "#/components/schemas/Course/properties/entrypoint"
-                references:
-                  $ref: "#/components/schemas/Course/properties/references"
-                prompt:
-                  $ref: "#/components/schemas/Course/properties/prompt"
-      responses:
-        "201":
-          description: Successfully created the course.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Course"
-        "403":
-          description: Insufficient permissions to perform this operation.
-
-  /courses/list:
-    get:
-      tags:
-        - Courses
-      summary: List courses
-      description: Retrieve a paginated list of courses with optional filtering and ordering.
-      security:
-        - {}
-        - bearerAuth: []
-      parameters:
-        - name: courseSeriesID
-          description: Filter courses by the course series ID.
-          in: query
-          schema:
-            type: string
-        - name: owner
-          description: |
-            Filter courses by the owner's username.
-
-            Defaults to the authenticated user if not specified. Use `*` to include courses from all users.
-            Historical usernames are accepted and transparently normalized to the canonical username.
-          in: query
-          schema:
-            $ref: "#/components/schemas/User/properties/username"
-        - name: orderBy
-          description: Field by which to order the results.
-          in: query
-          schema:
-            type: string
-            enum:
-              - createdAt
-              - updatedAt
-              - sequenceInCourseSeries
-            default: createdAt
-            examples:
-              - createdAt
-        - $ref: "#/components/parameters/SortOrder"
-        - $ref: "#/components/parameters/PageIndex"
-        - $ref: "#/components/parameters/PageSize"
-      responses:
-        "200":
-          description: Successful response.
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  total:
-                    $ref: "#/components/schemas/ByPage/properties/total"
-                  data:
-                    description: Array of course objects.
-                    type: array
-                    items:
-                      $ref: "#/components/schemas/Course"
-
-  /course/{id}:
-    get:
-      tags:
-        - Courses
-      summary: Get a course
-      description: Retrieve details of a specific course.
-      security:
-        - {}
-        - bearerAuth: []
-      parameters:
-        - name: id
-          description: ID of the course to get.
-          in: path
-          required: true
-          schema:
-            $ref: "#/components/schemas/Model/properties/id"
-      responses:
-        "200":
-          description: Successful response.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Course"
-    patch:
-      tags:
-        - Courses
-      summary: Update a course
-      description: |
-        Update the details of a specific course.
-
-        #### Permission requirements
-
-        - Only users with the `courseAdmin` role can update courses.
-      parameters:
-        - name: id
-          description: ID of the course to update.
-          in: path
-          required: true
-          schema:
-            $ref: "#/components/schemas/Model/properties/id"
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              minProperties: 1
-              properties:
-                title:
-                  $ref: "#/components/schemas/Course/properties/title"
-                thumbnail:
-                  $ref: "#/components/schemas/Course/properties/thumbnail"
-                entrypoint:
-                  $ref: "#/components/schemas/Course/properties/entrypoint"
-                references:
-                  $ref: "#/components/schemas/Course/properties/references"
-                prompt:
-                  $ref: "#/components/schemas/Course/properties/prompt"
-      responses:
-        "200":
-          description: Successfully updated the course.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Course"
-        "403":
-          description: Insufficient permissions to perform this operation.
-    delete:
-      tags:
-        - Courses
-      summary: Delete a course
-      description: |
-        Permanently delete a specific course by its ID.
-
-        #### Permission requirements
-
-        - Only users with the `courseAdmin` role can delete courses.
-      parameters:
-        - name: id
-          description: ID of the course to delete.
-          in: path
-          required: true
-          schema:
-            $ref: "#/components/schemas/Model/properties/id"
-      responses:
-        "204":
-          description: Successfully deleted the course.
-        "403":
-          description: Insufficient permissions to perform this operation.
-
-  /course-series:
-    post:
-      tags:
-        - Course Series
-      summary: Create a course series
-      description: |
-        Create a new course series with the necessary details.
-
-        #### Permission requirements
-
-        - Only users with the `courseAdmin` role can create course series.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              required:
-                - title
-                - courseIDs
-                - order
-              properties:
-                title:
-                  $ref: "#/components/schemas/CourseSeries/properties/title"
-                thumbnail:
-                  $ref: "#/components/schemas/CourseSeries/properties/thumbnail"
-                description:
-                  $ref: "#/components/schemas/CourseSeries/properties/description"
-                courseIDs:
-                  $ref: "#/components/schemas/CourseSeries/properties/courseIDs"
-                order:
-                  $ref: "#/components/schemas/CourseSeries/properties/order"
-      responses:
-        "201":
-          description: Successfully created the course series.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/CourseSeries"
-        "403":
-          description: Insufficient permissions to perform this operation.
-
-  /course-serieses/list:
-    get:
-      tags:
-        - Course Series
-      summary: List course series
-      description: Retrieve a paginated list of course series with optional filtering and ordering.
-      security:
-        - {}
-        - bearerAuth: []
-      parameters:
-        - name: orderBy
-          description: Field by which to order the results.
-          in: query
-          schema:
-            type: string
-            enum:
-              - createdAt
-              - updatedAt
-              - order
-            default: order
-            examples:
-              - order
-        - name: owner
-          description: |
-            Filter course serieses by the owner's username.
-
-            Defaults to the authenticated user if not specified. Use `*` to include course series from all users.
-            Historical usernames are accepted and transparently normalized to the canonical username.
-          in: query
-          schema:
-            $ref: "#/components/schemas/User/properties/username"
-        - $ref: "#/components/parameters/SortOrder"
-        - $ref: "#/components/parameters/PageIndex"
-        - $ref: "#/components/parameters/PageSize"
-      responses:
-        "200":
-          description: Successful response.
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  total:
-                    $ref: "#/components/schemas/ByPage/properties/total"
-                  data:
-                    description: Array of course series objects.
-                    type: array
-                    items:
-                      $ref: "#/components/schemas/CourseSeries"
-
-  /course-series/{id}:
-    get:
-      tags:
-        - Course Series
-      summary: Get a course series
-      description: Retrieve details of a specific course series.
-      security:
-        - {}
-        - bearerAuth: []
-      parameters:
-        - name: id
-          description: ID of the course series to get.
-          in: path
-          required: true
-          schema:
-            $ref: "#/components/schemas/Model/properties/id"
-      responses:
-        "200":
-          description: Successful response.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/CourseSeries"
-    patch:
-      tags:
-        - Course Series
-      summary: Update a course series
-      description: |
-        Update the details of a specific course series.
-
-        #### Permission requirements
-
-        - Only users with the `courseAdmin` role can update course series.
-      parameters:
-        - name: id
-          description: ID of the course series to update.
-          in: path
-          required: true
-          schema:
-            $ref: "#/components/schemas/Model/properties/id"
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              minProperties: 1
-              properties:
-                title:
-                  $ref: "#/components/schemas/CourseSeries/properties/title"
-                thumbnail:
-                  $ref: "#/components/schemas/CourseSeries/properties/thumbnail"
-                description:
-                  $ref: "#/components/schemas/CourseSeries/properties/description"
-                courseIDs:
-                  $ref: "#/components/schemas/CourseSeries/properties/courseIDs"
-                order:
-                  $ref: "#/components/schemas/CourseSeries/properties/order"
-      responses:
-        "200":
-          description: Successfully updated the course series.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/CourseSeries"
-        "403":
-          description: Insufficient permissions to perform this operation.
-    delete:
-      tags:
-        - Course Series
-      summary: Delete a course series
-      description: |
-        Permanently delete a specific course series by its ID.
-
-        #### Permission requirements
-
-        - Only users with the `courseAdmin` role can delete course series.
-      parameters:
-        - name: id
-          description: ID of the course series to delete.
-          in: path
-          required: true
-          schema:
-            $ref: "#/components/schemas/Model/properties/id"
-      responses:
-        "204":
-          description: Successfully deleted the course series.
-        "403":
-          description: Insufficient permissions to perform this operation.
-  /copilot/sse/message:
-    post:
-      tags:
-        - Copilot
-      summary: Generate a structured SSE stream message
-      description: |
-        Generate a structured SSE stream message by sending a list of input messages.
-
-        The response is a Server-Sent Events (SSE) stream where each `data:` line contains a single JSON object.
-
-        #### Event semantics
-
-        | Event | Data schema | Semantics |
-        |-------|-------------|-----------|
-        | `text_delta` | `CopilotSSETextDeltaEvent` | Incremental assistant text fragment. Concatenate `text` values in order to reconstruct `content.text`. |
-        | `tool_call_delta` | `CopilotSSEToolCallDeltaEvent` | Incremental fragment for one assistant tool call. Merge fragments by `index`; `id`, `function.name`, and `function.arguments` are omitted when a fragment does not update them. |
-        | `done` | `CopilotSSEDoneEvent` | Terminal success event. Emitted after all prior deltas. `finishReason` is the provider finish reason such as `stop` or `tool_calls`. |
-        | `error` | `CopilotSSEErrorEvent` | Terminal failure event emitted if streaming fails after the HTTP response has started. No `done` event follows `error`. |
-
-        A successful stream may contain any number of `text_delta` and `tool_call_delta` events before the final
-        `done` event. Assistant responses may be text-only, tool-call-only, or contain both.
-
-        #### Quota & rate limits
-
-        - Each message consumes 1 quota from the authenticated user's allowance.
-        - Per-user short-window rate limits also apply to prevent bursts. Hitting them returns 429 with `Retry-After`.
-        - Long-window quota limits vary based on the authenticated user's plan.
-        - When the long-window quota limit is reached, the 403 response includes a `Retry-After` header with the wait
-          time in seconds.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/CopilotMessageRequest"
-      responses:
-        "200":
-          description: |
-            Structured SSE stream established.
-
-            Parse the stream as SSE frames and then decode each event's JSON `data` payload according to the event
-            type.
-          content:
-            "text/event-stream":
-              schema:
-                type: string
-                description: |
-                  Server-Sent Events stream containing `text_delta`, `tool_call_delta`, `done`, and `error` events.
-              examples:
-                textOnly:
-                  summary: Text-only assistant response
-                  value: |
-                    event: text_delta
-                    data: {"text":"Hello"}
-
-                    event: text_delta
-                    data: {"text":"!"}
-
-                    event: done
-                    data: {"finishReason":"stop"}
-                textAndToolCall:
-                  summary: Assistant text followed by a tool call
-                  value: |
-                    event: text_delta
-                    data: {"text":"Let me check that for you."}
-
-                    event: tool_call_delta
-                    data: {"index":0,"id":"call_1","function":{"name":"list_projects","arguments":"{\"query\":\"demo\"}"}}
-
-                    event: done
-                    data: {"finishReason":"tool_calls"}
-                providerError:
-                  summary: Stream failure after the response has started
-                  value: |
-                    event: error
-                    data: {"reason":"streamFailed","message":"stream failed"}
-        "403":
-          description: Insufficient permissions or quota to perform this operation.
-          headers:
-            Retry-After:
-              description: Seconds to wait before retrying after hitting the long-window quota limit.
-              schema:
-                type: integer
-        "429":
-          description: Too many requests to perform this operation.
-          headers:
-            Retry-After:
-              description: Seconds to wait before retrying after hitting the short-window rate limit.
-              schema:
-                type: integer
-
-  /ai/description:
-    post:
-      tags:
-        - AI
-      summary: Generate AI description
-      description: |
-        Generate an AI-powered descriptive summary of a game from the player's perspective based on provided game
-        content (such as spx source code and project structure).
-
-        #### Quota & rate limits
-
-        - Each request consumes 1 quota from the authenticated user's AI description allowance.
-        - Per-user short-window rate limits also apply to prevent bursts. Hitting them returns 429 with `Retry-After`.
-        - Quota limits vary based on the authenticated user's plan.
-        - When the long-window quota limit is reached, the 403 response includes a `Retry-After` header with the wait
-          time in seconds.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              required:
-                - content
-              properties:
-                content:
-                  description: The game content to generate a description for (e.g., spx source code, project structure).
-                  type: string
-                  examples:
-                    - |
-                      Game: TicTacToe
-                      Description: A classic Tic-Tac-Toe game.
-
-                      === File: main.spx ===
-                      var (
-                          // board is the main Tic-Tac-Toe board, where 1 represents "X" and 2 represents "O".
-                          board [3][3]int
-                      )
-
-                      // onStart handles the game start event.
-                      onStart => {
-                        // ...
-                      }
-                knowledge:
-                  description: Optional background knowledge used to ground project description generation.
-                  type: string
-                  maxLength: 120000
-                  examples:
-                    - |
-                      # About spx
-
-                      spx is a Scratch-like 2D Game Engine for STEM education.
-      responses:
-        "200":
-          description: Successfully generated AI description.
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  description:
-                    description: AI-generated descriptive summary of the game world from the player's perspective.
-                    type: string
-                    examples:
-                      - |
-                        This is a Tic-Tac-Toe game played on a 3x3 grid. The player uses `X` marks while the AI opponent
-                        uses `O` marks. Players take turns placing their marks in empty squares, with the goal of getting
-                        three marks in a row horizontally, vertically, or diagonally. The game supports mouse click
-                        interaction. Click on an empty square to place your mark. The game ends when either player
-                        achieves three in a row or the board is completely filled.
-        "403":
-          description: Insufficient permissions or quota to perform this operation.
-          headers:
-            Retry-After:
-              description: Seconds to wait before retrying after hitting the long-window quota limit.
-              schema:
-                type: integer
-        "429":
-          description: Too many requests to perform this operation.
-          headers:
-            Retry-After:
-              description: Seconds to wait before retrying after hitting the short-window rate limit.
-              schema:
-                type: integer
-
-  /ai/interaction/turn:
-    post:
-      tags:
-        - AI
-      summary: Perform an AI interaction turn
-      description: |
-        Send a message and context to the AI, receive a response including text and an optional command.
-
-        #### Quota & rate limits
-
-        - Each turn consumes 1 quota from the authenticated user's AI interaction turn allowance.
-        - Per-user short-window rate limits also apply to prevent bursts. Hitting them returns 429 with `Retry-After`.
-        - Long-window quota limits vary based on the authenticated user's plan.
-        - When the long-window quota limit is reached, the 403 response includes a `Retry-After` header with the wait
-          time in seconds.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                content:
-                  description: The core user input message.
-                  type: string
-                  examples:
-                    - What should I do next?
-                context:
-                  description: Specific context for the current user input.
-                  type: object
-                  additionalProperties: true
-                  examples:
-                    - position: [10, 20]
-                      health: 80
-                role:
-                  description: Persona the AI should adopt.
-                  type: string
-                  examples:
-                    - Guide
-                roleContext:
-                  description: Additional context specific to the role.
-                  type: object
-                  additionalProperties: true
-                  examples:
-                    - style: friendly
-                      knowledgeScope: game rules
-                knowledgeBase:
-                  description: Background knowledge provided to the AI.
-                  type: object
-                  additionalProperties: true
-                  examples:
-                    - worldName: TestWorld
-                      gravity: 9.8
-                commandSpecs:
-                  description: Commands the AI is allowed to call.
-                  type: array
-                  items:
-                    type: object
-                    properties:
-                      name:
-                        description: Unique identifier for the command.
-                        type: string
-                        examples:
-                          - Move
-                      description:
-                        description: Explanation of what the command does.
-                        type: string
-                        examples:
-                          - Move the character
-                      parameters:
-                        description: Parameters the command accepts.
-                        type: array
-                        items:
-                          type: object
-                          properties:
-                            name:
-                              description: Parameter name.
-                              type: string
-                              examples:
-                                - Direction
-                            type:
-                              description: Go type name of the parameter.
-                              type: string
-                              examples:
-                                - string
-                            description:
-                              description: Purpose of the parameter.
-                              type: string
-                              examples:
-                                - "Direction to move: up, down, left, right"
-                history:
-                  description: Record of previous interactions in this session.
-                  type: array
-                  items:
-                    $ref: "#/components/schemas/AIInteractionTurn"
-                archivedHistory:
-                  description: Content of archived historical interactions.
-                  type: string
-                  examples:
-                    - "Previous conversation summary..."
-                continuationTurn:
-                  description: |
-                    Current turn number in a multi-turn interaction sequence.
-
-                    A value of 0 means this is the initial turn from user input. Values > 0 indicate continuation turns
-                    where the AI continues the current interaction sequence based on the outcomes of commands executed
-                    within this sequence.
-                  type: integer
-                  format: int32
-                  minimum: 0
-                  default: 0
-                  examples:
-                    - 0
-      responses:
-        "200":
-          description: Successful AI interaction.
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  text:
-                    description: Textual part of the AI's response.
-                    type: string
-                    examples:
-                      - Okay, I suggest moving to (1, 1).
-                  commandName:
-                    description: Name of the command the AI wants to execute.
-                    type: string
-                    examples:
-                      - MakeMove
-                  commandArgs:
-                    description: Arguments for the command to be executed.
-                    type: object
-                    additionalProperties: true
-                    examples:
-                      - Row: 1
-                        Col: 1
-                        Result: ""
-        "403":
-          description: Insufficient permissions or quota to perform this operation.
-          headers:
-            Retry-After:
-              description: Seconds to wait before retrying after hitting the long-window quota limit.
-              schema:
-                type: integer
-        "429":
-          description: Too many requests to perform this operation.
-          headers:
-            Retry-After:
-              description: Seconds to wait before retrying after hitting the short-window rate limit.
-              schema:
-                type: integer
-
-  /ai/interaction/archive:
-    post:
-      tags:
-        - AI
-      summary: Archive AI interaction history
-      description: |
-        Archive a batch of interaction turns into a condensed summary for future context.
-
-        #### Quota & rate limits
-
-        - Each archive request consumes 1 quota from the authenticated user's AI interaction archive allowance.
-        - Per-user short-window rate limits also apply to prevent bursts. Hitting them returns 429 with `Retry-After`.
-        - Long-window quota limits vary based on the authenticated user's plan.
-        - When the long-window quota limit is reached, the 403 response includes a `Retry-After` header with the wait
-          time in seconds.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              required:
-                - turns
-              properties:
-                turns:
-                  description: Interaction turns to be archived.
-                  type: array
-                  items:
-                    $ref: "#/components/schemas/AIInteractionTurn"
-                existingArchive:
-                  description: Existing archived content to be merged with new turns.
-                  type:
-                    - string
-                    - "null"
-                  examples:
-                    - "Previous conversation summary..."
-      responses:
-        "200":
-          description: Successfully archived interaction history.
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  content:
-                    description: The consolidated archive content.
-                    type: string
-                    examples:
-                      - "Complete conversation summary including new turns..."
-        "403":
-          description: Insufficient permissions or quota to perform this operation.
-          headers:
-            Retry-After:
-              description: Seconds to wait before retrying after hitting the long-window quota limit.
-              schema:
-                type: integer
-        "429":
-          description: Too many requests to perform this operation.
-          headers:
-            Retry-After:
-              description: Seconds to wait before retrying after hitting the short-window rate limit.
-              schema:
-                type: integer
-
-  /aigc/task:
-    post:
-      tags:
-        - AIGC
-      summary: Create an AIGC task
-      description: |
-        Create an asynchronous AIGC task for resource-intensive operations like image generation, video generation, or
-        audio generation.
-
-        All generation operations are processed asynchronously. Use the returned task ID to poll for status via
-        `GET /aigc/task/{taskID}` or subscribe to real-time updates via `GET /aigc/task/{taskID}/events`.
-
-        #### Supported task types
-
-        | Type | Description |
-        |------|-------------|
-        | `removeBackground` | Remove image background |
-        | `generateCostume` | Generate costume image |
-        | `generateAnimationVideo` | Generate animation video |
-        | `extractVideoFrames` | Extract frames from video |
-        | `generateBackdrop` | Generate backdrop image |
-
-        #### Quota & rate limits
-
-        - Each task consumes quota from the authenticated user's AIGC allowance based on the task type.
-        - Per-user short-window rate limits apply. Hitting them returns 429 with `Retry-After`.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              required:
-                - type
-                - parameters
-              properties:
-                type:
-                  $ref: "#/components/schemas/AIGCTask/properties/type"
-                parameters:
-                  description: Task parameters. Structure depends on task type.
-                  oneOf:
-                    - title: removeBackground
-                      type: object
-                      required:
-                        - imageUrl
-                      properties:
-                        imageUrl:
-                          description: Universal URL of the image to remove background from (e.g. kodo://bucket/key).
-                          type: string
-                          format: uri
-                          examples:
-                            - kodo://bucket/character.png
-                    - title: generateCostume
-                      type: object
-                      required:
-                        - settings
-                      properties:
-                        settings:
-                          $ref: "#/components/schemas/AIGCCostumeSettings"
-                        n:
-                          description: Number of costume images to generate.
-                          type: integer
-                          minimum: 1
-                          maximum: 4
-                          default: 1
-                          examples:
-                            - 4
-                    - title: generateAnimationVideo
-                      type: object
-                      required:
-                        - settings
-                      properties:
-                        settings:
-                          $ref: "#/components/schemas/AIGCAnimationSettings"
-                    - title: extractVideoFrames
-                      type: object
-                      required:
-                        - videoUrl
-                        - duration
-                      properties:
-                        videoUrl:
-                          description: Universal URL of the video to extract frames from (e.g. kodo://bucket/key).
-                          type: string
-                          format: uri
-                          examples:
-                            - kodo://bucket/animation.mp4
-                        startTime:
-                          description: Start time (in milliseconds) from which to extract frames. Precision is 100ms.
-                          type: integer
-                          minimum: 0
-                          multipleOf: 100
-                          default: 0
-                          examples:
-                            - 0
-                            - 1500
-                        duration:
-                          description: Duration (in milliseconds) of the segment to extract frames from. Precision is 100ms.
-                          type: integer
-                          minimum: 0
-                          multipleOf: 100
-                          maximum: 60000
-                          examples:
-                            - 3000
-                            - 10000
-                        interval:
-                          description: Interval between frames in milliseconds. Precision is 100ms.
-                          type: integer
-                          minimum: 100
-                          multipleOf: 100
-                          maximum: 1000
-                          default: 100
-                          examples:
-                            - 100
-                    - title: generateBackdrop
-                      type: object
-                      required:
-                        - settings
-                      properties:
-                        settings:
-                          $ref: "#/components/schemas/AIGCBackdropSettings"
-                        n:
-                          description: Number of backdrop images to generate.
-                          type: integer
-                          minimum: 1
-                          maximum: 4
-                          default: 1
-                          examples:
-                            - 4
-      responses:
-        "202":
-          description: Task accepted and queued for processing.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/AIGCTask"
-        "400":
-          description: Invalid task type or parameters.
-        "403":
-          description: Insufficient permissions or quota.
-          headers:
-            Retry-After:
-              description: Seconds to wait before retrying after hitting the long-window quota limit.
-              schema:
-                type: integer
-        "429":
-          description: Too many requests.
-          headers:
-            Retry-After:
-              description: Seconds to wait before retrying after hitting the short-window rate limit.
-              schema:
-                type: integer
-
-  /aigc/task/{taskID}:
-    get:
-      tags:
-        - AIGC
-      summary: Get AIGC task status
-      description: |
-        Get the current status of an AIGC task.
-
-        Poll this endpoint to check if the task is complete. For real-time updates, use the SSE endpoint
-        `GET /aigc/task/{taskID}/events` instead.
-      parameters:
-        - name: taskID
-          description: The task ID to get.
-          in: path
-          required: true
-          schema:
-            type: string
-      responses:
-        "200":
-          description: Task status retrieved.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/AIGCTask"
-        "404":
-          description: Task not found.
-
-  /aigc/task/{taskID}/events:
-    get:
-      tags:
-        - AIGC
-      summary: Subscribe to AIGC task events
-      description: |
-        Subscribe to real-time task status updates via Server-Sent Events (SSE).
-
-        The first event is always a `snapshot` containing the current task state. This eliminates the need to call
-        `GET /aigc/task/{taskID}` separately and avoids race conditions between fetching current state and subscribing
-        to updates.
-
-        The connection remains open until the task completes, is cancelled, or fails. If the task is already in a
-        terminal state (`completed`, `cancelled`, or `failed`) when connecting, the `snapshot` event will contain the
-        final state and the connection will close immediately.
-
-        #### Event types
-
-        | Event | Data | Description |
-        |-------|------|-------------|
-        | `snapshot` | Full `AIGCTask` object | Initial state, always sent first |
-        | `cancelling` | `{}` | Task cancellation in progress |
-        | `completed` | `{"result": {...}}` | Task completed successfully |
-        | `cancelled` | `{}` | Task was cancelled |
-        | `failed` | `{"error": {"reason": "...", "message": "..."}}` | Task failed |
-
-        #### Example: task in progress
-
-        ```
-        GET /aigc/task/task-123/events
-
-        event: snapshot
-        data: {"id": "task-123", "status": "processing"}
-
-        event: completed
-        data: {"result": {"imageUrls": ["kodo://bucket/path/to/file.png"]}}
-        ```
-
-        #### Example: task already completed
-
-        ```
-        GET /aigc/task/task-456/events
-
-        event: snapshot
-        data: {"id": "task-456", "status": "completed", "result": {"imageUrls": ["kodo://bucket/path/to/file.png"]}}
-
-        (connection closed)
-        ```
-
-        #### Example: task pending
-
-        ```
-        GET /aigc/task/task-789/events
-
-        event: snapshot
-        data: {"id": "task-789", "status": "pending"}
-
-        event: completed
-        data: {"result": {"imageUrls": ["kodo://bucket/path/to/file.png"]}}
-        ```
-
-        #### Example: task cancelled
-
-        ```
-        GET /aigc/task/task-abc/events
-
-        event: snapshot
-        data: {"id": "task-abc", "status": "processing"}
-
-        event: cancelling
-        data: {}
-
-        event: cancelled
-        data: {}
-
-        (connection closed)
-        ```
-      parameters:
-        - name: taskID
-          description: The task ID to subscribe to.
-          in: path
-          required: true
-          schema:
-            type: string
-      responses:
-        "200":
-          description: SSE stream established.
-          content:
-            text/event-stream:
-              schema:
-                type: string
-                description: Server-Sent Events stream.
-        "404":
-          description: Task not found.
-
-  /aigc/task/{taskID}/cancellation:
-    post:
-      tags:
-        - AIGC
-      summary: Cancel an AIGC task
-      description: |
-        Cancel a pending or processing AIGC task.
-
-        If subscribed via `GET /aigc/task/{taskID}/events`, a `cancelling` event will be emitted when cancellation
-        begins, followed by a `cancelled` event when complete.
-
-        #### Cancellation rules
-
-        | Current Status | Result |
-        |----------------|--------|
-        | `pending` | Immediately `cancelled`, quota refunded |
-        | `processing` | Transitions to `cancelling`, then `cancelled` |
-        | `cancelling` | No-op, returns current state |
-        | `completed` | `409 Conflict` |
-        | `cancelled` | No-op (idempotent), returns current state |
-        | `failed` | `409 Conflict` |
-
-        #### Quota refund
-
-        - Tasks cancelled from `pending` status receive a full quota refund.
-        - Tasks cancelled from `processing` status do not receive a refund (resources already consumed).
-      parameters:
-        - name: taskID
-          description: The task ID to cancel.
-          in: path
-          required: true
-          schema:
-            type: string
-      responses:
-        "202":
-          description: Cancellation request accepted.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/AIGCTask"
-        "404":
-          description: Task not found.
-        "409":
-          description: Task cannot be cancelled because it has already completed or failed.
-
-  /aigc/asset-adoption:
-    post:
+      operationId: createAIGCAssetAdoption
       tags:
         - AIGC
       summary: Adopt an AIGC-generated asset
@@ -2161,9 +3246,7 @@ paths:
                   description: IDs of relevant AIGC tasks that produced the asset.
                   type: array
                   items:
-                    description: AIGCTask ID.
-                    type: string
-                    format: int64
+                    $ref: "#/components/schemas/Model/properties/id"
                   examples:
                     - - "1"
                       - "2"
@@ -2177,6 +3260,7 @@ paths:
                     - type
                     - description
                     - extraSettings
+                    - filesHash
                     - files
                   properties:
                     displayName:
@@ -2184,30 +3268,37 @@ paths:
                     type:
                       $ref: "#/components/schemas/Asset/properties/type"
                     description:
-                      $ref: "#/components/schemas/Asset/properties/description"
+                      allOf:
+                        - $ref: "#/components/schemas/Asset/properties/description"
+                      minLength: 1
                     extraSettings:
                       $ref: "#/components/schemas/Asset/properties/extraSettings"
                     filesHash:
                       $ref: "#/components/schemas/Asset/properties/filesHash"
                     files:
-                      $ref: "#/components/schemas/Asset/properties/files"
+                      allOf:
+                        - $ref: "#/components/schemas/Asset/properties/files"
+                      minProperties: 1
       responses:
         "204":
           description: Asset adoption recorded.
         "400":
           description: Invalid parameters.
+        "401":
+          $ref: "#/components/responses/Unauthorized"
         "403":
           description: Insufficient permissions for given tasks.
 
-  /aigc/asset-settings/enrichment:
+  /aigc/asset-settings-enrichments:
     post:
+      operationId: enrichAssetSettings
       tags:
         - AIGC
       summary: Enrich asset settings
       description: |
         Use AI to enrich partial asset settings with detailed descriptions and parameters.
 
-        #### Quota & rate limits
+        Quota and rate limits:
 
         - Each request consumes 1 quota from the authenticated user's AIGC allowance.
         - Per-user short-window rate limits apply. Hitting them returns 429 with `Retry-After`.
@@ -2220,6 +3311,47 @@ paths:
               required:
                 - assetType
                 - input
+              allOf:
+                - if:
+                    required:
+                      - assetType
+                    properties:
+                      assetType:
+                        const: sprite
+                  then:
+                    properties:
+                      settings:
+                        $ref: "#/components/schemas/AIGCSpriteSettings"
+                - if:
+                    required:
+                      - assetType
+                    properties:
+                      assetType:
+                        const: costume
+                  then:
+                    properties:
+                      settings:
+                        $ref: "#/components/schemas/AIGCCostumeSettings"
+                - if:
+                    required:
+                      - assetType
+                    properties:
+                      assetType:
+                        const: animation
+                  then:
+                    properties:
+                      settings:
+                        $ref: "#/components/schemas/AIGCAnimationSettings"
+                - if:
+                    required:
+                      - assetType
+                    properties:
+                      assetType:
+                        const: backdrop
+                  then:
+                    properties:
+                      settings:
+                        $ref: "#/components/schemas/AIGCBackdropSettings"
               properties:
                 assetType:
                   description: Type of asset to enrich settings for.
@@ -2232,26 +3364,21 @@ paths:
                 input:
                   description: User's text description of the asset.
                   type: string
+                  minLength: 1
                   examples:
                     - A fire demon character with glowing ember cracks
                 settings:
                   description: Optional partial settings to be enriched. Structure depends on assetType.
-                  oneOf:
-                    - $ref: "#/components/schemas/AIGCSpriteSettings"
-                    - $ref: "#/components/schemas/AIGCCostumeSettings"
-                    - $ref: "#/components/schemas/AIGCAnimationSettings"
-                    - $ref: "#/components/schemas/AIGCBackdropSettings"
+                  type: object
                 spriteSettings:
-                  description:
-                    Optional existing sprite settings to provide context for enrichment. Only used when
-                    `assetType` is `costume` or `animation`.
+                  description: Optional existing sprite settings to provide context for costume or animation enrichment.
                   $ref: "#/components/schemas/AIGCSpriteSettings"
                 projectSettings:
                   description: Optional project settings to provide context for enrichment.
                   $ref: "#/components/schemas/AIGCProjectSettings"
                 lang:
                   description: |
-                    Language the AI should use for all generated text (names, descriptions, etc.).
+                    Language the AI should use for all generated text.
                     When provided, the output strictly follows this language regardless of the input language.
                     When omitted, the AI infers language from the user input.
                   type: string
@@ -2264,11 +3391,13 @@ paths:
           content:
             application/json:
               schema:
-                oneOf:
+                anyOf:
                   - $ref: "#/components/schemas/AIGCSpriteSettings"
                   - $ref: "#/components/schemas/AIGCCostumeSettings"
                   - $ref: "#/components/schemas/AIGCAnimationSettings"
                   - $ref: "#/components/schemas/AIGCBackdropSettings"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
         "403":
           description: Insufficient permissions or quota.
           headers:
@@ -2284,15 +3413,16 @@ paths:
               schema:
                 type: integer
 
-  /aigc/sprite/content-settings:
+  /aigc/sprite-content-settings:
     post:
+      operationId: generateSpriteContentSettings
       tags:
         - AIGC
       summary: Generate sprite content settings
       description: |
         Generate costume and animation settings for a sprite based on its settings.
 
-        #### Quota & rate limits
+        Quota and rate limits:
 
         - Each request consumes 1 quota from the authenticated user's AIGC allowance.
         - Per-user short-window rate limits apply. Hitting them returns 429 with `Retry-After`.
@@ -2309,7 +3439,7 @@ paths:
                   $ref: "#/components/schemas/AIGCSpriteSettings"
                 lang:
                   description: |
-                    Language the AI should use for all generated text (names, descriptions, etc.).
+                    Language the AI should use for all generated text.
                     When provided, the output strictly follows this language regardless of the input language.
                     When omitted, the AI infers language from the user input.
                   type: string
@@ -2323,6 +3453,10 @@ paths:
             application/json:
               schema:
                 type: object
+                required:
+                  - costumes
+                  - animations
+                  - animationBindings
                 properties:
                   costumes:
                     description: Settings for costumes to generate.
@@ -2337,8 +3471,8 @@ paths:
                   animationBindings:
                     description: |
                       Recommended mapping from sprite state enum values to animation names.
-                      Keys are sprite state enum values; values are animation name strings that should
-                      match the 'name' field from the animations array, omitted if no animation is bound to that state.
+                      Keys are sprite state enum values; values are animation name strings that should match the `name`
+                      field from the animations array, omitted if no animation is bound to that state.
                     type: object
                     additionalProperties: false
                     properties:
@@ -2351,6 +3485,8 @@ paths:
                     example:
                       default: "idle"
                       step: "walk"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
         "403":
           description: Insufficient permissions or quota.
           headers:
@@ -2366,24 +3502,28 @@ paths:
               schema:
                 type: integer
 
-  /util/upinfo:
-    get:
+  /upload-sessions:
+    post:
+      operationId: createUploadSession
       tags:
-        - Utils
-      summary: Get upload information
-      description: Retrieve necessary information and tokens required for file uploads.
+        - Files
+      summary: Create an upload session
+      description: Create short-lived upload credentials and configuration for file uploads.
       responses:
-        "200":
-          description: Successful response.
+        "201":
+          description: Upload session created.
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/UpInfo"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
 
-  /util/fileurls:
+  /file-url-signatures:
     post:
+      operationId: createFileURLSignatures
       tags:
-        - Utils
+        - Files
       summary: Generate signed URLs for files
       description: Create signed web URLs for the specified files to allow secure access.
       security: []
@@ -2393,40 +3533,53 @@ paths:
           application/json:
             schema:
               type: object
+              required:
+                - objects
               properties:
                 objects:
                   description: List of universal URLs of the objects.
                   type: array
                   items:
                     type: string
+                    minLength: 1
+                    format: uri
+                    pattern: "^kodo://[^/?#@:]+/[^?#]+$"
                   examples:
                     - - kodo://xbuilder-usercontent-test/files/FjgMMuSaAsRWx1t7UAQnQ5r4YsAe-195
       responses:
-        "201":
+        "200":
           description: Successfully generated signed URLs for the files.
           content:
             application/json:
               schema:
                 type: object
+                required:
+                  - objectUrls
                 properties:
                   objectUrls:
                     description: Map from universal URLs to signed web URLs for the objects.
-                    type: array
-                    items:
-                      type: object
+                    type: object
+                    propertyNames:
+                      type: string
+                      format: uri
+                      pattern: "^kodo://[^/?#@:]+/[^?#]+$"
+                    additionalProperties:
+                      type: string
+                      format: uri
                     examples:
-                      - - kodo://xbuilder-usercontent-test/files/FjgMMuSaAsRWx1t7UAQnQ5r4YsAe-195: https://xbuilder-usercontent-test.gopluscdn.com/files/FjgMMuSaAsRWx1t7UAQnQ5r4YsAe-195?e=1727658000&token=t_6AOOkCdDu4m7fPleblcK0gMBZfbGQzeEIVt5Au:EMJdLqcCWrqQ5pRd01diOv7nhQw=
+                      - kodo://xbuilder-usercontent-test/files/FjgMMuSaAsRWx1t7UAQnQ5r4YsAe-195: https://xbuilder-usercontent-test.gopluscdn.com/files/FjgMMuSaAsRWx1t7UAQnQ5r4YsAe-195?e=1727658000&token=t_6AOOkCdDu4m7fPleblcK0gMBZfbGQzeEIVt5Au:EMJdLqcCWrqQ5pRd01diOv7nhQw=
 
-  /util/sb2xbp:
+  /project-conversions:
     post:
+      operationId: convertProject
       tags:
-        - Utils
-      summary: Convert Scratch to XBP
+        - Files
+      summary: Convert a project file
       description: |
         Convert a Scratch format file to XBP (XBuilder Project) format.
 
-        This endpoint accepts a Scratch project file (version 2 or 3) and converts it to the XBP format
-        used by the XBuilder platform.
+        This endpoint accepts a Scratch project file, version 2 or 3, and converts it to the XBP format used by the
+        XBuilder platform.
       security:
         - {}
         - bearerAuth: []
@@ -2440,15 +3593,13 @@ paths:
                 - file
               properties:
                 file:
-                  description: |
-                    Scratch project file (e.g. .sb2, .sb3 or project zip). Form field name must be `file`, Maximum size
-                    32 MiB.
+                  description: Scratch project file, such as .sb2, .sb3, or project zip. Form field name must be `file`. Maximum size is 64 MiB.
                   type: string
                   format: binary
-                  maxLength: 33554432
+                  maxLength: 67108864
       responses:
-        "201":
-          description: Conversion successful. Returns a zip archive containing the .xbp project file.
+        "200":
+          description: Conversion successful. Returns a zip archive containing the XBP project file.
           content:
             application/zip:
               schema:
@@ -2474,11 +3625,13 @@ components:
           description: Canonical route of the requested resource.
           schema:
             type: string
+            format: uri-reference
+            minLength: 1
         Cache-Control:
           description: |
             Cache policy for canonical redirects.
 
-            `no-cache` requires revalidation before reuse because historical routes may later be reused by different
+            `no-cache` requires revalidation before reuse because non-canonical routes may later be reused by different
             resources.
           schema:
             type: string
@@ -2496,16 +3649,24 @@ components:
         application/json:
           schema:
             $ref: "#/components/schemas/MovedResourceError"
+    Unauthorized:
+      description: Unauthorized. Authentication required.
 
   schemas:
     Model:
       type: object
       description: Base model with common fields for all entities.
+      required:
+        - id
+        - createdAt
+        - updatedAt
       properties:
         id:
-          description: Unique identifier.
+          description: Unique positive identifier as a canonical decimal string.
           type: string
-          format: int64
+          minLength: 1
+          maxLength: 19
+          pattern: '^([1-9][0-9]{0,17}|[1-8][0-9]{18}|9[0-1][0-9]{17}|92[0-1][0-9]{16}|922[0-2][0-9]{15}|9223[0-2][0-9]{14}|92233[0-6][0-9]{13}|922337[0-1][0-9]{12}|92233720[0-2][0-9]{10}|922337203[0-5][0-9]{9}|9223372036[0-7][0-9]{8}|92233720368[0-4][0-9]{7}|922337203685[0-3][0-9]{6}|9223372036854[0-6][0-9]{5}|92233720368547[0-6][0-9]{4}|922337203685477[0-4][0-9]{3}|9223372036854775[0-7][0-9]{2}|922337203685477580[0-7])$'
           examples:
             - "1"
         createdAt:
@@ -2513,13 +3674,13 @@ components:
           type: string
           format: date-time
           examples:
-            - 2006-01-02T15:04:05Z07:00
+            - 2006-01-02T15:04:05+07:00
         updatedAt:
           description: Last update timestamp.
           type: string
           format: date-time
           examples:
-            - 2006-01-02T15:04:05Z07:00
+            - 2006-01-02T15:04:05+07:00
 
     MovedResourceCanonical:
       description: |
@@ -2537,26 +3698,28 @@ components:
         path:
           description: Canonical route path of the requested resource.
           type: string
+          format: uri-reference
+          minLength: 1
           examples:
-            - /project/john/NiuXiaoQi
+            - /projects/john/NiuXiaoQi
         username:
           description: Canonical username of the moved user route.
-          type: string
+          $ref: "#/components/schemas/User/properties/username"
           examples:
             - john
         owner:
           description: Canonical owner username of the moved project or project release route.
-          type: string
+          $ref: "#/components/schemas/User/properties/username"
           examples:
             - john
         name:
           description: Canonical project name of the moved project or project release route.
-          type: string
+          $ref: "#/components/schemas/Project/properties/name"
           examples:
             - NiuXiaoQi
         release:
           description: Canonical release name of the moved project release route.
-          type: string
+          $ref: "#/components/schemas/ProjectRelease/properties/name"
           examples:
             - v1.2.3
 
@@ -2594,6 +3757,20 @@ components:
     User:
       description: User account information.
       type: object
+      required:
+        - id
+        - createdAt
+        - updatedAt
+        - username
+        - displayName
+        - avatar
+        - description
+        - plan
+        - followerCount
+        - followingCount
+        - projectCount
+        - publicProjectCount
+        - likedProjectCount
       properties:
         id:
           $ref: "#/components/schemas/Model/properties/id"
@@ -2604,15 +3781,20 @@ components:
         username:
           description: Unique username of the user.
           type: string
+          minLength: 1
+          maxLength: 100
+          pattern: "^[A-Za-z0-9_-]{1,100}$"
           examples:
             - john
         displayName:
           description: Display name of the user.
           type: string
+          minLength: 1
+          maxLength: 100
           examples:
             - John Doe
         avatar:
-          description: URL of the user's avatar image.
+          description: Public URL or universal URL of the user's avatar image.
           type: string
           format: uri
           examples:
@@ -2670,13 +3852,23 @@ components:
             Capabilities of the user.
 
             **This field is only present for the authenticated user's own profile.**
-          oneOf:
-            - $ref: "#/components/schemas/UserCapabilities"
-            - type: "null"
+          $ref: "#/components/schemas/UserCapabilities"
+
+    AuthenticatedUser:
+      description: Authenticated user account information.
+      allOf:
+        - $ref: "#/components/schemas/User"
+        - type: object
+          required:
+            - capabilities
 
     UserCapabilities:
       type: object
       description: User permission capabilities.
+      required:
+        - canManageAssets
+        - canManageCourses
+        - canUsePremiumLLM
       properties:
         canManageAssets:
           description: Whether the user can manage asset library.
@@ -2697,6 +3889,25 @@ components:
     Project:
       type: object
       description: Project information including files, metadata, and statistics.
+      required:
+        - id
+        - createdAt
+        - updatedAt
+        - owner
+        - name
+        - type
+        - displayName
+        - version
+        - files
+        - visibility
+        - description
+        - instructions
+        - extraSettings
+        - thumbnail
+        - viewCount
+        - likeCount
+        - releaseCount
+        - remixCount
       properties:
         id:
           $ref: "#/components/schemas/Model/properties/id"
@@ -2708,24 +3919,20 @@ components:
           $ref: "#/components/schemas/User/properties/username"
         remixedFrom:
           description: Full name of the project release from which the project is remixed.
-          oneOf:
-            - $ref: "#/components/schemas/ProjectReleaseFullName"
-            - type: "null"
+          $ref: "#/components/schemas/ProjectReleaseFullName"
         latestRelease:
           description: Latest release of the project.
-          oneOf:
-            - $ref: "#/components/schemas/ProjectRelease"
-            - type: "null"
+          $ref: "#/components/schemas/ProjectRelease"
         name:
           description: Unique name of the project.
           type: string
+          minLength: 1
+          maxLength: 100
+          pattern: "^[A-Za-z0-9_-]{1,100}$"
           examples:
             - NiuXiaoQi
         type:
-          description: |
-            Type of the project.
-
-            When omitted in legacy data, it should be interpreted as `game` for backward compatibility.
+          description: Type of the project.
           type: string
           enum:
             - game
@@ -2734,6 +3941,8 @@ components:
         displayName:
           description: Display name of the project.
           type: string
+          minLength: 1
+          maxLength: 100
           examples:
             - Niu Xiao Qi
         version:
@@ -2745,6 +3954,8 @@ components:
         files:
           description: File paths and their corresponding universal URLs associated with the project.
           type: object
+          additionalProperties:
+            type: string
           examples:
             - NiuXiaoQi.spx: data:;,
               assets/backdrop.jpeg: kodo://xbuilder-usercontent-test/files/FnPtX9heX2eXE8vRIiITmFXQVAOz-5352
@@ -2772,9 +3983,9 @@ components:
               artStyle: pixel-art
               perspective: side-scrolling
         thumbnail:
-          description: URL of the project's thumbnail image.
+          description: Thumbnail reference of the project's thumbnail image.
           type: string
-          format: uri
+          format: uri-reference
           examples:
             - https://example.com/project-thumbnail.png
         viewCount:
@@ -2809,12 +4020,25 @@ components:
     ProjectFullName:
       description: Full name of a project in the format `owner/project`.
       type: string
+      minLength: 3
+      maxLength: 201
+      pattern: "^[A-Za-z0-9_-]{1,100}/[A-Za-z0-9_-]{1,100}$"
       examples:
         - john/NiuXiaoQi
 
     ProjectRelease:
       description: A versioned release of a project.
       type: object
+      required:
+        - id
+        - createdAt
+        - updatedAt
+        - projectFullName
+        - name
+        - description
+        - files
+        - thumbnail
+        - remixCount
       properties:
         id:
           $ref: "#/components/schemas/Model/properties/id"
@@ -2834,13 +4058,14 @@ components:
         description:
           description: Brief description of the release.
           type: string
+          minLength: 1
           examples:
             - First release.
         files:
           description: File paths and their corresponding universal URLs associated with the release.
           $ref: "#/components/schemas/Project/properties/files"
         thumbnail:
-          description: URL of the release's thumbnail image.
+          description: Thumbnail reference of the release.
           $ref: "#/components/schemas/Project/properties/thumbnail"
         remixCount:
           description: Number of times the release has been remixed.
@@ -2849,12 +4074,27 @@ components:
     ProjectReleaseFullName:
       description: Full name of a project release in the format `owner/project/release`.
       type: string
+      minLength: 10
+      pattern: '^[A-Za-z0-9_-]{1,100}/[A-Za-z0-9_-]{1,100}/v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$'
       examples:
         - john/NiuXiaoQi/v1.2.3
 
     Asset:
       description: Reusable asset such as sprite, backdrop, or sound.
       type: object
+      required:
+        - id
+        - createdAt
+        - updatedAt
+        - owner
+        - displayName
+        - type
+        - category
+        - description
+        - extraSettings
+        - files
+        - filesHash
+        - visibility
       properties:
         id:
           $ref: "#/components/schemas/Model/properties/id"
@@ -2868,6 +4108,8 @@ components:
         displayName:
           description: Display name of the asset.
           type: string
+          minLength: 1
+          maxLength: 100
           examples:
             - NiuXiaoQi
         type:
@@ -2883,6 +4125,7 @@ components:
           deprecated: true
           description: Category to which the asset belongs.
           type: string
+          minLength: 1
           examples:
             - People
         description:
@@ -2899,12 +4142,15 @@ components:
         files:
           description: File paths and their corresponding universal URLs associated with the asset.
           type: object
+          additionalProperties:
+            type: string
           examples:
             - assets/sprites/NiuXiaoQi/costume.png: kodo://xbuilder-usercontent-test/files/FoSC8ngQn_jzAIPBqCp9VZLBVkSq-52661
               assets/sprites/NiuXiaoQi/index.json: data:application/json,%7B%22heading%22%3A90%2C%22x%22%3A0%2C%22y%22%3A0%2C%22size%22%3A1%2C%22rotationStyle%22%3A%22normal%22%2C%22costumeIndex%22%3A0%2C%22visible%22%3Atrue%2C%22isDraggable%22%3Afalse%2C%22pivot%22%3A%7B%22x%22%3A71%2C%22y%22%3A-75%7D%2C%22costumes%22%3A%5B%7B%22x%22%3A0%2C%22y%22%3A0%2C%22faceRight%22%3A0%2C%22bitmapResolution%22%3A2%2C%22name%22%3A%22costume%22%2C%22path%22%3A%22costume.png%22%2C%22builder_id%22%3A%22VCxSMAnlb3WI1IyikqjCV%22%7D%5D%2C%22fAnimations%22%3A%7B%7D%2C%22animBindings%22%3A%7B%7D%2C%22builder_id%22%3A%22fZFB5R_Mwwq95FB6xIVYu%22%7D
         filesHash:
           description: Hash of the asset files.
           type: string
+          minLength: 1
           examples:
             - h1:qUqP5cyxm6YcTAhz05Hph5gvu9M=
         visibility:
@@ -2913,6 +4159,16 @@ components:
     Course:
       description: Educational course with learning content.
       type: object
+      required:
+        - id
+        - createdAt
+        - updatedAt
+        - owner
+        - title
+        - thumbnail
+        - entrypoint
+        - references
+        - prompt
       properties:
         id:
           $ref: "#/components/schemas/Model/properties/id"
@@ -2926,20 +4182,24 @@ components:
         title:
           description: Title of the course.
           type: string
+          minLength: 1
+          maxLength: 200
           examples:
             - Introduction to XGo
         thumbnail:
-          description: URL of the course's thumbnail image.
+          description: Thumbnail reference of the course.
           type: string
-          format: uri
+          format: uri-reference
+          minLength: 1
           examples:
-            - https://example.com/course-thumbnail.png
+            - kodo://xbuilder-usercontent-test/files/FvYyHLNrtx8qFHSwnLjEe57UA2fF-2824936
         entrypoint:
-          description: Starting URL of the course.
+          description: Starting entrypoint of the course.
           type: string
-          format: uri
+          format: uri-reference
+          minLength: 1
           examples:
-            - https://example.com/course/intro
+            - /editor/john/loop
         references:
           description: References associated with the course.
           type: array
@@ -2954,6 +4214,9 @@ components:
     CourseReference:
       description: Reference to a resource associated with a course.
       type: object
+      required:
+        - type
+        - fullName
       properties:
         type:
           description: Type of the reference.
@@ -2964,13 +4227,23 @@ components:
             - project
         fullName:
           description: Full name of the reference, in the format `owner/project`.
-          type: string
+          $ref: "#/components/schemas/ProjectFullName"
           examples:
             - john/NiuXiaoQi
 
     CourseSeries:
       description: Collection of related courses.
       type: object
+      required:
+        - id
+        - createdAt
+        - updatedAt
+        - owner
+        - title
+        - thumbnail
+        - description
+        - courseIDs
+        - order
       properties:
         id:
           $ref: "#/components/schemas/Model/properties/id"
@@ -2984,14 +4257,16 @@ components:
         title:
           description: Title of the course series.
           type: string
+          minLength: 1
+          maxLength: 200
           examples:
             - XGo Programming Series
         thumbnail:
-          description: URL of the course series' thumbnail image.
+          description: Thumbnail reference of the course series.
           type: string
-          format: uri
+          format: uri-reference
           examples:
-            - https://example.com/course-thumbnail.png
+            - kodo://xbuilder-usercontent-test/files/FvYyHLNrtx8qFHSwnLjEe57UA2fF-2824936
         description:
           description: Description of the course series.
           type: string
@@ -3001,7 +4276,7 @@ components:
           description: Array of course IDs included in this series.
           type: array
           items:
-            type: string
+            $ref: "#/components/schemas/Model/properties/id"
           examples:
             - ["1", "2", "3"]
         order:
@@ -3042,6 +4317,8 @@ components:
         text:
           description: Text content of the message.
           type: string
+          minLength: 1
+          maxLength: 40000
           examples:
             - Hello!
 
@@ -3072,7 +4349,14 @@ components:
       required:
         - role
       additionalProperties: false
-      minProperties: 2
+      anyOf:
+        - required:
+            - content
+        - required:
+            - toolCalls
+          properties:
+            toolCalls:
+              minItems: 1
       properties:
         role:
           description: Role of the message.
@@ -3086,7 +4370,6 @@ components:
         toolCalls:
           description: Structured tool calls emitted by the copilot message.
           type: array
-          minItems: 1
           items:
             $ref: "#/components/schemas/CopilotRequestToolCall"
 
@@ -3109,6 +4392,7 @@ components:
         toolCallId:
           description: Tool call identifier of the assistant tool call this result corresponds to.
           type: string
+          minLength: 1
           examples:
             - call_1
         content:
@@ -3126,6 +4410,7 @@ components:
 
             This request shape supports prior assistant `toolCalls` and tool result messages with `toolCallId`.
           type: array
+          maxItems: 50
           items:
             $ref: "#/components/schemas/CopilotMessage"
           examples:
@@ -3155,7 +4440,14 @@ components:
                 function:
                   name: create_project
                   description: Create a new project.
-                  parameters: { "name": "My Project" }
+                  parameters:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                    required:
+                      - name
+                    additionalProperties: false
 
     CopilotRequestToolCall:
       description: Structured tool call supplied on a prior copilot message.
@@ -3201,7 +4493,7 @@ components:
             - '{"name":"My Project"}'
 
     CopilotSSETextDeltaEvent:
-      description: Payload of a `text_delta` SSE event from `POST /copilot/sse/message`.
+      description: Payload of a `text_delta` SSE event from `POST /copilot/messages`.
       type: object
       required:
         - text
@@ -3215,7 +4507,7 @@ components:
 
     CopilotSSEToolCallDeltaEvent:
       description: |
-        Payload of a `tool_call_delta` SSE event from `POST /copilot/sse/message`.
+        Payload of a `tool_call_delta` SSE event from `POST /copilot/messages`.
 
         Merge fragments by `index` to reconstruct one entry in assistant `toolCalls`.
       type: object
@@ -3255,7 +4547,7 @@ components:
             - '{"query":"demo"}'
 
     CopilotSSEDoneEvent:
-      description: Payload of a terminal `done` SSE event from `POST /copilot/sse/message`.
+      description: Payload of a terminal `done` SSE event from `POST /copilot/messages`.
       type: object
       required:
         - finishReason
@@ -3269,7 +4561,7 @@ components:
             - tool_calls
 
     CopilotSSEErrorEvent:
-      description: Payload of a terminal `error` SSE event from `POST /copilot/sse/message`.
+      description: Payload of a terminal `error` SSE event from `POST /copilot/messages`.
       type: object
       required:
         - reason
@@ -3290,6 +4582,9 @@ components:
     CopilotTool:
       description: Tool available for copilot to use.
       type: object
+      required:
+        - type
+        - function
       properties:
         type:
           description: Type of the tool.
@@ -3300,10 +4595,14 @@ components:
             - function
         function:
           type: object
+          required:
+            - name
           properties:
             name:
               description: Name of the function.
               type: string
+              maxLength: 64
+              pattern: "^[a-zA-Z0-9_-]{1,64}$"
               examples:
                 - create_project
             description:
@@ -3312,10 +4611,16 @@ components:
               examples:
                 - create project
             parameters:
-              description: Parameters of the function with JSON raw.
+              description: JSON Schema object that describes the function parameters.
               type: object
               examples:
-                - { "name": "NiuXiaoQi" }
+                - type: object
+                  properties:
+                    name:
+                      type: string
+                  required:
+                    - name
+                  additionalProperties: false
 
     AIInteractionTurn:
       description: Single turn in an AI interaction session.
@@ -3326,7 +4631,7 @@ components:
           type: string
           examples:
             - It's your turn.
-        requestContext:
+        context:
           description: Context for the user's input text for the turn.
           type: object
           additionalProperties: true
@@ -3381,6 +4686,12 @@ components:
     AIGCTask:
       description: AIGC task object.
       type: object
+      required:
+        - id
+        - createdAt
+        - updatedAt
+        - type
+        - status
       properties:
         id:
           $ref: "#/components/schemas/Model/properties/id"
@@ -3413,9 +4724,11 @@ components:
             - processing
         result:
           description: Task result. Only available when status is completed.
-          oneOf:
+          anyOf:
             - title: removeBackground
               type: object
+              required:
+                - imageUrl
               properties:
                 imageUrl:
                   description: Universal URL of the image with background removed (e.g. kodo://bucket/key).
@@ -3434,6 +4747,8 @@ components:
                     format: uri
             - title: generateAnimationVideo
               type: object
+              required:
+                - videoUrl
               properties:
                 videoUrl:
                   description: Universal URL of the generated animation video (e.g. kodo://bucket/key).
@@ -3441,6 +4756,8 @@ components:
                   format: uri
             - title: extractVideoFrames
               type: object
+              required:
+                - frameUrls
               properties:
                 frameUrls:
                   description: Universal URLs of the extracted frame images (e.g. kodo://bucket/key).
@@ -3462,6 +4779,9 @@ components:
         error:
           description: Error details. Only available when status is failed.
           type: object
+          required:
+            - reason
+            - message
           properties:
             reason:
               description: Machine-readable error reason for programmatic handling.
@@ -3511,6 +4831,7 @@ components:
         name:
           description: Name of the project.
           type: string
+          maxLength: 100
           examples:
             - My First Project
         description:
@@ -3530,6 +4851,7 @@ components:
         name:
           description: Name of the asset.
           type: string
+          maxLength: 100
           examples:
             - Fire Demon
         description:
@@ -3592,6 +4914,8 @@ components:
       allOf:
         - $ref: "#/components/schemas/AIGCGraphicAssetSettings"
         - type: object
+          required:
+            - loopMode
           properties:
             referenceFrameUrl:
               description: Universal URL of the reference frame image to guide the animation generation (e.g. kodo://bucket/key).
@@ -3622,6 +4946,12 @@ components:
     UpInfo:
       description: Upload credentials and configuration.
       type: object
+      required:
+        - token
+        - expires
+        - maxSize
+        - bucket
+        - region
       properties:
         token:
           description: Upload token used for authenticating upload requests.
@@ -3669,6 +4999,7 @@ components:
         text:
           description: The text content.
           type: string
+          minLength: 1
           maxLength: 2000
           examples:
             - "Generate a description for a sprite named 'Tornado'."
@@ -3700,6 +5031,7 @@ components:
             Format: `data:image/png;base64,<base64_data>`
           type: string
           format: uri
+          minLength: 1
           maxLength: 7000000
           examples:
             - "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
@@ -3707,6 +5039,9 @@ components:
     ByPage:
       description: Paginated response wrapper.
       type: object
+      required:
+        - total
+        - data
       properties:
         total:
           description: Total number of result items in the result set.


### PR DESCRIPTION
Replace the existing product API paths with the new resource-oriented contract. Move authenticated-user collections under `/user/*`, public user collections under `/users/{username}/*`, and relationship membership operations to idempotent `PUT` routes.

Add operation IDs, specific path parameter names, and `Location` headers for created resources while preserving moved-resource response semantics for renamed resources.

Updates #3144