### PR TITLE
Fix transparent stage background in viewers

### DIFF
--- a/spx-gui/src/components/editor/map-editor/map-viewer/MapViewer.vue
+++ b/spx-gui/src/components/editor/map-editor/map-viewer/MapViewer.vue
@@ -4,6 +4,7 @@ import { computed, nextTick, onMounted, reactive, ref, shallowRef, watch, watchE
 import Konva from 'konva'
 import type { KonvaEventObject } from 'konva/lib/Node'
 import type { LayerConfig } from 'konva/lib/Layer'
+import type { RectConfig } from 'konva/lib/shapes/Rect'
 
 import stageBgUrl from '@/assets/images/stage-bg.svg'
 import { UILoading } from '@/components/ui'
@@ -248,6 +249,15 @@ watchEffect(() => {
   img.addEventListener('load', () => {
     backdropImg.value = img
   })
+})
+
+const konvaStageBackgroundRectConfig = computed(() => {
+  return {
+    // Keep the stage white base aligned with SPX when there is no backdrop or the backdrop is transparent.
+    width: mapSize.value.width,
+    height: mapSize.value.height,
+    fill: '#fff'
+  } satisfies RectConfig
 })
 
 const konvaBackdropRectConfig = computed(() => {
@@ -547,6 +557,7 @@ const handleWheel = (e: KonvaEventObject<WheelEvent>) => {
   >
     <v-stage v-if="stageConfig != null" ref="stageRef" :config="stageConfig" @wheel="handleWheel">
       <v-layer ref="mapRef" :config="mapConfig" @dragmove="handleMapDragMove" @dragend="handleMapDragEnd">
+        <v-rect :config="konvaStageBackgroundRectConfig"></v-rect>
         <v-rect v-if="konvaBackdropRectConfig" :config="konvaBackdropRectConfig"></v-rect>
         <DecoratorNode
           v-for="(decorator, idx) in props.project.tilemap?.decorators ?? []"

--- a/spx-gui/src/components/editor/preview/stage-viewer/StageViewer.vue
+++ b/spx-gui/src/components/editor/preview/stage-viewer/StageViewer.vue
@@ -11,6 +11,7 @@
   >
     <v-stage v-if="stageConfig != null" ref="stageRef" :config="stageConfig" @wheel="handleWheel">
       <v-layer ref="mapRef" :config="mapConfig" @dragmove="handleMapDragMove" @dragend="handleMapDragEnd">
+        <v-rect :config="konvaStageBackgroundRectConfig"></v-rect>
         <v-rect v-if="konvaBackdropRectConfig" :config="konvaBackdropRectConfig"></v-rect>
         <DecoratorNode
           v-for="(decorator, idx) in editorCtx.project.tilemap?.decorators ?? []"
@@ -89,6 +90,7 @@ import Konva from 'konva'
 import type { KonvaEventObject } from 'konva/lib/Node'
 import type { StageConfig } from 'konva/lib/Stage'
 import type { LayerConfig } from 'konva/lib/Layer'
+import type { RectConfig } from 'konva/lib/shapes/Rect'
 
 import stageBgUrl from '@/assets/images/stage-bg.svg'
 import { UILoading } from '@/components/ui'
@@ -297,6 +299,15 @@ watchEffect(() => {
   img.addEventListener('load', () => {
     backdropImg.value = img
   })
+})
+
+const konvaStageBackgroundRectConfig = computed(() => {
+  return {
+    // Keep the stage white base aligned with SPX when there is no backdrop or the backdrop is transparent.
+    width: mapSize.value.width,
+    height: mapSize.value.height,
+    fill: '#fff'
+  } satisfies RectConfig
 })
 
 const konvaBackdropRectConfig = computed(() => {


### PR DESCRIPTION
## Summary

- Add a white stage-sized base rect below backdrop rendering in Stage Viewer.
- Add the same stage-sized white base in Map Viewer so the outer map area remains visible beyond the stage.
- Document that the white base matches SPX behavior when there is no backdrop or the backdrop is transparent.

## Verification

- Prettier check for the two changed Vue files
- Targeted ESLint for the two changed Vue files

