### PR TITLE
Support course series file sync

### DIFF
--- a/spx-gui/src/apis/project-release.ts
+++ b/spx-gui/src/apis/project-release.ts
@@ -23,11 +23,15 @@ export type ProjectRelease = {
 
 export type CreateProjectReleaseParams = Pick<ProjectRelease, 'name' | 'description' | 'thumbnail'>
 
-export function createProjectRelease(owner: string, project: string, params: CreateProjectReleaseParams) {
-  return client.post(
-    `/projects/${encodeURIComponent(owner)}/${encodeURIComponent(project)}/releases`,
-    params
-  ) as Promise<ProjectRelease>
+export function createProjectRelease(
+  owner: string,
+  project: string,
+  params: CreateProjectReleaseParams,
+  signal?: AbortSignal
+) {
+  return client.post(`/projects/${encodeURIComponent(owner)}/${encodeURIComponent(project)}/releases`, params, {
+    signal
+  }) as Promise<ProjectRelease>
 }
 
 export type ListProjectReleasesParams = PaginationParams & {

--- a/spx-gui/src/components/course/management/CourseItemMini.vue
+++ b/spx-gui/src/components/course/management/CourseItemMini.vue
@@ -1,7 +1,7 @@
 <script lang="ts" setup>
 import type { Course } from '@/apis/course'
 import { useAsyncComputedLegacy } from '@/utils/utils'
-import { createFileWithWebUrl } from '@/models/common/cloud'
+import { createFileWithUniversalUrl } from '@/models/common/cloud'
 import { UIImg } from '@/components/ui'
 
 const props = defineProps<{
@@ -13,7 +13,7 @@ const props = defineProps<{
 
 const thumbnailUrl = useAsyncComputedLegacy(async (onCleanup) => {
   if (props.course.thumbnail == null) return null
-  const file = createFileWithWebUrl(props.course.thumbnail)
+  const file = createFileWithUniversalUrl(props.course.thumbnail)
   return file.url(onCleanup)
 })
 </script>

--- a/spx-gui/src/components/course/management/CourseSeriesEditModal.vue
+++ b/spx-gui/src/components/course/management/CourseSeriesEditModal.vue
@@ -1,7 +1,9 @@
 <script lang="ts" setup>
 import { computed, ref, watch } from 'vue'
+import saveAs from 'file-saver'
 import { useI18n } from '@/utils/i18n'
-import { useMessageHandle } from '@/utils/exception'
+import { DefaultException, useMessageHandle } from '@/utils/exception'
+import { selectFile } from '@/utils/file'
 import {
   addCourseSeries,
   updateCourseSeries,
@@ -9,6 +11,13 @@ import {
   type AddUpdateCourseSeriesParams
 } from '@/apis/course-series'
 import { listSignedInUserCourses, type Course } from '@/apis/course'
+import { useSignedInUser } from '@/stores/user'
+import {
+  exportCourseSeriesFile,
+  inspectCourseSeriesFileImport,
+  importCourseSeriesFile,
+  importCourseSeriesFileAsNew
+} from './course-series-file'
 import {
   UIFormModal,
   UIForm,
@@ -17,7 +26,8 @@ import {
   UINumberInput,
   UIButton,
   useMessage,
-  useForm
+  useForm,
+  useConfirmDialog
 } from '@/components/ui'
 import CourseSelector from './CourseSelector.vue'
 import SelectedCoursesList from './SelectedCoursesList.vue'
@@ -35,6 +45,8 @@ const emit = defineEmits<{
 
 const i18n = useI18n()
 const m = useMessage()
+const confirm = useConfirmDialog()
+const signedInUser = useSignedInUser()
 
 const isEditMode = computed(() => props.courseSeries !== null)
 const modalTitle = computed(() =>
@@ -148,6 +160,88 @@ const handleSubmit = useMessageHandle(
     zh: isEditMode.value ? '更新课程系列失败' : '创建课程系列失败'
   }
 )
+
+const handleImport = useMessageHandle(
+  async () => {
+    const username = signedInUser.value?.username
+    if (username == null) {
+      throw new DefaultException({ en: 'Please sign in first', zh: '请先登录' })
+    }
+
+    const courseSeries = props.courseSeries
+    const file = await selectFile({ accept: ['xbcs.zip'] })
+    const inspection = await m.withLoading(
+      inspectCourseSeriesFileImport(courseSeries, file, username),
+      i18n.t({ en: 'Inspecting course series file', zh: '检查课程系列文件中' })
+    )
+
+    await confirm({
+      type: 'warning',
+      title: i18n.t({ en: 'Import course series file', zh: '导入课程系列文件' }),
+      content: getImportConfirmContent(courseSeries, inspection.deletedCourses, inspection.overwrittenProjects),
+      confirmText: i18n.t({ en: 'Import', zh: '导入' })
+    })
+
+    await m.withLoading(
+      courseSeries != null
+        ? importCourseSeriesFile(courseSeries, file, username)
+        : importCourseSeriesFileAsNew(file, username),
+      i18n.t({ en: 'Importing course series file', zh: '导入课程系列文件中' })
+    )
+    m.success(i18n.t({ en: 'Course series imported successfully', zh: '课程系列导入成功' }))
+    emit('resolved')
+  },
+  {
+    en: 'Failed to import course series file',
+    zh: '导入课程系列文件失败'
+  }
+)
+
+const handleExport = useMessageHandle(
+  async () => {
+    if (props.courseSeries == null) throw new Error('Course series expected')
+    const exported = await m.withLoading(
+      exportCourseSeriesFile(props.courseSeries),
+      i18n.t({ en: 'Exporting course series file', zh: '导出课程系列文件中' })
+    )
+    saveAs(exported, exported.name)
+  },
+  {
+    en: 'Failed to export course series file',
+    zh: '导出课程系列文件失败'
+  }
+)
+
+function getImportConfirmContent(
+  courseSeries: CourseSeries | null,
+  deletedCourses: string[],
+  overwrittenProjects: string[]
+) {
+  const deletedCourseText = formatNameList(deletedCourses)
+  const overwrittenProjectText = formatNameList(overwrittenProjects)
+  if (courseSeries != null) {
+    return i18n.t({
+      en: `Courses currently in "${courseSeries.title}" will be deleted and rebuilt from the imported file. Deleted courses: ${deletedCourseText}. Overwritten projects: ${overwrittenProjectText}. This operation cannot be undone. Continue?`,
+      zh: `当前课程系列“${courseSeries.title}”中的旧课程会被删除，并根据导入文件重建。会删除的课程：${deletedCourseText}。会覆盖并发布的项目：${overwrittenProjectText}。此操作不可撤销，确定继续吗？`
+    })
+  }
+  return i18n.t({
+    en: `A new course series will be created from the imported file. Overwritten projects: ${overwrittenProjectText}. Continue?`,
+    zh: `将根据导入文件创建一个新的课程系列。会覆盖并发布的项目：${overwrittenProjectText}。确定继续吗？`
+  })
+}
+
+function formatNameList(names: string[]) {
+  if (names.length === 0) return i18n.t({ en: 'None', zh: '无' })
+  const visibleNames = names.slice(0, 8).map((name) => `"${name}"`)
+  if (names.length <= visibleNames.length) {
+    return i18n.t({ en: visibleNames.join(', '), zh: visibleNames.join('、') })
+  }
+  return i18n.t({
+    en: `${visibleNames.join(', ')} and ${names.length - visibleNames.length} more`,
+    zh: `${visibleNames.join('、')} 等 ${names.length} 个`
+  })
+}
 </script>
 
 <template>
@@ -252,6 +346,12 @@ const handleSubmit = useMessageHandle(
       </div>
 
       <footer class="mt-5 flex justify-end gap-3 border-t border-dividing-line-2 pt-5">
+        <UIButton v-if="isEditMode" type="neutral" :loading="handleExport.isLoading.value" @click="handleExport.fn">
+          {{ $t({ en: 'Export to file', zh: '导出到文件' }) }}
+        </UIButton>
+        <UIButton type="neutral" :loading="handleImport.isLoading.value" @click="handleImport.fn">
+          {{ $t({ en: 'Import from file...', zh: '从文件导入...' }) }}
+        </UIButton>
         <UIButton type="neutral" @click="emit('cancelled')">
           {{ $t({ en: 'Cancel', zh: '取消' }) }}
         </UIButton>

--- a/spx-gui/src/components/course/management/course-series-file.test.ts
+++ b/spx-gui/src/components/course/management/course-series-file.test.ts
@@ -202,10 +202,13 @@ describe('exportCourseSeriesFile', () => {
 
 describe('importCourseSeriesFile', () => {
   it('rewrites exact editor project segment and preserves local order', async () => {
+    const ctrl = new AbortController()
+
     await importCourseSeriesFile(
       existingSeries,
       await makeCourseSeriesFile('/editor/curator/EntryProject/lesson?tab=code'),
-      'alice'
+      'alice',
+      ctrl.signal
     )
 
     expect(addCourse).toHaveBeenCalledWith(
@@ -216,7 +219,7 @@ describe('importCourseSeriesFile', () => {
         references: [{ type: 'project', fullName: 'alice/RefProject' }],
         prompt: 'Imported prompt'
       },
-      undefined
+      ctrl.signal
     )
     expect(updateCourseSeries).toHaveBeenCalledWith(
       existingSeries.id,
@@ -224,7 +227,15 @@ describe('importCourseSeriesFile', () => {
         order: existingSeries.order,
         courseIDs: ['imported-course']
       }),
-      undefined
+      ctrl.signal
+    )
+    expect(createProjectRelease).toHaveBeenCalledWith(
+      'alice',
+      'EntryProject',
+      expect.objectContaining({
+        description: 'Imported from course series "Imported series"'
+      }),
+      ctrl.signal
     )
   })
 

--- a/spx-gui/src/components/course/management/course-series-file.test.ts
+++ b/spx-gui/src/components/course/management/course-series-file.test.ts
@@ -1,0 +1,303 @@
+import dayjs from 'dayjs'
+import timezone from 'dayjs/plugin/timezone'
+import utc from 'dayjs/plugin/utc'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { zip, unzip, type Zippable } from '@/utils/zip'
+import { ApiException, ApiExceptionCode } from '@/apis/common/exception'
+import { addCourse, deleteCourse, getCourse, type Course } from '@/apis/course'
+import { addCourseSeries, updateCourseSeries, type CourseSeries } from '@/apis/course-series'
+import { getProject, ProjectType, updateProject, Visibility } from '@/apis/project'
+import { createProjectRelease } from '@/apis/project-release'
+import { cloudHelpers, createFileWithUniversalUrl, saveFile } from '@/models/common/cloud'
+import { File as LazyFile } from '@/models/common/file'
+import { xbpHelpers } from '@/models/common/xbp'
+import { exportCourseSeriesFile, importCourseSeriesFile, inspectCourseSeriesFileImport } from './course-series-file'
+
+dayjs.extend(utc)
+dayjs.extend(timezone)
+
+vi.mock('@/apis/course', () => ({
+  getCourse: vi.fn(),
+  addCourse: vi.fn(),
+  deleteCourse: vi.fn()
+}))
+
+vi.mock('@/apis/course-series', () => ({
+  addCourseSeries: vi.fn(),
+  updateCourseSeries: vi.fn()
+}))
+
+vi.mock('@/apis/project', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/apis/project')>()),
+  getProject: vi.fn(),
+  updateProject: vi.fn()
+}))
+
+vi.mock('@/apis/project-release', () => ({
+  createProjectRelease: vi.fn()
+}))
+
+vi.mock('@/models/common/cloud', () => ({
+  cloudHelpers: {
+    load: vi.fn(),
+    save: vi.fn()
+  },
+  createFileWithUniversalUrl: vi.fn(),
+  saveFile: vi.fn()
+}))
+
+vi.mock('@/models/common/xbp', () => ({
+  xbpHelpers: {
+    save: vi.fn(),
+    load: vi.fn()
+  }
+}))
+
+const existingSeries: CourseSeries = {
+  id: 'series-id',
+  owner: 'alice',
+  title: '编程 课程',
+  thumbnail: 'kodo://bucket/series-thumbnail.png',
+  description: 'Course series description',
+  order: 42,
+  courseIDs: ['course-1'],
+  createdAt: '2026-01-01T00:00:00Z',
+  updatedAt: '2026-01-01T00:00:00Z'
+}
+
+const existingCourse: Course = {
+  id: 'course-1',
+  owner: 'curator',
+  title: 'Course 1',
+  thumbnail: 'kodo://bucket/course-thumbnail.png',
+  entrypoint: '/editor/curator/EntryProject/lesson?tab=code',
+  references: [{ type: 'project', fullName: 'curator/RefProject' }],
+  prompt: 'Prompt'
+}
+
+beforeEach(() => {
+  vi.resetAllMocks()
+
+  vi.mocked(getCourse).mockImplementation(async (id) => {
+    if (id === existingCourse.id) return existingCourse
+    return { ...existingCourse, id, title: `Old ${id}` }
+  })
+  vi.mocked(createFileWithUniversalUrl).mockImplementation((url) => {
+    const data = new TextEncoder().encode(`content:${url}`)
+    return new LazyFile(url.split('/').pop() ?? 'thumbnail.png', () => Promise.resolve(data.buffer), {
+      type: 'image/png'
+    })
+  })
+  vi.mocked(saveFile).mockImplementation(async (file) => `kodo://imported/${file.name}`)
+  vi.mocked(cloudHelpers.load).mockImplementation(async (owner, name) => {
+    return {
+      metadata: {
+        id: `project-${owner}-${name}`,
+        owner,
+        name,
+        displayName: name,
+        type: ProjectType.Game,
+        visibility: Visibility.Public,
+        description: '',
+        instructions: '',
+        createdAt: '2026-01-01T00:00:00Z',
+        updatedAt: '2026-01-01T00:00:00Z',
+        version: 1,
+        files: {},
+        thumbnail: '',
+        remixedFrom: null,
+        latestRelease: null,
+        viewCount: 0,
+        likeCount: 0,
+        releaseCount: 0,
+        remixCount: 0,
+        isLiked: false,
+        isMine: true,
+        isFeatured: false,
+        isPublished: true,
+        aiDescription: '',
+        extraSettings: {},
+        aiDescriptionHash: null
+      },
+      files: {}
+    } as unknown as Awaited<ReturnType<typeof cloudHelpers.load>>
+  })
+  vi.mocked(cloudHelpers.save).mockImplementation(
+    async (serialized) => serialized as Awaited<ReturnType<typeof cloudHelpers.save>>
+  )
+  vi.mocked(xbpHelpers.save).mockImplementation(
+    async (serialized) => new File([JSON.stringify(serialized.metadata)], `${serialized.metadata.name}.xbp`)
+  )
+  vi.mocked(xbpHelpers.load).mockImplementation(async (file) => {
+    const name = file.name.replace(/\.xbp$/, '')
+    return {
+      metadata: {
+        id: `source-${name}`,
+        owner: 'curator',
+        name,
+        displayName: `Display ${name}`,
+        type: ProjectType.Game,
+        description: `Description ${name}`,
+        instructions: `Instructions ${name}`,
+        extraSettings: {},
+        visibility: Visibility.Public
+      },
+      files: {}
+    } as Awaited<ReturnType<typeof xbpHelpers.load>>
+  })
+  vi.mocked(getProject).mockRejectedValue(
+    new ApiException(ApiExceptionCode.errorNotFound, 'Not found', {
+      req: new Request('https://api.example.com/projects/alice/project')
+    })
+  )
+  vi.mocked(addCourse).mockResolvedValue({ ...existingCourse, id: 'imported-course' })
+  vi.mocked(updateCourseSeries).mockImplementation(async (id, params) => ({
+    id,
+    owner: 'alice',
+    ...params,
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-01T00:00:00Z'
+  }))
+  vi.mocked(addCourseSeries).mockImplementation(async (params) => ({
+    id: 'created-series',
+    owner: 'alice',
+    ...params,
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-01T00:00:00Z'
+  }))
+  vi.mocked(deleteCourse).mockResolvedValue(undefined)
+  vi.mocked(updateProject).mockResolvedValue({} as Awaited<ReturnType<typeof updateProject>>)
+  vi.mocked(createProjectRelease).mockResolvedValue({} as Awaited<ReturnType<typeof createProjectRelease>>)
+})
+
+describe('exportCourseSeriesFile', () => {
+  it('exports a self-contained package with related projects', async () => {
+    const file = await exportCourseSeriesFile(existingSeries)
+    const unzipped = await unzip(new Uint8Array(await file.arrayBuffer()))
+    const manifest = JSON.parse(new TextDecoder().decode(unzipped['course-series.json']!)) as Record<string, any>
+
+    expect(file.name).toBe('编程 课程.xbcs.zip')
+    expect(manifest.courseSeries).toMatchObject({
+      title: existingSeries.title,
+      description: existingSeries.description,
+      thumbnail: { path: 'thumbnails/course-series.png' }
+    })
+    expect(manifest.courseSeries).not.toHaveProperty('order')
+    expect(manifest.courses[0].thumbnail).toEqual({ path: 'thumbnails/courses/0.png' })
+    expect(manifest.projects.map((project: { fullName: string }) => project.fullName)).toEqual([
+      'curator/RefProject',
+      'curator/EntryProject'
+    ])
+    expect(Object.keys(unzipped)).toEqual(
+      expect.arrayContaining([
+        'course-series.json',
+        'thumbnails/course-series.png',
+        'thumbnails/courses/0.png',
+        'projects/0.xbp',
+        'projects/1.xbp'
+      ])
+    )
+  })
+})
+
+describe('importCourseSeriesFile', () => {
+  it('rewrites exact editor project segment and preserves local order', async () => {
+    await importCourseSeriesFile(
+      existingSeries,
+      await makeCourseSeriesFile('/editor/curator/EntryProject/lesson?tab=code'),
+      'alice'
+    )
+
+    expect(addCourse).toHaveBeenCalledWith(
+      {
+        title: 'Imported course',
+        thumbnail: 'kodo://imported/thumbnails/courses/0.png',
+        entrypoint: '/editor/alice/EntryProject/lesson?tab=code',
+        references: [{ type: 'project', fullName: 'alice/RefProject' }],
+        prompt: 'Imported prompt'
+      },
+      undefined
+    )
+    expect(updateCourseSeries).toHaveBeenCalledWith(
+      existingSeries.id,
+      expect.objectContaining({
+        order: existingSeries.order,
+        courseIDs: ['imported-course']
+      }),
+      undefined
+    )
+  })
+
+  it('does not rewrite longer project names that only share a prefix', async () => {
+    await importCourseSeriesFile(
+      existingSeries,
+      await makeCourseSeriesFile('/editor/curator/EntryProjectPlus/lesson?tab=code'),
+      'alice'
+    )
+
+    expect(addCourse).toHaveBeenCalledWith(
+      expect.objectContaining({
+        entrypoint: '/editor/curator/EntryProjectPlus/lesson?tab=code'
+      }),
+      undefined
+    )
+  })
+})
+
+describe('inspectCourseSeriesFileImport', () => {
+  it('reports deleted courses and overwritten projects', async () => {
+    vi.mocked(getProject).mockImplementation(async (_owner, name) => {
+      if (name !== 'EntryProject') {
+        throw new ApiException(ApiExceptionCode.errorNotFound, 'Not found', {
+          req: new Request(`https://api.example.com/projects/alice/${name}`)
+        })
+      }
+      return { owner: 'alice', name } as Awaited<ReturnType<typeof getProject>>
+    })
+
+    const inspection = await inspectCourseSeriesFileImport(
+      existingSeries,
+      await makeCourseSeriesFile('/editor/curator/EntryProject/lesson?tab=code'),
+      'alice'
+    )
+
+    expect(inspection).toEqual({
+      deletedCourses: ['Course 1'],
+      overwrittenProjects: ['EntryProject']
+    })
+  })
+})
+
+async function makeCourseSeriesFile(entrypoint: string) {
+  const zippable: Zippable = {
+    'course-series.json': new TextEncoder().encode(
+      JSON.stringify({
+        format: 'xbuilder-course-series',
+        version: 1,
+        courseSeries: {
+          title: 'Imported series',
+          description: 'Imported description',
+          thumbnail: { path: 'thumbnails/course-series.png' }
+        },
+        courses: [
+          {
+            title: 'Imported course',
+            thumbnail: { path: 'thumbnails/courses/0.png' },
+            entrypoint,
+            references: [{ type: 'project', fullName: 'curator/RefProject' }],
+            prompt: 'Imported prompt'
+          }
+        ],
+        projects: [
+          { fullName: 'curator/EntryProject', name: 'EntryProject', path: 'projects/0.xbp' },
+          { fullName: 'curator/RefProject', name: 'RefProject', path: 'projects/1.xbp' }
+        ]
+      })
+    ),
+    'thumbnails/course-series.png': new TextEncoder().encode('series thumbnail'),
+    'thumbnails/courses/0.png': new TextEncoder().encode('course thumbnail'),
+    'projects/0.xbp': new TextEncoder().encode('entry project'),
+    'projects/1.xbp': new TextEncoder().encode('ref project')
+  }
+  return new File([await zip(zippable)], 'Imported series.xbcs.zip', { type: 'application/zip' })
+}

--- a/spx-gui/src/components/course/management/course-series-file.ts
+++ b/spx-gui/src/components/course/management/course-series-file.ts
@@ -298,11 +298,16 @@ async function importProject(
   if (serialized.metadata.instructions != null) metadataUpdates.instructions = serialized.metadata.instructions
   if (serialized.metadata.extraSettings != null) metadataUpdates.extraSettings = serialized.metadata.extraSettings
   if (Object.keys(metadataUpdates).length > 0) await updateProject(owner, name, metadataUpdates, signal)
-  await createProjectRelease(owner, name, {
-    name: generateReleaseName(),
-    description: `Imported from course series "${manifest.courseSeries.title}"`,
-    thumbnail: ''
-  })
+  await createProjectRelease(
+    owner,
+    name,
+    {
+      name: generateReleaseName(),
+      description: `Imported from course series "${manifest.courseSeries.title}"`,
+      thumbnail: ''
+    },
+    signal
+  )
   return `${owner}/${name}`
 }
 

--- a/spx-gui/src/components/course/management/course-series-file.ts
+++ b/spx-gui/src/components/course/management/course-series-file.ts
@@ -1,0 +1,386 @@
+import dayjs from 'dayjs'
+import { zip, unzip, type Zippable } from '@/utils/zip'
+import { extname } from '@/utils/path'
+import { DefaultException } from '@/utils/exception'
+import { getExtFromMime } from '@/utils/file'
+import { ApiException, ApiExceptionCode } from '@/apis/common/exception'
+import { getCourse, addCourse, deleteCourse, type Course, type Reference } from '@/apis/course'
+import { addCourseSeries, updateCourseSeries, type CourseSeries } from '@/apis/course-series'
+import { getProject, ProjectType, updateProject, Visibility, type UpdateProjectParams } from '@/apis/project'
+import { createProjectRelease } from '@/apis/project-release'
+import { cloudHelpers, createFileWithUniversalUrl, saveFile } from '@/models/common/cloud'
+import { File as LazyFile } from '@/models/common/file'
+import { xbpHelpers } from '@/models/common/xbp'
+
+const manifestFileName = 'course-series.json'
+const format = 'xbuilder-course-series'
+const version = 1
+
+type CourseSeriesFileThumbnail = {
+  path: string
+}
+
+type CourseSeriesFileCourse = Pick<Course, 'title' | 'entrypoint' | 'references' | 'prompt'> & {
+  thumbnail: CourseSeriesFileThumbnail
+}
+
+type CourseSeriesFileProject = {
+  fullName: string
+  name: string
+  path: string
+}
+
+type CourseSeriesFileManifest = {
+  format: typeof format
+  version: typeof version
+  courseSeries: Pick<CourseSeries, 'title' | 'description'> & {
+    thumbnail: CourseSeriesFileThumbnail
+  }
+  courses: CourseSeriesFileCourse[]
+  projects: CourseSeriesFileProject[]
+}
+
+type ParsedProjectFullName = {
+  owner: string
+  name: string
+}
+
+export type CourseSeriesFileImportInspection = {
+  deletedCourses: string[]
+  overwrittenProjects: string[]
+}
+
+export async function exportCourseSeriesFile(courseSeries: CourseSeries, signal?: AbortSignal) {
+  const courses = await Promise.all(courseSeries.courseIDs.map((id) => getCourse(id, signal)))
+  const projects = collectRelatedProjects(courses)
+  const zippable: Zippable = {}
+
+  const courseSeriesThumbnail = await exportThumbnail(
+    courseSeries.thumbnail,
+    'thumbnails/course-series',
+    zippable,
+    signal
+  )
+  const exportedCourses = await Promise.all(
+    courses.map(
+      async (course, index): Promise<CourseSeriesFileCourse> => ({
+        title: course.title,
+        entrypoint: course.entrypoint,
+        references: course.references,
+        prompt: course.prompt,
+        thumbnail: await exportThumbnail(course.thumbnail, `thumbnails/courses/${index}`, zippable, signal)
+      })
+    )
+  )
+
+  const exportedProjects = await Promise.all(
+    projects.map(async (project, index): Promise<CourseSeriesFileProject> => {
+      const serialized = await cloudHelpers.load(project.owner, project.name, true, signal)
+      const file = await xbpHelpers.save(serialized, signal)
+      const path = `projects/${index}.xbp`
+      zippable[path] = new Uint8Array(await file.arrayBuffer())
+      return { fullName: project.fullName, name: project.name, path }
+    })
+  )
+
+  const manifest: CourseSeriesFileManifest = {
+    format,
+    version,
+    courseSeries: {
+      title: courseSeries.title,
+      description: courseSeries.description,
+      thumbnail: courseSeriesThumbnail
+    },
+    courses: exportedCourses,
+    projects: exportedProjects
+  }
+  zippable[manifestFileName] = new TextEncoder().encode(JSON.stringify(manifest))
+
+  const zipped = await zip(zippable, { level: 6, signal })
+  return new File([zipped], `${courseSeries.title}.xbcs.zip`, { type: 'application/zip' })
+}
+
+export async function importCourseSeriesFile(
+  courseSeries: CourseSeries,
+  file: globalThis.File,
+  signedInUsername: string,
+  signal?: AbortSignal
+) {
+  const data = await loadCourseSeriesFile(file, signal)
+  return importCourseSeriesFileData(courseSeries, data, signedInUsername, signal)
+}
+
+export async function importCourseSeriesFileAsNew(
+  file: globalThis.File,
+  signedInUsername: string,
+  signal?: AbortSignal
+) {
+  const data = await loadCourseSeriesFile(file, signal)
+  const courseSeries = await addCourseSeries(
+    {
+      title: data.manifest.courseSeries.title,
+      thumbnail: '',
+      description: data.manifest.courseSeries.description,
+      order: 1,
+      courseIDs: []
+    },
+    signal
+  )
+  return importCourseSeriesFileData(courseSeries, data, signedInUsername, signal)
+}
+
+export async function inspectCourseSeriesFileImport(
+  courseSeries: CourseSeries | null,
+  file: globalThis.File,
+  signedInUsername: string,
+  signal?: AbortSignal
+): Promise<CourseSeriesFileImportInspection> {
+  const data = await loadCourseSeriesFile(file, signal)
+  const deletedCourses =
+    courseSeries == null
+      ? []
+      : await Promise.all(courseSeries.courseIDs.map(async (id) => (await getCourse(id, signal)).title))
+  const overwrittenProjects = await Promise.all(
+    data.manifest.projects.map(async (project) => {
+      const existingProject = await getSignedInUserProject(signedInUsername, project.name, signal)
+      return existingProject?.name ?? null
+    })
+  )
+  return { deletedCourses, overwrittenProjects: overwrittenProjects.filter((p) => p != null) }
+}
+
+async function loadCourseSeriesFile(file: globalThis.File, signal?: AbortSignal) {
+  const arrayBuffer = await file.arrayBuffer()
+  const unzipped = await unzip(new Uint8Array(arrayBuffer), { signal })
+  const manifest = JSON.parse(
+    new TextDecoder().decode(getRequiredEntry(unzipped, manifestFileName))
+  ) as CourseSeriesFileManifest
+  if (manifest.format !== format || manifest.version !== version) {
+    throw new DefaultException({
+      en: 'Unsupported course series file format',
+      zh: '不支持的课程系列文件格式'
+    })
+  }
+  return { manifest, unzipped }
+}
+
+async function importCourseSeriesFileData(
+  courseSeries: CourseSeries,
+  { manifest, unzipped }: Awaited<ReturnType<typeof loadCourseSeriesFile>>,
+  signedInUsername: string,
+  signal?: AbortSignal
+) {
+  const projectFullNameMap = new Map<string, string>()
+  for (const project of manifest.projects) {
+    const importedFullName = await importProject(project, manifest, unzipped, signedInUsername, signal)
+    projectFullNameMap.set(project.fullName, importedFullName)
+  }
+
+  const importedCourses = []
+  for (const course of manifest.courses) {
+    importedCourses.push(
+      await addCourse(
+        {
+          title: course.title,
+          thumbnail: await importThumbnail(course.thumbnail, unzipped, signal),
+          entrypoint: rewriteProjectFullNames(course.entrypoint, projectFullNameMap),
+          references: rewriteReferences(course.references, projectFullNameMap),
+          prompt: course.prompt
+        },
+        signal
+      )
+    )
+  }
+
+  const importedCourseSeries = await updateCourseSeries(
+    courseSeries.id,
+    {
+      title: manifest.courseSeries.title,
+      thumbnail: await importThumbnail(manifest.courseSeries.thumbnail, unzipped, signal),
+      description: manifest.courseSeries.description,
+      // Keep the local sort order because it depends on other course series in the current environment.
+      order: courseSeries.order,
+      courseIDs: importedCourses.map((course) => course.id)
+    },
+    signal
+  )
+
+  await Promise.all(courseSeries.courseIDs.map((courseID) => deleteCourse(courseID)))
+  return importedCourseSeries
+}
+
+async function exportThumbnail(
+  universalUrl: string,
+  pathWithoutExt: string,
+  zippable: Zippable,
+  signal?: AbortSignal
+): Promise<CourseSeriesFileThumbnail> {
+  if (universalUrl === '') {
+    throw new DefaultException({
+      en: 'Course series file export requires all thumbnails to be uploaded',
+      zh: '导出课程系列文件要求所有缩略图都已上传'
+    })
+  }
+
+  const file = createFileWithUniversalUrl(universalUrl)
+  const ext = extname(file.name) || `.${getExtFromMime(file.type) ?? 'jpg'}`
+  const path = `${pathWithoutExt}${ext}`
+  zippable[path] = new Uint8Array(await file.arrayBuffer(signal))
+  return { path }
+}
+
+async function importThumbnail(
+  thumbnail: CourseSeriesFileThumbnail,
+  unzipped: Record<string, Uint8Array<ArrayBuffer>>,
+  signal?: AbortSignal
+) {
+  const data = getRequiredEntry(unzipped, thumbnail.path)
+  return saveFile(createLazyFile(thumbnail.path, data), signal)
+}
+
+function collectRelatedProjects(courses: Course[]) {
+  const projects = new Map<string, ParsedProjectFullName & { fullName: string }>()
+  for (const course of courses) {
+    for (const reference of course.references) {
+      if (reference.type !== 'project') continue
+      const parsed = parseProjectFullName(reference.fullName)
+      projects.set(reference.fullName, { ...parsed, fullName: reference.fullName })
+    }
+    const entrypointProject = parseEditorProjectFullName(course.entrypoint)
+    if (entrypointProject != null) projects.set(entrypointProject.fullName, entrypointProject)
+  }
+  return [...projects.values()]
+}
+
+function parseEditorProjectFullName(entrypoint: string) {
+  const parsed = parseEditorEntrypoint(entrypoint)
+  if (parsed == null) return null
+  const fullName = `${parsed.owner}/${parsed.name}`
+  return { ...parseProjectFullName(fullName), fullName }
+}
+
+function parseProjectFullName(fullName: string): ParsedProjectFullName {
+  const parts = fullName.split('/')
+  if (parts.length !== 2 || parts[0] === '' || parts[1] === '') {
+    throw new DefaultException({
+      en: `Invalid project reference: ${fullName}`,
+      zh: `无效的项目引用：${fullName}`
+    })
+  }
+  return { owner: decodeURIComponent(parts[0]), name: decodeURIComponent(parts[1]) }
+}
+
+async function importProject(
+  project: CourseSeriesFileProject,
+  manifest: CourseSeriesFileManifest,
+  unzipped: Record<string, Uint8Array<ArrayBuffer>>,
+  signedInUsername: string,
+  signal?: AbortSignal
+) {
+  const serialized = await xbpHelpers.load(new File([getRequiredEntry(unzipped, project.path)], `${project.name}.xbp`))
+  const existingProject = await getSignedInUserProject(signedInUsername, project.name, signal)
+  const owner = existingProject?.owner ?? signedInUsername
+  const name = existingProject?.name ?? project.name
+  const sourceMetadata = { ...serialized.metadata }
+  delete sourceMetadata.id
+  const metadata = {
+    ...sourceMetadata,
+    owner,
+    name,
+    displayName: serialized.metadata.displayName ?? project.name,
+    type: serialized.metadata.type ?? ProjectType.Game,
+    visibility: Visibility.Public
+  }
+  if (existingProject != null) metadata.id = existingProject.id
+
+  await cloudHelpers.save({ metadata, files: serialized.files }, signal)
+  const metadataUpdates: UpdateProjectParams = {}
+  if (serialized.metadata.description != null) metadataUpdates.description = serialized.metadata.description
+  if (serialized.metadata.instructions != null) metadataUpdates.instructions = serialized.metadata.instructions
+  if (serialized.metadata.extraSettings != null) metadataUpdates.extraSettings = serialized.metadata.extraSettings
+  if (Object.keys(metadataUpdates).length > 0) await updateProject(owner, name, metadataUpdates, signal)
+  await createProjectRelease(owner, name, {
+    name: generateReleaseName(),
+    description: `Imported from course series "${manifest.courseSeries.title}"`,
+    thumbnail: ''
+  })
+  return `${owner}/${name}`
+}
+
+async function getSignedInUserProject(owner: string, name: string, signal?: AbortSignal) {
+  try {
+    return await getProject(owner, name, signal)
+  } catch (e) {
+    if (e instanceof ApiException && e.code === ApiExceptionCode.errorNotFound) return null
+    throw e
+  }
+}
+
+function rewriteReferences(references: Reference[], projectFullNameMap: Map<string, string>): Reference[] {
+  return references.map((reference) => {
+    if (reference.type !== 'project') return reference
+    return { ...reference, fullName: projectFullNameMap.get(reference.fullName) ?? reference.fullName }
+  })
+}
+
+function rewriteProjectFullNames(value: string, projectFullNameMap: Map<string, string>) {
+  const parsed = parseEditorEntrypoint(value)
+  if (parsed == null) return value
+
+  const source = `${parsed.owner}/${parsed.name}`
+  const target = projectFullNameMap.get(source)
+  if (target == null) return value
+
+  const { owner, name } = parseProjectFullName(target)
+  parsed.url.pathname = `/editor/${encodeURIComponent(owner)}/${encodeURIComponent(name)}${parsed.restPath}`
+  return parsed.isAbsolute ? parsed.url.toString() : `${parsed.url.pathname}${parsed.url.search}${parsed.url.hash}`
+}
+
+function parseEditorEntrypoint(value: string) {
+  const base = 'https://xbuilder.invalid'
+
+  let url: URL
+  let isAbsolute = false
+  try {
+    url = new URL(value)
+    isAbsolute = true
+  } catch {
+    try {
+      url = new URL(value, base)
+    } catch {
+      return null
+    }
+  }
+
+  const segments = url.pathname.split('/').filter((segment) => segment !== '')
+  if (segments[0] !== 'editor' || segments[1] == null || segments[2] == null) return null
+
+  const owner = decodeURIComponent(segments[1])
+  const name = decodeURIComponent(segments[2])
+  const restPath = segments.length > 3 ? `/${segments.slice(3).join('/')}` : ''
+
+  return { url, isAbsolute, owner, name, restPath }
+}
+
+function getRequiredEntry(unzipped: Record<string, Uint8Array<ArrayBuffer>>, path: string) {
+  const entry = unzipped[path]
+  if (entry == null) {
+    throw new DefaultException({
+      en: `Invalid course series file: missing ${path}`,
+      zh: `无效的课程系列文件：缺少 ${path}`
+    })
+  }
+  return entry
+}
+
+function createLazyFile(path: string, data: Uint8Array<ArrayBuffer>) {
+  return new LazyFile(path, () =>
+    Promise.resolve(data.buffer.slice(data.byteOffset, data.byteOffset + data.byteLength))
+  )
+}
+
+function generateReleaseName() {
+  const timeStr = dayjs().tz('UTC').format('YYYYMMDDHHmmss')
+  const build = `${timeStr}.${Math.random().toString(16).slice(2, 8)}`
+  return `v0.0.0+${build}`
+}

--- a/spx-gui/src/components/course/management/course-series-file.ts
+++ b/spx-gui/src/components/course/management/course-series-file.ts
@@ -11,6 +11,7 @@ import { createProjectRelease } from '@/apis/project-release'
 import { cloudHelpers, createFileWithUniversalUrl, saveFile } from '@/models/common/cloud'
 import { File as LazyFile } from '@/models/common/file'
 import { xbpHelpers } from '@/models/common/xbp'
+import type { PartialMetadata } from '@/models/project'
 
 const manifestFileName = 'course-series.json'
 const format = 'xbuilder-course-series'
@@ -281,17 +282,15 @@ async function importProject(
   const existingProject = await getSignedInUserProject(signedInUsername, project.name, signal)
   const owner = existingProject?.owner ?? signedInUsername
   const name = existingProject?.name ?? project.name
-  const sourceMetadata = { ...serialized.metadata }
-  delete sourceMetadata.id
-  const metadata = {
-    ...sourceMetadata,
+  const metadata: PartialMetadata = {
+    ...serialized.metadata,
+    id: existingProject?.id,
     owner,
     name,
     displayName: serialized.metadata.displayName ?? project.name,
     type: serialized.metadata.type ?? ProjectType.Game,
     visibility: Visibility.Public
   }
-  if (existingProject != null) metadata.id = existingProject.id
 
   await cloudHelpers.save({ metadata, files: serialized.files }, signal)
   const metadataUpdates: UpdateProjectParams = {}


### PR DESCRIPTION
## Summary
- add course series file import and export support for syncing tutorial series across environments
- move import and export actions into the course series edit modal with destructive import warnings
- bundle related projects and thumbnails into the exported package and cover the helper with unit tests

## Testing
- npm run test -- --run src/components/course/management/course-series-file.test.ts
- npm run lint -- src/components/course/management/course-series-file.ts src/components/course/management/course-series-file.test.ts src/components/course/management/CourseSeriesEditModal.vue src/components/course/management/CourseItemMini.vue
- npm run type-check

Refs #3229
