### PR TITLE
fix(api): align string length constraints

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1030,6 +1030,7 @@ paths:
           in: query
           schema:
             type: string
+            maxLength: 100
             examples:
               - Niu Xiao Qi
         - name: visibility
@@ -1203,6 +1204,7 @@ paths:
           in: query
           schema:
             type: string
+            maxLength: 100
             examples:
               - Niu Xiao Qi
         - name: visibility
@@ -1366,7 +1368,10 @@ paths:
           description: Filter assets by display name pattern.
           in: query
           schema:
-            $ref: "#/components/schemas/Asset/properties/displayName"
+            type: string
+            maxLength: 100
+            examples:
+              - NiuXiaoQi
         - name: type
           description: Filter assets by type.
           in: query
@@ -1879,6 +1884,7 @@ paths:
           in: query
           schema:
             type: string
+            maxLength: 100
             examples:
               - Niu Xiao Qi
         - name: type
@@ -1972,6 +1978,7 @@ paths:
           in: query
           schema:
             type: string
+            maxLength: 100
             examples:
               - Niu Xiao Qi
         - name: type
@@ -2055,7 +2062,10 @@ paths:
           description: Filter assets by display name pattern.
           in: query
           schema:
-            $ref: "#/components/schemas/Asset/properties/displayName"
+            type: string
+            maxLength: 100
+            examples:
+              - NiuXiaoQi
         - name: type
           description: Filter assets by type.
           in: query
@@ -2242,6 +2252,7 @@ paths:
           in: query
           schema:
             type: string
+            maxLength: 100
             examples:
               - Niu Xiao Qi
         - name: visibility
@@ -2648,7 +2659,10 @@ paths:
           description: Filter assets by display name pattern.
           in: query
           schema:
-            $ref: "#/components/schemas/Asset/properties/displayName"
+            type: string
+            maxLength: 100
+            examples:
+              - NiuXiaoQi
         - name: type
           description: Filter assets by type.
           in: query
@@ -4415,6 +4429,7 @@ paths:
           in: query
           schema:
             type: string
+            maxLength: 100
             examples:
               - john
         - name: orderBy
@@ -5523,6 +5538,7 @@ components:
         description:
           description: Brief bio or description of the user.
           type: string
+          maxLength: 200
           examples:
             - Two giants live in Britain's land...
         plan:
@@ -6357,11 +6373,13 @@ components:
         description:
           description: Brief description of the project.
           type: string
+          maxLength: 400
           examples:
             - NiuXiaoQi in your area.
         instructions:
           description: Instructions on how to interact with the project.
           type: string
+          maxLength: 400
           examples:
             - Just run it.
         extraSettings:
@@ -6441,6 +6459,7 @@ components:
         name:
           description: Unique name of the project release, adhering to [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.html).
           type: string
+          maxLength: 255
           pattern: '^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$'
           examples:
             - v1.2.3
@@ -6448,6 +6467,7 @@ components:
           description: Brief description of the release.
           type: string
           minLength: 1
+          maxLength: 400
           examples:
             - First release.
         files:
@@ -6461,9 +6481,14 @@ components:
           $ref: "#/components/schemas/Project/properties/remixCount"
 
     ProjectReleaseFullName:
-      description: Full name of a project release in the format `owner/project/release`.
+      description: |
+        Full name of a project release in the format `owner/project/release`.
+
+        `maxLength` is derived from 100-character owner and project names, two `/` separators, and a 255-character
+        release name.
       type: string
       minLength: 10
+      maxLength: 457
       pattern: '^[A-Za-z0-9_-]{1,100}/[A-Za-z0-9_-]{1,100}/v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$'
       examples:
         - john/NiuXiaoQi/v1.2.3
@@ -6597,6 +6622,7 @@ components:
         prompt:
           description: Prompt text for the course (used for copilot assistance).
           type: string
+          maxLength: 4000
           examples:
             - Learn the basics of XGo programming language
 
@@ -6659,6 +6685,7 @@ components:
         description:
           description: Description of the course series.
           type: string
+          maxLength: 400
           examples:
             - A series of courses on XBuilder programming.
         courseIDs:

--- a/spx-gui/src/apis/asset.ts
+++ b/spx-gui/src/apis/asset.ts
@@ -61,13 +61,22 @@ export type AssetData = {
 }
 
 export type ListAssetsParams = PaginationParams & {
+  /** Filter assets by display name pattern */
   keyword?: string
+  /** Filter assets by type */
   type?: AssetType
-  /** @deprecated Not recommended for use as the field `category` is deprecated. */
+  /**
+   * Filter assets by category
+   * @deprecated Not recommended for use as the field `category` is deprecated.
+   */
   category?: string
+  /** Filter assets by files hash */
   filesHash?: string
+  /** Filter assets by visibility */
   visibility?: Visibility
+  /** Field by which to order the results */
   orderBy?: 'createdAt' | 'updatedAt' | 'displayName'
+  /** Order in which to sort the results */
   sortOrder?: 'asc' | 'desc'
 }
 

--- a/spx-gui/src/apis/course-series.ts
+++ b/spx-gui/src/apis/course-series.ts
@@ -1,5 +1,8 @@
 import { client, type ByPage, type PaginationParams } from './common'
 
+export const courseSeriesTitleMaxLength = 200
+export const courseSeriesDescriptionMaxLength = 400
+
 export type CourseSeries = {
   /** Unique identifier */
   id: string

--- a/spx-gui/src/apis/course.ts
+++ b/spx-gui/src/apis/course.ts
@@ -1,5 +1,8 @@
 import { client, type ByPage, type PaginationParams } from './common'
 
+export const courseTitleMaxLength = 200
+export const coursePromptMaxLength = 4000
+
 export type ProjectReference = {
   type: 'project'
   /** Full name of the project, in the format `owner/project`. */

--- a/spx-gui/src/apis/project-release.ts
+++ b/spx-gui/src/apis/project-release.ts
@@ -1,5 +1,7 @@
 import { client, type ByPage, type FileCollection, type PaginationParams } from './common'
 
+export const projectReleaseDescriptionMaxLength = 400
+
 export type ProjectRelease = {
   /** Unique identifier */
   id: string

--- a/spx-gui/src/apis/project.ts
+++ b/spx-gui/src/apis/project.ts
@@ -7,6 +7,10 @@ import type { Prettify } from '@/utils/types'
 
 export { Visibility }
 
+export const projectDisplayNameMaxLength = 100
+export const projectDescriptionMaxLength = 400
+export const projectInstructionsMaxLength = 400
+
 export enum ProjectType {
   /** 2D game project based on spx. */
   Game = 'game'
@@ -142,6 +146,8 @@ type ListProjectsOrderBy =
   | 'remixCount'
   | 'recentLikeCount'
   | 'recentRemixCount'
+
+export const projectSearchKeywordMaxLength = 100
 
 type ListProjectsBaseParams = PaginationParams & {
   /** Filter remixed projects by the full name of the source project or project release */

--- a/spx-gui/src/apis/user.ts
+++ b/spx-gui/src/apis/user.ts
@@ -1,6 +1,9 @@
 import { client, type ByPage, type PaginationParams } from './common'
 import { ApiException, ApiExceptionCode } from './common/exception'
 
+export const userDisplayNameMaxLength = 100
+export const userDescriptionMaxLength = 200
+
 export type User = {
   /** Unique identifier */
   id: string

--- a/spx-gui/src/components/community/user/EditProfileModal.vue
+++ b/spx-gui/src/components/community/user/EditProfileModal.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
 import { computed, ref } from 'vue'
-import { type User } from '@/apis/user'
+import { userDescriptionMaxLength, userDisplayNameMaxLength, type User } from '@/apis/user'
 import { selectFile } from '@/utils/file'
 import { DefaultException, useMessageHandle } from '@/utils/exception'
 import { useI18n } from '@/utils/i18n'
@@ -48,14 +48,21 @@ const form = useForm({
 function validateDisplayName(val: string) {
   const trimmed = val.trim()
   if (trimmed === '') return t({ en: 'The name must not be blank', zh: '名字不可为空' })
-  if (trimmed.length > 100) return t({ en: 'The name must be 100 characters or fewer', zh: '名字不能超过 100 字' })
+  if (trimmed.length > userDisplayNameMaxLength)
+    return t({
+      en: `The name must be ${userDisplayNameMaxLength} characters or fewer`,
+      zh: `名字不能超过 ${userDisplayNameMaxLength} 字`
+    })
   return null
 }
 
 function validateDescription(val: string) {
   const trimmed = val.trim()
-  if (trimmed.length > 200)
-    return t({ en: 'The description must be 200 characters or fewer', zh: '个人简介不能超过 200 字' })
+  if (trimmed.length > userDescriptionMaxLength)
+    return t({
+      en: `The description must be ${userDescriptionMaxLength} characters or fewer`,
+      zh: `个人简介不能超过 ${userDescriptionMaxLength} 字`
+    })
   return null
 }
 

--- a/spx-gui/src/components/copilot/CopilotInput.vue
+++ b/spx-gui/src/components/copilot/CopilotInput.vue
@@ -50,7 +50,7 @@ defineExpose({ focus })
           ref="textareaRef"
           v-model="inputStr"
           class="absolute h-full w-full resize-none border-none bg-transparent p-0 text-title outline-none placeholder:text-hint-2"
-          rows="1"
+          :rows="1"
           :disabled="loading"
           :placeholder="$t(placeholder)"
           @keypress.enter.prevent="handleSubmit"

--- a/spx-gui/src/components/copilot/CopilotRoot.vue
+++ b/spx-gui/src/components/copilot/CopilotRoot.vue
@@ -8,6 +8,7 @@ import { useI18n, type I18n } from '@/utils/i18n'
 import { escapeHTML, unicodeSafeSlice, until } from '@/utils/utils'
 import { useIsRouteLoaded } from '@/utils/route-loading'
 import * as projectApis from '@/apis/project'
+import { projectSearchKeywordMaxLength } from '@/apis/project'
 import { useMessageEvents, useModalEvents } from '@/components/ui'
 import { Copilot, type ICopilotContextProvider, type SessionExported, type ToolDefinition } from './copilot'
 import * as pageLink from './markdown-elements/PageLink'
@@ -27,7 +28,11 @@ const listProjectsParamsSchema = z.object({
     .boolean()
     .optional()
     .describe('List projects visible to the current session across all users. Do not use this with owner'),
-  keyword: z.string().optional().describe('Keyword in the project display name or project name'),
+  keyword: z
+    .string()
+    .max(projectSearchKeywordMaxLength)
+    .optional()
+    .describe('Keyword in the project display name or project name'),
   pageSize: z.number().describe('Number of projects to return per page'),
   pageIndex: z.number().describe('Page index, starting from 1')
 })

--- a/spx-gui/src/components/course/management/CourseEditModal.vue
+++ b/spx-gui/src/components/course/management/CourseEditModal.vue
@@ -2,7 +2,14 @@
 import { computed } from 'vue'
 import { useI18n } from '@/utils/i18n'
 import { useMessageHandle } from '@/utils/exception'
-import { addCourse, updateCourse, type Course, type AddUpdateCourseParams } from '@/apis/course'
+import {
+  addCourse,
+  coursePromptMaxLength,
+  courseTitleMaxLength,
+  updateCourse,
+  type Course,
+  type AddUpdateCourseParams
+} from '@/apis/course'
 import { UIFormModal, UIForm, UIFormItem, UITextInput, UIButton, useMessage, useForm } from '@/components/ui'
 import ThumbnailUploader from './ThumbnailUploader.vue'
 import ProjectReferencesInput from './ProjectReferencesInput.vue'
@@ -30,6 +37,11 @@ const form = useForm({
     props.course?.title || '',
     (v: string) => {
       if (v === '') return i18n.t({ en: 'Please enter course title', zh: '请输入课程标题' })
+      if (v.length > courseTitleMaxLength)
+        return i18n.t({
+          en: `Title too long (max ${courseTitleMaxLength} chars)`,
+          zh: `标题过长（最多 ${courseTitleMaxLength} 字符）`
+        })
       return null
     }
   ],
@@ -53,6 +65,11 @@ const form = useForm({
     props.course?.prompt || '',
     (v: string) => {
       if (v === '') return i18n.t({ en: 'Please enter Copilot prompt', zh: '请输入 Copilot 提示词' })
+      if (v.length > coursePromptMaxLength)
+        return i18n.t({
+          en: `Copilot prompt too long (max ${coursePromptMaxLength} chars)`,
+          zh: `Copilot 提示词过长（最多 ${coursePromptMaxLength} 字符）`
+        })
       return null
     }
   ]

--- a/spx-gui/src/components/course/management/CourseSeriesEditModal.vue
+++ b/spx-gui/src/components/course/management/CourseSeriesEditModal.vue
@@ -6,6 +6,8 @@ import { DefaultException, useMessageHandle } from '@/utils/exception'
 import { selectFile } from '@/utils/file'
 import {
   addCourseSeries,
+  courseSeriesDescriptionMaxLength,
+  courseSeriesTitleMaxLength,
   updateCourseSeries,
   type CourseSeries,
   type AddUpdateCourseSeriesParams
@@ -60,7 +62,11 @@ const form = useForm({
     '',
     (v: string) => {
       if (v === '') return i18n.t({ en: 'Please enter series title', zh: '请输入系列标题' })
-      if (v.length > 200) return i18n.t({ en: 'Title too long (max 200 chars)', zh: '标题过长（最多200字符）' })
+      if (v.length > courseSeriesTitleMaxLength)
+        return i18n.t({
+          en: `Title too long (max ${courseSeriesTitleMaxLength} chars)`,
+          zh: `标题过长（最多 ${courseSeriesTitleMaxLength} 字符）`
+        })
       return null
     }
   ],
@@ -71,7 +77,17 @@ const form = useForm({
       return null
     }
   ],
-  description: [''],
+  description: [
+    '',
+    (v: string) => {
+      if (v.length > courseSeriesDescriptionMaxLength)
+        return i18n.t({
+          en: `Description too long (max ${courseSeriesDescriptionMaxLength} chars)`,
+          zh: `描述过长（最多 ${courseSeriesDescriptionMaxLength} 字符）`
+        })
+      return null
+    }
+  ],
   order: [1],
   courseIDs: [
     [] as string[],

--- a/spx-gui/src/components/editor/navbar/EditorProjectDisplayName.vue
+++ b/spx-gui/src/components/editor/navbar/EditorProjectDisplayName.vue
@@ -1,10 +1,11 @@
 <script setup lang="ts">
 import { computed, nextTick, ref, watch } from 'vue'
-import { useMessageHandle } from '@/utils/exception'
+import { DefaultException, useMessageHandle } from '@/utils/exception'
 import { useNetwork } from '@/utils/network'
 import { cloudHelpers } from '@/models/common/cloud'
 import { type SpxProject } from '@/models/spx/project'
 import { useSignedInUser, useUser } from '@/stores/user'
+import { projectDisplayNameMaxLength } from '@/apis/project'
 import { UIIcon, UITextInput } from '@/components/ui'
 
 const props = defineProps<{
@@ -72,6 +73,12 @@ const handleSubmit = useMessageHandle(
     if (newName === '' || newName === project.displayName) {
       reset()
       return
+    }
+    if (newName.length > projectDisplayNameMaxLength) {
+      throw new DefaultException({
+        en: `The project display name must be ${projectDisplayNameMaxLength} characters or fewer`,
+        zh: `项目显示名不能超过 ${projectDisplayNameMaxLength} 字`
+      })
     }
     try {
       editing.value = false // Optimistically update UI before the async operation

--- a/spx-gui/src/components/project/ProjectPublishModal.vue
+++ b/spx-gui/src/components/project/ProjectPublishModal.vue
@@ -4,7 +4,8 @@ import { useFileUrl } from '@/utils/file'
 import { useMessageHandle } from '@/utils/exception'
 import { useI18n } from '@/utils/i18n'
 import { Visibility } from '@/apis/common'
-import { createProjectRelease } from '@/apis/project-release'
+import { projectDescriptionMaxLength, projectInstructionsMaxLength } from '@/apis/project'
+import { createProjectRelease, projectReleaseDescriptionMaxLength } from '@/apis/project-release'
 import { cloudHelpers, saveFile } from '@/models/common/cloud'
 import type { SpxProject } from '@/models/spx/project'
 import { isProjectUsingAIInteraction } from '@/utils/project'
@@ -37,18 +38,28 @@ if (firstTime) {
 
 const form = useForm({
   releaseDescription: [defaultDescription, validateReleaseDescription],
-  projectDescription: [props.project.description ?? '', validateText],
-  projectInstructions: [props.project.instructions ?? '', validateText]
+  projectDescription: [
+    props.project.description ?? '',
+    (val: string) => validateText(val, projectDescriptionMaxLength)
+  ],
+  projectInstructions: [
+    props.project.instructions ?? '',
+    (val: string) => validateText(val, projectInstructionsMaxLength)
+  ]
 })
 
-function validateText(val: string) {
-  if (val.length > 400) return t({ en: 'The input must be 400 characters or fewer', zh: '输入不能超过 400 字' })
+function validateText(val: string, maxLength: number) {
+  if (val.length > maxLength)
+    return t({
+      en: `The input must be ${maxLength} characters or fewer`,
+      zh: `输入不能超过 ${maxLength} 字`
+    })
   return null
 }
 
 function validateReleaseDescription(val: string) {
   if (val.trim() === '') return t({ en: 'Release description is required', zh: '发布内容不能为空' })
-  return validateText(val)
+  return validateText(val, projectReleaseDescriptionMaxLength)
 }
 
 function handleCancel() {

--- a/spx-gui/src/components/ui/input/UITextInput.vue
+++ b/spx-gui/src/components/ui/input/UITextInput.vue
@@ -101,7 +101,7 @@ const props = withDefaults(
     readonly?: boolean
     placeholder?: string
     autofocus?: boolean
-    rows?: number | string
+    rows?: number
   }>(),
   {
     type: undefined,


### PR DESCRIPTION
Add explicit OpenAPI limits for search keywords, user and project text fields, release identifiers, and course metadata so the API contract captures existing product boundaries.

Apply matching frontend limits to user-facing inputs and Copilot tool schemas so client behavior stays aligned with the API contract.