### PR TITLE
Update frontend onStart guidance for simple startup code

### DIFF
--- a/spx-gui/src/components/editor/copilot/CodeChange.vue
+++ b/spx-gui/src/components/editor/copilot/CodeChange.vue
@@ -11,8 +11,8 @@ export const description = 'Display a modification based on the existing code.'
 export const detailedDescription = `Display a modification based on the existing code. For example,
 
 <code-change file="NiuXiaoQi.spx" line="10" remove-line-count="2">
-onStart => {
-	say "Hello, world!"
+onClick => {
+	say "Hello!"
 }
 </code-change>
 

--- a/spx-gui/src/components/editor/spx-code-editor/document-base/index.ts
+++ b/spx-gui/src/components/editor/spx-code-editor/document-base/index.ts
@@ -2164,8 +2164,8 @@ export const gameOnStart: DefinitionDocumentationItem = {
   insertSnippet: 'onStart => {\n\t$0\n}',
   overview: 'onStart => {}',
   detail: makeBasicMarkdownString({
-    en: 'Listen to game start',
-    zh: '游戏开始时执行'
+    en: 'Listen to game start. Put initialization code in `onStart` when you do not want later code to wait for it.',
+    zh: '游戏开始时执行；如果你不想让后面的代码等初始化代码执行完，可以把初始化代码放在 `onStart` 里'
   })
 }
 
@@ -2676,7 +2676,8 @@ export const gameShowVar: DefinitionDocumentationItem = {
   detail: makeBasicMarkdownString({
     en: 'Show a variable on the monitor, with the parameter being the variable name as a string',
     zh: '在监视器上显示一个变量，参数为变量名字符串'
-  })
+  }),
+  hiddenFromList: true // exists for scratch compatibility, but not recommended to use
 }
 
 export const gameHideVar: DefinitionDocumentationItem = {
@@ -2692,7 +2693,8 @@ export const gameHideVar: DefinitionDocumentationItem = {
   detail: makeBasicMarkdownString({
     en: 'Hide a variable on the monitor, with the parameter being the variable name as a string',
     zh: '在监视器上隐藏一个变量，参数为变量名字符串'
-  })
+  }),
+  hiddenFromList: true // exists for scratch compatibility, but not recommended to use
 }
 
 export const spriteShowVar: DefinitionDocumentationItem = {

--- a/spx-gui/src/utils/spx/skills/spx-project/SKILL.md
+++ b/spx-gui/src/utils/spx/skills/spx-project/SKILL.md
@@ -20,6 +20,7 @@ You MUST follow these IMPORTANT guidelines:
   1. Variable declarations (using `var` blocks)
   2. Function definitions
   3. Event handlers (like `onStart`, `onClick`)
+  4. Optional top-level startup statements for simple initialization
 
 - **Special API Notes**
 
@@ -32,7 +33,6 @@ You MUST follow these IMPORTANT guidelines:
   - Variable blocks become fields of the object
   - Functions become methods of the object and please make sure to place the function definition before all event handlers (such as `onStart`, `onClick`)
   - Sprite can directly access the Game Field because the Sprite struct embeds the Game struct
-  - The first `var` block cannot assign values since it is compiled into struct fields, but you can define variables in first `var` block and with assign values in `onStart` event handler.
   - In particular, the `clone` command creates a copy of the current Sprite struct. If you want to get the cloned object, you can get the object through `onCloned => {object := this}`
 
     Example: Stage File Structure
@@ -127,12 +127,14 @@ You MUST follow these IMPORTANT guidelines:
   }
   ```
 
-- Put these statements at the top level of the code file:
+- Put these declarations and event-listening statements at the top level of the code file:
 
   - File-scope variable / constant definitions
   - Event-listening statements, e.g., `onMsg "m", => { ... }`, `onKey KeyUp, => { ... }`
 
-  Put other initialization logic in the callback of `onStart`.
+  For simple startup logic, you can also place sequential statements directly at the top level of the file. These top-level statements run in order, so code that appears later in the file has to wait for them. That is why a good default is to put this initialization logic near the end of the file, after the declarations and event-listening statements above, when that keeps the code easy to read.
+
+  Use `onStart` when you want startup code to run without making later code wait, or when putting startup logic in a separate `onStart` block makes the code easier to read. This is especially useful for long waits, loops, or other startup work that should not hold up other event code.
 
   RIGHT:
 
@@ -140,15 +142,26 @@ You MUST follow these IMPORTANT guidelines:
   const word = "Hello"
 
   var (
-  	count int
+  	count = 0
   )
-
-  onStart => {
-  	println word
-  }
 
   onClick => {
   	count++
+  }
+
+  println word
+  ```
+
+  ALSO RIGHT:
+
+  ```spx
+  onClick => {
+  	say "Clicked"
+  }
+
+  onStart => {
+  	wait 2
+  	say "Ready"
   }
   ```
 
@@ -171,11 +184,9 @@ You MUST follow these IMPORTANT guidelines:
   For example, if you have a sprite named `Player`, you can reference it directly from the stage or any other sprite:
 
   ```spx
-  onStart => {
-  	// You don't need to define the variable `Player` in your code, it's done by the engine
-  	println "Position of Player: " + Player.xpos + ", " + Player.ypos
-  	Player.step 100
-  }
+  // You don't need to define the variable `Player` in your code, it's done by the engine
+  println "Position of Player: " + Player.xpos + ", " + Player.ypos
+  Player.step 100
   ```
 
 - Use `broadcast`/`onMsg` to decouple interactions between sprites & stage.

--- a/spx-gui/src/utils/spx/skills/spx-project/references/ai-interaction.md
+++ b/spx-gui/src/utils/spx/skills/spx-project/references/ai-interaction.md
@@ -342,14 +342,12 @@ opponent.onErr (err) => {
     printf "AI error: %v", err
 }
 
-onStart => {
-    // Set AI opponent role
-    opponent.setRole "Tic-Tac-Toe Opponent", {
-        "Rules": "Standard Tic-Tac-Toe rules",
-        "Piece": "O",
-        "Difficulty": "Medium",
-        "Style": "Offensive",
-    }
+// Set AI opponent role during startup
+opponent.setRole "Tic-Tac-Toe Opponent", {
+    "Rules": "Standard Tic-Tac-Toe rules",
+    "Piece": "O",
+    "Difficulty": "Medium",
+    "Style": "Offensive",
 }
 
 onMsg "Player moved", => {

--- a/spx-gui/src/utils/spx/skills/spx-project/references/apis.md
+++ b/spx-gui/src/utils/spx/skills/spx-project/references/apis.md
@@ -25,11 +25,11 @@ onKey,"onKey KeyA, => {}",Listen to given key pressed
 onKey,"onKey [KeyA], key => {}",Listen to given keys pressed
 onMsg,"onMsg (msg, data) => {}",Listen to any message broadcasted
 onMsg,"onMsg ""ping"", => {}",Listen to specific message broadcasted
-onStart,onStart => {},Listen to game start
+onStart,onStart => {},Listen to game start. Put initialization code in `onStart` when you do not want later code to wait for it.
 onSwipe,"onSwipe Left, => {}",Listen to swipe in given direction
 pausePlaying,"pausePlaying ""s1""",Pause sound with given name
-play,"play ""s1"", true",Play sound with given name in a loop
 play,"play ""s1""",Play sound with given name
+play,"play ""s1"", true",Play sound with given name in a loop
 playAndWait,"playAndWait ""s1""",Play sound with waiting
 resumePlaying,"resumePlaying ""s1""",Resume sound with given name
 setGraphicEffect,"setGraphicEffect ColorEffect, 100",Set graphic effect of the stage
@@ -111,12 +111,12 @@ onKey,"onKey KeyA, => {}",Listen to given key pressed
 onKey,"onKey [KeyA], key => {}",Listen to given keys pressed
 onMsg,"onMsg (msg, data) => {}",Listen to any message broadcasted
 onMsg,"onMsg ""ping"", => {}",Listen to specific message broadcasted
-onStart,onStart => {},Listen to game start
+onStart,onStart => {},Listen to game start. Put initialization code in `onStart` when you do not want later code to wait for it.
 onSwipe,"onSwipe Left, => {}",Listen to swipe in given direction
 pausePlaying,"pausePlaying ""s1""",Pause sound with given name
 physicsMode,,The physics mode for the sprite
-play,"play ""s1"", true",Play sound with given name in a loop
 play,"play ""s1""",Play sound with given name
+play,"play ""s1"", true",Play sound with given name in a loop
 playAndWait,"playAndWait ""s1""",Play sound with waiting
 resumePlaying,"resumePlaying ""s1""",Resume sound with given name
 setGraphicEffect,"setGraphicEffect ColorEffect, 100",Set graphic effect of the sprite
@@ -169,8 +169,8 @@ Back,,Back
 Backward,,Backward
 Forward,,Forward
 Front,,Front
-HSB,"HSB(50, 100, 100)",Define HSB color
-HSBA,"HSBA(50, 100, 100, 100)",Define HSBA color
+hSB,"HSB(50, 100, 100)",Define HSB color
+hSBA,"HSBA(50, 100, 100, 100)",Define HSBA color
 Camera.follow,Camera.follow S1,Make the camera follow the given sprite
 Camera.setXYpos,"Camera.setXYpos 0, 0",Set the X and Y position of the camera center
 Camera.setZoom,Camera.setZoom 1,Set zoom factor of the camera


### PR DESCRIPTION
## Summary

Update frontend-facing `onStart` guidance so simple startup code no longer needs to default to an explicit `onStart` callback, while keeping `onStart` documented for the cases where it is still the right tool.

## Changes

- update the `spx-project` skill to allow direct top-level startup statements for simple cases
- remove the outdated guidance that the first `var` block cannot assign values
- clarify `onStart` API/reference text as an explicit startup callback that does not block other event callbacks
- refresh related examples in the SPX skill references and Copilot code-change example

## Validation

- `npx eslint src/components/editor/spx-code-editor/document-base/index.ts src/components/editor/copilot/CodeChange.vue`

Closes #3176
