### PR TITLE
Avoid potential memory leak in AnimationPlayer

### DIFF
--- a/spx-gui/src/components/editor/sprite/animation/AnimationPlayer.vue
+++ b/spx-gui/src/components/editor/sprite/animation/AnimationPlayer.vue
@@ -12,7 +12,7 @@
 <script setup lang="ts">
 import { onUnmounted, ref, watchEffect } from 'vue'
 import { registerPlayer as registerAudioPlayer } from '@/utils/player-registry'
-import { useActivated } from '@/utils/utils'
+import { timeout, useActivated } from '@/utils/utils'
 import { Cancelled, capture } from '@/utils/exception'
 import { AnimationSoundPlayback } from '@/models/spx/animation'
 import type { Costume } from '@/models/spx/costume'
@@ -74,23 +74,18 @@ function playAudioWithPlaybackOnce(audio: HTMLAudioElement, duration: number, si
     const newAudio = new Audio(audio.src)
     newAudio.muted = mutedRef.value
     audios.add(newAudio)
-    newAudio.addEventListener('ended', () => audios.delete(newAudio), { once: true })
-    signal.addEventListener(
-      'abort',
-      () => {
-        newAudio.pause()
-        audios.delete(newAudio)
-      },
-      { once: true }
-    )
-    setTimeout(
-      () => {
-        // Stop the newAudio after some time to prevent too many overlapping audios
-        newAudio.pause()
-        audios.delete(newAudio)
-      },
-      duration * 1000 * concurrentAudioLimit
-    )
+
+    const ctrl = new AbortController()
+    function stopAndCleanup() {
+      if (ctrl.signal.aborted) return
+      ctrl.abort(new Cancelled('stop and cleanup'))
+      newAudio.pause()
+      audios.delete(newAudio)
+    }
+    newAudio.addEventListener('ended', stopAndCleanup, { signal: ctrl.signal })
+    signal.addEventListener('abort', stopAndCleanup, { signal: ctrl.signal })
+    // Stop the newAudio after some time to prevent too many overlapping audios
+    timeout(duration * 1000 * concurrentAudioLimit, ctrl.signal).then(stopAndCleanup)
     newAudio.play()
   }
   playOnce()


### PR DESCRIPTION
Fix memory leak issue mentioned in https://github.com/goplus/builder/pull/3246#discussion_r3359753284 :

> 1. In `playAudioWithPlaybackOnce`, a new `'abort'` event listener is added to `signal` every time `playOnce` runs (every cycle). If the animation loops for a long time, this will accumulate a large number of dangling event listeners, causing a memory leak.

