### PR TITLE
[Page] Update: Adjust editor and tutorials layout

### DIFF
--- a/spx-gui/.env
+++ b/spx-gui/.env
@@ -53,7 +53,7 @@ VITE_DISABLE_AIGC="false"
 VITE_SPX_VERSION="2.0.1"
 
 # Whether to show the license information (including copyright) in the footer.
-VITE_SHOW_LICENSE="true"
+VITE_SHOW_LICENSE="false"
 
 # Sentry configuration for error and performance monitoring
 # DSN is required if you want to use Sentry (leave empty to disable)

--- a/spx-gui/.env
+++ b/spx-gui/.env
@@ -53,7 +53,7 @@ VITE_DISABLE_AIGC="false"
 VITE_SPX_VERSION="2.0.1"
 
 # Whether to show the license information (including copyright) in the footer.
-VITE_SHOW_LICENSE="false"
+VITE_SHOW_LICENSE="true"
 
 # Sentry configuration for error and performance monitoring
 # DSN is required if you want to use Sentry (leave empty to disable)

--- a/spx-gui/src/pages/editor/index.vue
+++ b/spx-gui/src/pages/editor/index.vue
@@ -1,4 +1,3 @@
-<!-- TODO: review root background color and promote it to a shared UI token if it becomes reused. -->
 <template>
   <section class="min-h-full w-full flex flex-col bg-grey-300">
     <header class="flex-none">

--- a/spx-gui/src/pages/editor/index.vue
+++ b/spx-gui/src/pages/editor/index.vue
@@ -1,6 +1,6 @@
 <!-- TODO: review root background color and promote it to a shared UI token if it becomes reused. -->
 <template>
-  <section class="min-h-full w-full flex flex-col bg-[#f1f5f7]">
+  <section class="min-h-full w-full flex flex-col bg-grey-300">
     <header class="flex-none">
       <EditorNavbar :project="state?.project ?? null" :state="state" />
     </header>

--- a/spx-gui/src/pages/tutorials/course-series.vue
+++ b/spx-gui/src/pages/tutorials/course-series.vue
@@ -99,7 +99,7 @@ const { fn: handleCourseClick } = useMessageHandle(
     <!-- TODO: Temporarily import the community component -->
     <CommunityNavbar />
 
-    <CenteredWrapper size="medium" class="my-6">
+    <CenteredWrapper size="medium" class="my-6 flex-1">
       <UICard class="h-[145px] flex gap-10 bg-grey-100 p-5">
         <UILoading v-if="courseSeriesIsLoading" cover mask="solid" />
         <UIError v-else-if="courseSeriesError != null" :retry="courseSeriesRefetch">

--- a/spx-gui/src/pages/tutorials/course-series.vue
+++ b/spx-gui/src/pages/tutorials/course-series.vue
@@ -99,7 +99,7 @@ const { fn: handleCourseClick } = useMessageHandle(
     <!-- TODO: Temporarily import the community component -->
     <CommunityNavbar />
 
-    <CenteredWrapper size="medium" class="my-6 flex-1">
+    <CenteredWrapper size="medium" class="my-6 flex-[1_0_auto]">
       <UICard class="h-[145px] flex gap-10 bg-grey-100 p-5">
         <UILoading v-if="courseSeriesIsLoading" cover mask="solid" />
         <UIError v-else-if="courseSeriesError != null" :retry="courseSeriesRefetch">


### PR DESCRIPTION
### Issue

- N/A

### Background

Align the editor and tutorials pages with the expected UI behavior: use the shared grey background token, keep the course-series content area filling the remaining page height, and show the required license information in local/default configuration.

### Changes

- Updated the editor page root background to use `bg-grey-300`.
- Let the course-series content wrapper grow with `flex-1` so the footer can sit at the bottom of the page.
- Enabled license footer display through `VITE_SHOW_LICENSE`.

### Scope

- Editor page
- Tutorials course-series page
- Community footer visibility in default env

### Design System Impact

- [ ] Yes
- [x] No
