### PR TITLE
docs(openapi): allow JPEG account avatar uploads

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -595,7 +595,7 @@ paths:
                   maxLength: 5242880
             encoding:
               file:
-                contentType: image/png
+                contentType: image/png, image/jpeg
       responses:
         "204":
           description: Account user avatar updated.
@@ -4588,7 +4588,7 @@ paths:
                   maxLength: 5242880
             encoding:
               file:
-                contentType: image/png
+                contentType: image/png, image/jpeg
       responses:
         "204":
           description: Account user avatar updated.


### PR DESCRIPTION
Document JPEG as an accepted multipart content type for current-user and admin account avatar upload endpoints.