### PR TITLE
Fix potential deadlock during token refreshing

### DIFF
--- a/spx-gui/src/apis/common/client.test.ts
+++ b/spx-gui/src/apis/common/client.test.ts
@@ -116,7 +116,8 @@ describe('Client', () => {
   describe('explicit authorization headers', () => {
     it('should preserve an explicit Authorization header instead of overwriting it with the token provider', async () => {
       fetchMock.mockResolvedValueOnce(new Response(JSON.stringify({ username: 'alice' }), { status: 200 }))
-      client.setTokenProvider(async () => 'shared-token')
+      const tokenProvider = vi.fn(async () => 'shared-token')
+      client.setTokenProvider(tokenProvider)
 
       await client.get('/user', undefined, {
         headers: new Headers({ Authorization: 'Bearer direct-token' })
@@ -124,6 +125,7 @@ describe('Client', () => {
 
       const req = fetchMock.mock.calls[0]?.[0] as Request
       expect(req.headers.get('Authorization')).toBe('Bearer direct-token')
+      expect(tokenProvider).toHaveBeenCalledTimes(0)
     })
   })
 })

--- a/spx-gui/src/apis/common/client.ts
+++ b/spx-gui/src/apis/common/client.ts
@@ -85,6 +85,13 @@ export class Client {
   private fetchFn: typeof fetch
   private defaultTimeout = 10 * 1000 // 10 seconds
 
+  private async injectAuthorization(headers: Headers) {
+    if (headers.has('Authorization')) return
+    const token = await this.tokenProvider()
+    if (token == null) return
+    headers.set('Authorization', `Bearer ${token}`)
+  }
+
   /** Prepare request object, stringifying payload as JSON */
   private async prepareJSONRequest(path: string, payload: unknown, options?: RequestOptions): Promise<Request> {
     const traceData = Sentry.getTraceData()
@@ -93,11 +100,10 @@ export class Client {
     const url = this.baseUrl + path
     const method = options?.method ?? 'GET'
     const body = payload != null ? JSON.stringify(payload) : null
-    const token = await this.tokenProvider()
-    options?.signal?.throwIfAborted()
     const headers = options?.headers ?? new Headers()
+    await this.injectAuthorization(headers)
+    options?.signal?.throwIfAborted()
     if (body != null) headers.set('Content-Type', 'application/json')
-    if (token != null && !headers.has('Authorization')) headers.set('Authorization', `Bearer ${token}`)
     if (sentryTraceHeader != null) headers.set('Sentry-Trace', sentryTraceHeader)
     if (sentryBaggageHeader != null) headers.set('Baggage', sentryBaggageHeader)
     return new Request(url, { method, headers, body })
@@ -140,10 +146,9 @@ export class Client {
     const sentryBaggageHeader = traceData['baggage']
     const url = this.baseUrl + path
     const method = options?.method ?? 'GET'
-    const token = await this.tokenProvider()
-    options?.signal?.throwIfAborted()
     const headers = options?.headers ?? new Headers()
-    if (token != null && !headers.has('Authorization')) headers.set('Authorization', `Bearer ${token}`)
+    await this.injectAuthorization(headers)
+    options?.signal?.throwIfAborted()
     if (sentryTraceHeader != null) headers.set('Sentry-Trace', sentryTraceHeader)
     if (sentryBaggageHeader != null) headers.set('Baggage', sentryBaggageHeader)
     const req = new Request(url, { method, headers, body: payload })

--- a/spx-gui/src/apis/user.ts
+++ b/spx-gui/src/apis/user.ts
@@ -48,7 +48,18 @@ export async function isUsernameTaken(username: string) {
   }
 }
 
-export function getSignedInUser(options?: { headers?: Headers }): Promise<SignedInUser> {
+export function getSignedInUser(
+  /** Optional access token for authentication */
+  token?: string
+): Promise<SignedInUser> {
+  const options =
+    token == null
+      ? undefined
+      : {
+          headers: new Headers({
+            Authorization: `Bearer ${token}`
+          })
+        }
   return client.get(`/user`, undefined, options) as Promise<SignedInUser>
 }
 

--- a/spx-gui/src/stores/user/signed-in.ts
+++ b/spx-gui/src/stores/user/signed-in.ts
@@ -37,11 +37,7 @@ interface TokenResponse {
 }
 
 async function fetchSignedInUsernameByAccessToken(accessToken: string) {
-  const user = await apis.getSignedInUser({
-    headers: new Headers({
-      Authorization: `Bearer ${accessToken}`
-    })
-  })
+  const user = await apis.getSignedInUser(accessToken)
   return user.username
 }
 
@@ -99,6 +95,11 @@ export async function ensureAccessToken(): Promise<string | null> {
   tokenRefreshPromise = (async () => {
     try {
       const resp = await casdoorSdk.refreshAccessToken(userState.refreshToken!)
+      if ('error' in resp && typeof resp.error === 'string') {
+        // If refreshing failed, `casdoorSdk.refreshAccessToken` returns an object with field `error` and `error_description`
+        // instead of throwing an error. We have to check this manually and throw an error to be handled by callers.
+        throw new Error(`Failed to refresh access token: ${resp.error} (${(resp as any).error_description})`)
+      }
       await handleTokenResponse(resp)
     } catch (e) {
       console.error('failed to refresh access token', e)


### PR DESCRIPTION
Fix issue mentioned in https://github.com/goplus/builder/pull/3246#discussion_r3359753277 :

> **Critical Deadlock Risk:** Calling `this.tokenProvider()` unconditionally at the start of every request will cause a deadlock during the token refresh flow. When `ensureAccessToken` refreshes the token, it calls `fetchSignedInUsernameByAccessToken`, which makes a request to `/user`. That request will call `this.tokenProvider()` again, which awaits the pending `tokenRefreshPromise`, resulting in a deadlock.