### PR TITLE
[Page] Feature: Add representative community pages for explore, login, project, loading, and share

### DIFF
--- a/ui/pages/spx/community-explore.pen
+++ b/ui/pages/spx/community-explore.pen
@@ -6,16 +6,11 @@
       "id": "0hRWl",
       "x": -728,
       "y": -113,
-      "name": "page",
+      "name": "PageExplore",
       "width": 1440,
+      "height": 900,
       "fill": "$2:grey300",
       "layout": "vertical",
-      "padding": [
-        0,
-        0,
-        40,
-        0
-      ],
       "justifyContent": "center",
       "alignItems": "center",
       "children": [
@@ -23,8 +18,8 @@
           "id": "v86y0o",
           "type": "ref",
           "ref": "2:WiWwa",
-          "x": 0.0001975079347187812,
-          "y": 0,
+          "x": 0.00018589109107464467,
+          "y": -0.005576084248048119,
           "children": [
             {
               "id": "m3gbS3",
@@ -35,266 +30,292 @@
         },
         {
           "type": "frame",
-          "id": "t6rfA",
-          "name": "content",
+          "id": "KAwBf",
+          "name": "Header",
           "clip": true,
           "width": 1440,
-          "fill": "$2:grey300",
-          "layout": "vertical",
-          "gap": "$2:space-5",
+          "fill": "$2:grey100",
           "justifyContent": "center",
           "alignItems": "center",
           "children": [
             {
               "type": "frame",
-              "id": "KAwBf",
-              "name": "sub header",
+              "id": "S2MnU",
+              "name": "HeaderContent",
               "clip": true,
-              "width": 1440,
-              "fill": "$2:grey100",
-              "justifyContent": "center",
+              "width": 988,
+              "padding": [
+                16,
+                0
+              ],
+              "justifyContent": "space_between",
               "alignItems": "center",
               "children": [
                 {
+                  "id": "QTG0g",
+                  "type": "ref",
+                  "ref": "2:tfxWX",
+                  "x": 0,
+                  "y": 19.907360582425405,
+                  "children": [
+                    {
+                      "id": "Rmaxe",
+                      "type": "ref",
+                      "ref": "2:OHwu4",
+                      "content": "Explore"
+                    }
+                  ]
+                },
+                {
                   "type": "frame",
-                  "id": "S2MnU",
-                  "name": "sub header content",
-                  "clip": true,
-                  "width": 988,
-                  "padding": [
-                    16,
-                    0
-                  ],
-                  "justifyContent": "space_between",
+                  "id": "BLqmE",
+                  "name": "Filters",
+                  "gap": 8,
                   "alignItems": "center",
                   "children": [
                     {
-                      "id": "QTG0g",
+                      "id": "oDKtH",
                       "type": "ref",
-                      "ref": "2:tfxWX",
+                      "ref": "2:xjqut",
                       "x": 0,
-                      "y": 19.907360582425405,
+                      "y": 0,
                       "children": [
                         {
-                          "id": "Rmaxe",
+                          "id": "rBTF7",
                           "type": "ref",
-                          "ref": "2:OHwu4",
-                          "content": "Explore"
+                          "ref": "2:BeWL7",
+                          "descendants": {
+                            "2:QHYfc": {
+                              "enabled": false
+                            },
+                            "2:WEgxF": {
+                              "content": "Most recently liked"
+                            }
+                          }
                         }
                       ]
                     },
                     {
-                      "type": "frame",
-                      "id": "BLqmE",
-                      "name": "Filter Wrapper",
-                      "gap": 8,
-                      "alignItems": "center",
+                      "id": "lMP5h",
+                      "type": "ref",
+                      "ref": "2:elraQ",
+                      "x": 166,
+                      "y": 0,
                       "children": [
                         {
-                          "id": "oDKtH",
+                          "id": "bL2oB",
                           "type": "ref",
-                          "ref": "2:xjqut",
-                          "x": 0,
-                          "y": 0,
-                          "children": [
-                            {
-                              "id": "rBTF7",
-                              "type": "ref",
-                              "ref": "2:BeWL7",
-                              "descendants": {
-                                "2:QHYfc": {
-                                  "enabled": false
-                                },
-                                "2:WEgxF": {
-                                  "content": "Most recently liked"
-                                }
-                              }
+                          "ref": "2:l4xRZ",
+                          "descendants": {
+                            "2:9l9rS": {
+                              "enabled": false
+                            },
+                            "2:wGppc": {
+                              "content": "My following created"
                             }
-                          ]
-                        },
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "id": "kO3hS",
+                      "type": "ref",
+                      "ref": "2:elraQ",
+                      "x": 345,
+                      "y": 0,
+                      "children": [
                         {
-                          "id": "lMP5h",
+                          "id": "CoAgK",
                           "type": "ref",
-                          "ref": "2:elraQ",
-                          "x": 166,
-                          "y": 0,
-                          "children": [
-                            {
-                              "id": "bL2oB",
-                              "type": "ref",
-                              "ref": "2:l4xRZ",
-                              "descendants": {
-                                "2:9l9rS": {
-                                  "enabled": false
-                                },
-                                "2:wGppc": {
-                                  "content": "My following created"
-                                }
-                              }
+                          "ref": "2:l4xRZ",
+                          "descendants": {
+                            "2:9l9rS": {
+                              "enabled": false
+                            },
+                            "2:wGppc": {
+                              "content": "Most recently remixed"
                             }
-                          ]
-                        },
-                        {
-                          "id": "kO3hS",
-                          "type": "ref",
-                          "ref": "2:elraQ",
-                          "x": 345,
-                          "y": 0,
-                          "children": [
-                            {
-                              "id": "CoAgK",
-                              "type": "ref",
-                              "ref": "2:l4xRZ",
-                              "descendants": {
-                                "2:9l9rS": {
-                                  "enabled": false
-                                },
-                                "2:wGppc": {
-                                  "content": "Most recently remixed"
-                                }
-                              }
-                            }
-                          ]
+                          }
                         }
                       ]
                     }
                   ]
                 }
               ]
-            },
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "RPDj9",
+          "name": "Body",
+          "width": 1440,
+          "height": 788,
+          "fill": "$2:grey300",
+          "stroke": {
+            "align": "inside",
+            "thickness": 1
+          },
+          "layout": "vertical",
+          "children": [
             {
               "type": "frame",
-              "id": "4cSa8",
-              "name": "Grid",
-              "gap": "$2:space-4",
+              "id": "q3FqR",
+              "name": "Content",
+              "width": 1440,
+              "height": "fill_container",
+              "stroke": {
+                "align": "inside",
+                "thickness": 1
+              },
+              "layout": "vertical",
+              "padding": [
+                "$2:space-5",
+                210,
+                40,
+                210
+              ],
+              "alignItems": "center",
               "children": [
                 {
-                  "id": "B6Yfo",
-                  "type": "ref",
-                  "ref": "2:Yg1nD",
-                  "x": 0,
-                  "y": 0,
-                  "rotation": 0,
-                  "width": "fit_content",
-                  "height": "fit_content",
+                  "type": "frame",
+                  "id": "fdIDz",
+                  "name": "ResultsSection",
+                  "clip": true,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1
+                  },
+                  "layout": "vertical",
+                  "alignItems": "center",
                   "children": [
                     {
-                      "id": "PRP6g",
-                      "type": "ref",
-                      "ref": "2:7j4Je"
-                    }
-                  ]
-                },
-                {
-                  "id": "q5qCu",
-                  "type": "ref",
-                  "ref": "2:Yg1nD",
-                  "x": 248,
-                  "y": 0,
-                  "rotation": 0,
-                  "children": [
-                    {
-                      "id": "usQYv",
-                      "type": "ref",
-                      "ref": "2:gmlTw"
-                    }
-                  ]
-                },
-                {
-                  "id": "Ejz6r",
-                  "type": "ref",
-                  "ref": "2:Yg1nD",
-                  "x": 496,
-                  "y": 0,
-                  "rotation": 0,
-                  "children": [
-                    {
-                      "id": "djg1H",
-                      "type": "ref",
-                      "ref": "2:gmlTw"
-                    }
-                  ]
-                },
-                {
-                  "id": "YbRl1",
-                  "type": "ref",
-                  "ref": "2:Yg1nD",
-                  "x": 744,
-                  "y": 0,
-                  "rotation": 0,
-                  "children": [
-                    {
-                      "id": "HjvbH",
-                      "type": "ref",
-                      "ref": "2:7j4Je"
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "type": "frame",
-              "id": "NytXi",
-              "name": "Grid",
-              "gap": "$2:space-4",
-              "children": [
-                {
-                  "id": "3h7NN",
-                  "type": "ref",
-                  "ref": "2:Yg1nD",
-                  "x": 0,
-                  "y": 0,
-                  "rotation": 0,
-                  "children": [
-                    {
-                      "id": "Epo4q",
-                      "type": "ref",
-                      "ref": "2:7j4Je"
-                    }
-                  ]
-                },
-                {
-                  "id": "XdEEx",
-                  "type": "ref",
-                  "ref": "2:Yg1nD",
-                  "x": 248,
-                  "y": 0,
-                  "rotation": 0,
-                  "children": [
-                    {
-                      "id": "JVEMh",
-                      "type": "ref",
-                      "ref": "2:gmlTw"
-                    }
-                  ]
-                },
-                {
-                  "id": "JFylt",
-                  "type": "ref",
-                  "ref": "2:Yg1nD",
-                  "x": 496,
-                  "y": 0,
-                  "rotation": 0,
-                  "children": [
-                    {
-                      "id": "ylZjz",
-                      "type": "ref",
-                      "ref": "2:7j4Je"
-                    }
-                  ]
-                },
-                {
-                  "id": "a1HMt",
-                  "type": "ref",
-                  "ref": "2:Yg1nD",
-                  "x": 744,
-                  "y": 0,
-                  "rotation": 0,
-                  "children": [
-                    {
-                      "id": "OdPJt",
-                      "type": "ref",
-                      "ref": "2:7j4Je"
+                      "type": "frame",
+                      "id": "HLihP",
+                      "name": "CardList",
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1
+                      },
+                      "gap": "$2:space-5",
+                      "padding": [
+                        "$2:space-2",
+                        0,
+                        "$2:space-4",
+                        0
+                      ],
+                      "children": [
+                        {
+                          "id": "czWcd",
+                          "type": "ref",
+                          "ref": "2:Yg1nD",
+                          "x": 0,
+                          "y": 8,
+                          "rotation": 0,
+                          "width": "fit_content",
+                          "height": "fit_content",
+                          "gap": "$2:space-5",
+                          "children": [
+                            {
+                              "id": "f4Dg8Z",
+                              "type": "ref",
+                              "ref": "2:7j4Je"
+                            },
+                            {
+                              "id": "RwKAh",
+                              "type": "ref",
+                              "ref": "2:Yg1nD",
+                              "x": 0,
+                              "y": 274,
+                              "rotation": 0,
+                              "children": [
+                                {
+                                  "id": "r3mutG",
+                                  "type": "ref",
+                                  "ref": "2:gmlTw"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "id": "PoqcB",
+                          "type": "ref",
+                          "ref": "2:Yg1nD",
+                          "x": 252,
+                          "y": 8,
+                          "rotation": 0,
+                          "gap": "$2:space-5",
+                          "children": [
+                            {
+                              "id": "brzJF",
+                              "type": "ref",
+                              "ref": "2:gmlTw"
+                            },
+                            {
+                              "id": "Wz1ft",
+                              "type": "ref",
+                              "ref": "2:Yg1nD",
+                              "x": 0,
+                              "y": 274,
+                              "rotation": 0,
+                              "children": [
+                                {
+                                  "id": "TYrgg",
+                                  "type": "ref",
+                                  "ref": "2:gmlTw"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "id": "C55qI",
+                          "type": "ref",
+                          "ref": "2:Yg1nD",
+                          "x": 504,
+                          "y": 8,
+                          "rotation": 0,
+                          "gap": "$2:space-5",
+                          "children": [
+                            {
+                              "id": "AhHv9",
+                              "type": "ref",
+                              "ref": "2:gmlTw"
+                            },
+                            {
+                              "id": "TTE8l",
+                              "type": "ref",
+                              "ref": "2:Yg1nD",
+                              "x": 0,
+                              "y": 274,
+                              "rotation": 0,
+                              "children": [
+                                {
+                                  "id": "Malgt",
+                                  "type": "ref",
+                                  "ref": "2:gmlTw"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "id": "eup5F",
+                          "type": "ref",
+                          "ref": "2:Yg1nD",
+                          "x": 756,
+                          "y": 8,
+                          "rotation": 0,
+                          "children": [
+                            {
+                              "id": "a1Nj8b",
+                              "type": "ref",
+                              "ref": "2:gmlTw"
+                            }
+                          ]
+                        }
+                      ]
                     }
                   ]
                 }

--- a/ui/pages/spx/community-home.pen
+++ b/ui/pages/spx/community-home.pen
@@ -6,7 +6,7 @@
       "id": "zQsHr",
       "x": 0,
       "y": 0,
-      "name": "page",
+      "name": "PageHome",
       "width": 1440,
       "height": 1412,
       "fill": "$r:grey300",
@@ -34,6 +34,7 @@
         {
           "type": "frame",
           "id": "U2vTu4",
+          "name": "Body",
           "width": 1440,
           "fill": "$r:grey300",
           "stroke": {
@@ -45,7 +46,7 @@
             {
               "type": "frame",
               "id": "ft4bi",
-              "name": "Container",
+              "name": "Content",
               "width": 1440,
               "stroke": {
                 "align": "inside",
@@ -64,7 +65,7 @@
                 {
                   "type": "frame",
                   "id": "wARjE",
-                  "name": "Frame 1000004790",
+                  "name": "MainContent",
                   "stroke": {
                     "align": "inside",
                     "thickness": 1
@@ -79,7 +80,7 @@
                     {
                       "type": "frame",
                       "id": "HCYbL",
-                      "name": "Frame 1000004673",
+                      "name": "CommunityFeed",
                       "clip": true,
                       "width": "fill_container",
                       "fill": "$r:grey100",
@@ -93,7 +94,7 @@
                         {
                           "type": "frame",
                           "id": "yhhdN",
-                          "name": "Banner",
+                          "name": "HeroBanner",
                           "width": "fill_container",
                           "height": 230,
                           "fill": "$r:blue100",
@@ -109,13 +110,13 @@
                             {
                               "type": "frame",
                               "id": "qBwfY",
-                              "name": "文字",
+                              "name": "HeroContent",
                               "gap": 10,
                               "children": [
                                 {
                                   "type": "frame",
                                   "id": "br4yM",
-                                  "name": "Frame 1000003090",
+                                  "name": "HeroBody",
                                   "width": 400,
                                   "layout": "vertical",
                                   "gap": 28,
@@ -123,7 +124,7 @@
                                     {
                                       "type": "frame",
                                       "id": "crXfo",
-                                      "name": "Frame 1000003089",
+                                      "name": "HeroHeader",
                                       "width": "fill_container",
                                       "layout": "vertical",
                                       "gap": 8,
@@ -186,14 +187,14 @@
                     {
                       "type": "frame",
                       "id": "yzBtD",
-                      "name": "Section Liking",
+                      "name": "CommunityLikingSection",
                       "layout": "vertical",
                       "gap": "$r:space-5",
                       "children": [
                         {
                           "type": "frame",
                           "id": "WwSDE",
-                          "name": "section1Header",
+                          "name": "Header",
                           "width": "fill_container",
                           "justifyContent": "space_between",
                           "alignItems": "center",
@@ -216,7 +217,7 @@
                             {
                               "type": "frame",
                               "id": "OV6Vu",
-                              "name": "ViewAllWrapper",
+                              "name": "SecondaryAction",
                               "gap": 4,
                               "alignItems": "center",
                               "children": [
@@ -262,7 +263,7 @@
                         {
                           "type": "frame",
                           "id": "QoacQ",
-                          "name": "Grid",
+                          "name": "CardList",
                           "gap": "$r:space-5",
                           "children": [
                             {
@@ -348,14 +349,14 @@
                     {
                       "type": "frame",
                       "id": "9bBWi",
-                      "name": "Section Remixing",
+                      "name": "CommunityRemixingSection",
                       "layout": "vertical",
                       "gap": "$r:space-5",
                       "children": [
                         {
                           "type": "frame",
                           "id": "pdEpo",
-                          "name": "section1Header",
+                          "name": "Header",
                           "width": "fill_container",
                           "justifyContent": "space_between",
                           "alignItems": "center",
@@ -378,7 +379,7 @@
                             {
                               "type": "frame",
                               "id": "AmAGf",
-                              "name": "ViewAllWrapper",
+                              "name": "SecondaryAction",
                               "gap": 4,
                               "alignItems": "center",
                               "children": [
@@ -424,7 +425,7 @@
                         {
                           "type": "frame",
                           "id": "WFMW4",
-                          "name": "Grid",
+                          "name": "CardList",
                           "gap": "$r:space-5",
                           "children": [
                             {
@@ -510,14 +511,14 @@
                     {
                       "type": "frame",
                       "id": "ZRuN8",
-                      "name": "Section Remixing",
+                      "name": "FollowingCreationSection",
                       "layout": "vertical",
                       "gap": "$r:space-5",
                       "children": [
                         {
                           "type": "frame",
                           "id": "eB4hv",
-                          "name": "section1Header",
+                          "name": "Header",
                           "width": "fill_container",
                           "justifyContent": "space_between",
                           "alignItems": "center",
@@ -540,7 +541,7 @@
                             {
                               "type": "frame",
                               "id": "dgCOp",
-                              "name": "ViewAllWrapper",
+                              "name": "SecondaryAction",
                               "gap": 4,
                               "alignItems": "center",
                               "children": [
@@ -586,7 +587,7 @@
                         {
                           "type": "frame",
                           "id": "Xr7Ls",
-                          "name": "Grid",
+                          "name": "CardList",
                           "gap": "$r:space-5",
                           "children": [
                             {

--- a/ui/pages/spx/community-loading.pen
+++ b/ui/pages/spx/community-loading.pen
@@ -1,0 +1,112 @@
+{
+  "version": "2.11",
+  "children": [
+    {
+      "type": "frame",
+      "id": "ofW9x",
+      "x": -672,
+      "y": -481,
+      "name": "PageLoading",
+      "clip": true,
+      "width": 1440,
+      "height": 900,
+      "fill": "$9:grey300",
+      "stroke": {
+        "align": "inside",
+        "thickness": 1
+      },
+      "layout": "vertical",
+      "alignItems": "center",
+      "children": [
+        {
+          "id": "cm5BB",
+          "type": "ref",
+          "ref": "9:WiWwa",
+          "x": 0.00018589109107464483,
+          "y": 0,
+          "children": [
+            {
+              "id": "vSWuG",
+              "type": "ref",
+              "ref": "9:cnhih",
+              "descendants": {
+                "9:vxyh6": {
+                  "fill": "$9:grey300"
+                },
+                "9:xIVoM": {
+                  "fill": "$9:grey600"
+                },
+                "9:vV9hb": {
+                  "fill": "$9:grey600"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "f0mDR",
+          "name": "Body",
+          "width": "fill_container",
+          "height": 852,
+          "stroke": {
+            "align": "inside",
+            "thickness": 1
+          },
+          "layout": "vertical",
+          "gap": "$9:radius-3",
+          "padding": [
+            "$9:space-5",
+            0
+          ],
+          "justifyContent": "center",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "H4HZWV",
+              "name": "LoadingScreen",
+              "width": 1082,
+              "height": 812,
+              "fill": [
+                {
+                  "type": "image",
+                  "enabled": true,
+                  "url": "../../images/project-fullscreen.png",
+                  "mode": "fill"
+                },
+                "#24292f99"
+              ],
+              "cornerRadius": "$9:border-radius-1",
+              "stroke": {
+                "align": "inside",
+                "thickness": 3.1157803535461426
+              },
+              "layout": "none",
+              "children": [
+                {
+                  "id": "Z1Fuea",
+                  "type": "ref",
+                  "ref": "9:Yg1nD",
+                  "x": 411,
+                  "y": 320.4521952169764,
+                  "rotation": 1.4033418597069752e-14,
+                  "children": [
+                    {
+                      "id": "knRcJ",
+                      "type": "ref",
+                      "ref": "9:5XouD"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "imports": {
+    "9": "../../components/spx/builder-component.lib.pen"
+  }
+}

--- a/ui/pages/spx/community-login.pen
+++ b/ui/pages/spx/community-login.pen
@@ -6,7 +6,7 @@
       "id": "ROyt9",
       "x": 6978,
       "y": 3547,
-      "name": "Login/pc",
+      "name": "PageLoginDesktop",
       "clip": true,
       "width": 1440,
       "height": 1016,
@@ -28,7 +28,7 @@
         {
           "type": "frame",
           "id": "OHdeB",
-          "name": "login-container-pc",
+          "name": "LoginPanel",
           "width": 1000,
           "fill": "$r:grey100",
           "cornerRadius": 16,
@@ -55,7 +55,7 @@
             {
               "type": "frame",
               "id": "0SPCV",
-              "name": "login-top-area",
+              "name": "Header",
               "width": "fill_container",
               "padding": [
                 36,
@@ -80,7 +80,7 @@
             {
               "type": "frame",
               "id": "hXdrd",
-              "name": "login-middle-area",
+              "name": "Content",
               "width": "fill_container",
               "justifyContent": "space_between",
               "alignItems": "center",
@@ -88,7 +88,7 @@
                 {
                   "type": "frame",
                   "id": "Uxg4s",
-                  "name": "login-illustration-pc-container",
+                  "name": "Illustration",
                   "width": 500,
                   "layout": "vertical",
                   "gap": 10,
@@ -107,7 +107,7 @@
                 {
                   "type": "frame",
                   "id": "vGtql",
-                  "name": "login-signin-pc-container",
+                  "name": "SignInPanel",
                   "clip": true,
                   "width": 500,
                   "height": 460,
@@ -130,7 +130,7 @@
                     {
                       "type": "frame",
                       "id": "WxNZJ",
-                      "name": "login-logo-name",
+                      "name": "Brand",
                       "stroke": {
                         "align": "inside",
                         "thickness": 1
@@ -197,7 +197,7 @@
       "id": "CF3U2",
       "x": 8497,
       "y": 3719,
-      "name": "Login/app",
+      "name": "PageLoginApp",
       "clip": true,
       "width": 390,
       "height": 844,
@@ -220,7 +220,7 @@
         {
           "type": "frame",
           "id": "EMvsJ",
-          "name": "login-container-app",
+          "name": "Content",
           "layout": "vertical",
           "gap": 64,
           "justifyContent": "center",
@@ -229,7 +229,7 @@
             {
               "type": "frame",
               "id": "5s6ZN",
-              "name": "login-signin-app-container",
+              "name": "Brand",
               "clip": true,
               "layout": "vertical",
               "gap": "$r:space-3",

--- a/ui/pages/spx/community-project.pen
+++ b/ui/pages/spx/community-project.pen
@@ -4,20 +4,13 @@
     {
       "type": "frame",
       "id": "pljWP",
-      "x": -721,
-      "y": -1231,
-      "name": "page-run",
+      "x": 483,
+      "y": -1678,
+      "name": "PageRunning",
       "width": 1440,
-      "height": 1096,
+      "height": 1116,
       "fill": "$m:grey300",
       "layout": "vertical",
-      "gap": 20,
-      "padding": [
-        0,
-        0,
-        40,
-        0
-      ],
       "justifyContent": "center",
       "alignItems": "center",
       "children": [
@@ -25,8 +18,8 @@
           "id": "FVq8K",
           "type": "ref",
           "ref": "m:WiWwa",
-          "x": 0.0001975079347187812,
-          "y": 12.494423915796858,
+          "x": 0.00018589109107464467,
+          "y": -0.005576084248104962,
           "children": [
             {
               "id": "wMq6E",
@@ -37,679 +30,374 @@
         },
         {
           "type": "frame",
-          "id": "D1KNC",
-          "name": "Main Content Card",
-          "fill": "$m:grey100",
-          "cornerRadius": "$m:radius-4",
-          "gap": 40,
-          "padding": "$m:space-5",
-          "justifyContent": "center",
-          "children": [
-            {
-              "type": "frame",
-              "id": "MGE18",
-              "name": "Left Column",
-              "width": 744,
-              "layout": "vertical",
-              "gap": "$m:space-3",
-              "justifyContent": "center",
-              "alignItems": "center",
-              "children": [
-                {
-                  "type": "frame",
-                  "id": "m5zVU",
-                  "name": "runner",
-                  "width": "fill_container",
-                  "height": 558,
-                  "fill": [
-                    {
-                      "type": "image",
-                      "enabled": true,
-                      "url": "../../images/project-run.png",
-                      "mode": "fill"
-                    },
-                    "#24292f99"
-                  ],
-                  "cornerRadius": 8,
-                  "justifyContent": "center",
-                  "alignItems": "center",
-                  "children": [
-                    {
-                      "id": "XBnTZ",
-                      "type": "ref",
-                      "ref": "m:xjqut",
-                      "x": 332.9948785543445,
-                      "y": 263,
-                      "children": [
-                        {
-                          "id": "LFj5H",
-                          "type": "ref",
-                          "ref": "m:BeWL7",
-                          "descendants": {
-                            "m:2XGef": {
-                              "content": "Y"
-                            },
-                            "m:WEgxF": {
-                              "content": "Run",
-                              "x": 36,
-                              "y": 5.006055476592933,
-                              "rotation": 0.026683455116293515
-                            }
-                          }
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "type": "frame",
-                  "id": "N1Rog",
-                  "name": "Operations Row",
-                  "width": "fill_container",
-                  "gap": 12,
-                  "justifyContent": "end",
-                  "children": [
-                    {
-                      "id": "CMPoU",
-                      "type": "ref",
-                      "ref": "m:8dhVn",
-                      "x": 712,
-                      "y": 0,
-                      "children": [
-                        {
-                          "id": "e43Ys",
-                          "type": "ref",
-                          "ref": "m:1dx2o",
-                          "descendants": {
-                            "m:EOln9": {
-                              "content": "m",
-                              "fontFamily": "XBuilder_NewIcons_02"
-                            }
-                          }
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "type": "frame",
-              "id": "bEtUt",
-              "name": "Right Column",
-              "width": 416,
-              "layout": "vertical",
-              "gap": "$m:space-4",
-              "children": [
-                {
-                  "id": "zClKQ",
-                  "type": "ref",
-                  "ref": "m:Yg1nD",
-                  "x": 0,
-                  "y": 0,
-                  "rotation": 0,
-                  "children": [
-                    {
-                      "id": "glgye",
-                      "type": "ref",
-                      "ref": "m:Vjvc8"
-                    }
-                  ]
-                },
-                {
-                  "id": "Og2bI",
-                  "type": "ref",
-                  "ref": "m:Yg1nD",
-                  "x": 0,
-                  "y": 194,
-                  "rotation": 0,
-                  "children": [
-                    {
-                      "id": "WC1DU",
-                      "type": "ref",
-                      "ref": "m:0AvUj"
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "type": "frame",
-          "id": "wXvM2",
-          "name": "Community Liking Section",
-          "width": "fill_container",
-          "layout": "vertical",
-          "gap": "$m:space-4",
-          "justifyContent": "center",
-          "alignItems": "center",
-          "children": [
-            {
-              "type": "frame",
-              "id": "lBsFY",
-              "name": "Section Header",
-              "width": 1224,
-              "justifyContent": "space_between",
-              "alignItems": "center",
-              "children": [
-                {
-                  "id": "kTHL2",
-                  "type": "ref",
-                  "ref": "m:tfxWX",
-                  "x": 0,
-                  "y": 0,
-                  "children": [
-                    {
-                      "id": "aaD5o",
-                      "type": "ref",
-                      "ref": "m:Lm2P8",
-                      "content": "The community is liking"
-                    }
-                  ]
-                },
-                {
-                  "type": "frame",
-                  "id": "xsHws",
-                  "name": "ViewAllWrapper",
-                  "gap": 4,
-                  "alignItems": "center",
-                  "children": [
-                    {
-                      "id": "7msE1",
-                      "type": "ref",
-                      "ref": "m:tfxWX",
-                      "x": 0,
-                      "y": 0,
-                      "children": [
-                        {
-                          "id": "jr8iF",
-                          "type": "ref",
-                          "ref": "m:0rSuk",
-                          "content": "View all",
-                          "fill": "$m:turquoise500"
-                        }
-                      ]
-                    },
-                    {
-                      "id": "CgMQg",
-                      "type": "ref",
-                      "ref": "m:bW00p",
-                      "x": 55,
-                      "y": 3,
-                      "children": [
-                        {
-                          "id": "H7LHW",
-                          "type": "ref",
-                          "ref": "m:R1pbv",
-                          "children": [
-                            {
-                              "id": "rHD2Y",
-                              "type": "ref",
-                              "ref": "m:5VNGi",
-                              "fill": "$m:turquoise500",
-                              "fontFamily": "XBuilder_NewIcons_02"
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "type": "frame",
-              "id": "nxf2P",
-              "name": "Grid",
-              "gap": "$m:space-4",
-              "children": [
-                {
-                  "id": "kGp9M",
-                  "type": "ref",
-                  "ref": "m:m6A5K",
-                  "x": 0,
-                  "y": 5.682361148043719e-14,
-                  "children": [
-                    {
-                      "id": "dIf8S",
-                      "type": "ref",
-                      "ref": "m:9T690"
-                    }
-                  ]
-                },
-                {
-                  "id": "bDTdT",
-                  "type": "ref",
-                  "ref": "m:m6A5K",
-                  "x": 248.00000000000006,
-                  "y": 5.682361148043719e-14,
-                  "children": [
-                    {
-                      "id": "tRCem",
-                      "type": "ref",
-                      "ref": "m:ZP33l"
-                    }
-                  ]
-                },
-                {
-                  "id": "chirl",
-                  "type": "ref",
-                  "ref": "m:m6A5K",
-                  "x": 496.0000000000001,
-                  "y": 5.682361148043719e-14,
-                  "children": [
-                    {
-                      "id": "8fjeW",
-                      "type": "ref",
-                      "ref": "m:ZP33l"
-                    }
-                  ]
-                },
-                {
-                  "id": "n77Cm",
-                  "type": "ref",
-                  "ref": "m:m6A5K",
-                  "x": 744.0000000000002,
-                  "y": 5.682361148043719e-14,
-                  "children": [
-                    {
-                      "id": "B4Tkn",
-                      "type": "ref",
-                      "ref": "m:ZP33l"
-                    }
-                  ]
-                },
-                {
-                  "id": "l1WrV",
-                  "type": "ref",
-                  "ref": "m:m6A5K",
-                  "x": 992.0000000000003,
-                  "y": 5.682361148043719e-14,
-                  "children": [
-                    {
-                      "id": "0jY01",
-                      "type": "ref",
-                      "ref": "m:ZP33l"
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "type": "frame",
-      "id": "otyjk",
-      "x": -720,
-      "y": 1231,
-      "name": "Running in full screen",
-      "width": 1440,
-      "height": 900,
-      "fill": "$m:grey100",
-      "layout": "vertical",
-      "gap": "$m:space-5",
-      "padding": [
-        0,
-        0,
-        40,
-        0
-      ],
-      "alignItems": "center",
-      "children": [
-        {
-          "id": "JcMtk",
-          "type": "ref",
-          "ref": "m:WiWwa",
-          "x": 0.0001975079347187812,
-          "y": 0,
-          "children": [
-            {
-              "id": "c7kBz",
-              "type": "ref",
-              "ref": "m:O7syE"
-            }
-          ]
-        },
-        {
-          "type": "frame",
-          "id": "yIonU",
-          "name": "Content Area",
-          "width": 1090,
-          "height": 818,
-          "fill": {
-            "type": "image",
-            "enabled": true,
-            "url": "../../images/project-fullscreen.png",
-            "mode": "stretch"
+          "id": "MsMSc",
+          "name": "Body",
+          "width": 1440,
+          "fill": "$m:grey300",
+          "stroke": {
+            "align": "inside",
+            "thickness": 1
           },
-          "justifyContent": "center",
-          "alignItems": "center"
-        }
-      ]
-    },
-    {
-      "type": "frame",
-      "id": "HgruV",
-      "x": -721,
-      "y": -10,
-      "name": "page-running",
-      "width": 1440,
-      "height": 1096,
-      "fill": "$m:grey300",
-      "layout": "vertical",
-      "gap": 20,
-      "padding": [
-        0,
-        0,
-        40,
-        0
-      ],
-      "justifyContent": "center",
-      "alignItems": "center",
-      "children": [
-        {
-          "id": "teJml",
-          "type": "ref",
-          "ref": "m:WiWwa",
-          "x": 0.00019750793483246803,
-          "y": 12.494423915796858,
-          "children": [
-            {
-              "id": "zdjtd",
-              "type": "ref",
-              "ref": "m:O7syE"
-            }
-          ]
-        },
-        {
-          "type": "frame",
-          "id": "WUMXI",
-          "name": "Main Content Card",
-          "fill": "$m:grey100",
-          "cornerRadius": 16,
-          "gap": 40,
-          "padding": "$m:space-5",
+          "gap": "$m:radius-3",
+          "padding": [
+            "$m:space-5",
+            210,
+            40,
+            210
+          ],
           "justifyContent": "center",
           "children": [
             {
               "type": "frame",
-              "id": "6MXRT",
-              "name": "Left Column",
-              "width": 744,
+              "id": "F4wcRu",
+              "name": "Content",
+              "width": 1240,
+              "stroke": {
+                "align": "inside",
+                "thickness": 1
+              },
               "layout": "vertical",
-              "gap": "$m:space-3",
+              "gap": "$m:space-5",
               "justifyContent": "center",
               "alignItems": "center",
               "children": [
                 {
                   "type": "frame",
-                  "id": "GdZTf",
-                  "name": "runner",
-                  "width": "fill_container",
-                  "height": 558,
-                  "fill": [
-                    {
-                      "type": "image",
-                      "enabled": true,
-                      "url": "../../images/project-run.png",
-                      "mode": "fill"
-                    },
-                    "#24292f99"
-                  ],
+                  "id": "R0lBX",
+                  "name": "RunningPreviewPanel",
+                  "width": 1240,
+                  "fill": "$m:grey100",
                   "cornerRadius": 8,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1
+                  },
+                  "gap": 40,
+                  "padding": 20,
                   "justifyContent": "center",
-                  "alignItems": "center",
                   "children": [
                     {
-                      "id": "n6ogG",
-                      "type": "ref",
-                      "ref": "m:Yg1nD",
-                      "x": 242,
-                      "y": 193.45219521697632,
-                      "rotation": 0,
+                      "type": "frame",
+                      "id": "rEZ4C",
+                      "name": "Preview",
+                      "width": 744,
+                      "layout": "vertical",
+                      "gap": "$m:space-3",
+                      "justifyContent": "center",
+                      "alignItems": "center",
                       "children": [
                         {
-                          "id": "W2mKu",
-                          "type": "ref",
-                          "ref": "m:5XouD"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "type": "frame",
-                  "id": "3Wr2U",
-                  "name": "Operations Row",
-                  "width": "fill_container",
-                  "gap": 12,
-                  "justifyContent": "end",
-                  "children": [
-                    {
-                      "id": "DNtIl",
-                      "type": "ref",
-                      "ref": "m:8dhVn",
-                      "x": 712,
-                      "y": 0,
-                      "children": [
-                        {
-                          "id": "e6EcG",
-                          "type": "ref",
-                          "ref": "m:1dx2o",
-                          "descendants": {
-                            "m:EOln9": {
-                              "content": "m",
-                              "fontFamily": "XBuilder_NewIcons_02"
-                            }
-                          }
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "type": "frame",
-              "id": "AMqzE",
-              "name": "Right Column",
-              "width": 416,
-              "layout": "vertical",
-              "gap": "$m:space-4",
-              "children": [
-                {
-                  "id": "VWkHI",
-                  "type": "ref",
-                  "ref": "m:Yg1nD",
-                  "x": 0,
-                  "y": 0,
-                  "rotation": 0,
-                  "children": [
-                    {
-                      "id": "Iw32a",
-                      "type": "ref",
-                      "ref": "m:Vjvc8"
-                    }
-                  ]
-                },
-                {
-                  "id": "09mgR",
-                  "type": "ref",
-                  "ref": "m:Yg1nD",
-                  "x": 0,
-                  "y": 194,
-                  "rotation": 0,
-                  "children": [
-                    {
-                      "id": "bLiDO",
-                      "type": "ref",
-                      "ref": "m:0AvUj"
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "type": "frame",
-          "id": "fB8xC",
-          "name": "Community Liking Section",
-          "width": "fill_container",
-          "layout": "vertical",
-          "gap": "$m:space-4",
-          "justifyContent": "center",
-          "alignItems": "center",
-          "children": [
-            {
-              "type": "frame",
-              "id": "gagdz",
-              "name": "Section Header",
-              "width": 1224,
-              "justifyContent": "space_between",
-              "alignItems": "center",
-              "children": [
-                {
-                  "id": "lIY4l",
-                  "type": "ref",
-                  "ref": "m:tfxWX",
-                  "x": 0,
-                  "y": 0,
-                  "children": [
-                    {
-                      "id": "PMsjS",
-                      "type": "ref",
-                      "ref": "m:Lm2P8",
-                      "content": "The community is liking"
-                    }
-                  ]
-                },
-                {
-                  "type": "frame",
-                  "id": "Y4sdtA",
-                  "name": "ViewAllWrapper",
-                  "gap": 4,
-                  "alignItems": "center",
-                  "children": [
-                    {
-                      "id": "VqEvf",
-                      "type": "ref",
-                      "ref": "m:tfxWX",
-                      "x": 0,
-                      "y": 0,
-                      "children": [
-                        {
-                          "id": "VaKnV",
-                          "type": "ref",
-                          "ref": "m:0rSuk",
-                          "content": "View all",
-                          "fill": "$m:turquoise500"
-                        }
-                      ]
-                    },
-                    {
-                      "id": "Me5lL",
-                      "type": "ref",
-                      "ref": "m:bW00p",
-                      "x": 55,
-                      "y": 3,
-                      "children": [
-                        {
-                          "id": "mhTlx",
-                          "type": "ref",
-                          "ref": "m:R1pbv",
+                          "type": "frame",
+                          "id": "dZe7u",
+                          "name": "PreviewSurface",
+                          "width": "fill_container",
+                          "height": 558,
+                          "fill": [
+                            {
+                              "type": "image",
+                              "enabled": true,
+                              "url": "../../images/project-run.png",
+                              "mode": "fill"
+                            },
+                            "#24292f99"
+                          ],
+                          "cornerRadius": 8,
+                          "justifyContent": "center",
+                          "alignItems": "center",
                           "children": [
                             {
-                              "id": "KVOv9",
+                              "id": "KeXoz",
                               "type": "ref",
-                              "ref": "m:5VNGi",
-                              "fill": "$m:turquoise500",
-                              "fontFamily": "XBuilder_NewIcons_02"
+                              "ref": "m:xjqut",
+                              "x": 332.9948785543445,
+                              "y": 263,
+                              "children": [
+                                {
+                                  "id": "qFUSX",
+                                  "type": "ref",
+                                  "ref": "m:BeWL7",
+                                  "descendants": {
+                                    "m:2XGef": {
+                                      "content": "Y"
+                                    },
+                                    "m:WEgxF": {
+                                      "content": "Run",
+                                      "x": 36,
+                                      "y": 5.006055476592933,
+                                      "rotation": 0.026683455116293515
+                                    }
+                                  }
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "JRbde",
+                          "name": "Actions",
+                          "width": "fill_container",
+                          "gap": 12,
+                          "justifyContent": "end",
+                          "children": [
+                            {
+                              "id": "f8fYzc",
+                              "type": "ref",
+                              "ref": "m:8dhVn",
+                              "x": 712,
+                              "y": 0,
+                              "children": [
+                                {
+                                  "id": "tyDhs",
+                                  "type": "ref",
+                                  "ref": "m:1dx2o",
+                                  "descendants": {
+                                    "m:EOln9": {
+                                      "content": "m",
+                                      "fontFamily": "XBuilder_NewIcons_02"
+                                    }
+                                  }
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "wS54X",
+                      "name": "Info",
+                      "width": 416,
+                      "layout": "vertical",
+                      "gap": "$m:space-4",
+                      "children": [
+                        {
+                          "id": "ONuko",
+                          "type": "ref",
+                          "ref": "m:Yg1nD",
+                          "x": 0,
+                          "y": 0,
+                          "rotation": 0,
+                          "children": [
+                            {
+                              "id": "gstS7",
+                              "type": "ref",
+                              "ref": "m:Vjvc8"
+                            }
+                          ]
+                        },
+                        {
+                          "id": "kuBOq",
+                          "type": "ref",
+                          "ref": "m:Yg1nD",
+                          "x": 0,
+                          "y": 194,
+                          "rotation": 0,
+                          "children": [
+                            {
+                              "id": "jhGjG",
+                              "type": "ref",
+                              "ref": "m:0AvUj"
                             }
                           ]
                         }
                       ]
                     }
                   ]
-                }
-              ]
-            },
-            {
-              "type": "frame",
-              "id": "TZrpy",
-              "name": "Grid",
-              "gap": "$m:space-4",
-              "children": [
-                {
-                  "id": "UAqZW",
-                  "type": "ref",
-                  "ref": "m:m6A5K",
-                  "x": 0,
-                  "y": 5.682361148043719e-14,
-                  "children": [
-                    {
-                      "id": "2k3Ou",
-                      "type": "ref",
-                      "ref": "m:9T690"
-                    }
-                  ]
                 },
                 {
-                  "id": "X9L46",
-                  "type": "ref",
-                  "ref": "m:m6A5K",
-                  "x": 248.00000000000006,
-                  "y": 5.682361148043719e-14,
+                  "type": "frame",
+                  "id": "e6OfO",
+                  "name": "CommunitySection",
+                  "clip": true,
+                  "width": "fit_content(1240)",
+                  "cornerRadius": "$m:border-radius-2",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1
+                  },
+                  "layout": "vertical",
+                  "alignItems": "center",
                   "children": [
                     {
-                      "id": "XgdY1",
-                      "type": "ref",
-                      "ref": "m:ZP33l"
-                    }
-                  ]
-                },
-                {
-                  "id": "F0PMx",
-                  "type": "ref",
-                  "ref": "m:m6A5K",
-                  "x": 496.0000000000001,
-                  "y": 5.682361148043719e-14,
-                  "children": [
+                      "type": "frame",
+                      "id": "d8lmx",
+                      "name": "Header",
+                      "width": "fill_container",
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": {
+                          "bottom": 1
+                        }
+                      },
+                      "gap": 4,
+                      "padding": [
+                        "$m:space-3",
+                        0
+                      ],
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "id": "aRX5J",
+                          "type": "ref",
+                          "ref": "m:tfxWX",
+                          "x": 0,
+                          "y": 12,
+                          "flipX": false,
+                          "flipY": false,
+                          "width": 226,
+                          "height": "fit_content",
+                          "children": [
+                            {
+                              "id": "wNeFA",
+                              "type": "ref",
+                              "ref": "m:Lm2P8",
+                              "content": "The community is liking"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "D80thr",
+                          "name": "SecondaryAction",
+                          "height": 24,
+                          "gap": 4,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "id": "bJSKh",
+                              "type": "ref",
+                              "ref": "m:tfxWX",
+                              "x": 0,
+                              "y": 1,
+                              "children": [
+                                {
+                                  "id": "B8mOG3",
+                                  "type": "ref",
+                                  "ref": "m:0rSuk",
+                                  "content": "View all",
+                                  "fill": "$m:turquoise500"
+                                }
+                              ]
+                            },
+                            {
+                              "id": "Su2aa",
+                              "type": "ref",
+                              "ref": "m:bW00p",
+                              "x": 55,
+                              "y": 4,
+                              "children": [
+                                {
+                                  "id": "MPpXz",
+                                  "type": "ref",
+                                  "ref": "m:R1pbv",
+                                  "children": [
+                                    {
+                                      "id": "eT7uc",
+                                      "type": "ref",
+                                      "ref": "m:5VNGi",
+                                      "fill": "$m:turquoise500",
+                                      "fontFamily": "XBuilder_NewIcons_02"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
                     {
-                      "id": "fHeUB",
-                      "type": "ref",
-                      "ref": "m:ZP33l"
-                    }
-                  ]
-                },
-                {
-                  "id": "Fhuxu",
-                  "type": "ref",
-                  "ref": "m:m6A5K",
-                  "x": 744.0000000000002,
-                  "y": 5.682361148043719e-14,
-                  "children": [
-                    {
-                      "id": "yG6eQ",
-                      "type": "ref",
-                      "ref": "m:ZP33l"
-                    }
-                  ]
-                },
-                {
-                  "id": "QiLW0",
-                  "type": "ref",
-                  "ref": "m:m6A5K",
-                  "x": 992.0000000000003,
-                  "y": 5.682361148043719e-14,
-                  "children": [
-                    {
-                      "id": "YbM9a",
-                      "type": "ref",
-                      "ref": "m:ZP33l"
+                      "type": "frame",
+                      "id": "c0Uu6v",
+                      "name": "CardList",
+                      "width": "fill_container",
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1
+                      },
+                      "gap": "$m:space-5",
+                      "padding": [
+                        "$m:space-2",
+                        0,
+                        32,
+                        0
+                      ],
+                      "children": [
+                        {
+                          "id": "JmEZo",
+                          "type": "ref",
+                          "ref": "m:m6A5K",
+                          "x": 0,
+                          "y": 8.000000000000057,
+                          "children": [
+                            {
+                              "id": "qv90Z",
+                              "type": "ref",
+                              "ref": "m:9T690"
+                            }
+                          ]
+                        },
+                        {
+                          "id": "wyE7o",
+                          "type": "ref",
+                          "ref": "m:m6A5K",
+                          "x": 252.00000000000006,
+                          "y": 8,
+                          "rotation": 0,
+                          "children": [
+                            {
+                              "id": "eCPXw",
+                              "type": "ref",
+                              "ref": "m:9T690"
+                            }
+                          ]
+                        },
+                        {
+                          "id": "y9qhy",
+                          "type": "ref",
+                          "ref": "m:m6A5K",
+                          "x": 504.00000000000006,
+                          "y": 8.000000000000057,
+                          "children": [
+                            {
+                              "id": "dyrVz",
+                              "type": "ref",
+                              "ref": "m:9T690"
+                            }
+                          ]
+                        },
+                        {
+                          "id": "kG3Vj",
+                          "type": "ref",
+                          "ref": "m:m6A5K",
+                          "x": 756.0000000000001,
+                          "y": 8.000000000000057,
+                          "children": [
+                            {
+                              "id": "nllzX",
+                              "type": "ref",
+                              "ref": "m:9T690"
+                            }
+                          ]
+                        },
+                        {
+                          "id": "Z9U3C",
+                          "type": "ref",
+                          "ref": "m:m6A5K",
+                          "x": 1008.0000000000002,
+                          "y": 8.000000000000057,
+                          "children": [
+                            {
+                              "id": "zc54x",
+                              "type": "ref",
+                              "ref": "m:9T690"
+                            }
+                          ]
+                        }
+                      ]
                     }
                   ]
                 }

--- a/ui/pages/spx/community-search.pen
+++ b/ui/pages/spx/community-search.pen
@@ -6,7 +6,7 @@
       "id": "so3Mg",
       "x": -720,
       "y": -92,
-      "name": "page",
+      "name": "PageSearch",
       "height": 900,
       "fill": "$t:grey300",
       "layout": "vertical",
@@ -17,8 +17,8 @@
           "id": "stYWm",
           "type": "ref",
           "ref": "t:WiWwa",
-          "x": 0.0003949726852182021,
-          "y": -1.505576084203085,
+          "x": 0.0003717389978524254,
+          "y": -0.005576084248048119,
           "children": [
             {
               "id": "fYG5L",
@@ -30,7 +30,7 @@
         {
           "type": "frame",
           "id": "j0KrA",
-          "name": "content",
+          "name": "HeaderSection",
           "clip": true,
           "width": 1440,
           "fill": "$t:grey300",
@@ -41,7 +41,7 @@
             {
               "type": "frame",
               "id": "hhuwk",
-              "name": "sub header",
+              "name": "Header",
               "clip": true,
               "width": 1440,
               "fill": "$t:grey100",
@@ -51,7 +51,7 @@
                 {
                   "type": "frame",
                   "id": "HWMDT",
-                  "name": "sub header content",
+                  "name": "HeaderContent",
                   "clip": true,
                   "width": 988,
                   "padding": [
@@ -126,6 +126,7 @@
         {
           "type": "frame",
           "id": "rAUZ7",
+          "name": "Body",
           "width": 1440,
           "height": 788,
           "fill": "$t:grey300",
@@ -138,7 +139,7 @@
             {
               "type": "frame",
               "id": "P27RNF",
-              "name": "Container",
+              "name": "Content",
               "width": 1440,
               "height": "fill_container",
               "stroke": {
@@ -157,7 +158,7 @@
                 {
                   "type": "frame",
                   "id": "Q69Pf",
-                  "name": "list",
+                  "name": "ResultsList",
                   "width": 988,
                   "stroke": {
                     "align": "inside",
@@ -175,7 +176,7 @@
                     {
                       "type": "frame",
                       "id": "DHEUM",
-                      "name": "Grid",
+                      "name": "CardGridTopRow",
                       "gap": "$t:space-5",
                       "children": [
                         {
@@ -259,7 +260,7 @@
                     {
                       "type": "frame",
                       "id": "gkOw6",
-                      "name": "Grid",
+                      "name": "CardGridBottomRow",
                       "gap": "$t:space-5",
                       "children": [
                         {
@@ -345,7 +346,7 @@
                 {
                   "type": "frame",
                   "id": "Z87Sw",
-                  "name": "Frame 1000002981",
+                  "name": "PaginationSection",
                   "width": 988,
                   "fill": "$t:grey100",
                   "cornerRadius": 8,

--- a/ui/pages/spx/community-share.pen
+++ b/ui/pages/spx/community-share.pen
@@ -1,0 +1,4 @@
+{
+  "version": "2.11",
+  "children": []
+}

--- a/ui/pages/spx/community-share.pen
+++ b/ui/pages/spx/community-share.pen
@@ -1,4 +1,514 @@
 {
   "version": "2.11",
-  "children": []
+  "children": [
+    {
+      "type": "frame",
+      "id": "J9FW6",
+      "x": -12998,
+      "y": 4489,
+      "name": "ShareProject",
+      "clip": true,
+      "width": 1440,
+      "height": 900,
+      "stroke": {
+        "align": "inside",
+        "thickness": 1
+      },
+      "layout": "vertical",
+      "children": [
+        {
+          "id": "fq9nN",
+          "type": "ref",
+          "ref": "B:WiWwa",
+          "x": 0.0003717389978524254,
+          "y": 0,
+          "children": [
+            {
+              "id": "XDEQK",
+              "type": "ref",
+              "ref": "B:O7syE"
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "bcgax",
+          "name": "PageBody",
+          "width": "fill_container",
+          "height": 1072,
+          "fill": "#f6f8faff",
+          "stroke": {
+            "align": "inside",
+            "thickness": 1
+          },
+          "gap": 10,
+          "padding": [
+            24,
+            210,
+            40,
+            210
+          ],
+          "justifyContent": "center",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "nnRCg",
+              "name": "Content",
+              "width": 1240,
+              "stroke": {
+                "align": "inside",
+                "thickness": 1
+              },
+              "layout": "vertical",
+              "gap": 20,
+              "justifyContent": "center",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "ZN9OJ",
+                  "name": "Surface",
+                  "width": 1240,
+                  "fill": "$B:grey100",
+                  "cornerRadius": "$B:border-radius-2",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1
+                  },
+                  "gap": 40,
+                  "padding": "$B:space-5",
+                  "justifyContent": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "ri78D",
+                      "name": "Leading",
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1
+                      },
+                      "layout": "vertical",
+                      "gap": "$B:space-3",
+                      "justifyContent": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "U12cf",
+                          "name": "Preview",
+                          "clip": true,
+                          "width": 744,
+                          "height": 558,
+                          "cornerRadius": 8,
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": 1
+                          },
+                          "layout": "vertical",
+                          "gap": "$B:radius-3",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "jxNq1",
+                              "name": "Media",
+                              "clip": true,
+                              "width": "fill_container",
+                              "height": "fill_container",
+                              "fill": [
+                                {
+                                  "type": "image",
+                                  "enabled": true,
+                                  "url": "../../images/ai-genetated-backdrop.png",
+                                  "mode": "fit"
+                                },
+                                "#24292f99"
+                              ],
+                              "stroke": {
+                                "align": "inside",
+                                "thickness": 1
+                              },
+                              "effect": {
+                                "type": "blur",
+                                "radius": "$B:shadow-blur-1"
+                              },
+                              "layout": "none"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "xLMC5",
+                          "name": "Actions",
+                          "width": 744,
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": 1
+                          },
+                          "gap": "$B:space-3",
+                          "justifyContent": "end",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "eMi0j",
+                              "name": "Component/preview-button",
+                              "stroke": {
+                                "align": "inside",
+                                "thickness": 1
+                              },
+                              "gap": "$B:space-3",
+                              "justifyContent": "center",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "frame",
+                                  "id": "pAFYU",
+                                  "name": "Button",
+                                  "width": 32,
+                                  "height": 32,
+                                  "fill": "$B:grey300",
+                                  "cornerRadius": "$B:border-radius-1",
+                                  "stroke": {
+                                    "align": "inside",
+                                    "thickness": 1,
+                                    "fill": "$B:grey400"
+                                  },
+                                  "gap": "$B:space-1",
+                                  "padding": "$B:space-2",
+                                  "justifyContent": "center",
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "id": "E0TDM",
+                                      "type": "ref",
+                                      "ref": "B:bW00p",
+                                      "x": 8,
+                                      "y": 8,
+                                      "children": [
+                                        {
+                                          "id": "mtWiK",
+                                          "type": "ref",
+                                          "ref": "B:WMGYM"
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "GHb5A",
+                      "name": "Trailing",
+                      "clip": true,
+                      "width": "fill_container",
+                      "height": 602,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1
+                      },
+                      "layout": "vertical",
+                      "children": [
+                        {
+                          "id": "XuhHv",
+                          "type": "ref",
+                          "ref": "B:Yg1nD",
+                          "x": 0,
+                          "y": 9.699202649247038e-14,
+                          "rotation": 1.4033418597069752e-14,
+                          "children": [
+                            {
+                              "id": "rIiRw",
+                              "type": "ref",
+                              "ref": "B:Vjvc8"
+                            }
+                          ]
+                        },
+                        {
+                          "id": "Mdxsn",
+                          "type": "ref",
+                          "ref": "B:Yg1nD",
+                          "x": 0,
+                          "y": 178.0000000000002,
+                          "rotation": 1.4033418597069752e-14,
+                          "children": [
+                            {
+                              "id": "ODPHB",
+                              "type": "ref",
+                              "ref": "B:0AvUj"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "ioMQ1",
+                  "name": "Panel",
+                  "clip": true,
+                  "width": "fit_content(1240)",
+                  "cornerRadius": 12,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1
+                  },
+                  "layout": "vertical",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "G1dLX",
+                      "name": "Header",
+                      "width": "fill_container",
+                      "height": 52,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": {
+                          "bottom": 1
+                        }
+                      },
+                      "gap": 4,
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "id": "WGcjd",
+                          "type": "ref",
+                          "ref": "B:tfxWX",
+                          "x": 0,
+                          "y": 12,
+                          "children": [
+                            {
+                              "id": "Wd98k",
+                              "type": "ref",
+                              "ref": "B:Lm2P8",
+                              "content": "The community is liking",
+                              "fontStyle": "normal",
+                              "fontWeight": "600"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "u2i15",
+                          "name": ".component/view more",
+                          "width": 104,
+                          "height": 24,
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": 1
+                          },
+                          "gap": "$B:space-2",
+                          "justifyContent": "end",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "id": "GkGDE",
+                              "type": "ref",
+                              "ref": "B:tfxWX",
+                              "x": -1,
+                              "y": 0,
+                              "children": [
+                                {
+                                  "id": "nDMvk",
+                                  "type": "ref",
+                                  "ref": "B:2UD0N",
+                                  "content": "View more",
+                                  "fill": "$B:turquoise500",
+                                  "fontStyle": "normal",
+                                  "fontWeight": "500",
+                                  "fontSize": 15
+                                }
+                              ]
+                            },
+                            {
+                              "id": "WIHSc",
+                              "type": "ref",
+                              "ref": "B:bW00p",
+                              "x": 84,
+                              "y": 2,
+                              "children": [
+                                {
+                                  "id": "PFt5B",
+                                  "type": "ref",
+                                  "ref": "B:R1pbv",
+                                  "descendants": {
+                                    "B:KuyD8": {
+                                      "fontSize": 20,
+                                      "fill": "$B:turquoise500"
+                                    }
+                                  }
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "GQAio",
+                      "name": "List",
+                      "width": "fill_container",
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1
+                      },
+                      "gap": "$B:space-5",
+                      "padding": [
+                        "$B:space-2",
+                        0,
+                        32,
+                        0
+                      ],
+                      "children": [
+                        {
+                          "id": "F1vTD",
+                          "type": "ref",
+                          "ref": "B:m6A5K",
+                          "x": 0,
+                          "y": 8.000000000000057,
+                          "children": [
+                            {
+                              "id": "lZIUF",
+                              "type": "ref",
+                              "ref": "B:9T690"
+                            }
+                          ]
+                        },
+                        {
+                          "id": "IIObt",
+                          "type": "ref",
+                          "ref": "B:m6A5K",
+                          "x": 252.00000000000006,
+                          "y": 8.000000000000057,
+                          "children": [
+                            {
+                              "id": "ZtgCj",
+                              "type": "ref",
+                              "ref": "B:9T690"
+                            }
+                          ]
+                        },
+                        {
+                          "id": "hFAA5",
+                          "type": "ref",
+                          "ref": "B:m6A5K",
+                          "x": 504.0000000000001,
+                          "y": 8.000000000000057,
+                          "children": [
+                            {
+                              "id": "ALXuI",
+                              "type": "ref",
+                              "ref": "B:9T690"
+                            }
+                          ]
+                        },
+                        {
+                          "id": "ia6Z5",
+                          "type": "ref",
+                          "ref": "B:m6A5K",
+                          "x": 756.0000000000002,
+                          "y": 8.000000000000057,
+                          "children": [
+                            {
+                              "id": "AgXZo",
+                              "type": "ref",
+                              "ref": "B:9T690"
+                            }
+                          ]
+                        },
+                        {
+                          "id": "dJBZb",
+                          "type": "ref",
+                          "ref": "B:m6A5K",
+                          "x": 1008.0000000000002,
+                          "y": 8.000000000000057,
+                          "children": [
+                            {
+                              "id": "pcHTd",
+                              "type": "ref",
+                              "ref": "B:9T690"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "cbe08",
+          "layoutPosition": "absolute",
+          "x": 0,
+          "y": 0,
+          "name": "Overlay",
+          "clip": true,
+          "width": 1440,
+          "height": 900,
+          "fill": "#24292fbf",
+          "stroke": {
+            "align": "inside",
+            "thickness": 1
+          },
+          "layout": "vertical",
+          "justifyContent": "center",
+          "alignItems": "center",
+          "children": [
+            {
+              "id": "CDfmF",
+              "type": "ref",
+              "ref": "B:S5gj5",
+              "x": 440,
+              "y": 358.47619047619224,
+              "descendants": {
+                "B:x5bh9": {
+                  "children": [
+                    {
+                      "id": "inYYV",
+                      "type": "ref",
+                      "ref": "B:hBPUt"
+                    }
+                  ]
+                },
+                "B:mGJha": {
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "id": "U0wdMB",
+                      "type": "ref",
+                      "ref": "B:NHMDu",
+                      "padding": [
+                        0,
+                        0,
+                        "$B:space-2",
+                        0
+                      ]
+                    }
+                  ]
+                },
+                "B:H8u2tW": {
+                  "enabled": false
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "imports": {
+    "B": "../../components/spx/builder-component.lib.pen"
+  }
 }


### PR DESCRIPTION
### Issue

Related to #xxxx

### Background

Expand representative page coverage under `ui-pages/community` to improve community scenario completeness and provide reusable page references for key user flows.

### Changes

- Restored representative explore page under community
- Restored representative login page under community
- Restored representative project page under community
- Added community loading page
- Added community share page
- Refined page structure consistency and reuse patterns

### Scope

- `ui-pages/community-explore`
- `ui-pages/community-login`
- `ui-pages/community-project`
- `ui-pages/community-loading`
- `ui-pages/community-share`
- `ui/components/spx/builder-component.lib.pen`

### Design System Impact

- [ ] Yes
- [x] No