### PR TITLE
fix(spx-gui): hide pivot marker in thumbnails

### DIFF
--- a/spx-gui/src/components/editor/common/viewer/NodeTransformer.vue
+++ b/spx-gui/src/components/editor/common/viewer/NodeTransformer.vue
@@ -88,11 +88,13 @@ defineExpose({
   getNode() {
     return transformer.value?.getNode()
   },
-  withHidden<T>(callback: () => T): T {
+  async withHidden<T>(callback: () => T | Promise<T>): Promise<Awaited<T>> {
     transformer.value?.getNode().hide()
-    const ret = callback()
-    transformer.value?.getNode().show()
-    return ret
+    try {
+      return await callback()
+    } finally {
+      transformer.value?.getNode().show()
+    }
   }
 })
 </script>

--- a/spx-gui/src/components/editor/common/viewer/SpriteNode.vue
+++ b/spx-gui/src/components/editor/common/viewer/SpriteNode.vue
@@ -85,6 +85,7 @@ onMounted(() => {
 // maps the sprite pivot to the Konva node origin with offsetX/offsetY, so the marker can simply use
 // the same local position as the sprite node. This is a small, low-risk patch compared with teaching
 // CustomTransformer to support custom transform origins via Konva internal method overrides.
+// TODO: Consider moving this marker into NodeTransformer so editor-only overlays share one hiding path.
 const pivotMarkerRef = ref<KonvaNodeInstance<Group>>()
 
 // Keep the selected sprite's pivot marker above all sprite nodes.
@@ -262,6 +263,17 @@ function toSize(node: Konva.Node) {
 function handleClick() {
   emit('selected')
 }
+
+defineExpose({
+  async withPivotMarkerHidden<T>(callback: () => T | Promise<T>): Promise<Awaited<T>> {
+    pivotMarkerRef.value?.getNode().hide()
+    try {
+      return await callback()
+    } finally {
+      pivotMarkerRef.value?.getNode().show()
+    }
+  }
+})
 </script>
 
 <template>

--- a/spx-gui/src/components/editor/preview/stage-viewer/StageViewer.vue
+++ b/spx-gui/src/components/editor/preview/stage-viewer/StageViewer.vue
@@ -32,6 +32,7 @@
         <v-group>
           <SpriteNode
             v-for="localConfig in visibleSpriteLocalConfigs"
+            ref="spriteNodeRefs"
             :key="localConfig.id"
             :local-config="localConfig"
             :selected="editorCtx.state.selectedSprite?.id === localConfig.id"
@@ -138,6 +139,7 @@ const mapRef = ref<{
 const viewportSize = computed(() => editorCtx.project.viewportSize)
 const mapSize = computed(() => editorCtx.project.stage.getMapSize())
 const nodeTransformerRef = ref<InstanceType<typeof NodeTransformer>>()
+const spriteNodeRefs = ref<(InstanceType<typeof SpriteNode> | null)[]>([])
 const nodeReadyMap = reactive(new Map<string, boolean>())
 const mousePos = ref<Pos | null>(null)
 
@@ -509,20 +511,28 @@ function ensureCanTakeScreenshot() {
   if (!canTakeScreenshot.value) throw new Error('stage viewer is not renderable for screenshot')
 }
 
+const selectedSpriteNode = computed(() => {
+  const selectedSpriteId = editorCtx.state.selectedSprite?.id
+  if (selectedSpriteId == null) return null
+  const idx = visibleSpriteLocalConfigs.value.findIndex(({ id }) => id === selectedSpriteId)
+  return spriteNodeRefs.value[idx] ?? null
+})
+
 async function takeScreenshot(name: string, signal?: AbortSignal) {
   ensureCanTakeScreenshot()
   const stage = await untilNotNull(stageRef, signal)
   const nodeTransformer = await untilNotNull(nodeTransformerRef, signal)
   await until(() => !loading.value, signal)
   ensureCanTakeScreenshot()
-  // Omit transform control when taking screenshot
-  const blob = await nodeTransformer.withHidden(
-    () =>
-      stage.getStage().toBlob({
-        mimeType: 'image/jpeg',
-        // @ts-expect-error: field missing in type definition, see details in https://github.com/konvajs/konva/issues/1977
-        imageSmoothingEnabled: false
-      }) as Promise<Blob>
+  const takeBlob = () =>
+    stage.getStage().toBlob({
+      mimeType: 'image/jpeg',
+      // @ts-expect-error: field missing in type definition, see details in https://github.com/konvajs/konva/issues/1977
+      imageSmoothingEnabled: false
+    }) as Promise<Blob>
+  // Omit editor-only controls when taking screenshot.
+  const blob = await nodeTransformer.withHidden(() =>
+    selectedSpriteNode.value == null ? takeBlob() : selectedSpriteNode.value.withPivotMarkerHidden(takeBlob)
   )
   return fromBlob(`${name}.jpg`, blob)
 }


### PR DESCRIPTION
## Summary

- hide selected sprite pivot markers while Stage Viewer is taking project thumbnail screenshots
- keep the behavior aligned with the existing transformer screenshot hiding path

Closes #3251

## Testing

- `npm run type-check`
- `npm run lint`
