### PR TITLE
Support finer backdrop control with pivot and actual size

### DIFF
--- a/spx-gui/src/components/asset/scratch/LoadFromScratch.vue
+++ b/spx-gui/src/components/asset/scratch/LoadFromScratch.vue
@@ -69,6 +69,8 @@ import { Backdrop } from '@/models/spx/backdrop'
 import { Costume } from '@/models/spx/costume'
 import { fromBlob } from '@/models/common/file'
 import { useMessageHandle } from '@/utils/exception'
+import { isSvgMimeType } from '@/utils/file'
+import { getSVGViewBoxRect } from '@/utils/img'
 import type { ExportedScratchCostume, ExportedScratchSound, ExportedScratchSprite } from '@/utils/scratch'
 import { type SpxProject } from '@/models/spx/project'
 import type { AssetModel } from '@/models/spx/common/asset'
@@ -131,17 +133,33 @@ const selectBackdrop = (backdrop: ExportedScratchCostume) => {
 const scratchToSpxFile = (scratchFile: ExportedScratchFile) => {
   return fromBlob(`${scratchFile.name}.${scratchFile.extension}`, scratchFile.blob)
 }
+
+async function getPivotFromScratchCostume(asset: ExportedScratchCostume) {
+  let x = asset.rotationCenterX
+  let y = asset.rotationCenterY
+  // Scratch stores SVG rotation centers in the SVG viewBox coordinate space.
+  // Builder/SPX uses image-top-left as pivot origin, so subtract viewBox origin for SVG.
+  if (isSvgMimeType(asset.blob.type)) {
+    const svgText = await asset.blob.text()
+    const viewBoxRect = getSVGViewBoxRect(svgText)
+    x -= viewBoxRect.x
+    y -= viewBoxRect.y
+  }
+  return {
+    x: x / asset.bitmapResolution,
+    y: y / asset.bitmapResolution
+  }
+}
+
 const importSprite = async (asset: ExportedScratchSprite) => {
   const costumes = await Promise.all(
-    asset.costumes.map((costume) =>
-      Costume.create(costume.name, scratchToSpxFile(costume), {
+    asset.costumes.map(async (costume) => {
+      const pivot = await getPivotFromScratchCostume(costume)
+      return Costume.create(costume.name, scratchToSpxFile(costume), {
         bitmapResolution: costume.bitmapResolution,
-        pivot: {
-          x: costume.rotationCenterX / costume.bitmapResolution,
-          y: costume.rotationCenterY / costume.bitmapResolution
-        }
+        pivot
       })
-    )
+    })
   )
   const sprite = Sprite.create(asset.name)
   for (const costume of costumes) {
@@ -161,12 +179,10 @@ const importSound = async (asset: ExportedScratchSound) => {
 
 const importBackdrop = async (asset: ExportedScratchCostume) => {
   const file = scratchToSpxFile(asset)
+  const pivot = await getPivotFromScratchCostume(asset)
   const backdrop = await Backdrop.create(asset.name, file, {
     bitmapResolution: asset.bitmapResolution,
-    pivot: {
-      x: asset.rotationCenterX / asset.bitmapResolution,
-      y: asset.rotationCenterY / asset.bitmapResolution
-    }
+    pivot
   })
   props.project.stage.addBackdrop(backdrop)
   return backdrop

--- a/spx-gui/src/components/asset/scratch/LoadFromScratch.vue
+++ b/spx-gui/src/components/asset/scratch/LoadFromScratch.vue
@@ -162,7 +162,11 @@ const importSound = async (asset: ExportedScratchSound) => {
 const importBackdrop = async (asset: ExportedScratchCostume) => {
   const file = scratchToSpxFile(asset)
   const backdrop = await Backdrop.create(asset.name, file, {
-    bitmapResolution: asset.bitmapResolution
+    bitmapResolution: asset.bitmapResolution,
+    pivot: {
+      x: asset.rotationCenterX / asset.bitmapResolution,
+      y: asset.rotationCenterY / asset.bitmapResolution
+    }
   })
   props.project.stage.addBackdrop(backdrop)
   return backdrop

--- a/spx-gui/src/components/editor/common/viewer/common.ts
+++ b/spx-gui/src/components/editor/common/viewer/common.ts
@@ -1,6 +1,7 @@
+import type { KonvaEventObject } from 'konva/lib/Node'
+
 import { Sprite } from '@/models/spx/sprite'
 import type { Widget } from '@/models/spx/widget'
-import type { KonvaEventObject } from 'konva/lib/Node'
 
 import { SpriteLocalConfig, WidgetLocalConfig } from './quick-config/utils'
 

--- a/spx-gui/src/components/editor/map-editor/map-viewer/MapViewer.vue
+++ b/spx-gui/src/components/editor/map-editor/map-viewer/MapViewer.vue
@@ -250,8 +250,13 @@ watchEffect(() => {
   })
 })
 
-const konvaBackdropConfig = computed(() => {
+const konvaBackdropRectConfig = computed(() => {
   if (backdropImg.value == null || stageConfig.value == null) {
+    return null
+  }
+
+  const backdrop = props.project.stage.defaultBackdrop
+  if (backdrop == null) {
     return null
   }
 
@@ -281,18 +286,28 @@ const konvaBackdropConfig = computed(() => {
       fillPatternScaleY: scale
     }
   } else if (props.project.stage.mapMode === MapMode.repeat) {
-    const offsetX = (stageWidth - imageWidth) / 2
-    const offsetY = (stageHeight - imageHeight) / 2
-
+    const patternScale = 1 / backdrop.bitmapResolution
     return {
       fillPatternImage: backdropImg.value,
       width: stageWidth,
       height: stageHeight,
       fillPatternRepeat: 'repeat',
-      fillPatternX: offsetX,
-      fillPatternY: offsetY,
-      fillPatternScaleX: 1,
-      fillPatternScaleY: 1
+      fillPatternX: 0,
+      fillPatternY: 0,
+      fillPatternScaleX: patternScale,
+      fillPatternScaleY: patternScale
+    }
+  } else if (props.project.stage.mapMode === MapMode.actualSize) {
+    const patternScale = 1 / backdrop.bitmapResolution
+    return {
+      fillPatternImage: backdropImg.value,
+      width: stageWidth,
+      height: stageHeight,
+      fillPatternRepeat: 'no-repeat',
+      fillPatternX: stageWidth / 2 - backdrop.pivot.x,
+      fillPatternY: stageHeight / 2 - backdrop.pivot.y,
+      fillPatternScaleX: patternScale,
+      fillPatternScaleY: patternScale
     }
   }
   console.warn('Unsupported map mode:', props.project.stage.mapMode)
@@ -532,7 +547,7 @@ const handleWheel = (e: KonvaEventObject<WheelEvent>) => {
   >
     <v-stage v-if="stageConfig != null" ref="stageRef" :config="stageConfig" @wheel="handleWheel">
       <v-layer ref="mapRef" :config="mapConfig" @dragmove="handleMapDragMove" @dragend="handleMapDragEnd">
-        <v-rect v-if="konvaBackdropConfig" :config="konvaBackdropConfig"></v-rect>
+        <v-rect v-if="konvaBackdropRectConfig" :config="konvaBackdropRectConfig"></v-rect>
         <DecoratorNode
           v-for="(decorator, idx) in props.project.tilemap?.decorators ?? []"
           :key="idx"

--- a/spx-gui/src/components/editor/preview/stage-viewer/StageViewer.vue
+++ b/spx-gui/src/components/editor/preview/stage-viewer/StageViewer.vue
@@ -11,7 +11,7 @@
   >
     <v-stage v-if="stageConfig != null" ref="stageRef" :config="stageConfig" @wheel="handleWheel">
       <v-layer ref="mapRef" :config="mapConfig" @dragmove="handleMapDragMove" @dragend="handleMapDragEnd">
-        <v-rect v-if="konvaBackdropConfig" :config="konvaBackdropConfig"></v-rect>
+        <v-rect v-if="konvaBackdropRectConfig" :config="konvaBackdropRectConfig"></v-rect>
         <DecoratorNode
           v-for="(decorator, idx) in editorCtx.project.tilemap?.decorators ?? []"
           :key="idx"
@@ -299,8 +299,13 @@ watchEffect(() => {
   })
 })
 
-const konvaBackdropConfig = computed(() => {
+const konvaBackdropRectConfig = computed(() => {
   if (backdropImg.value == null || stageConfig.value == null) {
+    return null
+  }
+
+  const backdrop = editorCtx.project.stage.defaultBackdrop
+  if (backdrop == null) {
     return null
   }
 
@@ -330,18 +335,28 @@ const konvaBackdropConfig = computed(() => {
       fillPatternScaleY: scale
     }
   } else if (editorCtx.project.stage.mapMode === MapMode.repeat) {
-    const offsetX = (stageWidth - imageWidth) / 2
-    const offsetY = (stageHeight - imageHeight) / 2
-
+    const patternScale = 1 / backdrop.bitmapResolution
     return {
       fillPatternImage: backdropImg.value,
       width: stageWidth,
       height: stageHeight,
       fillPatternRepeat: 'repeat',
-      fillPatternX: offsetX,
-      fillPatternY: offsetY,
-      fillPatternScaleX: 1,
-      fillPatternScaleY: 1
+      fillPatternX: 0,
+      fillPatternY: 0,
+      fillPatternScaleX: patternScale,
+      fillPatternScaleY: patternScale
+    }
+  } else if (editorCtx.project.stage.mapMode === MapMode.actualSize) {
+    const patternScale = 1 / backdrop.bitmapResolution
+    return {
+      fillPatternImage: backdropImg.value,
+      width: stageWidth,
+      height: stageHeight,
+      fillPatternRepeat: 'no-repeat',
+      fillPatternX: stageWidth / 2 - backdrop.pivot.x,
+      fillPatternY: stageHeight / 2 - backdrop.pivot.y,
+      fillPatternScaleX: patternScale,
+      fillPatternScaleY: patternScale
     }
   }
   console.warn('Unsupported map mode:', editorCtx.project.stage.mapMode)

--- a/spx-gui/src/components/editor/stage/backdrop/BackdropModeSelector.vue
+++ b/spx-gui/src/components/editor/stage/backdrop/BackdropModeSelector.vue
@@ -1,26 +1,7 @@
 <template>
   <div class="flex items-center gap-xl text-grey-800">
-    <div class="flex items-center gap-1">
-      <div>
-        {{ $t({ en: 'Backdrop Mode', zh: '背景模式' }) }}
-      </div>
-      <UITooltip>
-        <template #default>
-          <pre>{{
-            $t({
-              en: `•Tile Mode: The image will be tiled (repeated) to fill the stage
-•Scale Mode: The image will be proportionally scaled to ensure it covers the stage; some parts of the image may be cropped
-`,
-              zh: `•平铺模式：图片会平铺（重复）以填满舞台
-•缩放模式：图片会被按比例缩放，以确保刚好覆盖舞台；图片的某些部分可能会被裁剪
-`
-            })
-          }}</pre>
-        </template>
-        <template #trigger>
-          <UIIcon type="question" />
-        </template>
-      </UITooltip>
+    <div>
+      {{ $t({ en: 'Backdrop Mode', zh: '背景模式' }) }}
     </div>
     <UIButtonGroup
       v-radar="{ name: 'Backdrop mode selector', desc: 'Selector to choose backdrop mode for the stage' }"
@@ -28,17 +9,50 @@
       :value="editorCtx.project.stage.mapMode"
       @update:value="(v) => handleUpdateMapMode(v as MapMode)"
     >
-      <UIButtonGroupItem value="repeat">
-        {{ $t({ en: 'Tile', zh: '平铺' }) }}
-      </UIButtonGroupItem>
-      <UIButtonGroupItem value="fillRatio">
-        {{ $t({ en: 'Scale', zh: '缩放' }) }}
-      </UIButtonGroupItem>
+      <UITooltip>
+        {{
+          $t({
+            en: 'The image will be tiled (repeated) to fill the stage',
+            zh: '图片会平铺（重复）以填满舞台'
+          })
+        }}
+        <template #trigger>
+          <UIButtonGroupItem value="repeat">
+            {{ $t({ en: 'Tile', zh: '平铺' }) }}
+          </UIButtonGroupItem>
+        </template>
+      </UITooltip>
+      <UITooltip>
+        {{
+          $t({
+            en: 'The image will be proportionally scaled to cover the stage; some parts may be cropped',
+            zh: '图片会被按比例缩放，以覆盖舞台；图片的某些部分可能会被裁剪'
+          })
+        }}
+        <template #trigger>
+          <UIButtonGroupItem value="fillRatio">
+            {{ $t({ en: 'Scale', zh: '缩放' }) }}
+          </UIButtonGroupItem>
+        </template>
+      </UITooltip>
+      <UITooltip>
+        {{
+          $t({
+            en: 'The image will be aligned to the stage center without scaling or tiling',
+            zh: '图片会以原始尺寸显示，并与舞台中心对齐，不缩放也不平铺'
+          })
+        }}
+        <template #trigger>
+          <UIButtonGroupItem value="actualSize">
+            {{ $t({ en: 'Original', zh: '原图' }) }}
+          </UIButtonGroupItem>
+        </template>
+      </UITooltip>
     </UIButtonGroup>
   </div>
 </template>
 <script setup lang="ts">
-import { UITooltip, UIButtonGroup, UIButtonGroupItem, UIIcon } from '@/components/ui'
+import { UITooltip, UIButtonGroup, UIButtonGroupItem } from '@/components/ui'
 import { useEditorCtx } from '../../EditorContextProvider.vue'
 import type { MapMode } from '@/models/spx/stage'
 

--- a/spx-gui/src/models/common/file.ts
+++ b/spx-gui/src/models/common/file.ts
@@ -5,7 +5,7 @@
  */
 
 import { markRaw } from 'vue'
-import { getMimeFromExt } from '@/utils/file'
+import { getMimeFromExt, isSvgMimeType } from '@/utils/file'
 import { getSVGSize } from '@/utils/img'
 import { extname } from '@/utils/path'
 import { Disposable, getCleanupSignal, type Disposer } from '@/utils/disposable'
@@ -205,7 +205,7 @@ async function getBitmapImageSize(bitmapImgFile: File) {
 export async function getImageSize(file: File): Promise<Size> {
   if (file.meta.imgSize != null) return file.meta.imgSize
   let size: Size
-  if (file.type === 'image/svg+xml') {
+  if (isSvgMimeType(file.type)) {
     const svgText = await toText(file)
     size = await getSVGSize(svgText)
   } else {

--- a/spx-gui/src/models/spx/backdrop.test.ts
+++ b/spx-gui/src/models/spx/backdrop.test.ts
@@ -19,18 +19,20 @@ describe('Backdrop', () => {
   it('should clone correctly', () => {
     const stage = makeStage()
     const backdrop = stage.backdrops[0]
+    backdrop.setPivot({ x: 12, y: 34 })
 
     const clone = backdrop.clone()
     expect(clone.id).not.toEqual(backdrop.id)
     expect(clone.name).toEqual(backdrop.name)
     expect(clone.img).toEqual(backdrop.img)
+    expect(clone.pivot).toEqual(backdrop.pivot)
     expect(clone.bitmapResolution).toEqual(backdrop.bitmapResolution)
 
     stage.addBackdrop(clone)
     expect(clone.stage).toEqual(stage)
   })
 
-  it('should populate file metadata size when loading with image dimensions', () => {
+  it('should populate file metadata size when loading with image dimensions', async () => {
     const assetPath = 'backgrounds/backdrop.png'
     const file = new File('backdrop.png', async () => new ArrayBuffer(0), {
       type: 'image/png',
@@ -41,10 +43,12 @@ describe('Backdrop', () => {
       [resolvePath('assets', assetPath)]: file
     }
 
-    const backdrop = Backdrop.load(
+    const backdrop = await Backdrop.load(
       {
         name: 'BackdropA',
         path: assetPath,
+        x: 100,
+        y: 50,
         bitmapResolution: 2,
         imageWidth: 400,
         imageHeight: 300
@@ -53,8 +57,125 @@ describe('Backdrop', () => {
       { includeId: false }
     )
 
+    expect(backdrop.pivot).toEqual({ x: 50, y: 25 })
     expect(backdrop.img.meta.imgSize).toEqual({ width: 400, height: 300 })
     expect(file.meta.imgSize).toEqual({ width: 400, height: 300 })
+  })
+
+  it('should default pivot to image center when loading without x and y', async () => {
+    const assetPath = 'backgrounds/backdrop.png'
+    const file = new File('backdrop.png', async () => new ArrayBuffer(0), {
+      type: 'image/png',
+      meta: {
+        imgSize: {
+          width: 400,
+          height: 300
+        }
+      }
+    })
+    const files: Files = {
+      [resolvePath('assets', assetPath)]: file
+    }
+
+    const backdrop = await Backdrop.load(
+      {
+        name: 'BackdropA',
+        path: assetPath,
+        bitmapResolution: 2
+      },
+      files,
+      { includeId: false }
+    )
+
+    expect(backdrop.pivot).toEqual({ x: 100, y: 75 })
+
+    const [config] = backdrop.export({ includeId: false })
+    expect(config.x).toBe(200)
+    expect(config.y).toBe(150)
+  })
+
+  it('should ignore legacy meaningless x and y when faceRight is present', async () => {
+    const assetPath = 'backgrounds/backdrop.png'
+    const file = new File('backdrop.png', async () => new ArrayBuffer(0), {
+      type: 'image/png',
+      meta: {
+        imgSize: {
+          width: 400,
+          height: 300
+        }
+      }
+    })
+    const files: Files = {
+      [resolvePath('assets', assetPath)]: file
+    }
+
+    const backdrop = await Backdrop.load(
+      {
+        name: 'BackdropA',
+        path: assetPath,
+        x: 0,
+        y: 0,
+        faceRight: 90,
+        bitmapResolution: 2
+      },
+      files,
+      { includeId: false }
+    )
+
+    expect(backdrop.pivot).toEqual({ x: 100, y: 75 })
+  })
+
+  it('should get raw size from image metadata', async () => {
+    const file = new File('stage.png', async () => new ArrayBuffer(0), {
+      type: 'image/png',
+      meta: {
+        imgSize: {
+          width: 512,
+          height: 288
+        }
+      }
+    })
+    const backdrop = new Backdrop('BackdropRawSize', file)
+
+    const rawSize = await backdrop.getRawSize()
+
+    expect(rawSize).toEqual({ width: 512, height: 288 })
+  })
+
+  it('should get size divided by bitmap resolution', async () => {
+    const file = new File('stage.png', async () => new ArrayBuffer(0), {
+      type: 'image/png',
+      meta: {
+        imgSize: {
+          width: 512,
+          height: 288
+        }
+      }
+    })
+    const backdrop = new Backdrop('BackdropSize', file, {
+      bitmapResolution: 2
+    })
+
+    const size = await backdrop.getSize()
+
+    expect(size).toEqual({ width: 256, height: 144 })
+  })
+
+  it('should default create pivot to image center', async () => {
+    const file = new File('stage.png', async () => new ArrayBuffer(0), {
+      type: 'image/png',
+      meta: {
+        imgSize: {
+          width: 512,
+          height: 288
+        }
+      }
+    })
+
+    const backdrop = await Backdrop.create('BackdropC', file)
+
+    expect(backdrop.pivot).toEqual({ x: 128, y: 72 })
+    expect(backdrop.bitmapResolution).toBe(2)
   })
 
   it('should include metadata image size when exporting', () => {
@@ -69,11 +190,14 @@ describe('Backdrop', () => {
     })
     const backdrop = new Backdrop('BackdropB', file, {
       id: 'backdrop-id',
+      pivot: { x: 40, y: 24 },
       bitmapResolution: 2
     })
 
     const [config] = backdrop.export({ includeId: true })
 
+    expect(config.x).toEqual(80)
+    expect(config.y).toEqual(48)
     expect(config.imageWidth).toEqual(512)
     expect(config.imageHeight).toEqual(288)
   })

--- a/spx-gui/src/models/spx/backdrop.ts
+++ b/spx-gui/src/models/spx/backdrop.ts
@@ -1,19 +1,24 @@
 import { reactive } from 'vue'
 import { nanoid } from 'nanoid'
+import { isSvgMimeType } from '@/utils/file'
 import { extname, resolve } from '@/utils/path'
 import { adaptImg } from '@/utils/spx'
-import type { File, Files } from '../common/file'
+import { getImageSize, type File, type Files } from '../common/file'
 import { getBackdropName, validateBackdropName } from './common/asset-name'
 import type { AssetMetadata } from './common/asset'
+import type { Pivot } from './costume'
 import type { Stage } from './stage'
 
 export type BackdropInits = {
   id?: string
+  pivot?: Pivot
   bitmapResolution?: number
   assetMetadata?: AssetMetadata
 }
 
-export type RawBackdropConfig = Omit<BackdropInits, 'id' | 'assetMetadata'> & {
+export type RawBackdropConfig = Omit<BackdropInits, 'id' | 'assetMetadata' | 'pivot'> & {
+  x?: number
+  y?: number
   builder_id?: string
   builder_assetMetadata?: AssetMetadata
   name?: string
@@ -22,6 +27,12 @@ export type RawBackdropConfig = Omit<BackdropInits, 'id' | 'assetMetadata'> & {
   imageWidth?: number
   /* Optional image height for engine performance optimization */
   imageHeight?: number
+  /**
+   * @deprecated Legacy compatibility field produced by old Builder backdrop export behavior
+   * that reused costume logic. This is not part of SPX behavior/spec.
+   * Used only when loading historical Builder data.
+   */
+  faceRight?: number
 }
 
 const backdropAssetPath = 'assets'
@@ -53,9 +64,26 @@ export class Backdrop {
     this.img = img
   }
 
+  pivot: Pivot
+  setPivot(pivot: Pivot) {
+    this.pivot = pivot
+  }
+
   bitmapResolution: number
   setBitmapResolution(bitmapResolution: number) {
     this.bitmapResolution = bitmapResolution
+  }
+
+  async getRawSize() {
+    return getImageSize(this.img)
+  }
+
+  async getSize() {
+    const rawSize = await this.getRawSize()
+    return {
+      width: rawSize.width / this.bitmapResolution,
+      height: rawSize.height / this.bitmapResolution
+    }
   }
 
   assetMetadata: AssetMetadata | null
@@ -66,6 +94,7 @@ export class Backdrop {
   constructor(name: string, file: File, inits?: BackdropInits) {
     this.name = name
     this.img = file
+    this.pivot = inits?.pivot ?? { x: 0, y: 0 }
     this.bitmapResolution = inits?.bitmapResolution ?? 1
     this.id = inits?.id ?? nanoid()
     this.assetMetadata = inits?.assetMetadata ?? null
@@ -76,26 +105,42 @@ export class Backdrop {
    * Create instance with default inits
    * NOTE: the "default" means default behavior for builder, not the default behavior of spx
    */
-  static async create(nameBase: string, file: File, inits?: BackdropInits) {
+  static async create(nameBase: string, file: File, { bitmapResolution, pivot, ...extraInits }: BackdropInits = {}) {
     const adaptedFile = await adaptImg(file)
+    if (bitmapResolution == null) {
+      bitmapResolution = isSvgMimeType(file.type) ? 1 : 2
+    }
+    if (pivot == null) {
+      const size = await getImageSize(adaptedFile)
+      pivot = {
+        x: size.width / bitmapResolution / 2,
+        y: size.height / bitmapResolution / 2
+      }
+    }
     return new Backdrop(getBackdropName(null, nameBase), adaptedFile, {
-      bitmapResolution: /svg/.test(file.type) ? 1 : 2,
-      ...inits
+      ...extraInits,
+      bitmapResolution,
+      pivot
     })
   }
 
   clone(preserveId = false) {
     return new Backdrop(this.name, this.img, {
       id: preserveId ? this.id : undefined,
+      pivot: this.pivot,
       bitmapResolution: this.bitmapResolution,
       assetMetadata: this.assetMetadata ?? undefined
     })
   }
 
-  static load(
+  static async load(
     {
       name,
       path,
+      x,
+      y,
+      faceRight,
+      bitmapResolution = 1,
       builder_id: id,
       builder_assetMetadata: assetMetadata,
       imageWidth,
@@ -112,8 +157,25 @@ export class Backdrop {
     if (imageWidth != null && imageHeight != null && file.meta.imgSize == null) {
       file.meta.imgSize = { width: imageWidth, height: imageHeight }
     }
+    // Compatibility: some legacy backdrop data was exported via costume logic and may carry
+    // meaningless x/y = 0 together with a numeric faceRight. In this case, ignore x/y and
+    // derive pivot from image size.
+    const isLegacyMeaninglessPivot = typeof faceRight === 'number' && x === 0 && y === 0
+    const usePivotFromConfig = x != null && y != null && !isLegacyMeaninglessPivot
+    let pivot: Pivot
+    if (usePivotFromConfig) {
+      pivot = { x: x / bitmapResolution, y: y / bitmapResolution }
+    } else {
+      const size = await getImageSize(file)
+      pivot = {
+        x: size.width / bitmapResolution / 2,
+        y: size.height / bitmapResolution / 2
+      }
+    }
     return new Backdrop(name, file, {
       ...inits,
+      bitmapResolution,
+      pivot,
       id: includeId ? id : undefined,
       assetMetadata: includeAssetMetadata ? assetMetadata : undefined
     })
@@ -126,6 +188,8 @@ export class Backdrop {
   }: BackdropExportLoadOptions = {}): [RawBackdropConfig, Files] {
     const filename = this.name + extname(this.img.name)
     const config: RawBackdropConfig = {
+      x: this.pivot.x * this.bitmapResolution,
+      y: this.pivot.y * this.bitmapResolution,
       bitmapResolution: this.bitmapResolution,
       name: this.name,
       path: filename

--- a/spx-gui/src/models/spx/backdrop.ts
+++ b/spx-gui/src/models/spx/backdrop.ts
@@ -17,7 +17,19 @@ export type BackdropInits = {
 }
 
 export type RawBackdropConfig = Omit<BackdropInits, 'id' | 'assetMetadata' | 'pivot'> & {
+  /**
+   * Offset on x-axis of the backdrop pivot from left-top corner of the image.
+   * Positive value means right direction, negative means left direction.
+   * Note: This value is relative to the backdrop's raw size and is not divided by bitmapResolution;
+   * for SVG, this image-top-left-based value differs from Scratch's rotationCenterX which is based on viewBox origin.
+   */
   x?: number
+  /**
+   * Offset on y-axis of the backdrop pivot from left-top corner of the image.
+   * Positive value means down direction, negative means up direction.
+   * Note: This value is relative to the backdrop's raw size and is not divided by bitmapResolution;
+   * for SVG, this image-top-left-based value differs from Scratch's rotationCenterY which is based on viewBox origin.
+   */
   y?: number
   builder_id?: string
   builder_assetMetadata?: AssetMetadata

--- a/spx-gui/src/models/spx/common/asset.ts
+++ b/spx-gui/src/models/spx/common/asset.ts
@@ -3,11 +3,10 @@ import type { LocaleMessage } from '@/utils/i18n'
 import { AssetType, type AssetData } from '@/apis/asset'
 import { Sound } from '../sound'
 import { Sprite } from '../sprite'
-import { Costume } from '../costume'
 import { Backdrop, type BackdropInits } from '../backdrop'
 import type { SpriteGen } from '../gen/sprite-gen'
 import type { BackdropGen } from '../gen/backdrop-gen'
-import { fromBlob, fromConfig, toConfig } from '../../common/file'
+import { fromConfig, toConfig } from '../../common/file'
 import { getFiles, saveFiles } from '../../common/cloud'
 import { resourceBackdropName, resourceSoundName, resourceSpriteName } from './resource'
 
@@ -91,7 +90,7 @@ export async function asset2Backdrop({ files: fileCollection, ...metadata }: Ass
   const configFile = files[virtualBackdropConfigFileName]
   if (configFile == null) throw new Error('no config file found')
   const config = (await toConfig(configFile)) as BackdropInits
-  const backdrop = Backdrop.load(config, files, { includeId: false, includeAssetMetadata: false })
+  const backdrop = await Backdrop.load(config, files, { includeId: false, includeAssetMetadata: false })
   backdrop.setAssetMetadata(metadata)
   return backdrop
 }
@@ -115,44 +114,4 @@ export async function asset2Sound({ files: fileCollection, ...metadata }: AssetD
   const sound = sounds[0]
   sound.setAssetMetadata(metadata)
   return sound
-}
-
-export async function genSpriteFromCanvas(name: string, width: number, height: number, color: string) {
-  const canvas = await genAssetFromCanvas(name, width, height, color)
-  const sprite = Sprite.create(name)
-  const costume = new Costume(name, canvas)
-  sprite.addCostume(costume)
-  return sprite
-}
-
-export async function genBackdropFromCanvas(name: string, width: number, height: number, color: string) {
-  const canvas = await genAssetFromCanvas(name, width, height, color)
-  const backdrop = await Backdrop.create(name, canvas)
-  return backdrop
-}
-
-export async function genAssetFromCanvas(name: string, width: number, height: number, color: string) {
-  const canvas = document.createElement('canvas')
-  const ctx = canvas.getContext('2d')!
-
-  // check if the name ends with .png
-  const filename = name.toLowerCase().endsWith('.png') ? name : `${name}.png`
-  // Set canvas dimensions
-  canvas.width = width
-  canvas.height = height
-
-  // Draw a square
-  ctx.fillStyle = color
-  ctx.fillRect(0, 0, width, height)
-
-  // Convert canvas to Blob
-  const blob = await new Promise<Blob>((resolve) => {
-    canvas.toBlob((blob) => {
-      resolve(blob!)
-    }, 'image/png')
-  })
-
-  // Create file from Blob
-  const file = fromBlob(filename, blob)
-  return file
 }

--- a/spx-gui/src/models/spx/costume.ts
+++ b/spx-gui/src/models/spx/costume.ts
@@ -1,6 +1,7 @@
 import { reactive } from 'vue'
 import { nanoid } from 'nanoid'
 
+import { isSvgMimeType } from '@/utils/file'
 import { extname, resolve } from '@/utils/path'
 import { adaptImg } from '@/utils/spx'
 import { File, type Files, getImageSize } from '../common/file'
@@ -147,7 +148,7 @@ export class Costume {
   static async create(nameBase: string, file: File, inits?: CostumeInits) {
     const adaptedFile = await adaptImg(file)
     return new Costume(getCostumeName(null, nameBase), adaptedFile, {
-      bitmapResolution: /svg/.test(file.type) ? 1 : 2,
+      bitmapResolution: isSvgMimeType(file.type) ? 1 : 2,
       ...inits
     })
   }

--- a/spx-gui/src/models/spx/costume.ts
+++ b/spx-gui/src/models/spx/costume.ts
@@ -34,12 +34,14 @@ export type RawCostumeConfig = Omit<CostumeInits, 'id' | 'pivot'> & {
    * Offset on x-axis of the costume pivot from left-top corner of the image.
    * Positive value means right direction, negative means left direction.
    * Note: This value is relative to the costume's raw size and is not divided by bitmapResolution;
+   * for SVG, this image-top-left-based value differs from Scratch's rotationCenterX which is based on viewBox origin.
    */
   x?: number
   /**
    * Offset on y-axis of the costume pivot from left-top corner of the image.
    * Positive value means down direction, negative means up direction.
    * Note: This value is relative to the costume's raw size and is not divided by bitmapResolution;
+   * for SVG, this image-top-left-based value differs from Scratch's rotationCenterY which is based on viewBox origin.
    */
   y?: number
   builder_id?: string

--- a/spx-gui/src/models/spx/gen/backdrop-gen.test.ts
+++ b/spx-gui/src/models/spx/gen/backdrop-gen.test.ts
@@ -4,6 +4,7 @@ import { ArtStyle, BackdropCategory, Perspective } from '@/apis/common'
 import { setupAigcMock } from './aigc-mock' // Put me before importing `@/apis/aigc` to ensure the mock is set up correctly
 import { TaskStatus, TaskType } from '@/apis/aigc'
 import { createI18n } from '@/utils/i18n'
+import * as fileHelpers from '@/models/common/file'
 import { sndFiles } from '@/models/common/test'
 import { GenState } from '@/components/editor/gen'
 import { makeSpxProject } from '../common/test'
@@ -11,6 +12,8 @@ import { BackdropGen } from './backdrop-gen'
 
 const aigcMock = setupAigcMock()
 const i18n = createI18n({ lang: 'en' })
+// TODO: Consider replacing this spy by pre-filling file.meta.imgSize in test fixtures.
+vi.spyOn(fileHelpers, 'getImageSize').mockReturnValue(Promise.resolve({ width: 100, height: 100 }))
 
 describe('BackdropGen', () => {
   beforeEach(() => {

--- a/spx-gui/src/models/spx/gen/backdrop-gen.ts
+++ b/spx-gui/src/models/spx/gen/backdrop-gen.ts
@@ -261,7 +261,9 @@ export class BackdropGen extends Disposable {
         )
       )
     }
-    if (resultConfig != null) inits.result = Backdrop.load(resultConfig, files, { assetPath: `${assetsPath}/result` })
+    if (resultConfig != null) {
+      inits.result = await Backdrop.load(resultConfig, files, { assetPath: `${assetsPath}/result` })
+    }
     const gen = new BackdropGen(i18n, project, inits)
     gen.restoreGenerateTask()
     return gen

--- a/spx-gui/src/models/spx/gen/costume-gen.test.ts
+++ b/spx-gui/src/models/spx/gen/costume-gen.test.ts
@@ -12,6 +12,7 @@ import { CostumeGen } from './costume-gen'
 
 const aigcMock = setupAigcMock()
 const i18n = createI18n({ lang: 'en' })
+// TODO: Consider replacing this spy by pre-filling file.meta.imgSize in test fixtures.
 vi.spyOn(fileHelpers, 'getImageSize').mockReturnValue(Promise.resolve({ width: 100, height: 100 }))
 
 describe('CostumeGen', () => {

--- a/spx-gui/src/models/spx/gen/sprite-gen.test.ts
+++ b/spx-gui/src/models/spx/gen/sprite-gen.test.ts
@@ -14,6 +14,7 @@ import type { AnimationGen } from './animation-gen'
 import { SpriteGen } from './sprite-gen'
 
 const aigcMock = setupAigcMock()
+// TODO: Consider replacing this spy by pre-filling file.meta.imgSize in test fixtures.
 vi.spyOn(fileHelpers, 'getImageSize').mockReturnValue(Promise.resolve({ width: 100, height: 100 }))
 
 async function finishCostumeGen(name: string, gen: CostumeGen) {

--- a/spx-gui/src/models/spx/stage.test.ts
+++ b/spx-gui/src/models/spx/stage.test.ts
@@ -1,6 +1,6 @@
 import { nextTick } from 'vue'
 import { describe, it, expect } from 'vitest'
-import { Stage } from './stage'
+import { MapMode, Stage } from './stage'
 import { Monitor } from './widget/monitor'
 import { Backdrop } from './backdrop'
 import { File } from '../common/file'
@@ -329,5 +329,27 @@ describe('Stage', () => {
     })
     stage.addWidgetAfter(widget3, widget1.id)
     expect(stage.widgets.map((w) => w.id)).toEqual([widget1.id, widget3.id, widget2.id])
+  })
+
+  it('should preserve actualSize map mode when loading and exporting', async () => {
+    const stage = await Stage.load(
+      {
+        map: {
+          width: 480,
+          height: 360,
+          mode: 'actualSize'
+        }
+      },
+      {}
+    )
+
+    expect(stage.mapMode).toBe(MapMode.actualSize)
+
+    const [stageConfig] = stage.export()
+    expect(stageConfig.map).toEqual({
+      width: 480,
+      height: 360,
+      mode: 'actualSize'
+    })
   })
 })

--- a/spx-gui/src/models/spx/stage.ts
+++ b/spx-gui/src/models/spx/stage.ts
@@ -329,7 +329,9 @@ export class Stage extends Disposable {
       layerSortMode,
       extraConfig
     })
-    const backdrops = (backdropConfigs ?? sceneConfigs ?? costumeConfigs ?? []).map((c) => Backdrop.load(c, files))
+    const backdrops = await Promise.all(
+      (backdropConfigs ?? sceneConfigs ?? costumeConfigs ?? []).map((c) => Backdrop.load(c, files))
+    )
     for (const backdrop of backdrops) {
       stage.addBackdrop(backdrop)
     }
@@ -378,15 +380,17 @@ export class Stage extends Disposable {
   }
 }
 
-// In Builder we only support repeat and fillRatio
+// In Builder we support repeat, fillRatio, and actualSize.
 export enum MapMode {
   // fill = 'fill',
   repeat = 'repeat',
-  fillRatio = 'fillRatio'
+  fillRatio = 'fillRatio',
+  actualSize = 'actualSize'
   // fillCut = 'fillCut'
 }
 
 function getMapMode(mode?: string): MapMode {
   if (mode === 'repeat') return MapMode.repeat
+  if (mode === 'actualSize') return MapMode.actualSize
   return MapMode.fillRatio
 }

--- a/spx-gui/src/utils/file.ts
+++ b/spx-gui/src/utils/file.ts
@@ -45,6 +45,10 @@ export function getExtFromMime(mime: string) {
   return mime2Ext[mime]
 }
 
+export function isSvgMimeType(type: string) {
+  return type === 'image/svg+xml'
+}
+
 export const imgExts = ['png', 'jpg', 'jpeg', 'svg', 'webp', 'bmp']
 export const audioExts = ['wav', 'mp3', 'ogg', 'webm']
 

--- a/spx-gui/src/utils/img.ts
+++ b/spx-gui/src/utils/img.ts
@@ -45,7 +45,7 @@ export async function toPng(blob: Blob) {
 // Chrome and Firefox behave differently when reading `viewBox.baseVal` of SVG without the `viewBox` attribute.
 // Chrome returns `{ x: 0, y: 0, width: 0, height: 0 }` by default, while Firefox returns null.
 // This method retrieves the `viewBox` attribute, ensuring consistent behavior when it exists, and returns `{ x: 0, y: 0, width: 0, height: 0 }` when it doesn't exist.
-function getSVGViewBoxRect(svgElement: SVGSVGElement) {
+function getSVGViewBoxRectFromElement(svgElement: SVGSVGElement) {
   const rect = svgElement.viewBox.baseVal as DOMRect | null // `viewBox.baseVal` may be null in Firefox if not set in SVG
   return {
     width: rect?.width ?? 0,
@@ -55,15 +55,24 @@ function getSVGViewBoxRect(svgElement: SVGSVGElement) {
   }
 }
 
-/** Get the size of the SVG image, keeping consistent with spx. */
-export async function getSVGSize(svgText: string) {
+function parseSVGText(svgText: string) {
   const parser = new DOMParser()
   const svg = parser.parseFromString(svgText, 'image/svg+xml').documentElement
   if (!(svg instanceof SVGSVGElement)) throw new Error('invalid svg')
+  return svg
+}
+
+export function getSVGViewBoxRect(svgText: string) {
+  return getSVGViewBoxRectFromElement(parseSVGText(svgText))
+}
+
+/** Get the size of the SVG image, keeping consistent with spx. */
+export async function getSVGSize(svgText: string) {
+  const svg = parseSVGText(svgText)
   // Keep consistent with spx, for details see:
   // * https://github.com/goplus/spx/blob/15b2e572746f3aaea519c2d9c0027188b50b62c8/internal/svgr/svg.go#L39
   // * https://github.com/qiniu/oksvg/blob/917f53935572252ba3da8909ca4fbedec418bde1/svgd.go#L1015-L1049
-  let { width, height } = getSVGViewBoxRect(svg)
+  let { width, height } = getSVGViewBoxRectFromElement(svg)
   if (width === 0) width = svg.width.baseVal.value
   if (height === 0) height = svg.height.baseVal.value
   return { width, height }

--- a/spx-gui/src/utils/img.ts
+++ b/spx-gui/src/utils/img.ts
@@ -1,4 +1,5 @@
 import { Disposable } from '@/utils/disposable'
+import { isSvgMimeType } from '@/utils/file'
 import { getImgDrawingCtx } from './canvas'
 
 /** Convert arbitrary-type (supported by current browser) image content to another type. */
@@ -13,7 +14,7 @@ export function convertImg(
     const img = new Image()
     img.onload = async () => {
       let size = { width: img.naturalWidth, height: img.naturalHeight }
-      if (input.type === 'image/svg+xml') {
+      if (isSvgMimeType(input.type)) {
         const svgText = await input.text()
         size = await getSVGSize(svgText)
       }
@@ -87,7 +88,7 @@ export async function getContentBoundingRect(imgBlob: Blob): Promise<Rect> {
     img.onload = async () => {
       try {
         let size = { width: img.naturalWidth, height: img.naturalHeight }
-        if (imgBlob.type === 'image/svg+xml') {
+        if (isSvgMimeType(imgBlob.type)) {
           const svgText = await imgBlob.text()
           size = await getSVGSize(svgText)
         }


### PR DESCRIPTION
## Summary

- support finer backdrop control with pivot data and an `actualSize` backdrop mode
- render `actualSize` backdrops in Stage Viewer and Map Viewer, including SVG `viewBox` offset handling
- carry backdrop pivot data through Scratch import and add tests for backdrop, stage, and SVG offset logic

Fixes #3185

## Testing

- `npm run test -- --run src/utils/img.test.ts src/models/spx/backdrop.test.ts`
- `npm run type-check`
