### PR TITLE
refactor(api): use absolute upload session expiration

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -4948,7 +4948,7 @@ components:
       type: object
       required:
         - token
-        - expires
+        - expiresAt
         - maxSize
         - bucket
         - region
@@ -4958,12 +4958,12 @@ components:
           type: string
           examples:
             - MY_ACCESS_KEY:wQ4ofysef1R7IKnrziqtomqyDvI=:eyJzY29wZSI6Im15LWJ1Y2tldDpzdW5mbG93ZXIuanBnIiwiZGVhZGxpbmUiOjE0NTE0OTEyMDAsInJldHVybkJvZHkiOiJ7XCJuYW1lXCI6JChmbmFtZSksXCJzaXplXCI6JChmc2l6ZSksXCJ3XCI6JChpbWFnZUluZm8ud2lkdGgpLFwiaFwiOiQoaW1hZ2VJbmZvLmhlaWdodCksXCJoYXNoXCI6JChldGFnKX0ifQ==
-        expires:
-          description: Expiration time of the upload token in seconds.
-          type: integer
-          format: int64
+        expiresAt:
+          description: Expiration timestamp of the upload token.
+          type: string
+          format: date-time
           examples:
-            - 1800
+            - 2006-01-02T15:04:05+07:00
         maxSize:
           description: Maximum allowed file size in bytes.
           type: integer

--- a/spx-gui/src/apis/file.ts
+++ b/spx-gui/src/apis/file.ts
@@ -9,8 +9,8 @@ import { UniversalUrlScheme, parseUniversalUrl } from '@/utils/universal-url'
 export type UploadSession = {
   /** Uptoken */
   token: string
-  /** Valid time for uptoken, unit: second */
-  expires: number
+  /** Expiration timestamp for uptoken */
+  expiresAt: string
   /** Maximum file size allowed in bytes */
   maxSize: number
   /** Bucket name */

--- a/spx-gui/src/models/common/cloud.ts
+++ b/spx-gui/src/models/common/cloud.ts
@@ -336,24 +336,29 @@ const uploadToKodo = (file: File, signal?: AbortSignal) =>
     return stringifyKodoUrl(bucket, parsed.key)
   })
 
-type UploadSession = Omit<RawUploadSession, 'expires'> & {
+type CachedUploadSession = Omit<RawUploadSession, 'expiresAt'> & {
   /** Timestamp (ms) after which the uptoken is considered expired */
   expiresAt: number
 }
 
-let uploadSession: UploadSession | null = null
-let fetchingUploadSession: Promise<UploadSession> | null = null
+let cachedUploadSession: CachedUploadSession | null = null
+let fetchingCachedUploadSession: Promise<CachedUploadSession> | null = null
 
 async function getUploadSessionWithCache() {
-  if (uploadSession != null && uploadSession.expiresAt > Date.now()) return uploadSession
-  if (fetchingUploadSession != null) return fetchingUploadSession
-  return (fetchingUploadSession = createUploadSession().then(({ expires, ...others }) => {
-    const bufferTime = 5 * 60 * 1000 // refresh uptoken 5min before it expires
-    const expiresAt = Date.now() + expires * 1000 - bufferTime
-    uploadSession = { ...others, expiresAt: expiresAt }
-    fetchingUploadSession = null
-    return uploadSession
-  }))
+  if (cachedUploadSession != null && cachedUploadSession.expiresAt > Date.now()) return cachedUploadSession
+  if (fetchingCachedUploadSession != null) return fetchingCachedUploadSession
+  return (fetchingCachedUploadSession = createUploadSession()
+    .then(({ expiresAt: rawExpiresAt, ...others }) => {
+      const uploadTokenRefreshBuffer = 5 * 60 * 1000
+      const rawExpiresAtMs = Date.parse(rawExpiresAt)
+      if (!Number.isFinite(rawExpiresAtMs)) throw new Error(`invalid upload session expiresAt: ${rawExpiresAt}`)
+      const expiresAt = rawExpiresAtMs - uploadTokenRefreshBuffer
+      cachedUploadSession = { ...others, expiresAt }
+      return cachedUploadSession
+    })
+    .finally(() => {
+      fetchingCachedUploadSession = null
+    }))
 }
 
 async function validateFileSizeForUpload(files: globalThis.File[]) {


### PR DESCRIPTION
Use the upload session `expiresAt` timestamp from the API contract instead of deriving cache expiry from a relative lifetime on the client.

This keeps frontend upload token caching aligned with the server-issued expiration time while preserving the existing early refresh window.