### PR TITLE
build: align staging and preview with production optimization

### DIFF
--- a/spx-gui/package.json
+++ b/spx-gui/package.json
@@ -7,7 +7,7 @@
     "postinstall": "./install-spx.sh",
     "predev": "./install-spx.sh && ./build-wasm.sh && ./build-tutorial-books.sh",
     "dev": "vite",
-    "build": "./build-tutorial-books.sh && vue-tsc --build --force && vite build --mode ${NODE_ENV:-production}",
+    "build": "./build-tutorial-books.sh && vue-tsc --build --force && NODE_ENV=production vite build --mode ${NODE_ENV:-production}",
     "preview": "vite preview",
     "type-check": "vue-tsc --build --force",
     "format-check": "prettier --check ./src",


### PR DESCRIPTION
## Summary

This PR makes staging, preview, and production builds use the same production build behavior while still loading the environment-specific Vite [mode](https://vite.dev/guide/env-and-mode#modes).

## Background
We found this while investigating a UITooltip trigger issue.

`UIIcon` contains template comments:

```html
<template>
  <!-- TODO: is there any way to avoid the wrapper `<div>`? -->
  <!-- eslint-disable-next-line vue/no-v-html -->
  <div :class="rootClass" :data-icon-type="type" v-html="typeIconMap[type]"></div>
</template>
```

When Vite/Vue builds with a non-production `NODE_ENV`, those comments can remain in the compiled output. When `UIIcon` is used as the tooltip trigger, the preserved comment node can prevent `UITooltip` from resolving the expected trigger element correctly, so the tooltip does not appear.

In production this was already fine, but staging and preview could behave differently from production.

## Change
The build script now:
- keeps `NODE_ENV=production` for the actual `vite build`
- still uses the outer `NODE_ENV` value as Vite `--mode`

That means:
- staging/preview can still load their own mode-specific config
- staging/preview/production now share the same production build optimizations and output behavior

## Non-goal
This PR does not try to fix the tooltip behavior in development builds. It only aligns behavior across staging, preview, and production.

## Validation
- Verified the current build path uses production optimization while keeping staging mode selection.
- Compared Vite output directly:
  - `NODE_ENV=staging npx vite build --mode staging` kept the `UIIcon` template comment in emitted JS
  - `NODE_ENV=production npx vite build --mode staging` removed that comment from emitted JS
- Confirmed the Docker/CI build path passes `NODE_ENV=staging`, so the updated script is wired through the deployment path.
