### PR TITLE
docs(openapi): document redirect URI patterns

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -5794,6 +5794,7 @@ components:
         - clientType
         - status
         - redirectURIs
+        - redirectURIPatterns
         - allowedOrigins
       properties:
         id:
@@ -5845,6 +5846,31 @@ components:
           items:
             type: string
             format: uri
+        redirectURIPatterns:
+          description: |
+            Allowed redirect URI patterns.
+
+            **Exact redirect URIs remain the primary allowlist.**
+
+            Wildcard patterns should be reserved for controlled preview or non-production callback hosts because broad
+            redirect matching can increase open redirect risk.
+
+            Pattern rules:
+
+            - The pattern must be an absolute `http` or `https` URL.
+            - The pattern must contain at most one `*`.
+            - The wildcard must be located in a subdomain within the hostname.
+            - The wildcard must be located in the subdomain furthest from the root domain.
+            - The wildcard may be prefixed or suffixed with valid hostname characters.
+            - The wildcard matches only one hostname label and does not match `.`.
+            - All non-host components, including path and query, are matched exactly.
+            - Fragments are not allowed.
+          readOnly: true
+          type: array
+          items:
+            type: string
+          examples:
+            - - https://app-*.example.com/oauth/callback
         allowedOrigins:
           description: |
             Allowed web origins.


### PR DESCRIPTION
Add the read-only `redirectURIPatterns` field to account app responses so the API contract exposes controlled wildcard callback matching.

Document the supported single-label hostname wildcard rules while keeping exact redirect URIs as the primary allowlist.