### PR TITLE
docs: add XBuilder Account product architecture

### DIFF
--- a/docs/product/account.md
+++ b/docs/product/account.md
@@ -1,0 +1,737 @@
+# XBuilder Account
+
+XBuilder Account is XBuilder's first-party account system. It is responsible for account principals, third-party
+identity binding, sign-in methods, account sessions, first-party app SSO, the account management module in XBuilder
+Admin Console, and the account foundation after migrating from Casdoor.
+
+This document defines the product and system boundary of XBuilder Account. It describes the target state after
+migration. It does not describe the current Casdoor runtime implementation, the final database schema, the complete
+OpenAPI contract, or concrete implementation tasks.
+
+## Background and goals
+
+XBuilder currently depends on our own Casdoor fork for account sign-in and token issuance. This fork has diverged
+significantly from upstream Casdoor and includes substantial XBuilder-specific sign-in behavior.
+
+The goal of XBuilder Account is to replace Casdoor and become XBuilder's own account and identity foundation. It is not
+a generic Auth0-style or Casdoor-style multi-tenant identity platform. It is also not a public third-party app platform
+for arbitrary external developers.
+
+Goals include:
+
+- Remove the runtime dependency on Casdoor
+- Use the existing `user` as the account principal
+- Support third-party identity sign-in
+- Support users with no password and only third-party identities
+- Support admin-created users
+- Support admins setting or clearing password credentials for users
+- Support username and password sign-in for users with admin-managed passwords
+- Support account session management required by hosted sign-in and SSO
+- Support XBuilder first-party sibling apps sharing the XBuilder account identity
+- Support platform-managed apps for first-party app SSO
+- Support first-party apps integrating product APIs through Account-issued token model or App-owned session model
+- Support the XBuilder Account management module and write account-related admin actions to admin audit logs
+
+Non-goals include:
+
+- Public username and password registration for regular users
+- Regular users setting or resetting passwords by themselves
+- A generic multi-tenant identity platform
+- An arbitrary public third-party app platform
+- App self-service registration
+- Managing XBuilder or sibling app product authorization data such as roles, plans, capabilities, quotas, memberships,
+  and seats
+- User deletion or user status management
+- Preserving Casdoor user IDs, groups, or other Casdoor concepts in the new runtime model
+
+## Core concepts
+
+| Concept | Meaning |
+| - | - |
+| `user` | XBuilder account principal. It reuses the existing user model, with field ownership split by Account and product boundaries |
+| `identity_provider` | Third-party identity provider in platform configuration, such as GitHub, Google, or Apple |
+| `user_identity` | Third-party identity bound to a `user` |
+| `user_password_credential` | Optional admin-managed password credential |
+| `user_session` | Account session owned by XBuilder Account for hosted sign-in and SSO continuity |
+| `app` | Platform-managed OAuth client configuration for first-party app SSO |
+| `app_secret` | OAuth client credential used by confidential apps in backend token exchange |
+| `app_grant` | Authorization relationship for a `user` to let an `app` access XBuilder Account |
+| `auth_flow` | Short-lived temporary state maintained by XBuilder Account in third-party callbacks, provider credential handoff, and OAuth authorization code flow, such as provider redirect state, pushed authorization request, authorization code, PKCE challenge, and one-time provider code consumption records |
+| `audit_log` | Audit log for XBuilder Admin management actions and security-related events |
+
+`app` is the product and management resource name. The OAuth protocol layer still uses the standard client concept and
+standard parameter names, such as `client_id`, `client_secret`, `redirect_uri`, `request_uri`, `code`, and `grant_type`.
+
+XBuilder Account can reuse the existing `user` table, but the account system boundary is not the same as the physical
+table boundary. Account API only exposes user fields owned by the account system, such as `id`, `username`,
+`displayName`, and `avatar`. Writable fields are defined by concrete endpoints. `description`, `roles`, `plan`,
+`capabilities`, statistics fields, and product fields belong to the XBuilder product or authorization system. They are
+not exposed or managed by XBuilder Account API.
+
+`auth_flow` is a logical concept. It only defines lifecycle and security semantics, and it does not constrain physical
+storage. Provider redirect state, pushed authorization request, authorization code, PKCE challenge, and provider code
+consumption records must all be short-lived. One-time state must be single-use. Failed provider callbacks, failed token
+exchanges, or repeated submissions must not leave valid replayable state behind.
+
+## System boundary
+
+```mermaid
+flowchart LR
+    subgraph Products["XBuilder products"]
+        XBuilder["xbuilder.com"]
+        XBuilderBackend["api.xbuilder.com"]
+        AdminConsole["XBuilder Admin Console<br/>xbuilder.com/admin/"]
+        SiblingApp["Sibling app"]
+        AppBackend["Sibling app backend"]
+    end
+
+    subgraph AccountBoundary["XBuilder Account boundary"]
+        AccountWeb["Account Web<br/>account.xbuilder.com"]
+        AccountAPI["Account API<br/>api.xbuilder.com/account/*"]
+    end
+
+    subgraph ProductAuthz["Product authorization"]
+        Authorization["XBuilder Authorization"]
+    end
+
+    Provider["External identity provider"]
+
+    XBuilder -->|hosted sign-in| AccountWeb
+    SiblingApp -->|hosted sign-in| AccountWeb
+    AccountWeb -->|same-origin facade<br/>/api/*| AccountAPI
+    XBuilder -->|product requests| XBuilderBackend
+    SiblingApp -->|product requests| AppBackend
+    XBuilderBackend -->|Account API| AccountAPI
+    AppBackend -->|Account API| AccountAPI
+    AccountAPI -->|provider verification| Provider
+    AdminConsole -->|account management| AccountAPI
+    AdminConsole -->|roles and plans management| Authorization
+    XBuilderBackend -->|roles and plans| Authorization
+    Authorization -.->|references stable user.id| AccountAPI
+
+    AccountAPI -.->|does not own product authorization| Authorization
+```
+
+## User sign-in behavior
+
+Regular users cannot publicly register username and password accounts.
+
+Regular users sign in through third-party identities by default. The first batch of third-party identity providers
+includes:
+
+- `wechat`
+- `qq`
+- `github`
+- `apple`
+- `google`
+- `x`
+
+Admins can create users. Admins can also set or clear passwords for users. Only users with an admin-managed password can
+sign in with username and password.
+
+User sign-in methods include third-party identities and admin-managed password credentials. Admins can remove any
+third-party identity and can also clear password credentials. After removal, a user may have no sign-in methods. The
+account still exists, but the user cannot sign in again until an admin sets a password credential again.
+
+Removing sign-in methods does not automatically revoke existing account sessions. Revoking existing account sessions is
+a separate management action.
+
+## Third-party identities
+
+Third-party identities must be matched by stable subject identifiers provided by providers. They must not be matched by
+provider-returned email or username. For shared account identity across first-party apps, prefer provider subjects that
+are stable across apps.
+
+Examples of stable subject identifiers:
+
+| Provider | Stable subject identifier |
+| - | - |
+| WeChat | `unionid` |
+| QQ | `unionid` |
+| GitHub | numeric user ID |
+| Apple | `sub` |
+| Google | `sub` |
+| X | user ID |
+
+Apple should be handled as an OIDC-style provider. Account binding must use Apple's stable `sub`, not the email returned
+by Apple, because users may use private relay email.
+
+WeChat and QQ `unionid` availability depends on provider configuration, app binding relationships, and authorization
+results. `openid` is a provider app or client scoped identifier. It can only be stored as an auxiliary identifier and
+must not be used as the principal subject for unified account identity across first-party apps. If `openid` is stored,
+the corresponding subject namespace must also be stored.
+
+If a WeChat or QQ sign-in result does not contain `unionid`, XBuilder Account should not silently create a cross-app
+account identity from `openid`. Account creation should rely on a verified stable subject across apps. A provider-scoped
+identity may only be linked through a user-confirmed account-linking flow.
+
+`user_identity` should store the provider, stable provider subject, subject namespace when needed, and the linked
+`user.id`. Limited display metadata such as provider username, display name, and avatar may be stored for display and
+troubleshooting. It must not be treated as the authoritative source for XBuilder account fields.
+
+Provider access tokens and refresh tokens should not be persisted. Full raw profile payloads should not be persisted.
+XBuilder Account should not act as a token vault for third-party API integrations. Product capabilities that need access
+to provider APIs should model, authorize, and store their own provider tokens separately.
+
+Third-party identity provider configuration should be managed by deployment configuration or server-controlled
+configuration. It is not part of the XBuilder Admin Console management scope.
+
+## First-party apps
+
+In this document, first-party apps are apps registered and managed by the XBuilder platform. `xbuilder.com` should be
+treated as a first-party app using XBuilder Account, not as the account system itself. Sibling apps under
+`*.xbuilder.com` should also be supported as first-party apps.
+
+These apps are platform-managed OAuth client configurations. They define redirect URI allowlists, allowed origins,
+client type, status, and credentials required by first-party app SSO.
+
+First-party apps share the same XBuilder account identity, but product authorization is managed by each app or by the
+corresponding product authorization system. XBuilder Account is responsible only for the account and SSO boundary, such
+as account existence, app status, redirect URI allowlists, credential checks, and token or code validity. App roles,
+memberships, workspaces, seats, and product permissions are product authorization concerns. They are not managed by
+XBuilder Account and are not contract fields for first-party app SSO.
+
+First-party app product API integration supports two models:
+
+- Account-issued token model: the app uses an app-scoped OAuth token issued by XBuilder Account as its product API
+  Bearer token. The app backend validates the token through token introspection and can read stable account identity
+  from Account API
+- App-owned session model: the app backend obtains stable `user.id` through XBuilder Account SSO, then creates,
+  validates, refreshes, and revokes its own app session
+
+Account-issued token model is suitable for apps that do not want to maintain their own session state and whose product
+requests all happen in user request paths. In this model, the app frontend may hold the Account-issued app-scoped OAuth
+token. The app backend should treat that token as the product API credential for the app, validate it on product
+requests, extract stable `user.id`, and then apply its own product authorization logic. Sibling apps can transparently
+forward OAuth endpoints through their own backend, so the frontend faces same-origin `/oauth/*` instead of directly
+calling `api.xbuilder.com/account/oauth/*`.
+
+When an app backend accepts Account-issued app-scoped OAuth tokens as product API credentials, it must verify that the
+token is bound to the current app. Product permissions are still determined by the app or the corresponding product
+authorization system. They are not expressed by XBuilder Account OAuth scopes.
+
+App-owned session model is suitable for apps that are independently deployed or operated, need backend-side access to
+XBuilder Account on behalf of users, need to define their own session refresh, logout, or revocation semantics, or do
+not want product requests to depend on XBuilder Account token validation. App sessions reference stable `user.id` and
+carry the app's own authorization context. They are not independent accounts and are not sessions managed by XBuilder
+Account. XBuilder Account does not store or revoke app sessions.
+
+Regardless of the model, product authorization for first-party apps is still owned by the app or the corresponding
+product authorization system. Account sessions, Account-issued app-scoped OAuth tokens, and app sessions should not
+encode roles, memberships, workspaces, seats, or product permissions.
+
+First-party app SSO should use OAuth 2.0 authorization code flow. The user-facing hosted sign-in entry is
+`account.xbuilder.com/sign-in`, not XBuilder Account API. First-party app frontends can enter this page through their
+own OAuth facade. Hosted sign-in handles account resolution, user creation, third-party identity binding, and app
+callback. It can also host interactions such as profile completion, account-linking confirmation, and identity conflict
+handling.
+
+Public and confidential apps must both use PKCE in authorization code flow. Public apps do not rely on app secrets.
+Confidential apps may also use app secrets as OAuth client credentials for backend token exchange. Secret values should
+only be returned when they are created.
+
+After sibling app frontends finish sign-in, they should only call their own backends. They should not rely on XBuilder
+Account APIs for ordinary product requests. Sibling apps should use `user.id` as the stable account reference. Mutable
+account fields such as `username`, `displayName`, and `avatar` may be cached by sibling apps for display, but XBuilder
+Account remains the authoritative source for these fields.
+
+## Sign-in integration model
+
+XBuilder Account provides unified hosted sign-in at `account.xbuilder.com/sign-in`. Hosted sign-in uses
+`account.xbuilder.com/api/*` as a same-origin API facade. The facade forwards to `api.xbuilder.com/account/*`. For
+example, `account.xbuilder.com/api/user` maps to `api.xbuilder.com/account/user`, and
+`account.xbuilder.com/api/oauth/token` maps to `api.xbuilder.com/account/oauth/token`. `api.xbuilder.com/account/*` is
+the authoritative XBuilder Account API entry point.
+
+`account.xbuilder.com/api/*` is the same-origin integration layer for Account Web. It is not a security boundary.
+Account API should not relax authentication or authorization because a request came through the facade. The facade
+mainly serves Account API requests from Account Web. It does not change the semantics of OAuth, Bearer token, or account
+session cookie authentication.
+
+```mermaid
+flowchart LR
+    App["App frontend"]
+    AppBackend["App backend"]
+    AccountWeb["Account Web<br/>account.xbuilder.com/sign-in"]
+    AccountFacade["Account Web API facade<br/>account.xbuilder.com/api/*"]
+    AccountAPI["Account API<br/>api.xbuilder.com/account/*"]
+    Provider["External identity provider"]
+
+    App -->|open hosted sign-in| AccountWeb
+    AccountWeb -->|same-origin API calls| AccountFacade
+    AccountFacade -->|forwards| AccountAPI
+    AccountAPI -->|provider authorize| Provider
+    Provider -->|provider callback| AccountAPI
+    AccountWeb -->|app callback| App
+    App -->|product requests| AppBackend
+    AppBackend -->|Account API calls| AccountAPI
+```
+
+Ordinary Web apps and native iOS or Android apps can both use hosted sign-in. Native apps should enter
+`account.xbuilder.com/sign-in` through the system browser or system authentication session, such as
+`ASWebAuthenticationSession` or Chrome Custom Tabs. They should not use embedded WebView.
+
+Provider credential acquisition has two ways:
+
+- Hosted provider acquisition: hosted sign-in redirects the user to the provider authorize page and obtains the provider
+  credential through the provider callback
+- Provider credential handoff: the client passes a short-lived provider code obtained beforehand to hosted sign-in for
+  consumption
+
+Provider credential handoff is suitable for WeChat Mini Program `wx.login()` codes, Apple authorization codes, Google
+server auth codes, and similar cases. The client can pass the credential to XBuilder Account through PAR extension
+parameters such as `xbuilder_provider` and `xbuilder_provider_code`. This only replaces the upstream provider web
+authorize stage. It does not replace the XBuilder Account sign-in flow. Regardless of whether the credential comes from
+hosted provider acquisition or handoff, XBuilder Account should use the same account resolution, user creation, and
+third-party identity binding logic. If profile completion, account-linking confirmation, or identity conflict handling
+is required, these interactions should happen inside hosted sign-in.
+
+Provider credential handoff errors should be returned through the PAR or authorize flow as OAuth errors. Expired,
+consumed, provider-mismatched, or unknown provider codes must not produce usable `request_uri` values. XBuilder Account
+must consume provider codes atomically with recording consumption state to avoid reusing the same provider code.
+
+## OAuth and product API integration
+
+XBuilder Account OAuth endpoints live under `api.xbuilder.com/account/oauth/*`. They only host OAuth and OAuth RFC
+extension protocol endpoints, and issue Account-issued app-scoped OAuth tokens. The token subject is stable `user.id`,
+and the token client is the concrete `app`. This document only defines the `account:user:read` Account API scope, which
+allows app backends to access `GET /account/user` with an Account-issued app-scoped OAuth token. This scope does not
+express product authorization state or any app's product API permissions.
+
+Account-issued app-scoped OAuth tokens can be used as product API credentials for the corresponding app. Whether a
+product API accepts the token depends on the app bound to the token and the authentication policy of the product
+backend. Product APIs must verify the token client/app and must not only check token active status.
+
+The two models share the same frontend-facing OAuth flow. The app frontend faces the app backend's OAuth facade. The app
+backend can transparently forward XBuilder Account's OAuth token response, or it can convert the Account token response
+into an app-owned session in its own `/oauth/token`. The flow is:
+
+```mermaid
+sequenceDiagram
+    participant App as App frontend
+    participant Backend as App backend
+    participant UserAgent as Browser / system auth session
+    participant AccountWeb as Account Web
+    participant AccountAPI as XBuilder Account API
+
+    App->>Backend: POST /oauth/par with PKCE challenge
+    Backend->>AccountAPI: Forward PAR request
+    AccountAPI-->>Backend: Return request_uri
+    Backend-->>App: Return request_uri
+    App->>UserAgent: Open app /oauth/authorize with request_uri
+    UserAgent->>Backend: GET /oauth/authorize facade
+    Backend-->>UserAgent: Redirect to Account hosted sign-in
+    UserAgent->>AccountWeb: Complete hosted sign-in
+    AccountWeb->>AccountAPI: Resolve account and app authorization
+    AccountAPI-->>AccountWeb: Return callback URL with authorization code
+    AccountWeb->>UserAgent: Redirect to app callback
+    UserAgent->>App: Deliver authorization code and state
+    App->>Backend: POST /oauth/token with code and PKCE verifier
+    Backend->>AccountAPI: Exchange code with PKCE verifier and client credentials when confidential
+    AccountAPI-->>Backend: Return Account-issued app-scoped OAuth tokens
+    alt Account-issued token model
+        Backend-->>App: Return Account-issued app-scoped OAuth tokens
+        App->>Backend: Product request with Bearer Account access token
+        Backend->>AccountAPI: POST /account/oauth/introspect
+        AccountAPI-->>Backend: Return token metadata
+    else App-owned session model
+        Backend->>Backend: Store XBuilder Account grant and token state, then create app session
+        Backend-->>App: Return app-issued session tokens
+        App->>Backend: Product request with Bearer app access token
+        Backend->>Backend: Validate app session
+    end
+    Backend->>AccountAPI: GET /account/user when account fields are needed
+    AccountAPI-->>Backend: Return account user
+```
+
+In Account-issued token model, the app backend does not maintain XBuilder Account token state for that user. It can use
+its own `/oauth/*` as a transparent OAuth facade forwarding to `api.xbuilder.com/account/oauth/*`. The app frontend
+still receives Account-issued app-scoped OAuth tokens. When receiving product requests, the app backend should use
+`/account/oauth/introspect` to validate the token and verify that the token is bound to the current app. When account
+fields are needed, the app backend can use `GET /account/user` to fetch the minimum account user fields if the token has
+the `account:user:read` scope. Third-party identities and account session management are not part of the default Account
+API surface for app-scoped OAuth tokens.
+
+`xbuilder.com` can also use Account-issued token model. For XBuilder product APIs, the token client/app should be
+`xbuilder`. After `api.xbuilder.com` accepts the token, it should use XBuilder Authorization and resource rules to
+determine product permissions for projects, assets, courses, AI interaction, and other resources. These product
+permissions must not be expressed by `account:user:read`.
+
+In App-owned session model, the app backend can expose a standard OAuth facade to its own frontend, such as its own
+`/oauth/authorize`, `/oauth/token`, and `/oauth/revoke`. This facade is not XBuilder Account API and should not be
+written into the XBuilder Account OpenAPI. The authorization code received by the app frontend in the callback is
+generated by XBuilder Account, but the frontend only treats it as an opaque code submitted to the app backend's
+`/oauth/token`. In `/oauth/token`, the app backend uses this code, the PKCE verifier, and necessary client credentials
+to complete token exchange with XBuilder Account. It then stores the XBuilder Account grant state and token state needed
+to access Account API on behalf of the user, creates its own app session, and returns app-issued session tokens to the
+frontend. The app frontend does not touch Account-issued app-scoped OAuth tokens. This keeps the frontend responsible
+only for the standard OAuth flow.
+
+`app_grant` is the record that a `user` has authorized an `app` to access XBuilder Account. OAuth authorization code
+exchange can create or reuse `app_grant`. Account-issued app-scoped OAuth tokens are associated with `app_grant`.
+`app_grant` is used for auditing, revocation, and backend access to Account API on behalf of the user. It is not the
+same as app session.
+
+## Token and session strategy
+
+XBuilder Account uses opaque tokens.
+
+Account session tokens, authorization codes, Account-issued app-scoped OAuth tokens, and refresh tokens should all be
+high-entropy random secrets. Token values do not encode user fields, product authorization state, or other mutable
+business state.
+
+XBuilder Account does not issue JWTs. User identity and mutable account state are resolved through server-side state and
+account APIs.
+
+Hosted sign-in uses a `__Host-` prefixed cookie on `account.xbuilder.com` to maintain account session. The cookie must
+set `HttpOnly`, `Secure`, `SameSite=Lax`, and `Path=/`, and must not set `Domain`. Account session is used to maintain
+sign-in page state and SSO continuation. It is not exposed to app frontends and is not a product API credential.
+
+Product API requests use server-revocable opaque credentials. Account-issued token model uses app-scoped OAuth tokens
+issued by XBuilder Account. App-owned session model uses session credentials owned by the app backend, usually app
+access tokens and app refresh tokens.
+
+Each app defines how its product API credentials are transmitted. Bearer access token is the recommended default.
+Product API credentials must not be passed through URLs, `postMessage`, or untrusted iframes.
+
+Access tokens should be short-lived, server-revocable, and should not encode user fields or product authorization state.
+Refresh tokens are used to update short-lived access tokens or continue sessions. They should live longer than access
+tokens, must be hashed on the server, and must be rotated after each use. If a rotated refresh token appears again, it
+should be treated as a replay risk signal and revoke the corresponding token family or grant.
+
+If app frontends need to store product API tokens, storage should be limited to browser storage or platform storage
+scoped to the current app.
+
+App frontends should refresh access tokens before they are close to expiration and should not rely only on refreshing
+after a 401. If a product request returns 401, the app frontend should refresh and retry the original request at most
+once. Concurrent refresh attempts in the same frontend runtime must be merged. When multiple Web tabs share the same
+sign-in state, they should coordinate which tab performs refresh and sync token updates through `BroadcastChannel` or
+`storage` events to avoid concurrent use of the same rotating refresh token. If refresh fails, the app frontend should
+clear local product API tokens and the current user cache, then enter hosted sign-in again.
+
+OAuth token revocation is used to revoke Account-issued app-scoped OAuth tokens or refresh tokens. `app_grant` validity
+is determined by the related token family and app status. When `app_grant` needs to be revoked, the refresh token family
+and active access tokens under that grant should be revoked, or the corresponding app should be disabled. Revoking
+account session affects hosted sign-in and SSO continuity. Logout, refresh, and revocation for App-owned session model
+are owned by each app backend.
+
+## Key flows
+
+### Third-party identity hosted sign-in completion flow
+
+1. XBuilder Account verifies the provider credential and uses the stable provider subject to find or create
+   `user_identity` and the linked `user`
+2. If profile completion, account-linking confirmation, or identity conflict handling is needed, XBuilder Account
+   completes these steps in the hosted sign-in page
+3. XBuilder Account creates or reuses account session
+4. XBuilder Account returns authorization code and OAuth state to the app callback according to the OAuth authorization
+   request
+5. App frontend submits the authorization code and PKCE verifier to the app backend's OAuth token endpoint
+6. App backend uses these parameters, with client credentials for confidential apps, to complete token exchange with
+   XBuilder Account
+7. In Account-issued token model, app backend returns Account-issued app-scoped OAuth tokens to the frontend. App
+   backend validates the token through token introspection and obtains stable `user.id`. When account fields are needed,
+   it can call `GET /account/user`
+8. In App-owned session model, app backend stores the XBuilder Account grant state and token state needed to access
+   Account API on behalf of the user, creates its own app session, and returns app-issued session tokens to the
+   frontend
+
+### Username and password sign-in
+
+1. The user submits username and password
+2. XBuilder Account validates only admin-managed `user_password_credential`
+3. If validation succeeds, account session is created
+4. Users without an admin-managed password cannot sign in with username and password
+
+### Account session lifecycle
+
+1. Hosted sign-in can keep valid account session within `account.xbuilder.com` and update session state when needed
+2. Logout ends the current account session
+3. Users or admins can revoke a specified account session or all account sessions for a user
+4. Revoking account session affects hosted sign-in and subsequent SSO. It does not by default revoke Account-issued
+   app-scoped OAuth tokens or app sessions
+
+## Admin console and admin permissions
+
+`xbuilder.com/admin/` is XBuilder Admin Console, not a frontend dedicated to XBuilder Account. It can host XBuilder
+Account, XBuilder Authorization, assets, courses, and other product management modules.
+
+The XBuilder Account admin permission is identified as `accountAdmin`.
+
+`accountAdmin` grants access to the XBuilder Account management module. It covers user management, admin-managed
+password management, viewing and removing third-party identities, revoking account sessions, app management, and app
+secret management.
+
+The XBuilder Authorization admin permission is identified as `authorizationAdmin`.
+
+`authorizationAdmin` grants access to the XBuilder Authorization management module. It covers authorization inputs and
+derived results such as user roles, plan, derived capabilities, and quota policies.
+
+Granting and checking `accountAdmin` and `authorizationAdmin` belong to the management scope of XBuilder Authorization.
+`accountAdmin` does not manage XBuilder product authorization data such as roles, plans, capabilities, or quotas. Admins
+who need to manage both the account system and the authorization system should have both `accountAdmin` and
+`authorizationAdmin`.
+
+Initial admin grants should be completed through deployment configuration, migration scripts, or operations commands
+that are only available during initialization. When XBuilder Authorization is unavailable or permission checks cannot be
+completed, Admin APIs must not allow requests.
+
+Admin audit logs record management actions and security-related events from account, authorization, and other management
+modules. Viewing audit logs is not part of the XBuilder Account management module itself. The XBuilder Admin API should
+control visible audit event scope according to admin permissions.
+
+The XBuilder Account management module should at least include these product capabilities:
+
+- View user lists and user details
+- Create users
+- Set or clear admin-managed passwords
+- View and remove user third-party identities
+- View and revoke user account sessions
+- Manage apps, including viewing, creating, updating, enabling, and disabling apps
+- Create and delete app secrets
+
+XBuilder product authorization data may appear in the same XBuilder Admin Console and on the same user detail page, but
+it does not belong to XBuilder Account.
+
+`/admin/account/*` endpoints should require `accountAdmin`. `/admin/authorization/*` endpoints should require
+`authorizationAdmin`.
+
+`/admin/audit-logs` endpoints should require admin permissions, and backend RBAC should determine the visible audit
+event scope.
+
+The admin console frontend can live in the open-source frontend repository and be deployed at `xbuilder.com/admin/`.
+
+Admin APIs should not be exposed as unrestricted public interfaces. `api.xbuilder.com/admin/*` should be restricted at
+the ingress layer and still protected by backend RBAC and audit logging.
+
+The main frontend can show an Admin Console entry in the user menu when the user has admin permissions.
+
+## API boundary
+
+This section only describes API boundaries. Concrete contracts should be defined in `docs/openapi.yaml` when endpoints
+are implemented.
+
+### Account identity provider endpoints
+
+```http
+GET  /account/identity-providers
+GET  /account/identity-providers/{provider}/authorize
+GET  /account/identity-providers/{provider}/callback
+POST /account/identity-providers/{provider}/callback
+```
+
+- These endpoints are provided by XBuilder Account backend and are mainly used by `account.xbuilder.com/sign-in`
+- `GET /account/identity-providers` returns identity providers available for hosted sign-in according to app context
+- `GET /account/identity-providers/{provider}/authorize` is used for provider redirect when hosted sign-in did not
+  receive a provider code through provider credential handoff
+- Provider callback needs to support both GET and POST because the concrete HTTP method depends on provider response
+  mode. For example, Sign in with Apple's `form_post` scenario uses POST callback
+- Provider callback should rely on provider redirect state for callback correlation and CSRF protection. It should not
+  apply ordinary frontend CSRF token checks
+
+### Account OAuth endpoints
+
+```http
+POST /account/oauth/par
+GET  /account/oauth/authorize
+POST /account/oauth/token
+POST /account/oauth/introspect
+POST /account/oauth/revoke
+```
+
+- OAuth protocol parameters should use standard names, such as `client_id`, `redirect_uri`, `request_uri`, `state`,
+  `code`, `grant_type`, `code_challenge`, and `code_verifier`
+- Confidential clients use `client_secret_basic` authentication
+- Public clients use `client_id` in token exchange, revocation, or other requests that need client identification
+- `POST /account/oauth/par` creates pushed authorization requests and can carry provider credential handoff through
+  `xbuilder_provider` and `xbuilder_provider_code`. Its returned `request_uri` is an opaque, short-lived, single-use
+  reference, not a dereferenceable URL
+- `GET /account/oauth/authorize` is a PAR-only OAuth authorization endpoint. It only accepts `client_id` and
+  `request_uri`. Authorization request parameters such as `response_type`, `redirect_uri`, `scope`, `state`, and
+  `code_challenge` must be submitted through `POST /account/oauth/par` first
+- `POST /account/oauth/token` is used for authorization code exchange and refresh token exchange
+- `POST /account/oauth/introspect` is an RFC 7662 token introspection endpoint and is only callable by authenticated app
+  backends
+- `POST /account/oauth/revoke` revokes Account-issued app-scoped OAuth tokens or refresh tokens
+
+### Current account endpoints
+
+```http
+GET    /account/user
+PATCH  /account/user
+GET    /account/user/identities
+
+POST   /account/session
+GET    /account/session
+DELETE /account/session
+GET    /account/sessions
+DELETE /account/sessions
+DELETE /account/sessions/{sessionID}
+```
+
+- `GET /account/user` returns user fields owned by the current account system. Account Web can access it with account
+  session cookie. App backends can access it with an Account-issued app-scoped OAuth token that has `account:user:read`
+  scope
+- `PATCH /account/user` only allows Account Web access with account session cookie, and updates writable account fields
+- `GET /account/user` and `PATCH /account/user` do not expose or update XBuilder product fields such as `description`
+- `GET /account/user/identities` returns the current user's third-party identities
+- `account:user:read` only authorizes `GET /account/user`. It does not authorize `GET /account/user/identities`, account
+  session endpoints, mutation endpoints, or admin endpoints
+- `POST /account/session` is called by Account Web to submit sign-in credentials. The backend validates the credentials
+  before creating the current account session
+- `GET /account/session` and `DELETE /account/session` manage the current account session used by hosted sign-in
+- `GET /account/sessions`, `DELETE /account/sessions`, and `DELETE /account/sessions/{sessionID}` manage the current
+  user's account sessions
+
+### XBuilder Account admin endpoints
+
+```http
+GET    /admin/account/users
+POST   /admin/account/users
+GET    /admin/account/users/{userID}
+PATCH  /admin/account/users/{userID}
+
+PUT    /admin/account/users/{userID}/password
+DELETE /admin/account/users/{userID}/password
+
+GET    /admin/account/users/{userID}/identities
+DELETE /admin/account/users/{userID}/identities/{identityID}
+
+GET    /admin/account/users/{userID}/sessions
+DELETE /admin/account/users/{userID}/sessions
+DELETE /admin/account/sessions/{sessionID}
+
+GET    /admin/account/apps
+POST   /admin/account/apps
+GET    /admin/account/apps/{appID}
+PATCH  /admin/account/apps/{appID}
+PUT    /admin/account/apps/{appID}/status
+
+GET    /admin/account/apps/{appID}/secrets
+POST   /admin/account/apps/{appID}/secrets
+DELETE /admin/account/apps/{appID}/secrets/{secretID}
+```
+
+- Apps do not provide `DELETE` deletion semantics. When an app needs to be taken offline, update app status to preserve
+  audit, historical authorization, and token association context
+
+### XBuilder Authorization admin endpoints
+
+```http
+GET   /admin/authorization/users/{userID}
+PATCH /admin/authorization/users/{userID}
+```
+
+- These authorization endpoints share the XBuilder Admin API namespace, but they are not XBuilder Account APIs
+- They manage the authorization inputs for a user in XBuilder Authorization
+- Writable fields are `roles` and `plan`
+- `capabilities` and quota policies are derived by XBuilder Authorization and should remain read-only
+
+### Admin audit endpoints
+
+```http
+GET /admin/audit-logs
+```
+
+- These endpoints share the XBuilder Admin API namespace, but they are not XBuilder Account APIs
+- They can contain audit events produced by account, authorization, and other management modules
+
+## Relationship with authorization system
+
+XBuilder Account is responsible for authentication, account identity, account session, and first-party app SSO. It is
+not responsible for centrally managing product authorization for each first-party app.
+
+XBuilder product roles, plans, capabilities, quotas, memberships, seats, and other product permissions still belong to
+the product authorization system. Sibling apps should also have their own authorization models. XBuilder Account can
+provide stable `user.id` values to these systems, but it does not manage this product authorization data or carry
+mutable authorization state in Account-issued app-scoped OAuth tokens.
+
+## Security boundary
+
+The admin console frontend is not a security boundary. Loading the admin console page in a browser does not mean the
+user has admin permissions. Admin APIs must be protected by backend RBAC and audit logs. Ingress restrictions can reduce
+exposure, but they cannot replace backend permission checks.
+
+Session tokens, refresh tokens, authorization codes, app secrets, and other security credentials must all have
+sufficient entropy. `request_uri` should be unguessable, short-lived, single-use, and bound to app. `authorization code`
+should be short-lived, single-use, and bound to app, redirect URI, and PKCE. Authorization response must return the
+original OAuth state for app validation. App secret values should only be returned when they are created.
+
+XBuilder Account must perform exact string matching on the redirect URI allowlist. Prefix, wildcard, or path prefix
+matching is forbidden. Token exchange must verify PKCE. Apps must validate OAuth state and authorization request.
+Provider identity linking must be based on stable provider subject and must not rely on email, username, or display
+fields.
+
+When app backends accept Account-issued app-scoped OAuth tokens as product API credentials, they must verify token
+active status, token subject, and token client/app. Product API credentials must not be shared across apps.
+
+Account session is only used for hosted sign-in and SSO continuity. It should not be passed through URLs, `postMessage`,
+or untrusted iframes, and should not be directly read or persisted by app frontends. Mutation endpoints authenticated by
+Account Web cookies should validate `Origin` or use equivalent CSRF protection.
+
+`account:user:read` only authorizes access to `GET /account/user`. It does not authorize third-party identity
+management, account session management, account field updates, or admin capabilities. These operations should be handled
+by Account Web with cookie authentication or by Admin API.
+
+When native iOS or Android apps host sign-in, they should use the system browser or system authentication session, such
+as `ASWebAuthenticationSession` or Chrome Custom Tabs. They should not use embedded WebView. Restricted runtimes such as
+WeChat Mini Programs can use provider credential handoff to pass short-lived provider codes to hosted sign-in. They
+should not pass long-lived tokens through URLs or `postMessage`.
+
+Provider credential handoff only allows short-lived, one-time, immediately consumable authorization-code-like provider
+credentials. Allowed examples include WeChat Mini Program `wx.login()` code, Apple authorization code, and Google server
+auth code. Provider access tokens, provider refresh tokens, ID tokens, `session_key`, account session tokens, app access
+tokens, app refresh tokens, app secrets, or other long-lived secrets should not be passed through provider credential
+handoff. After reading a provider code, XBuilder Account should immediately consume it and should not persist or return
+it to the frontend.
+
+## Migration direction
+
+Migration should be one-time, not long-term dual-write or gradual switching.
+
+Casdoor should only be used as the migration data source for migrating users, identities, password credential
+information, and existing XBuilder product authorization data.
+
+If historical WeChat or QQ identities only have `openid` and no `unionid`, migration must not use them for automatic
+cross-app merging. Such records can only be migrated as provider-scoped identities with subject namespace to the
+originally linked user, or become cross-app principal identities after `unionid` is filled before migration.
+
+Existing roles and plans in XBuilder product authorization data should be handled in the same migration. After
+migration, this data should be managed by XBuilder Authorization. It should not be managed by XBuilder Account or become
+contract fields for first-party app SSO.
+
+After migration, the runtime must no longer depend on Casdoor.
+
+Casdoor-derived identity identifiers should only be used as one-time migration mapping keys. They should not remain part
+of the runtime account model.
+
+After frontend migration, the frontend should no longer depend on Casdoor SDKs, Casdoor JWTs, or decoding username from
+tokens. `spx-gui` can keep the Bearer request model, but the Bearer value should be replaced with a product API token.
+
+## Glossary
+
+| Term | Meaning |
+| - | - |
+| XBuilder Account | XBuilder's first-party account system |
+| Account Web | Hosted sign-in and account-related Web UI on `account.xbuilder.com` |
+| Account API | XBuilder Account API on `api.xbuilder.com/account/*` |
+| OAuth client | OAuth client role. In this product context, it corresponds to `app` |
+| OAuth facade | OAuth-compatible endpoints exposed by an app backend to its own frontend, then internally integrated with XBuilder Account |
+| Hosted sign-in | Unified sign-in entry provided by `account.xbuilder.com/sign-in`. It hosts third-party identity sign-in, admin-managed password sign-in, provider credential handoff, profile completion, account-linking confirmation, identity conflict handling, and app callback |
+| Hosted provider acquisition | Hosted sign-in obtains provider credential through provider web authorize and callback |
+| Provider credential handoff | The client passes a short-lived provider code to hosted sign-in for consumption |
+| Hosted interaction | Profile completion, account-linking confirmation, or identity conflict handling in XBuilder Account hosted sign-in |
+| Account session | Account session owned by XBuilder Account for hosted sign-in and SSO continuity |
+| Account-issued app-scoped OAuth token | Opaque OAuth token issued by XBuilder Account to a concrete app. It can be used as the app's product API Bearer token |
+| Account-issued token model | Model where a first-party app directly uses Account-issued app-scoped OAuth token as product API credential |
+| App-owned session model | Model where a first-party app backend creates, refreshes, validates, and revokes app session itself |
+| App grant | Authorization relationship for a `user` to let an `app` access XBuilder Account |
+| `account:user:read` | Account API scope allowing Account-issued OAuth tokens to access `GET /account/user` |
+| Opaque token | Random token that encodes no business semantics and must be resolved by the server |
+| Token introspection | RFC 7662 token validation protocol for querying opaque token validity and metadata |
+| Authorization code | Short-lived one-time code returned to the app after first-party app SSO completes |
+| PKCE | Proof Key for Code Exchange |
+| PAR | Pushed Authorization Requests |
+| OIDC | OpenID Connect |
+| SSO | Single Sign-On |
+| RBAC | Role-Based Access Control |

--- a/docs/product/account.zh.md
+++ b/docs/product/account.zh.md
@@ -1,0 +1,531 @@
+# XBuilder Account
+
+XBuilder Account 是 XBuilder 的自有账号系统。它负责账号主体、第三方身份绑定、登录方式、account session、自有 app SSO、XBuilder Admin Console 中的账号管理模块，以及从 Casdoor 迁移后的账号基础能力。
+
+本文档定义 XBuilder Account 的产品与系统边界。它描述迁移完成后的目标状态，不描述当前 Casdoor 运行时实现，也不定义最终数据库 schema、完整 OpenAPI 契约或具体实现任务。
+
+## 背景与目标
+
+XBuilder 当前依赖我们自己的 Casdoor fork 提供账号登录和 token 签发。这个 fork 已经与上游 Casdoor 明显分叉，并包含较多 XBuilder 专用登录行为。
+
+XBuilder Account 的目标是替换 Casdoor，成为 XBuilder 产品自己的账号与身份基础设施。它不是一个通用 Auth0 或 Casdoor 风格的多租户身份平台，也不是面向任意第三方开发者开放的公开第三方 app 平台。
+
+目标包括：
+
+- 移除运行时对 Casdoor 的依赖
+- 使用现有 `user` 作为账号主体
+- 支持第三方身份登录
+- 支持没有密码、只有第三方身份的用户
+- 支持管理员创建用户
+- 支持管理员为用户设置或清除密码凭证
+- 支持已有管理员托管密码的用户使用用户名和密码登录
+- 支持 hosted sign-in 和 SSO 所需的 account session 管理能力
+- 支持 XBuilder 自有 sibling apps 共享 XBuilder 账号身份
+- 支持平台管理的 apps，用于自有 app SSO
+- 支持自有 app 使用 Account-issued token model 或 App-owned session model 接入产品 API
+- 支持 XBuilder Account 管理模块，并将账号相关管理操作写入 admin audit logs
+
+非目标包括：
+
+- 普通用户公开注册用户名和密码账号
+- 普通用户自行设置或重置密码
+- 通用多租户身份平台
+- 任意公开第三方 app 平台
+- app 自助注册
+- 管理 XBuilder 或 sibling app 的 roles、plans、capabilities、quotas、memberships、seats 等产品授权数据
+- 用户删除或用户状态管理
+- 在新运行时模型中保留 Casdoor user ID、groups 或其他 Casdoor 概念
+
+## 核心概念
+
+| 概念 | 含义 |
+| - | - |
+| `user` | XBuilder 账号主体，复用现有用户模型，字段归属按 Account 与产品边界划分 |
+| `identity_provider` | 平台配置中的第三方身份提供方，如 GitHub、Google、Apple 等 |
+| `user_identity` | 绑定到某个 `user` 的第三方身份 |
+| `user_password_credential` | 管理员托管的可选密码凭证 |
+| `user_session` | XBuilder Account 拥有的 account session，用于 hosted sign-in 和 SSO 连续性 |
+| `app` | 平台管理的 OAuth client configuration，用于自有 app SSO |
+| `app_secret` | confidential app 在后端 token exchange 中使用的 OAuth client credential |
+| `app_grant` | 某个 `user` 授权某个 `app` 访问 XBuilder Account 的授权关系 |
+| `auth_flow` | XBuilder Account 在第三方回调、provider credential handoff 和 OAuth 授权码流程中维护的短生命周期临时状态，如 provider redirect state、pushed authorization request、authorization code、PKCE challenge 和一次性 provider code 消费记录 |
+| `audit_log` | XBuilder Admin 管理操作和安全相关事件的审计日志 |
+
+`app` 是产品和管理资源名。OAuth 协议层仍然使用标准 client 概念和标准参数名，例如 `client_id`、`client_secret`、`redirect_uri`、`request_uri`、`code` 和 `grant_type`。
+
+XBuilder Account 可以复用现有 `user` 表，但账号系统边界不等同于物理表边界。Account API 只暴露账号系统拥有的用户字段，例如 `id`、`username`、`displayName` 和 `avatar`。其中可写字段由具体接口定义。`description`、`roles`、`plan`、`capabilities`、统计字段和产品字段属于 XBuilder 产品或授权系统，不由 XBuilder Account API 暴露或管理。
+
+`auth_flow` 是逻辑概念，只定义生命周期和安全语义，不约束物理存储方式。Provider redirect state、pushed authorization request、authorization code、PKCE challenge 和 provider code consumption records 都必须短生命周期保存。一次性状态必须一次性使用。失败的 provider callback、失败的 token exchange 或重复提交不得留下可 replay 的有效状态。
+
+## 系统边界
+
+```mermaid
+flowchart LR
+    subgraph Products["XBuilder products"]
+        XBuilder["xbuilder.com"]
+        XBuilderBackend["api.xbuilder.com"]
+        AdminConsole["XBuilder Admin Console<br/>xbuilder.com/admin/"]
+        SiblingApp["Sibling app"]
+        AppBackend["Sibling app backend"]
+    end
+
+    subgraph AccountBoundary["XBuilder Account boundary"]
+        AccountWeb["Account Web<br/>account.xbuilder.com"]
+        AccountAPI["Account API<br/>api.xbuilder.com/account/*"]
+    end
+
+    subgraph ProductAuthz["Product authorization"]
+        Authorization["XBuilder Authorization"]
+    end
+
+    Provider["External identity provider"]
+
+    XBuilder -->|hosted sign-in| AccountWeb
+    SiblingApp -->|hosted sign-in| AccountWeb
+    AccountWeb -->|same-origin facade<br/>/api/*| AccountAPI
+    XBuilder -->|product requests| XBuilderBackend
+    SiblingApp -->|product requests| AppBackend
+    XBuilderBackend -->|Account API| AccountAPI
+    AppBackend -->|Account API| AccountAPI
+    AccountAPI -->|provider verification| Provider
+    AdminConsole -->|account management| AccountAPI
+    AdminConsole -->|roles and plans management| Authorization
+    XBuilderBackend -->|roles and plans| Authorization
+    Authorization -.->|references stable user.id| AccountAPI
+
+    AccountAPI -.->|does not own product authorization| Authorization
+```
+
+## 用户登录行为
+
+普通用户不能使用用户名和密码公开注册。
+
+普通用户默认通过第三方身份登录。第一批第三方身份提供方包括：
+
+- `wechat`
+- `qq`
+- `github`
+- `apple`
+- `google`
+- `x`
+
+管理员可以创建用户。管理员也可以为用户设置或清除密码。只有已经拥有管理员托管密码的用户，才能使用用户名和密码登录。
+
+用户的登录方式包括第三方身份和管理员托管密码凭证。管理员可以移除任意第三方身份，也可以清除密码凭证。移除后，用户可能没有任何登录方式。此时账号仍然存在，但用户无法再次登录，直到管理员重新设置密码凭证。
+
+移除登录方式不会自动撤销已有 account sessions。撤销已有 account sessions 是独立的管理操作。
+
+## 第三方身份
+
+第三方身份必须使用 provider 提供的稳定主体标识进行匹配，不能使用 provider 返回的邮箱或用户名进行账号匹配。跨自有 app 共享账号身份时，应优先使用 provider 的跨 app 稳定主体标识。
+
+稳定主体标识示例：
+
+| Provider | 稳定主体标识 |
+| - | - |
+| WeChat | `unionid` |
+| QQ | `unionid` |
+| GitHub | numeric user ID |
+| Apple | `sub` |
+| Google | `sub` |
+| X | user ID |
+
+Apple 应按 OIDC 风格 provider 处理。账号绑定必须使用 Apple 稳定的 `sub`，不能使用 Apple 返回的邮箱，因为用户可能使用 private relay email。
+
+WeChat 和 QQ 的 `unionid` 可用性取决于 provider 配置、应用绑定关系和授权结果。`openid` 是 provider app/client scoped identifier，只能作为辅助标识保存，不能作为跨自有 app 统一账号身份的主体标识。如需记录 `openid`，必须同时记录对应的 subject namespace。
+
+如果 WeChat 或 QQ 登录结果缺少 `unionid`，XBuilder Account 不应静默使用 `openid` 创建跨 app 账号身份。账号创建应依赖已验证的跨 app 稳定主体标识。Provider-scoped identity 只能通过用户确认的账号绑定流程绑定。
+
+`user_identity` 应保存 provider、稳定 provider subject、必要时的 subject namespace，以及关联的 `user.id`。provider username、display name、avatar 等少量展示元数据可以用于展示和排障，但不能作为 XBuilder 账号字段的权威来源。
+
+Provider access token 和 refresh token 不应持久化。完整原始 profile payload 不应持久化。XBuilder Account 不作为第三方 API 集成的 token vault。需要访问 provider APIs 的产品能力应单独建模、授权和存储相关 token。
+
+第三方身份提供方配置应由部署配置或服务端受控配置管理，不属于 XBuilder Admin Console 管理范围。
+
+## 自有 app
+
+本文档中的自有 app 指由 XBuilder 平台登记和管理的 app。`xbuilder.com` 应被视为使用 XBuilder Account 的自有 app，而不是账号系统本身。`*.xbuilder.com` 下的 sibling apps 也应作为自有 app 支持。
+
+这些 app 是平台管理的 OAuth client configurations。它们定义 redirect URI allowlists、allowed origins、client type、status 以及自有 app SSO 所需凭证。
+
+自有 app 共享同一个 XBuilder 账号身份，但产品授权由各 app 或对应的产品授权系统负责。XBuilder Account 只负责账号存在性、app 状态、redirect URI allowlists、凭证校验、token/code 有效性等账号与 SSO 边界。App roles、memberships、workspaces、seats 和 product permissions 属于产品授权范围，不由 XBuilder Account 管理，也不作为自有 app SSO 的契约字段。
+
+自有 app 产品 API 接入支持两种模型：
+
+- Account-issued token model：app 使用 XBuilder Account 签发的 app-scoped OAuth token 作为产品 API Bearer token，app backend 通过 token introspection 校验 token，并可通过 Account API 读取稳定账号身份
+- App-owned session model：app backend 通过 XBuilder Account SSO 获得稳定的 `user.id`，并创建、校验、刷新和撤销自己的 app session
+
+Account-issued token model 适用于不希望维护自有 session，且产品请求都发生在用户请求链路中的 app。该模式下，app frontend 可以持有 Account-issued app-scoped OAuth token。App backend 应把这个 token 视为该 app 的产品 API credential，并在产品请求中校验 token、解析稳定 `user.id`，再执行自己的产品授权逻辑。Sibling apps 可以通过自己的 backend 透明转发 OAuth endpoints，让 frontend 面对同源 `/oauth/*`，而不是直接调用 `api.xbuilder.com/account/oauth/*`。
+
+App backend 接受 Account-issued app-scoped OAuth token 作为产品 API credential 时，必须校验 token 绑定的 app 与当前 app 一致。产品权限仍由 app 或对应的产品授权系统判断，不由 XBuilder Account OAuth scope 表达。
+
+App-owned session model 适用于独立部署、独立运维、需要后台代表用户访问 XBuilder Account、需要自行定义 session 刷新、退出和撤销语义，或不希望产品请求依赖 XBuilder Account token 校验的 app。App session 引用稳定的 `user.id`，并携带该 app 自己的 authorization context。它不是独立账号，也不是 XBuilder Account 管理的 session。XBuilder Account 不存储或撤销 app sessions。
+
+无论使用哪种模式，自有 app 的产品授权仍由 app 或对应的产品授权系统负责。Account session、Account-issued app-scoped OAuth token 和 app session 都不应编码 roles、memberships、workspaces、seats 或 product permissions。
+
+自有 app SSO 应使用 OAuth 2.0 authorization code flow。用户可见的 hosted sign-in 入口是 `account.xbuilder.com/sign-in`，不是 XBuilder Account API。自有 app frontend 可以经自己的 OAuth facade 进入该页面。Hosted sign-in 负责账号解析、用户创建、第三方身份绑定和 app callback，并可承载补充信息、账号绑定确认、身份冲突处理等 hosted interaction。
+
+Public 和 confidential apps 在 authorization code flow 中都必须使用 PKCE。Public apps 不依赖 app secret。Confidential apps 可以同时使用 app secrets 作为 OAuth client credentials 进行后端 token exchange。Secret value 只应在创建时返回。
+
+Sibling app frontend 登录完成后应只访问自己的 backend，不应在普通产品请求中依赖 XBuilder Account APIs。Sibling apps 应使用 `user.id` 作为稳定账号引用。`username`、`displayName`、`avatar` 等可变账号字段可以被 sibling apps 缓存用于展示，但 XBuilder Account 仍是这些字段的权威来源。
+
+## 登录接入模型
+
+XBuilder Account 通过 `account.xbuilder.com/sign-in` 承载统一 hosted sign-in。Hosted sign-in 使用 `account.xbuilder.com/api/*` 作为同源 API facade。该 facade 转发到 `api.xbuilder.com/account/*`，例如 `account.xbuilder.com/api/user` 对应 `api.xbuilder.com/account/user`，`account.xbuilder.com/api/oauth/token` 对应 `api.xbuilder.com/account/oauth/token`。`api.xbuilder.com/account/*` 是 XBuilder Account API 的权威入口。
+
+`account.xbuilder.com/api/*` 是 Account Web 的同源接入层，不是安全边界。Account API 不应因为请求来自 facade 就放宽鉴权或权限校验。Facade 主要承载 Account Web 的 Account API 请求，不改变 OAuth、Bearer token 或 account session cookie 的鉴权语义。
+
+```mermaid
+flowchart LR
+    App["App frontend"]
+    AppBackend["App backend"]
+    AccountWeb["Account Web<br/>account.xbuilder.com/sign-in"]
+    AccountFacade["Account Web API facade<br/>account.xbuilder.com/api/*"]
+    AccountAPI["Account API<br/>api.xbuilder.com/account/*"]
+    Provider["External identity provider"]
+
+    App -->|open hosted sign-in| AccountWeb
+    AccountWeb -->|same-origin API calls| AccountFacade
+    AccountFacade -->|forwards| AccountAPI
+    AccountAPI -->|provider authorize| Provider
+    Provider -->|provider callback| AccountAPI
+    AccountWeb -->|app callback| App
+    App -->|product requests| AppBackend
+    AppBackend -->|Account API calls| AccountAPI
+```
+
+普通 Web app 和 native iOS/Android app 都可以使用 hosted sign-in。Native apps 应通过系统浏览器或系统认证会话进入 `account.xbuilder.com/sign-in`，例如 `ASWebAuthenticationSession` 或 Chrome Custom Tabs，不应使用 embedded WebView。
+
+Provider credential acquisition 有两种方式：
+
+- Hosted provider acquisition：Hosted sign-in 将用户跳转到 provider authorize 页面，并通过 provider callback 获得 provider credential。
+- Provider credential handoff：客户端把预先获得的短生命周期 provider code 交给 hosted sign-in 消费。
+
+Provider credential handoff 适用于微信小程序 `wx.login()` code、Apple authorization code 或 Google server auth code 等场景。客户端可以通过 PAR extension parameters 将 credential 交给 XBuilder Account，例如 `xbuilder_provider` 和 `xbuilder_provider_code`。该方式只替换上游 provider web authorize 阶段，不替换 XBuilder Account 的账号登录流程。无论 credential 来自 hosted provider acquisition 还是 handoff，XBuilder Account 都应使用同一套账号解析、用户创建和第三方身份绑定逻辑。如果需要补充信息、确认账号绑定或处理身份冲突，这些交互应在 hosted sign-in 页面内完成。
+
+Provider credential handoff 的错误应通过 PAR 或 authorize 流程返回 OAuth error。过期、已消费、provider 不匹配或未知 provider code 都不得产生可继续使用的 `request_uri`。XBuilder Account 消费 provider code 与记录消费状态必须原子完成，避免同一个 provider code 被重复使用。
+
+## OAuth 与产品 API 接入
+
+XBuilder Account 的 OAuth endpoints 位于 `api.xbuilder.com/account/oauth/*`。它们只承载 OAuth 和 OAuth RFC 扩展协议端点，并签发 Account-issued app-scoped OAuth tokens。Token subject 是稳定的 `user.id`，token client 是具体 `app`。本文只定义 `account:user:read` Account API scope，用于允许 app backend 通过 Account-issued app-scoped OAuth token 访问 `GET /account/user`。该 scope 不表达产品授权状态，也不表达任何 app 的产品 API 权限。
+
+Account-issued app-scoped OAuth token 可以作为对应 app 的产品 API credential。产品 API 是否接受该 token，取决于 token 绑定的 app 和该产品 backend 的鉴权策略。产品 API 必须校验 token client/app，不应只校验 token active。
+
+两种模型共享同一条 frontend-facing OAuth flow。App frontend 面对 app backend 的 OAuth facade。App backend 可以透明转发 XBuilder Account 的 OAuth token response，也可以在自己的 `/oauth/token` 中把 Account token response 转换为 app-owned session。流程如下：
+
+```mermaid
+sequenceDiagram
+    participant App as App frontend
+    participant Backend as App backend
+    participant UserAgent as Browser / system auth session
+    participant AccountWeb as Account Web
+    participant AccountAPI as XBuilder Account API
+
+    App->>Backend: POST /oauth/par with PKCE challenge
+    Backend->>AccountAPI: Forward PAR request
+    AccountAPI-->>Backend: Return request_uri
+    Backend-->>App: Return request_uri
+    App->>UserAgent: Open app /oauth/authorize with request_uri
+    UserAgent->>Backend: GET /oauth/authorize facade
+    Backend-->>UserAgent: Redirect to Account hosted sign-in
+    UserAgent->>AccountWeb: Complete hosted sign-in
+    AccountWeb->>AccountAPI: Resolve account and app authorization
+    AccountAPI-->>AccountWeb: Return callback URL with authorization code
+    AccountWeb->>UserAgent: Redirect to app callback
+    UserAgent->>App: Deliver authorization code and state
+    App->>Backend: POST /oauth/token with code and PKCE verifier
+    Backend->>AccountAPI: Exchange code with PKCE verifier and client credentials when confidential
+    AccountAPI-->>Backend: Return Account-issued app-scoped OAuth tokens
+    alt Account-issued token model
+        Backend-->>App: Return Account-issued app-scoped OAuth tokens
+        App->>Backend: Product request with Bearer Account access token
+        Backend->>AccountAPI: POST /account/oauth/introspect
+        AccountAPI-->>Backend: Return token metadata
+    else App-owned session model
+        Backend->>Backend: Store XBuilder Account grant and token state, then create app session
+        Backend-->>App: Return app-issued session tokens
+        App->>Backend: Product request with Bearer app access token
+        Backend->>Backend: Validate app session
+    end
+    Backend->>AccountAPI: GET /account/user when account fields are needed
+    AccountAPI-->>Backend: Return account user
+```
+
+在 Account-issued token model 中，app backend 不维护该用户的 XBuilder Account token 状态。它可以把自己的 `/oauth/*` 作为透明 OAuth facade 转发到 `api.xbuilder.com/account/oauth/*`。App frontend 拿到的仍然是 Account-issued app-scoped OAuth token。App backend 应在收到产品请求时使用 `/account/oauth/introspect` 校验 token，并校验 token 绑定的 app 与当前 app 一致。需要账号字段时，app backend 可以在 token 具备 `account:user:read` scope 时使用 `GET /account/user` 获取当前账号的最小用户信息。第三方身份和 account session 管理不属于 app-scoped OAuth token 的默认 Account API surface。
+
+`xbuilder.com` 也可以使用 Account-issued token model。对 XBuilder 产品 API 来说，token client/app 应为 `xbuilder`。`api.xbuilder.com` 接受该 token 后，应通过 XBuilder Authorization 和资源规则判断 projects、assets、courses、AI interaction 等产品权限，而不是用 `account:user:read` 表达这些产品权限。
+
+在 App-owned session model 中，app backend 可以向自己的 frontend 暴露标准 OAuth facade，例如自己的 `/oauth/authorize`、`/oauth/token`、`/oauth/revoke`。这个 facade 不是 XBuilder Account API，也不应写入 XBuilder Account OpenAPI。App frontend 在 callback 中拿到的 authorization code 由 XBuilder Account 生成，但只把它当作提交给 app backend `/oauth/token` 的 opaque code。App backend 在 `/oauth/token` 中使用该 code、PKCE verifier 和必要的 client credentials 与 XBuilder Account 完成 token exchange，然后保存后续代表用户访问 Account API 所需的 XBuilder Account grant 状态和 token 状态，创建自己的 app session，并向 frontend 返回 app-issued session tokens。App frontend 不接触 Account-issued app-scoped OAuth tokens。这样 frontend 仍然只需要理解标准 OAuth flow。
+
+`app_grant` 是 XBuilder Account 对某个 `user` 授权某个 `app` 的记录。OAuth authorization code exchange 可以创建或复用 `app_grant`。Account-issued app-scoped OAuth tokens 与 `app_grant` 关联。`app_grant` 用于审计、撤销和后端代表用户访问 Account API，不等同于 app session。
+
+## Token 与 session 策略
+
+XBuilder Account 使用 opaque tokens。
+
+Account session tokens、authorization codes、Account-issued app-scoped OAuth tokens 和 refresh tokens 都应是高熵随机 secret。Token value 不编码用户字段、产品授权状态或其他可变业务状态。
+
+XBuilder Account 不签发 JWT。用户身份和可变账号状态通过服务端状态和账号 API 解析。
+
+Hosted sign-in 使用带 `__Host-` 前缀的 cookie 在 `account.xbuilder.com` 维护 account session。Cookie 必须设置 `HttpOnly`、`Secure`、`SameSite=Lax` 和 `Path=/`，不得设置 `Domain`。Account session 用于登录页内保持登录态和 SSO 续接，不暴露给 app frontend，也不是产品 API credential。
+
+产品 API 请求使用服务端可撤销的 opaque credential。Account-issued token model 使用 XBuilder Account 签发的 app-scoped OAuth tokens。App-owned session model 使用 app backend 自己拥有的 session credential，通常是 app access token 和 app refresh token。
+
+产品 API credential 的传递方式由各 app 自己定义。Bearer access token 是推荐的默认方式。产品 API credential 不得通过 URL、`postMessage` 或不受信任 iframe 传递。
+
+Access token 应短生命周期、可服务端撤销，并且不编码用户字段或产品授权状态。Refresh token 用于更新短生命周期 access token 或延续 session，应长于 access token，必须服务端保存哈希，并在每次使用后轮换。已被轮换的 refresh token 再次出现时，应作为 replay 风险信号撤销对应 token family 或 grant。
+
+App frontend 如需保存产品 API tokens，应限制在当前 app 作用域内的 browser storage 或平台 storage 中。
+
+App frontend 应在 access token 接近过期时提前刷新，不应只依赖 401 后刷新。产品请求返回 401 时，app frontend 最多刷新并重试原请求一次。同一前端运行环境内必须合并并发刷新。Web 多标签页共享同一登录态时，应协调由哪个标签页负责刷新，并通过 `BroadcastChannel` 或 `storage` event 同步 token 更新，避免多个标签页使用同一 refresh token 并发刷新。刷新失败时，app frontend 应清空本地产品 API tokens 和当前用户缓存，并重新进入 hosted sign-in。
+
+OAuth token revocation 用于撤销 Account-issued app-scoped OAuth token 或 refresh token。`app_grant` 的有效性由关联 token family 和 app 状态决定。需要撤销 `app_grant` 时，应撤销该 grant 下的 refresh token family 和仍有效 access tokens，或禁用对应 app。撤销 account session 会影响 hosted sign-in 和 SSO 连续性。App-owned session model 的退出、刷新和撤销由各 app backend 负责。
+
+## 关键流程
+
+### 第三方身份 hosted sign-in 完成流程
+
+1. XBuilder Account 验证 provider credential，并使用稳定 provider subject 查找或创建 `user_identity` 与关联的 `user`。
+2. 如果需要用户补充信息、确认账号绑定或处理身份冲突，XBuilder Account 在 hosted sign-in 页面中完成这些步骤。
+3. XBuilder Account 创建或复用 account session。
+4. XBuilder Account 根据 OAuth authorization request 向 app callback 返回 authorization code 和 OAuth state。
+5. App frontend 将 authorization code 和 PKCE verifier 提交给 app backend 的 OAuth token endpoint。
+6. App backend 使用这些参数，并在 confidential app 场景下附带 client credentials，与 XBuilder Account 完成 token exchange。
+7. Account-issued token model 下，app backend 将 Account-issued app-scoped OAuth tokens 返回给 frontend。App backend 使用 token introspection 校验 token，并取得稳定的 `user.id`。需要账号字段时，可以再调用 `GET /account/user`。
+8. App-owned session model 下，app backend 保存后续代表用户访问 Account API 所需的 XBuilder Account grant 状态和 token 状态，创建自己的 app session，并向 frontend 返回 app-issued session tokens。
+
+### 用户名和密码登录
+
+1. 用户提交用户名和密码。
+2. XBuilder Account 只校验管理员托管的 `user_password_credential`。
+3. 校验成功后创建 account session。
+4. 未设置管理员托管密码的用户不能使用用户名和密码登录。
+
+### Account session 生命周期
+
+1. Hosted sign-in 可以在 `account.xbuilder.com` 内保持有效 account session，并在必要时更新 session 状态。
+2. 退出登录结束当前 account session。
+3. 用户或管理员可以撤销指定 account session 或某个用户的所有 account sessions。
+4. 撤销 account session 会影响 hosted sign-in 和后续 SSO，不默认同步撤销 Account-issued app-scoped OAuth tokens 或 app sessions。
+
+## 管理台与管理权限
+
+`xbuilder.com/admin/` 是 XBuilder Admin Console，不是 XBuilder Account 专属前端。它可以承载 XBuilder Account、XBuilder Authorization、assets、courses 以及其他产品管理模块。
+
+XBuilder Account 管理权限标识为 `accountAdmin`。
+
+`accountAdmin` 授予访问 XBuilder Account 管理模块的权限，覆盖用户管理、管理员托管密码管理、查看和移除第三方身份、撤销 account sessions、app 管理和 app secret 管理。
+
+XBuilder Authorization 管理权限标识为 `authorizationAdmin`。
+
+`authorizationAdmin` 授予访问 XBuilder Authorization 管理模块的权限，覆盖用户 roles、plan、derived capabilities 和 quota policies 等授权输入和推导结果。
+
+`accountAdmin` 和 `authorizationAdmin` 的授予和判定属于 XBuilder Authorization 的管理范围。`accountAdmin` 不管理 XBuilder 产品授权数据，如 roles、plans、capabilities 或 quotas。需要同时管理账号系统和授权系统的管理员应同时拥有 `accountAdmin` 和 `authorizationAdmin`。
+
+首次管理员授予应通过部署配置、迁移脚本或只在初始化阶段可用的运维命令完成。XBuilder Authorization 不可用或无法完成权限判定时，Admin APIs 不得放行请求。
+
+Admin audit logs 记录账号、授权以及其他管理模块的管理操作和安全相关事件。查看 audit logs 不属于 XBuilder Account 管理模块本身，应由 XBuilder Admin API 根据管理员权限控制可见范围。
+
+XBuilder Account 管理模块至少应包含以下产品能力：
+
+- 查看用户列表和用户详情
+- 创建用户
+- 设置或清除管理员托管密码
+- 查看和移除用户第三方身份
+- 查看和撤销用户 account sessions
+- 管理 apps，包括查看、创建、更新和启用或停用 apps
+- 创建和删除 app secrets
+
+XBuilder 产品授权数据可以出现在同一个 XBuilder Admin Console 和同一个用户详情页中，但不属于 XBuilder Account。
+
+`/admin/account/*` endpoints 应要求 `accountAdmin`。`/admin/authorization/*` endpoints 应要求 `authorizationAdmin`。
+
+`/admin/audit-logs` endpoints 应要求管理权限，并由后端 RBAC 决定可见审计事件范围。
+
+管理台前端可以放在开源前端仓库中，并部署在 `xbuilder.com/admin/`。
+
+Admin APIs 不应作为无访问限制的公开接口暴露。`api.xbuilder.com/admin/*` 应在 ingress 层限制访问范围，并继续由后端 RBAC 和 audit logging 保护。
+
+主前端可以在用户具备管理权限时，在用户菜单中展示 Admin Console 入口。
+
+## API 边界
+
+本节只描述 API 边界。接口实现时，应在 `docs/openapi.yaml` 中定义具体契约。
+
+### Account identity provider endpoints
+
+```http
+GET  /account/identity-providers
+GET  /account/identity-providers/{provider}/authorize
+GET  /account/identity-providers/{provider}/callback
+POST /account/identity-providers/{provider}/callback
+```
+
+- 这些 endpoints 由 XBuilder Account backend 提供，主要供 `account.xbuilder.com/sign-in` 使用
+- `GET /account/identity-providers` 根据 app context 返回当前可用于 hosted sign-in 的 identity providers
+- `GET /account/identity-providers/{provider}/authorize` 用于 hosted sign-in 中未通过 provider credential handoff 提供 provider code 时的 provider redirect
+- Provider callback 需要同时支持 GET 和 POST，因为具体 HTTP method 取决于 provider response mode，例如 Sign in with Apple 的 `form_post` 场景会使用 POST callback
+- Provider callback 应依赖 provider redirect state 进行回调关联和 CSRF 防护，不应套用普通前端 CSRF token 校验
+
+### Account OAuth endpoints
+
+```http
+POST /account/oauth/par
+GET  /account/oauth/authorize
+POST /account/oauth/token
+POST /account/oauth/introspect
+POST /account/oauth/revoke
+```
+
+- OAuth protocol parameters 应使用标准名称，例如 `client_id`、`redirect_uri`、`request_uri`、`state`、`code`、`grant_type`、`code_challenge` 和 `code_verifier`
+- Confidential client 使用 `client_secret_basic` 认证
+- Public client 在 token exchange 或 revocation 等需要标识 client 的请求中使用 `client_id`
+- `POST /account/oauth/par` 创建 pushed authorization request，并可通过 `xbuilder_provider` 和 `xbuilder_provider_code` 承载 provider credential handoff。它返回的 `request_uri` 是 opaque、短生命周期、单次使用的 reference，不是可访问 URL
+- `GET /account/oauth/authorize` 是 PAR-only OAuth authorization endpoint，只接受 `client_id` 和 `request_uri`。`response_type`、`redirect_uri`、`scope`、`state`、`code_challenge` 等 authorization request parameters 必须先通过 `POST /account/oauth/par` 提交
+- `POST /account/oauth/token` 用于 authorization code exchange 和 refresh token exchange
+- `POST /account/oauth/introspect` 是 RFC 7662 token introspection endpoint，只允许已认证的 app backend 调用
+- `POST /account/oauth/revoke` 撤销 Account-issued app-scoped OAuth token 或 refresh token
+
+### Current account endpoints
+
+```http
+GET    /account/user
+PATCH  /account/user
+GET    /account/user/identities
+
+POST   /account/session
+GET    /account/session
+DELETE /account/session
+GET    /account/sessions
+DELETE /account/sessions
+DELETE /account/sessions/{sessionID}
+```
+
+- `GET /account/user` 返回当前账号系统拥有的用户字段。Account Web 可以使用 account session cookie 访问。App backend 可以使用具备 `account:user:read` scope 的 Account-issued app-scoped OAuth token 访问
+- `PATCH /account/user` 只允许 Account Web 使用 account session cookie 调用，用于更新可写账号字段
+- `GET /account/user` 和 `PATCH /account/user` 不暴露或更新 `description` 等 XBuilder 产品字段
+- `GET /account/user/identities` 返回当前用户的第三方身份
+- `account:user:read` 只授权 `GET /account/user`，不授权 `GET /account/user/identities`、account session endpoints、mutation endpoints 或 admin endpoints
+- `POST /account/session` 由 Account Web 调用，用于提交登录凭证，并由后端校验后创建当前 account session
+- `GET /account/session` 和 `DELETE /account/session` 管理 hosted sign-in 使用的当前 account session
+- `GET /account/sessions`、`DELETE /account/sessions` 和 `DELETE /account/sessions/{sessionID}` 管理当前用户的 account sessions
+
+### XBuilder Account admin endpoints
+
+```http
+GET    /admin/account/users
+POST   /admin/account/users
+GET    /admin/account/users/{userID}
+PATCH  /admin/account/users/{userID}
+
+PUT    /admin/account/users/{userID}/password
+DELETE /admin/account/users/{userID}/password
+
+GET    /admin/account/users/{userID}/identities
+DELETE /admin/account/users/{userID}/identities/{identityID}
+
+GET    /admin/account/users/{userID}/sessions
+DELETE /admin/account/users/{userID}/sessions
+DELETE /admin/account/sessions/{sessionID}
+
+GET    /admin/account/apps
+POST   /admin/account/apps
+GET    /admin/account/apps/{appID}
+PATCH  /admin/account/apps/{appID}
+PUT    /admin/account/apps/{appID}/status
+
+GET    /admin/account/apps/{appID}/secrets
+POST   /admin/account/apps/{appID}/secrets
+DELETE /admin/account/apps/{appID}/secrets/{secretID}
+```
+
+- Apps 不提供 `DELETE` 删除语义。需要下线 app 时应更新 app status，以保留审计、历史授权和 token 关联上下文
+
+### XBuilder Authorization admin endpoints
+
+```http
+GET   /admin/authorization/users/{userID}
+PATCH /admin/authorization/users/{userID}
+```
+
+- 这些 authorization endpoints 共享 XBuilder Admin API namespace，但不是 XBuilder Account APIs
+- 它们管理某个用户在 XBuilder Authorization 中的授权输入
+- 可写字段是 `roles` 和 `plan`
+- `capabilities` 和 quota policies 由 XBuilder Authorization 推导，应保持只读
+
+### Admin audit endpoints
+
+```http
+GET /admin/audit-logs
+```
+
+- 这些 endpoints 共享 XBuilder Admin API namespace，但不是 XBuilder Account APIs
+- 它们可以包含账号、授权以及其他管理模块产生的审计事件
+
+## 与授权系统的关系
+
+XBuilder Account 负责 authentication、account identity、account session 和自有 app SSO。它不负责集中化管理各个自有 app 的产品授权。
+
+XBuilder 产品自身的 roles、plans、capabilities、quotas、memberships、seats 或其他产品权限仍属于产品授权系统。Sibling apps 也应拥有自己的授权模型。XBuilder Account 可以为这些系统提供稳定的 `user.id`，但不管理这些产品授权数据，也不通过 Account-issued app-scoped OAuth token 承载这些可变授权状态。
+
+## 安全边界
+
+管理台前端不是安全边界。浏览器能加载管理台页面，不代表拥有管理权限。Admin APIs 必须由后端 RBAC 和审计日志保护。Ingress 限制可以降低暴露面，但不能替代后端权限校验。
+
+Session tokens、refresh tokens、authorization codes、app secrets 和其他安全凭证都必须具备足够熵。`request_uri` 应不可猜、短生命周期、单次使用，并绑定 app。`authorization code` 应短生命周期、一次性使用，并绑定 app、redirect URI 和 PKCE。Authorization response 必须回传原始 OAuth state 供 app 校验。App secret value 只应在创建时返回。
+
+XBuilder Account 必须对 redirect URI allowlist 做精确字符串匹配，禁止前缀、通配符或路径前缀匹配，并在 token exchange 时校验 PKCE。App 必须校验 OAuth state 和 authorization request。Provider identity linking 必须基于稳定 provider subject，不能依赖邮箱、用户名或展示字段。
+
+App backend 接受 Account-issued app-scoped OAuth token 作为产品 API credential 时，必须校验 token active、token subject 和 token client/app。不同 app 之间不能共享产品 API credential。
+
+Account session 只用于 hosted sign-in 和 SSO 连续性。它不应通过 URL、`postMessage` 或不受信任 iframe 传递，也不应被 app frontend 直接读取或持久化。Account Web 使用 cookie 鉴权的 mutation endpoints 应校验 `Origin` 或使用等价 CSRF 防护。
+
+`account:user:read` 只授权访问 `GET /account/user`，不授权第三方身份管理、account session 管理、账号字段更新或 admin 能力。这些操作应由 Account Web 使用 cookie 认证完成，或由 Admin API 承载。
+
+Native iOS/Android apps 承载 hosted sign-in 时应使用系统浏览器或系统认证会话，例如 `ASWebAuthenticationSession` 或 Chrome Custom Tabs，不应使用 embedded WebView。微信小程序等无法使用系统浏览器的受限运行环境，可以通过 provider credential handoff 向 hosted sign-in 传递短生命周期 provider code，不应通过 URL 或 `postMessage` 传递长期 token。
+
+Provider credential handoff 只允许使用短生命周期、一次性、可立即消费的 authorization-code-like provider credential。允许的例子包括微信小程序 `wx.login()` code、Apple authorization code 和 Google server auth code。不应通过 provider credential handoff 传递 provider access token、provider refresh token、ID token、`session_key`、account session token、app access token、app refresh token、app secret 或其他长期 secret。XBuilder Account 读取 provider code 后应立即消费，不应持久化或返回给 frontend。
+
+## 迁移方向
+
+迁移应是一次性的，而不是长期双写或逐步切换。
+
+Casdoor 只应作为迁移数据源，用于迁移 users、identities、密码凭证信息以及现有 XBuilder 产品授权数据。
+
+如果历史 WeChat 或 QQ identity 只有 `openid` 而没有 `unionid`，迁移不能用它进行跨 app 自动合并。此类记录只能作为带 subject namespace 的 provider-scoped identity 迁移到原有关联用户，或在迁移前补齐 `unionid` 后再作为跨 app 主体身份使用。
+
+现有 XBuilder 产品授权数据中的 roles 和 plans 应在同一次迁移中处理。迁移后，这些数据应归 XBuilder Authorization 管理，不由 XBuilder Account 管理，也不作为自有 app SSO 的契约字段。
+
+迁移完成后，运行时不应再依赖 Casdoor。
+
+Casdoor 来源的身份标识只应用作一次性迁移映射键，不应保留为运行时账号模型的一部分。
+
+前端迁移后不应继续依赖 Casdoor SDK、Casdoor JWT 或从 token 中 decode 用户名。`spx-gui` 可以保留 Bearer 请求模型，但 Bearer value 应替换为产品 API token。
+
+## 术语表
+
+| 术语 | 含义 |
+| - | - |
+| XBuilder Account | XBuilder 自有账号系统 |
+| Account Web | `account.xbuilder.com` 上的 hosted sign-in 和账号相关 Web UI |
+| Account API | `api.xbuilder.com/account/*` 上的 XBuilder Account API |
+| OAuth client | OAuth 协议中的 client 角色，在本文产品语境中对应 `app` |
+| OAuth facade | App backend 暴露给自己 frontend 的 OAuth-compatible endpoints，内部再对接 XBuilder Account |
+| Hosted sign-in | `account.xbuilder.com/sign-in` 提供的统一登录入口，承载第三方身份登录、管理员托管密码登录、provider credential handoff、补充信息、账号绑定确认、身份冲突处理和 app callback |
+| Hosted provider acquisition | Hosted sign-in 通过 provider web authorize 和 callback 获得 provider credential 的方式 |
+| Provider credential handoff | 客户端将短生命周期 provider code 交给 hosted sign-in 消费的方式 |
+| Hosted interaction | XBuilder Account hosted sign-in 页面中的补充信息、账号绑定确认或身份冲突处理等交互 |
+| Account session | XBuilder Account 拥有的账号 session，用于 hosted sign-in 和 SSO 连续性 |
+| Account-issued app-scoped OAuth token | XBuilder Account 签发给某个具体 app 的 opaque OAuth token，可作为该 app 的产品 API Bearer token |
+| Account-issued token model | 自有 app 直接使用 Account-issued app-scoped OAuth token 作为产品 API credential 的模型 |
+| App-owned session model | 自有 app backend 自己创建、刷新、校验和撤销 app session 的模型 |
+| App grant | 某个 `user` 授权某个 `app` 访问 XBuilder Account 的授权关系 |
+| `account:user:read` | 允许使用 Account-issued app-scoped OAuth token 访问 `GET /account/user` 的 Account API scope |
+| Opaque token | 不编码业务语义的随机 token，需由服务端解析 |
+| Token introspection | RFC 7662 定义的 token 校验协议，用于由服务端查询 opaque token 是否有效及其元数据 |
+| Authorization code | 自有 app SSO 完成后返回给 app 的短生命周期一次性 code，用于后续 exchange |
+| PKCE | Proof Key for Code Exchange |
+| PAR | Pushed Authorization Requests |
+| OIDC | OpenID Connect |
+| SSO | Single Sign-On |
+| RBAC | Role-Based Access Control |


### PR DESCRIPTION
Document the target XBuilder Account product architecture for replacing Casdoor. Cover account boundaries, hosted sign-in, Account OAuth, Account-issued token model, App-owned session model, admin scope, security constraints, and migration direction.

Updates #3112
