### PR TITLE
docs(account): document hosted sign-in locale hints

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -140,7 +140,7 @@ paths:
           description: Redirect back to hosted sign-in.
           headers:
             Location:
-              description: Hosted sign-in URL containing the original `clientID` and `requestURI`.
+              description: Hosted sign-in URL containing the original `clientID`, `requestURI`, and optional `uiLocales`.
               schema:
                 type: string
                 format: uri
@@ -206,7 +206,7 @@ paths:
           description: Redirect back to hosted sign-in.
           headers:
             Location:
-              description: Hosted sign-in URL containing the original `clientID` and `requestURI`.
+              description: Hosted sign-in URL containing the original `clientID`, `requestURI`, and optional `uiLocales`.
               schema:
                 type: string
                 format: uri
@@ -290,6 +290,18 @@ paths:
                   description: OAuth scope requested by the app.
                   allOf:
                     - $ref: "#/components/schemas/OAuthScope"
+                ui_locales:
+                  description: |
+                    Preferred UI locales for hosted sign-in, using space-separated BCP 47 language tags.
+
+                    The server uses a supported locale from this list when possible and may fall back to a default
+                    locale.
+                  type: string
+                  minLength: 1
+                  maxLength: 256
+                  pattern: "^[A-Za-z]{2,8}(?:-[A-Za-z0-9]{1,8})*(?: [A-Za-z]{2,8}(?:-[A-Za-z0-9]{1,8})*)*$"
+                  examples:
+                    - zh-CN zh en
                 xbuilder_provider:
                   description: Identity provider used for provider credential handoff.
                   $ref: "#/components/schemas/AccountIdentityProvider/properties/name"
@@ -329,7 +341,8 @@ paths:
         authorization request.
 
         If the account cannot be resolved or hosted interaction is required, this endpoint redirects to hosted sign-in.
-        The hosted sign-in URL carries `clientID` and `requestURI` query parameters for Account Web.
+        The hosted sign-in URL carries `clientID`, `requestURI`, and optional `uiLocales` query parameters for Account
+        Web.
 
         After the account is resolved and the OAuth authorization request can be completed, the authorization response
         redirects to the app callback with an authorization code and the original `state`, or with OAuth error
@@ -361,7 +374,7 @@ paths:
               description: |
                 Hosted sign-in URL or app callback URL.
 
-                Hosted sign-in URLs contain `clientID` and `requestURI`.
+                Hosted sign-in URLs contain `clientID`, `requestURI`, and optional `uiLocales`.
 
                 App callback URLs contain `code` and `state`, or OAuth error parameters and `state`.
               schema:

--- a/docs/product/account.md
+++ b/docs/product/account.md
@@ -564,15 +564,17 @@ POST /account/oauth/introspect
 POST /account/oauth/revoke
 ```
 
-- OAuth protocol parameters should use standard names, such as `client_id`, `redirect_uri`, `request_uri`, `state`,
-  `code`, `grant_type`, `code_challenge`, and `code_verifier`
+- OAuth protocol parameters should use standard or registered parameter names, such as `client_id`, `redirect_uri`,
+  `request_uri`, `state`, `code`, `grant_type`, `code_challenge`, `code_verifier`, and `ui_locales`
 - `scope` uses the OAuth space-delimited scope string format. Supported Account API scopes are `account:user:read` and
   `account:user:write`
 - Confidential clients use `client_secret_basic` authentication
 - Public clients use `client_id` in token exchange, revocation, or other requests that need client identification
 - `POST /account/oauth/par` creates pushed authorization requests and can carry provider credential handoff through
-  `xbuilder_provider` and `xbuilder_provider_code`. Its returned `request_uri` is an opaque, short-lived, single-use
-  reference, not a dereferenceable URL
+  `xbuilder_provider` and `xbuilder_provider_code`. It can also carry hosted sign-in language preference through
+  `ui_locales`. The server uses a supported locale from this list when possible and may fall back to a default locale.
+  This parameter only affects UI and does not participate in authentication or authorization. Its returned `request_uri`
+  is an opaque, short-lived, single-use reference, not a dereferenceable URL
 - `GET /account/oauth/authorize` is a PAR-only OAuth authorization endpoint. It only accepts `client_id` and
   `request_uri`. Authorization request parameters such as `response_type`, `redirect_uri`, `scope`, `state`, and
   `code_challenge` must be submitted through `POST /account/oauth/par` first
@@ -581,8 +583,8 @@ POST /account/oauth/revoke
   the next step is the app callback. When the account cannot be resolved or hosted interaction is needed, the next step
   is hosted sign-in
 - `GET /account/oauth/authorize` must not pass flow state to hosted sign-in through `Set-Cookie` or other response
-  headers. Hosted sign-in receives context through `clientID` and `requestURI`. Concrete state is stored in server-side
-  `auth_flow`
+  headers. Hosted sign-in receives context through `clientID`, `requestURI`, and optional `uiLocales`. Concrete state is
+  stored in server-side `auth_flow`
 - `POST /account/oauth/token` is used for authorization code exchange and refresh token exchange
 - `POST /account/oauth/introspect` is an RFC 7662 token introspection endpoint and is only callable by authenticated app
   backends
@@ -760,7 +762,7 @@ tokens. `spx-gui` can keep the Bearer request model, but the Bearer value should
 | Account API | XBuilder Account API on `api.xbuilder.com/account/*` |
 | OAuth client | OAuth client role. In this product context, it corresponds to `app` |
 | OAuth facade | OAuth-compatible endpoints exposed by an app backend to its own frontend, then internally integrated with XBuilder Account |
-| Hosted sign-in | Unified sign-in entry provided by `account.xbuilder.com/sign-in`. When Account Web needs to participate, it hosts third-party identity sign-in, admin-managed password sign-in, post-handoff interactions, profile completion, account-linking confirmation, and identity conflict handling. It can continue OAuth authorization requests with `clientID` and `requestURI` |
+| Hosted sign-in | Unified sign-in entry provided by `account.xbuilder.com/sign-in`. When Account Web needs to participate, it hosts third-party identity sign-in, admin-managed password sign-in, post-handoff interactions, profile completion, account-linking confirmation, and identity conflict handling. It can continue OAuth authorization requests with `clientID`, `requestURI`, and optional `uiLocales` |
 | Hosted provider acquisition | Hosted sign-in obtains provider credential through provider web authorize and callback |
 | Provider credential handoff | The client passes a short-lived provider code to XBuilder Account through PAR for consumption |
 | Hosted interaction | Profile completion, account-linking confirmation, identity conflict handling, or reauthentication in XBuilder Account hosted sign-in |

--- a/docs/product/account.zh.md
+++ b/docs/product/account.zh.md
@@ -391,14 +391,14 @@ POST /account/oauth/introspect
 POST /account/oauth/revoke
 ```
 
-- OAuth protocol parameters 应使用标准名称，例如 `client_id`、`redirect_uri`、`request_uri`、`state`、`code`、`grant_type`、`code_challenge` 和 `code_verifier`
+- OAuth 协议参数应使用标准或已注册的参数名，例如 `client_id`、`redirect_uri`、`request_uri`、`state`、`code`、`grant_type`、`code_challenge`、`code_verifier` 和 `ui_locales`
 - `scope` 使用 OAuth 空格分隔 scope string 格式。目前支持的 Account API scopes 是 `account:user:read` 和 `account:user:write`
 - Confidential client 使用 `client_secret_basic` 认证
 - Public client 在 token exchange 或 revocation 等需要标识 client 的请求中使用 `client_id`
-- `POST /account/oauth/par` 创建 pushed authorization request，并可通过 `xbuilder_provider` 和 `xbuilder_provider_code` 承载 provider credential handoff。它返回的 `request_uri` 是 opaque、短生命周期、单次使用的 reference，不是可访问 URL
+- `POST /account/oauth/par` 创建 pushed authorization request，并可通过 `xbuilder_provider` 和 `xbuilder_provider_code` 承载 provider credential handoff。它也可以通过 `ui_locales` 携带 hosted sign-in 语言偏好。服务端会尽可能从列表中选择支持的语言，也可以回退到默认语言。该参数只影响 UI，不参与 authentication 或 authorization。它返回的 `request_uri` 是 opaque、短生命周期、单次使用的 reference，不是可访问 URL
 - `GET /account/oauth/authorize` 是 PAR-only OAuth authorization endpoint，只接受 `client_id` 和 `request_uri`。`response_type`、`redirect_uri`、`scope`、`state`、`code_challenge` 等 authorization request parameters 必须先通过 `POST /account/oauth/par` 提交
 - `GET /account/oauth/authorize` 通过 `Location` 表达下一跳。账号可由 account session 或 PAR 中的 provider credential handoff 解析。账号已解析且不需要 hosted interaction 时，下一跳是 app callback。账号无法解析或需要 hosted interaction 时，下一跳是 hosted sign-in
-- `GET /account/oauth/authorize` 不得通过 `Set-Cookie` 或其他响应头向 hosted sign-in 传递流程状态。Hosted sign-in 需要的上下文通过 `clientID` 和 `requestURI` 传递，具体状态保存在服务端 `auth_flow` 中
+- `GET /account/oauth/authorize` 不得通过 `Set-Cookie` 或其他响应头向 hosted sign-in 传递流程状态。Hosted sign-in 需要的上下文通过 `clientID`、`requestURI` 和可选的 `uiLocales` 传递，具体状态保存在服务端 `auth_flow` 中
 - `POST /account/oauth/token` 用于 authorization code exchange 和 refresh token exchange
 - `POST /account/oauth/introspect` 是 RFC 7662 token introspection endpoint，只允许已认证的 app backend 调用
 - `POST /account/oauth/revoke` 撤销 Account-issued app-scoped OAuth token 或 refresh token
@@ -531,7 +531,7 @@ Casdoor 来源的身份标识只应用作一次性迁移映射键，不应保留
 | Account API | `api.xbuilder.com/account/*` 上的 XBuilder Account API |
 | OAuth client | OAuth 协议中的 client 角色，在本文产品语境中对应 `app` |
 | OAuth facade | App backend 暴露给自己 frontend 的 OAuth-compatible endpoints，内部再对接 XBuilder Account |
-| Hosted sign-in | `account.xbuilder.com/sign-in` 提供的统一登录入口，在需要 Account Web 介入时承载第三方身份登录、管理员托管密码登录、handoff 后续交互、补充信息、账号绑定确认和身份冲突处理，并可通过 `clientID` 和 `requestURI` 续接 OAuth authorization request |
+| Hosted sign-in | `account.xbuilder.com/sign-in` 提供的统一登录入口，在需要 Account Web 介入时承载第三方身份登录、管理员托管密码登录、handoff 后续交互、补充信息、账号绑定确认和身份冲突处理，并可通过 `clientID`、`requestURI` 和可选的 `uiLocales` 续接 OAuth authorization request |
 | Hosted provider acquisition | Hosted sign-in 通过 provider web authorize 和 callback 获得 provider credential 的方式 |
 | Provider credential handoff | 客户端将短生命周期 provider code 通过 PAR 交给 XBuilder Account 消费的方式 |
 | Hosted interaction | XBuilder Account hosted sign-in 页面中的补充信息、账号绑定确认、身份冲突处理或重新认证等交互 |


### PR DESCRIPTION
Document `ui_locales` on Account OAuth PAR and the corresponding `uiLocales` Account Web route parameter so hosted sign-in can preserve an app-selected UI language preference.