### PR TITLE
Show Account app redirect URI patterns

### DIFF
--- a/spx-gui/src/apis/account/common.ts
+++ b/spx-gui/src/apis/account/common.ts
@@ -68,6 +68,8 @@ export type AccountApp = AccountModel & {
   status: AccountAppStatus
   /** Allowed redirect URIs */
   redirectURIs: string[]
+  /** Read-only allowed redirect URI patterns */
+  redirectURIPatterns: string[]
   /** Allowed web origins */
   allowedOrigins: string[]
 }

--- a/spx-gui/src/apps/xbuilder/pages/admin/app.vue
+++ b/spx-gui/src/apps/xbuilder/pages/admin/app.vue
@@ -341,8 +341,8 @@ function deleteSecret(secretID: string) {
                 <div>{{ $t({ en: 'Redirect URI patterns', zh: '回调 URI 模式' }) }}</div>
                 <div class="flex flex-col gap-2 rounded-md border border-grey-300 bg-grey-100 px-3 py-2">
                   <code
-                    v-for="pattern in app.redirectURIPatterns"
-                    :key="pattern"
+                    v-for="(pattern, index) in app.redirectURIPatterns"
+                    :key="index"
                     class="break-all font-mono text-xs text-title"
                   >
                     {{ pattern }}

--- a/spx-gui/src/apps/xbuilder/pages/admin/app.vue
+++ b/spx-gui/src/apps/xbuilder/pages/admin/app.vue
@@ -13,6 +13,7 @@ import * as accountAdminApis from '@/apis/admin/account'
 import {
   accountAppAllowedOriginsTip,
   accountAppClientTypeLabels,
+  accountAppRedirectURIPatternsTip,
   accountAppRedirectURIsTip,
   accountAppStatusLabels,
   formatTime,
@@ -336,6 +337,19 @@ function deleteSecret(secretID: string) {
                 <UITextInput v-model:value="redirectURIs" type="textarea" :rows="5" />
                 <span class="text-xs text-grey-700">{{ $t(accountAppRedirectURIsTip) }}</span>
               </label>
+              <div v-if="app.redirectURIPatterns.length > 0" class="flex flex-col gap-2 text-sm text-grey-900">
+                <div>{{ $t({ en: 'Redirect URI patterns', zh: '回调 URI 模式' }) }}</div>
+                <div class="flex flex-col gap-2 rounded-md border border-grey-300 bg-grey-100 px-3 py-2">
+                  <code
+                    v-for="pattern in app.redirectURIPatterns"
+                    :key="pattern"
+                    class="break-all font-mono text-xs text-title"
+                  >
+                    {{ pattern }}
+                  </code>
+                </div>
+                <span class="text-xs text-grey-700">{{ $t(accountAppRedirectURIPatternsTip) }}</span>
+              </div>
               <label class="flex flex-col gap-1 text-sm text-grey-900">
                 {{ $t({ en: 'Allowed origins', zh: '允许的 Origin' }) }}
                 <UITextInput v-model:value="allowedOrigins" type="textarea" :rows="4" />

--- a/spx-gui/src/apps/xbuilder/pages/admin/common.ts
+++ b/spx-gui/src/apps/xbuilder/pages/admin/common.ts
@@ -18,6 +18,11 @@ export const accountAppRedirectURIsTip: LocaleMessage = {
   zh: '本应用完成授权后，Account 可以将用户重定向到的地址。每行一个 URI，服务端进行精确匹配；生产环境 Web URI 必须使用 HTTPS。'
 }
 
+export const accountAppRedirectURIPatternsTip: LocaleMessage = {
+  en: 'Read-only wildcard patterns for controlled preview or non-production callback hosts. Exact redirect URIs remain the primary allowlist. Patterns are managed outside the public Admin API and cannot be changed here.',
+  zh: '用于受控预览或非生产回调域名的只读通配模式。精确回调 URI 仍是主要 allowlist；这组模式不通过公开 Admin API 管理，也不能在这里修改。'
+}
+
 export const accountAppAllowedOriginsTip: LocaleMessage = {
   en: 'Origins allowed to host Account Web and receive identity provider callbacks for this app. Enter one origin per line, such as https://account.example.com. Do not include a path, query, or fragment.',
   zh: '允许承载 Account Web 并接收本应用第三方身份提供商回调的 Origin。每行一个，例如 https://account.example.com；不要包含路径、查询参数或 fragment。'


### PR DESCRIPTION
Refs #3277.

## Summary

- Add redirectURIPatterns to the shared Account app type.
- Show non-empty redirect URI patterns as read-only information in the Account app detail page.
- Explain that patterns are managed outside the public Admin API/UI and exact redirect URIs remain the primary allowlist.

## Checks

- npm run type-check
- npm run lint -- --no-fix
