### PR TITLE
docs(account): document scoped account profile writes

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -493,8 +493,8 @@ paths:
 
         Account Web may authenticate with an account session cookie.
 
-        App backends may authenticate with an Account-issued app-scoped OAuth access token with the
-        `account:user:read` Account API scope.
+        App backends may authenticate with an Account-issued app-scoped OAuth access token with the `account:user:read`
+        Account API scope.
       security:
         - accountSessionCookie: []
         - bearerAuth: []
@@ -506,7 +506,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/AccountUser"
         "401":
-          $ref: "#/components/responses/OAuthInvalidBearerToken"
+          $ref: "#/components/responses/AccountUnauthorized"
         "403":
           $ref: "#/components/responses/OAuthInsufficientScope"
     patch:
@@ -517,9 +517,15 @@ paths:
       description: |
         Update writable user fields managed by XBuilder Account for the current user.
 
+        Account Web may authenticate with an account session cookie.
+
+        App backends may authenticate with an Account-issued app-scoped OAuth access token with the `account:user:write`
+        Account API scope.
+
         Cookie-authenticated mutations must validate Origin or use equivalent CSRF protection.
       security:
         - accountSessionCookie: []
+        - bearerAuth: []
       requestBody:
         required: true
         content:
@@ -538,7 +544,9 @@ paths:
               schema:
                 $ref: "#/components/schemas/AccountUser"
         "401":
-          $ref: "#/components/responses/Unauthorized"
+          $ref: "#/components/responses/AccountUnauthorized"
+        "403":
+          $ref: "#/components/responses/OAuthInsufficientScope"
 
   /account/user/avatar:
     put:
@@ -549,9 +557,15 @@ paths:
       description: |
         Upload and replace the avatar image managed by XBuilder Account for the current user.
 
+        Account Web may authenticate with an account session cookie.
+
+        App backends may authenticate with an Account-issued app-scoped OAuth access token with the `account:user:write`
+        Account API scope.
+
         Cookie-authenticated mutations must validate Origin or use equivalent CSRF protection.
       security:
         - accountSessionCookie: []
+        - bearerAuth: []
       requestBody:
         required: true
         content:
@@ -575,7 +589,9 @@ paths:
         "400":
           description: Invalid request parameters.
         "401":
-          $ref: "#/components/responses/Unauthorized"
+          $ref: "#/components/responses/AccountUnauthorized"
+        "403":
+          $ref: "#/components/responses/OAuthInsufficientScope"
         "413":
           description: Avatar image file is too large.
         "415":
@@ -5303,16 +5319,6 @@ components:
         application/json:
           schema:
             $ref: "#/components/schemas/OAuthError"
-    OAuthInvalidBearerToken:
-      description: OAuth bearer token authentication failed.
-      headers:
-        WWW-Authenticate:
-          description: Bearer token authentication challenge.
-          schema:
-            type: string
-            examples:
-              - Bearer realm="XBuilder Account"
-              - Bearer realm="XBuilder Account", error="invalid_token"
     OAuthInsufficientScope:
       description: OAuth bearer token does not have the required scope.
       headers:
@@ -5322,6 +5328,7 @@ components:
             type: string
             examples:
               - Bearer realm="XBuilder Account", error="insufficient_scope", scope="account:user:read"
+              - Bearer realm="XBuilder Account", error="insufficient_scope", scope="account:user:write"
     OAuthUnsupportedMediaType:
       description: |
         OAuth form request content type is not supported.
@@ -5331,6 +5338,20 @@ components:
         application/json:
           schema:
             $ref: "#/components/schemas/OAuthError"
+    AccountUnauthorized:
+      description: |
+        Account authentication is required.
+
+        The request may authenticate with an account session cookie or an OAuth bearer token. When OAuth bearer token
+        authentication fails, the response includes `WWW-Authenticate`.
+      headers:
+        WWW-Authenticate:
+          description: Bearer token challenge returned for OAuth bearer token authentication failures.
+          schema:
+            type: string
+            examples:
+              - Bearer realm="XBuilder Account"
+              - Bearer realm="XBuilder Account", error="invalid_token"
 
   schemas:
     Model:
@@ -5879,12 +5900,14 @@ components:
       pattern: "^[A-Za-z0-9._~-]{43,128}$"
 
     OAuthScope:
-      description: Account API OAuth scope supported by XBuilder Account.
+      description: Space-delimited Account API OAuth scopes supported by XBuilder Account.
       type: string
-      enum:
-        - account:user:read
+      minLength: 1
+      pattern: "^(account:user:read|account:user:write|account:user:read account:user:write|account:user:write account:user:read)$"
       examples:
         - account:user:read
+        - account:user:write
+        - account:user:read account:user:write
 
     OAuthPushedAuthorizationResponse:
       type: object

--- a/docs/product/account.md
+++ b/docs/product/account.md
@@ -299,9 +299,9 @@ must consume provider codes atomically with recording consumption state to avoid
 
 XBuilder Account OAuth endpoints live under `api.xbuilder.com/account/oauth/*`. They only host OAuth and OAuth RFC
 extension protocol endpoints, and issue Account-issued app-scoped OAuth tokens. The token subject is stable `user.id`,
-and the token client is the concrete `app`. This document only defines the `account:user:read` Account API scope, which
-allows app backends to access `GET /account/user` with an Account-issued app-scoped OAuth token. This scope does not
-express product authorization state or any app's product API permissions.
+and the token client is the concrete `app`. This document defines Account API scopes for reading the current account
+user and updating `displayName` and `avatar`. These scopes do not express product authorization state or any app's
+product API permissions.
 
 Account-issued app-scoped OAuth tokens can be used as product API credentials for the corresponding app. Whether a
 product API accepts the token depends on the app bound to the token and the authentication policy of the product
@@ -370,8 +370,10 @@ its own `/oauth/*` as a transparent OAuth facade forwarding to `api.xbuilder.com
 still receives Account-issued app-scoped OAuth tokens. When receiving product requests, the app backend should use
 `/account/oauth/introspect` to validate the token and verify that the token is bound to the current app. When account
 fields are needed, the app backend can use `GET /account/user` to fetch the minimum account user fields if the token has
-the `account:user:read` scope. Third-party identities and account session management are not part of the default Account
-API surface for app-scoped OAuth tokens.
+the `account:user:read` scope. When a sibling app provides product-local UI for editing `displayName` or `avatar`, the
+app backend can use `PATCH /account/user` and `PUT /account/user/avatar` only if the token has the `account:user:write`
+scope. Third-party identities and account session management are not part of the Account API surface for app-scoped
+OAuth tokens.
 
 `xbuilder.com` can also use Account-issued token model. For XBuilder product APIs, the token client/app should be
 `xbuilder`. After `api.xbuilder.com` accepts the token, it should use XBuilder Authorization and resource rules to
@@ -564,6 +566,8 @@ POST /account/oauth/revoke
 
 - OAuth protocol parameters should use standard names, such as `client_id`, `redirect_uri`, `request_uri`, `state`,
   `code`, `grant_type`, `code_challenge`, and `code_verifier`
+- `scope` uses the OAuth space-delimited scope string format. Supported Account API scopes are `account:user:read` and
+  `account:user:write`
 - Confidential clients use `client_secret_basic` authentication
 - Public clients use `client_id` in token exchange, revocation, or other requests that need client identification
 - `POST /account/oauth/par` creates pushed authorization requests and can carry provider credential handoff through
@@ -603,14 +607,17 @@ DELETE /account/sessions/{sessionID}
 - `GET /account/user` returns user fields owned by the current account system. Account Web can access it with account
   session cookie. App backends can access it with an Account-issued app-scoped OAuth token that has `account:user:read`
   scope
-- `PATCH /account/user` only allows Account Web access with account session cookie, and updates writable account fields
-- `PUT /account/user/avatar` only allows Account Web access with account session cookie, and uploads and replaces the
-  avatar image through `multipart/form-data`
+- `PATCH /account/user` updates writable account fields. Account Web can access it with account session cookie. App
+  backends can access it with an Account-issued app-scoped OAuth token that has `account:user:write` scope
+- `PUT /account/user/avatar` uploads and replaces the avatar image through `multipart/form-data`. Account Web can
+  access it with account session cookie. App backends can access it with an Account-issued app-scoped OAuth token that
+  has `account:user:write` scope
 - `GET /account/user` and `PATCH /account/user` do not expose or update XBuilder product fields such as `description`
 - `GET /account/user/identities` returns the current user's third-party identities
-- `account:user:read` only authorizes `GET /account/user`. It does not authorize `PATCH /account/user`,
-  `PUT /account/user/avatar`, `GET /account/user/identities`, account session endpoints, mutation endpoints, or admin
-  endpoints
+- `account:user:read` only authorizes `GET /account/user`
+- `account:user:write` only authorizes `PATCH /account/user` and `PUT /account/user/avatar`. It does not authorize
+  `username`, third-party identity management, account session management, password management, product authorization,
+  or admin capabilities
 - `POST /account/session` is called by Account Web to submit sign-in credentials. The backend validates the credentials
   before creating the current account session
 - `GET /account/session` and `DELETE /account/session` manage the current account session used by hosted sign-in
@@ -704,9 +711,10 @@ or untrusted iframes, and should not be directly read or persisted by app fronte
 not set the account session cookie. Mutation endpoints authenticated by Account Web cookies should validate `Origin` or
 use equivalent CSRF protection.
 
-`account:user:read` only authorizes access to `GET /account/user`. It does not authorize third-party identity
-management, account session management, account field updates, or admin capabilities. These operations should be handled
-by Account Web with cookie authentication or by Admin API.
+`account:user:read` only authorizes access to `GET /account/user`. `account:user:write` only authorizes
+`PATCH /account/user` and `PUT /account/user/avatar`. It does not authorize `username`, third-party identity management,
+account session management, password management, product authorization, or admin capabilities. Those operations should
+be handled by Account Web with cookie authentication or by Admin API.
 
 When native iOS or Android apps use hosted sign-in, they should use the system browser or system authentication session,
 such as `ASWebAuthenticationSession` or Chrome Custom Tabs. They should not use embedded WebView. Restricted runtimes
@@ -762,6 +770,7 @@ tokens. `spx-gui` can keep the Bearer request model, but the Bearer value should
 | App-owned session model | Model where a first-party app backend creates, refreshes, validates, and revokes app session itself |
 | App grant | Authorization relationship for a `user` to let an `app` access XBuilder Account |
 | `account:user:read` | Account API scope allowing Account-issued OAuth tokens to access `GET /account/user` |
+| `account:user:write` | Account API scope allowing Account-issued OAuth tokens to access `PATCH /account/user` and `PUT /account/user/avatar` |
 | Opaque token | Random token that encodes no business semantics and must be resolved by the server |
 | Token introspection | RFC 7662 token validation protocol for querying opaque token validity and metadata |
 | Authorization code | Short-lived one-time code returned to the app after first-party app SSO completes |

--- a/docs/product/account.zh.md
+++ b/docs/product/account.zh.md
@@ -208,7 +208,7 @@ Provider credential handoff 的错误应通过 PAR 或 authorize 流程返回 OA
 
 ## OAuth 与产品 API 接入
 
-XBuilder Account 的 OAuth endpoints 位于 `api.xbuilder.com/account/oauth/*`。它们只承载 OAuth 和 OAuth RFC 扩展协议端点，并签发 Account-issued app-scoped OAuth tokens。Token subject 是稳定的 `user.id`，token client 是具体 `app`。本文只定义 `account:user:read` Account API scope，用于允许 app backend 通过 Account-issued app-scoped OAuth token 访问 `GET /account/user`。该 scope 不表达产品授权状态，也不表达任何 app 的产品 API 权限。
+XBuilder Account 的 OAuth endpoints 位于 `api.xbuilder.com/account/oauth/*`。它们只承载 OAuth 和 OAuth RFC 扩展协议端点，并签发 Account-issued app-scoped OAuth tokens。Token subject 是稳定的 `user.id`，token client 是具体 `app`。本文定义用于读取当前账号用户，以及更新 `displayName` 和 `avatar` 的 Account API scopes。这些 scopes 不表达产品授权状态，也不表达任何 app 的产品 API 权限。
 
 Account-issued app-scoped OAuth token 可以作为对应 app 的产品 API credential。产品 API 是否接受该 token，取决于 token 绑定的 app 和该产品 backend 的鉴权策略。产品 API 必须校验 token client/app，不应只校验 token active。
 
@@ -264,7 +264,7 @@ sequenceDiagram
 
 Provider credential handoff 如果已足够解析账号且不需要 hosted interaction，`/account/oauth/authorize` 直接返回 app callback。微信小程序等受限运行环境可以在程序内部处理这一跳。如果 authorize 返回 hosted sign-in 或其他交互 URL，app frontend 应打开该 URL 完成交互。
 
-在 Account-issued token model 中，app backend 不维护该用户的 XBuilder Account token 状态。它可以把自己的 `/oauth/*` 作为透明 OAuth facade 转发到 `api.xbuilder.com/account/oauth/*`。App frontend 拿到的仍然是 Account-issued app-scoped OAuth token。App backend 应在收到产品请求时使用 `/account/oauth/introspect` 校验 token，并校验 token 绑定的 app 与当前 app 一致。需要账号字段时，app backend 可以在 token 具备 `account:user:read` scope 时使用 `GET /account/user` 获取当前账号的最小用户信息。第三方身份和 account session 管理不属于 app-scoped OAuth token 的默认 Account API surface。
+在 Account-issued token model 中，app backend 不维护该用户的 XBuilder Account token 状态。它可以把自己的 `/oauth/*` 作为透明 OAuth facade 转发到 `api.xbuilder.com/account/oauth/*`。App frontend 拿到的仍然是 Account-issued app-scoped OAuth token。App backend 应在收到产品请求时使用 `/account/oauth/introspect` 校验 token，并校验 token 绑定的 app 与当前 app 一致。需要账号字段时，app backend 可以在 token 具备 `account:user:read` scope 时使用 `GET /account/user` 获取当前账号的最小用户信息。Sibling app 提供产品内 `displayName` 或 `avatar` 编辑 UI 时，app backend 只有在 token 具备 `account:user:write` scope 时才能使用 `PATCH /account/user` 和 `PUT /account/user/avatar`。第三方身份和 account session 管理不属于 app-scoped OAuth token 的 Account API surface。
 
 `xbuilder.com` 也可以使用 Account-issued token model。对 XBuilder 产品 API 来说，token client/app 应为 `xbuilder`。`api.xbuilder.com` 接受该 token 后，应通过 XBuilder Authorization 和资源规则判断 projects、assets、courses、AI interaction 等产品权限，而不是用 `account:user:read` 表达这些产品权限。
 
@@ -392,6 +392,7 @@ POST /account/oauth/revoke
 ```
 
 - OAuth protocol parameters 应使用标准名称，例如 `client_id`、`redirect_uri`、`request_uri`、`state`、`code`、`grant_type`、`code_challenge` 和 `code_verifier`
+- `scope` 使用 OAuth 空格分隔 scope string 格式。目前支持的 Account API scopes 是 `account:user:read` 和 `account:user:write`
 - Confidential client 使用 `client_secret_basic` 认证
 - Public client 在 token exchange 或 revocation 等需要标识 client 的请求中使用 `client_id`
 - `POST /account/oauth/par` 创建 pushed authorization request，并可通过 `xbuilder_provider` 和 `xbuilder_provider_code` 承载 provider credential handoff。它返回的 `request_uri` 是 opaque、短生命周期、单次使用的 reference，不是可访问 URL
@@ -419,11 +420,12 @@ DELETE /account/sessions/{sessionID}
 ```
 
 - `GET /account/user` 返回当前账号系统拥有的用户字段。Account Web 可以使用 account session cookie 访问。App backend 可以使用具备 `account:user:read` scope 的 Account-issued app-scoped OAuth token 访问
-- `PATCH /account/user` 只允许 Account Web 使用 account session cookie 调用，用于更新可写账号字段
-- `PUT /account/user/avatar` 只允许 Account Web 使用 account session cookie 调用，用于通过 `multipart/form-data` 上传并替换头像图片
+- `PATCH /account/user` 更新可写账号字段。Account Web 可以使用 account session cookie 访问。App backend 可以使用具备 `account:user:write` scope 的 Account-issued app-scoped OAuth token 访问
+- `PUT /account/user/avatar` 通过 `multipart/form-data` 上传并替换头像图片。Account Web 可以使用 account session cookie 访问。App backend 可以使用具备 `account:user:write` scope 的 Account-issued app-scoped OAuth token 访问
 - `GET /account/user` 和 `PATCH /account/user` 不暴露或更新 `description` 等 XBuilder 产品字段
 - `GET /account/user/identities` 返回当前用户的第三方身份
-- `account:user:read` 只授权 `GET /account/user`，不授权 `PATCH /account/user`、`PUT /account/user/avatar`、`GET /account/user/identities`、account session endpoints、mutation endpoints 或 admin endpoints
+- `account:user:read` 只授权 `GET /account/user`
+- `account:user:write` 只授权 `PATCH /account/user` 和 `PUT /account/user/avatar`。它不授权 `username`、第三方身份管理、account session 管理、密码管理、产品授权或 admin 能力
 - `POST /account/session` 由 Account Web 调用，用于提交登录凭证，并由后端校验后创建当前 account session
 - `GET /account/session` 和 `DELETE /account/session` 管理 hosted sign-in 使用的当前 account session
 - `GET /account/sessions`、`DELETE /account/sessions` 和 `DELETE /account/sessions/{sessionID}` 管理当前用户的 account sessions
@@ -498,7 +500,7 @@ App backend 接受 Account-issued app-scoped OAuth token 作为产品 API creden
 
 Account session 只用于 hosted sign-in 和 SSO 连续性。它不应通过 URL、`postMessage` 或不受信任 iframe 传递，也不应被 app frontend 直接读取或持久化。`/account/oauth/authorize` 不得设置 account session cookie。Account Web 使用 cookie 鉴权的 mutation endpoints 应校验 `Origin` 或使用等价 CSRF 防护。
 
-`account:user:read` 只授权访问 `GET /account/user`，不授权第三方身份管理、account session 管理、账号字段更新或 admin 能力。这些操作应由 Account Web 使用 cookie 认证完成，或由 Admin API 承载。
+`account:user:read` 只授权访问 `GET /account/user`。`account:user:write` 只授权 `PATCH /account/user` 和 `PUT /account/user/avatar`。它不授权 `username`、第三方身份管理、account session 管理、密码管理、产品授权或 admin 能力。这些操作应由 Account Web 使用 cookie 认证完成，或由 Admin API 承载。
 
 Native iOS/Android apps 使用 hosted sign-in 时应使用系统浏览器或系统认证会话，例如 `ASWebAuthenticationSession` 或 Chrome Custom Tabs，不应使用 embedded WebView。微信小程序等无法使用系统浏览器的受限运行环境，可以通过 provider credential handoff 将短生命周期 provider code 传递给 XBuilder Account，不应通过 URL 或 `postMessage` 传递长期 token。
 
@@ -539,6 +541,7 @@ Casdoor 来源的身份标识只应用作一次性迁移映射键，不应保留
 | App-owned session model | 自有 app backend 自己创建、刷新、校验和撤销 app session 的模型 |
 | App grant | 某个 `user` 授权某个 `app` 访问 XBuilder Account 的授权关系 |
 | `account:user:read` | 允许使用 Account-issued app-scoped OAuth token 访问 `GET /account/user` 的 Account API scope |
+| `account:user:write` | 允许使用 Account-issued app-scoped OAuth token 访问 `PATCH /account/user` 和 `PUT /account/user/avatar` 的 Account API scope |
 | Opaque token | 不编码业务语义的随机 token，需由服务端解析 |
 | Token introspection | RFC 7662 定义的 token 校验协议，用于由服务端查询 opaque token 是否有效及其元数据 |
 | Authorization code | 自有 app SSO 完成后返回给 app 的短生命周期一次性 code，用于后续 exchange |


### PR DESCRIPTION
Allow Account-issued app-scoped OAuth tokens to access the current account user mutation endpoints when they have the `account:user:write` scope.

Document the OAuth scope string format and add an Account-specific 401 response for endpoints that support both account session cookies and OAuth bearer tokens.