### PR TITLE
Document admin user search API

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -4416,7 +4416,7 @@ paths:
           schema:
             type: string
             examples:
-              - foo
+              - john
         - name: orderBy
           description: Field by which to order the results.
           in: query

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -4410,6 +4410,13 @@ paths:
 
         Requires the `accountAdmin` role.
       parameters:
+        - name: keyword
+          description: Filter account users by username or display name (nickname).
+          in: query
+          schema:
+            type: string
+            examples:
+              - nighca
         - name: orderBy
           description: Field by which to order the results.
           in: query

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -4411,12 +4411,12 @@ paths:
         Requires the `accountAdmin` role.
       parameters:
         - name: keyword
-          description: Filter account users by username or display name (nickname).
+          description: Filter account users by username or display name pattern.
           in: query
           schema:
             type: string
             examples:
-              - nighca
+              - foo
         - name: orderBy
           description: Field by which to order the results.
           in: query


### PR DESCRIPTION
## Summary

- add a keyword query parameter to the admin account user list API
- document that keyword search should match username and display name (nickname)

## Scope

- API spec only; backend and frontend implementation are intentionally left out

## Verification

- Parsed docs/openapi.yaml with the project YAML parser

Refs #3274
