### PR TITLE
Fix truncated sprite name discoverability

### DIFF
--- a/spx-gui/src/components/ui/block-items/UIBlockItemTitle.vue
+++ b/spx-gui/src/components/ui/block-items/UIBlockItemTitle.vue
@@ -19,8 +19,8 @@ const props = defineProps<{
 const slots = useSlots()
 const rootClass = computed(() =>
   cn(
-    'w-full flex items-center gap-2 px-1.5 text-center text-title',
-    props.size === 'large' ? 'h-5 text-sm' : 'h-5.5 text-2xs',
+    'w-full flex items-center text-center text-title',
+    props.size === 'large' ? 'h-5 gap-2 px-1.5 text-sm' : 'h-5.5 gap-0.5 px-1 text-2xs',
     props.class
   )
 )

--- a/spx-gui/src/components/ui/block-items/UIEditorSpriteItem.vue
+++ b/spx-gui/src/components/ui/block-items/UIEditorSpriteItem.vue
@@ -4,7 +4,11 @@
     <UIBlockItemTitle size="medium" :title="name">
       {{ name }}
       <template v-if="visible === false" #suffix>
-        <UIIcon class="cursor-auto text-grey-700" type="eyeOff" :title="$t({ en: 'Invisible', zh: '不可见' })" />
+        <UIIcon
+          class="size-3.5 flex-none cursor-auto text-grey-700"
+          type="eyeOff"
+          :title="$t({ en: 'Invisible', zh: '不可见' })"
+        />
       </template>
     </UIBlockItemTitle>
     <slot></slot>
@@ -33,7 +37,7 @@ const props = withDefaults(
 const selected = computed(() => props.selectable && props.selectable.selected)
 
 const imgStyle: CSSProperties = {
-  marginBottom: '5px',
+  marginBottom: '2px',
   height: '60px',
   width: '60px'
 }


### PR DESCRIPTION
Closes #3137

### Changes

- Add an explicit full-title prop to `UIEditorSpriteItem` so truncated labels can still expose the complete sprite name.
- Align the editor sprite item title row and invisible-eye icon spacing/sizing with the referenced prototype styling.

### Validation

- `npm run type-check`
- `npm run lint`
