### PR TITLE
[Docs] Update: Add draft PR template guidance

### DIFF
--- a/ui/docs/pr-template.md
+++ b/ui/docs/pr-template.md
@@ -2,7 +2,11 @@
 
 ## 标题规范
 
-**格式**：`[Scope] Type: Description`
+常规设计 PR 使用：
+
+```text
+[Scope] Type: Description
+```
 
 | Scope         | 说明           |
 |---------------|----------------|
@@ -22,7 +26,26 @@
 - `[Component] Update: Button disabled state`
 - `[Docs] Update: Organize UI design workflow docs`
 
+## Draft PR 标题
+
+如果 PR 是预期暂不合并的 demo / prototype / 临时方案，标题使用：
+
+```text
+[Draft] Type: Description
+```
+
+有 `[Draft]` 时不要再加 `[Page]` / `[Component]` / `[Docs]`，避免标题前缀过长。
+
+**示例**：
+
+- `[Draft] Feature: Add animation sound playback selector demo`
+- `[Draft] Update: Prototype sound generation flow`
+
+这类 PR 需要保持 GitHub Draft 状态，避免被误合并。
+
 ## 描述模板
+
+常规 PR：
 
 ```markdown
 ### Issue
@@ -51,7 +74,40 @@
 - [ ] No
 ```
 
+Draft / demo / prototype PR：
+
+```markdown
+[skip review]
+
+This is a frontend-only UI demo PR and is expected to stay in draft until the related implementation flow lands.
+
+### Issue
+
+Updates #issue_number
+
+### Background
+
+简述 demo / prototype 的目标，以及为什么当前 PR 暂不作为最终可合并实现。
+
+### Changes
+
+- 变更点 1
+- 变更点 2
+
+### Scope
+
+- 影响页面/组件 1
+- 明确不包含的后端、导出、持久化或生产逻辑
+
+### Design System Impact
+
+- [ ] Yes
+- [ ] No
+```
+
 ## 完整示例
+
+常规 PR：
 
 ```markdown
 [Page] Feature: Add notification banner design
@@ -73,6 +129,41 @@ Remind users to refresh page for latest version.
 
 - Community homepage
 - All authenticated pages
+
+### Design System Impact
+
+- [ ] Yes
+- [x] No
+```
+
+Draft PR：
+
+```markdown
+[Draft] Feature: Add animation sound playback selector demo
+
+[skip review]
+
+This is a frontend-only UI demo PR and is expected to stay in draft until the related model/export flow lands.
+
+### Issue
+
+Updates #3214
+
+### Background
+
+Animation sound binding needs a UI demo so users can choose whether a selected sound plays once independently or follows animation playback.
+
+### Changes
+
+- Added playback behavior selection to the animation sound selector.
+- Adjusted the sound selector panel states based on the design.
+- Kept the implementation frontend-only by using existing animation sound state.
+
+### Scope
+
+- Animation sound selector
+- Animation settings summary bar
+- Does not include backend, export, or persistence logic
 
 ### Design System Impact
 


### PR DESCRIPTION
### Background

Demo and prototype PRs need clearer guidance so reviewers can distinguish expected-not-to-merge work from merge-ready design changes.

### Changes

- Added draft PR title guidance for demo and prototype work.
- Added `[skip review]` guidance for demo-only PR descriptions.
- Documented that expected-not-to-merge PRs should remain in Draft state.

### Scope

- Design PR template documentation
- Demo/prototype PR workflow guidance

### Design System Impact

- [ ] Yes
- [x] No
