### PR TITLE
fix(animation): revert sound binding to onStart temporarily

### DIFF
--- a/spx-gui/src/models/spx/animation.test.ts
+++ b/spx-gui/src/models/spx/animation.test.ts
@@ -129,47 +129,47 @@ describe('Animation', () => {
     expect(exportedId).toBeUndefined()
   })
 
-  it('should export sound binding using onPlay', () => {
-    const project = makeProject()
-    const sprite = project.sprites[0]
-    const animation = sprite.animations[0]
-    animation.setSound(project.sounds[0].id)
+  // it('should export sound binding using onPlay', () => {
+  //   const project = makeProject()
+  //   const sprite = project.sprites[0]
+  //   const animation = sprite.animations[0]
+  //   animation.setSound(project.sounds[0].id)
 
-    const [config] = animation.export('', { sounds: project.sounds })
-    expect(config.onPlay).toEqual({ play: project.sounds[0].name, loop: false })
-    expect(config.onStart).toBeUndefined()
-  })
+  //   const [config] = animation.export('', { sounds: project.sounds })
+  //   expect(config.onPlay).toEqual({ play: project.sounds[0].name, loop: false })
+  //   expect(config.onStart).toBeUndefined()
+  // })
 
-  it('should export loop: true in onPlay when soundLoop is true', () => {
-    const project = makeProject()
-    const sprite = project.sprites[0]
-    const animation = sprite.animations[0]
-    animation.setSound(project.sounds[0].id)
-    animation.setSoundLoop(true)
+  // it('should export loop: true in onPlay when soundLoop is true', () => {
+  //   const project = makeProject()
+  //   const sprite = project.sprites[0]
+  //   const animation = sprite.animations[0]
+  //   animation.setSound(project.sounds[0].id)
+  //   animation.setSoundLoop(true)
 
-    const [config] = animation.export('', { sounds: project.sounds })
-    expect(config.onPlay).toEqual({ play: project.sounds[0].name, loop: true })
-  })
+  //   const [config] = animation.export('', { sounds: project.sounds })
+  //   expect(config.onPlay).toEqual({ play: project.sounds[0].name, loop: true })
+  // })
 
-  it('should load soundLoop from onPlay.loop', () => {
-    const project = makeProject()
-    const sprite = project.sprites[0]
-    const costumes = sprite.costumes
-    const sounds = project.sounds
+  // it('should load soundLoop from onPlay.loop', () => {
+  //   const project = makeProject()
+  //   const sprite = project.sprites[0]
+  //   const costumes = sprite.costumes
+  //   const sounds = project.sounds
 
-    const [animation] = Animation.load(
-      'default',
-      {
-        frameFrom: costumes[0].name,
-        frameTo: costumes[0].name,
-        onPlay: { play: sounds[0].name, loop: true }
-      },
-      costumes,
-      { sounds }
-    )
-    expect(animation.sound).toBe(sounds[0].id)
-    expect(animation.soundLoop).toBe(true)
-  })
+  //   const [animation] = Animation.load(
+  //     'default',
+  //     {
+  //       frameFrom: costumes[0].name,
+  //       frameTo: costumes[0].name,
+  //       onPlay: { play: sounds[0].name, loop: true }
+  //     },
+  //     costumes,
+  //     { sounds }
+  //   )
+  //   expect(animation.sound).toBe(sounds[0].id)
+  //   expect(animation.soundLoop).toBe(true)
+  // })
 
   it('should default soundLoop to false when loop field is absent', () => {
     const project = makeProject()

--- a/spx-gui/src/models/spx/animation.test.ts
+++ b/spx-gui/src/models/spx/animation.test.ts
@@ -129,47 +129,50 @@ describe('Animation', () => {
     expect(exportedId).toBeUndefined()
   })
 
-  // it('should export sound binding using onPlay', () => {
-  //   const project = makeProject()
-  //   const sprite = project.sprites[0]
-  //   const animation = sprite.animations[0]
-  //   animation.setSound(project.sounds[0].id)
+  // Temporary skip until goplus/spx#1574 is fixed and animation export switches back from onStart to onPlay.
+  it.skip('should export sound binding using onPlay', () => {
+    const project = makeProject()
+    const sprite = project.sprites[0]
+    const animation = sprite.animations[0]
+    animation.setSound(project.sounds[0].id)
 
-  //   const [config] = animation.export('', { sounds: project.sounds })
-  //   expect(config.onPlay).toEqual({ play: project.sounds[0].name, loop: false })
-  //   expect(config.onStart).toBeUndefined()
-  // })
+    const [config] = animation.export('', { sounds: project.sounds })
+    expect(config.onPlay).toEqual({ play: project.sounds[0].name, loop: false })
+    expect(config.onStart).toBeUndefined()
+  })
 
-  // it('should export loop: true in onPlay when soundLoop is true', () => {
-  //   const project = makeProject()
-  //   const sprite = project.sprites[0]
-  //   const animation = sprite.animations[0]
-  //   animation.setSound(project.sounds[0].id)
-  //   animation.setSoundLoop(true)
+  // Temporary skip until goplus/spx#1574 is fixed and animation export switches back from onStart to onPlay.
+  it.skip('should export loop: true in onPlay when soundLoop is true', () => {
+    const project = makeProject()
+    const sprite = project.sprites[0]
+    const animation = sprite.animations[0]
+    animation.setSound(project.sounds[0].id)
+    animation.setSoundLoop(true)
 
-  //   const [config] = animation.export('', { sounds: project.sounds })
-  //   expect(config.onPlay).toEqual({ play: project.sounds[0].name, loop: true })
-  // })
+    const [config] = animation.export('', { sounds: project.sounds })
+    expect(config.onPlay).toEqual({ play: project.sounds[0].name, loop: true })
+  })
 
-  // it('should load soundLoop from onPlay.loop', () => {
-  //   const project = makeProject()
-  //   const sprite = project.sprites[0]
-  //   const costumes = sprite.costumes
-  //   const sounds = project.sounds
+  // Temporary skip until goplus/spx#1574 is fixed and animation export switches back from onStart to onPlay.
+  it.skip('should load soundLoop from onPlay.loop', () => {
+    const project = makeProject()
+    const sprite = project.sprites[0]
+    const costumes = sprite.costumes
+    const sounds = project.sounds
 
-  //   const [animation] = Animation.load(
-  //     'default',
-  //     {
-  //       frameFrom: costumes[0].name,
-  //       frameTo: costumes[0].name,
-  //       onPlay: { play: sounds[0].name, loop: true }
-  //     },
-  //     costumes,
-  //     { sounds }
-  //   )
-  //   expect(animation.sound).toBe(sounds[0].id)
-  //   expect(animation.soundLoop).toBe(true)
-  // })
+    const [animation] = Animation.load(
+      'default',
+      {
+        frameFrom: costumes[0].name,
+        frameTo: costumes[0].name,
+        onPlay: { play: sounds[0].name, loop: true }
+      },
+      costumes,
+      { sounds }
+    )
+    expect(animation.sound).toBe(sounds[0].id)
+    expect(animation.soundLoop).toBe(true)
+  })
 
   it('should default soundLoop to false when loop field is absent', () => {
     const project = makeProject()

--- a/spx-gui/src/models/spx/animation.ts
+++ b/spx-gui/src/models/spx/animation.ts
@@ -230,7 +230,10 @@ export class Animation extends Disposable {
     }
     const soundName = sounds.find((s) => s.id === this.sound)?.name
     if (soundName != null) {
-      config.onPlay = { play: soundName, loop: this.soundLoop }
+      // Revert to legacy onStart temporarily. For details, see https://github.com/goplus/builder/issues/3172
+      // TODO: Use `onPlay` instead of `onStart` after goplus/spx#1574 resolved and spx updated.
+      // config.onPlay = { play: soundName, loop: this.soundLoop }
+      config.onStart = { play: soundName }
     }
     if (includeId) config.builder_id = this.id
     return [config, costumeConfigs, files]

--- a/spx-gui/src/models/spx/animation.ts
+++ b/spx-gui/src/models/spx/animation.ts
@@ -231,8 +231,7 @@ export class Animation extends Disposable {
     const soundName = sounds.find((s) => s.id === this.sound)?.name
     if (soundName != null) {
       // Revert to legacy onStart temporarily. For details, see https://github.com/goplus/builder/issues/3172
-      // TODO: Use `onPlay` instead of `onStart` after goplus/spx#1574 resolved and spx updated.
-      // config.onPlay = { play: soundName, loop: this.soundLoop }
+      // TODO: Use `onPlay` instead of `onStart` and pass loop after goplus/spx#1574 resolved and spx updated.
       config.onStart = { play: soundName }
     }
     if (includeId) config.builder_id = this.id


### PR DESCRIPTION
Closes #3172

## Summary
- revert animation sound binding from `onPlay` back to `onStart` temporarily
- remove the loop-specific animation sound export covered by the reverted binding
- update animation model tests to match the temporary fallback behavior

## Validation
- npm run test -- --run src/models/spx/animation.test.ts
- npx eslint src/models/spx/animation.ts src/models/spx/animation.test.ts
- npm run type-check
