### PR TITLE
Add empty `ui/prototype/` to avoid Vercel deployment failure

### DIFF
--- a/ui/prototype/.gitignore
+++ b/ui/prototype/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+.DS_Store

--- a/ui/prototype/index.html
+++ b/ui/prototype/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Prototype</title>
+</head>
+<body>
+  <p>not implemented</p>
+</body>
+</html>

--- a/ui/prototype/package-lock.json
+++ b/ui/prototype/package-lock.json
@@ -1,0 +1,12 @@
+{
+  "name": "builder-ui-prototype",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "builder-ui-prototype",
+      "version": "0.0.0"
+    }
+  }
+}

--- a/ui/prototype/package.json
+++ b/ui/prototype/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "builder-ui-prototype",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "echo 'not implemented'",
+    "build": "mkdir -p dist && cp index.html dist/index.html",
+    "preview": "echo 'not implemented'"
+  }
+}

--- a/ui/prototype/package.json
+++ b/ui/prototype/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "echo 'not implemented'",
-    "build": "mkdir -p dist && cp index.html dist/index.html",
+    "build": "rm -rf dist && mkdir -p dist && cp index.html dist/index.html",
     "preview": "echo 'not implemented'"
   }
 }


### PR DESCRIPTION
Avoid Vercel deployment failures due to missing directory:

> The specified Root Directory "ui/prototype" does not exist. Please update your Project Settings.

<img width="894" height="81" alt="image" src="https://github.com/user-attachments/assets/854f02e3-25bb-41ac-9b23-718b6563a253" />
