### PR TITLE
Define account grant token admin APIs

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -4831,6 +4831,8 @@ paths:
       description: |
         Retrieve a list of app grants of an account user.
 
+        Revoked grants are included in the response.
+
         Requires the `accountAdmin` role.
       parameters:
         - name: userID
@@ -5032,10 +5034,10 @@ paths:
 
   /admin/account/users/{userID}/grants/{grantID}/tokens/{tokenID}:
     delete:
-      operationId: deleteAdminAccountUserGrantToken
+      operationId: revokeAdminAccountUserGrantToken
       tags:
         - Account Admin
-      summary: Delete account app grant token as admin
+      summary: Revoke account app grant token as admin
       description: |
         Revoke an Account-issued OAuth token associated with an account user app grant.
 
@@ -5045,26 +5047,26 @@ paths:
         Requires the `accountAdmin` role.
       parameters:
         - name: userID
-          description: ID of the user whose app grant token is deleted.
+          description: ID of the user whose app grant token is revoked.
           in: path
           required: true
           schema:
             $ref: "#/components/schemas/Model/properties/id"
         - name: grantID
-          description: ID of the app grant whose token is deleted.
+          description: ID of the app grant whose token is revoked.
           in: path
           required: true
           schema:
             $ref: "#/components/schemas/Model/properties/id"
         - name: tokenID
-          description: ID of the app grant token to delete.
+          description: ID of the app grant token to revoke.
           in: path
           required: true
           schema:
             $ref: "#/components/schemas/Model/properties/id"
       responses:
         "204":
-          description: Account app grant token deleted.
+          description: Account app grant token revoked.
         "401":
           $ref: "#/components/responses/Unauthorized"
         "403":
@@ -6250,14 +6252,17 @@ components:
           examples:
             - accessToken
         tokenFamilyID:
-          description: Token family identifier used to group refresh token rotations.
+          description: |
+            Token family identifier.
+
+            All token types are assigned a family ID. For refresh tokens, the family ID groups refresh token rotations.
           type: string
           minLength: 1
         scope:
           description: Account OAuth scope associated with the token.
           $ref: "#/components/schemas/OAuthScope"
         remark:
-          description: Human-readable remark describing the token.
+          description: Human-readable remark describing the token. Empty when no remark is set.
           type: string
           maxLength: 200
           examples:
@@ -6277,7 +6282,7 @@ components:
           examples:
             - 2006-01-02T15:04:05+07:00
         consumedAt:
-          description: Timestamp when the refresh token was consumed during rotation.
+          description: Timestamp when the refresh token was consumed during rotation. Always null for access tokens.
           type:
             - string
             - "null"
@@ -6295,7 +6300,10 @@ components:
 
     CreateAccountAppTokenRequest:
       type: object
-      description: Request to create an Account-issued OAuth token for an app grant.
+      description: |
+        Request to create an Account-issued OAuth token for an app grant.
+
+        The token scope is inherited from the associated app grant and cannot be overridden.
       required:
         - tokenType
         - expiresAt
@@ -6311,7 +6319,7 @@ components:
           examples:
             - accessToken
         remark:
-          description: Human-readable remark describing the token.
+          description: Human-readable remark describing the token. When omitted, an empty remark is used.
           type: string
           maxLength: 200
           examples:
@@ -6324,7 +6332,7 @@ components:
           type: string
           format: date-time
           examples:
-            - 2006-07-01T00:00:00+07:00
+            - 2027-01-15T00:00:00Z
 
     CreatedAccountAppToken:
       description: Account app token created response including the one-time token value.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -6257,7 +6257,7 @@ components:
           description: Account OAuth scope associated with the token.
           $ref: "#/components/schemas/OAuthScope"
         remark:
-          description: Administrator-provided remark for maintaining the token.
+          description: Human-readable remark describing the token.
           type: string
           maxLength: 200
           examples:
@@ -6311,7 +6311,7 @@ components:
           examples:
             - accessToken
         remark:
-          description: Administrator-provided remark for maintaining the token.
+          description: Human-readable remark describing the token.
           type: string
           maxLength: 200
           examples:

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -4829,9 +4829,7 @@ paths:
         - Account Admin
       summary: List account user app grants as admin
       description: |
-        Retrieve a list of app grants of an account user.
-
-        Revoked grants are included in the response.
+        Retrieve a list of active app grants of an account user.
 
         Requires the `accountAdmin` role.
       parameters:

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -4822,9 +4822,9 @@ paths:
         "404":
           description: Account user not found.
 
-  /admin/account/users/{userID}/grants:
+  /admin/account/users/{userID}/app-grants:
     get:
-      operationId: listAdminAccountUserGrants
+      operationId: listAdminAccountUserAppGrants
       tags:
         - Account Admin
       summary: List account user app grants as admin
@@ -4878,24 +4878,18 @@ paths:
         "404":
           description: Account user not found.
 
-  /admin/account/users/{userID}/grants/{grantID}:
+  /admin/account/app-grants/{appGrantID}:
     get:
-      operationId: getAdminAccountUserGrant
+      operationId: getAdminAccountAppGrant
       tags:
         - Account Admin
-      summary: Get account user app grant as admin
+      summary: Get account app grant as admin
       description: |
-        Retrieve an app grant of an account user.
+        Retrieve an app grant.
 
         Requires the `accountAdmin` role.
       parameters:
-        - name: userID
-          description: ID of the user whose app grant is retrieved.
-          in: path
-          required: true
-          schema:
-            $ref: "#/components/schemas/Model/properties/id"
-        - name: grantID
+        - name: appGrantID
           description: ID of the app grant to get.
           in: path
           required: true
@@ -4913,28 +4907,22 @@ paths:
         "403":
           description: Insufficient permissions to perform this operation.
         "404":
-          description: Account user or app grant not found.
+          description: Account app grant not found.
 
-  /admin/account/users/{userID}/grants/{grantID}/tokens:
+  /admin/account/app-grants/{appGrantID}/tokens:
     get:
-      operationId: listAdminAccountUserGrantTokens
+      operationId: listAdminAccountAppGrantTokens
       tags:
         - Account Admin
       summary: List account app grant tokens as admin
       description: |
-        Retrieve active Account-issued OAuth tokens associated with an account user app grant.
+        Retrieve active Account-issued OAuth tokens associated with an account app grant.
 
         Tokens are active only when they are not expired, not revoked, and, for refresh tokens, not consumed.
 
         Requires the `accountAdmin` role.
       parameters:
-        - name: userID
-          description: ID of the user whose app grant tokens are listed.
-          in: path
-          required: true
-          schema:
-            $ref: "#/components/schemas/Model/properties/id"
-        - name: grantID
+        - name: appGrantID
           description: ID of the app grant whose tokens are listed.
           in: path
           required: true
@@ -4980,14 +4968,14 @@ paths:
         "403":
           description: Insufficient permissions to perform this operation.
         "404":
-          description: Account user or app grant not found.
+          description: Account app grant not found.
     post:
-      operationId: createAdminAccountUserGrantToken
+      operationId: createAdminAccountAppGrantToken
       tags:
         - Account Admin
       summary: Create account app grant token as admin
       description: |
-        Create an Account-issued OAuth token associated with an account user app grant.
+        Create an Account-issued OAuth token associated with an account app grant.
 
         Currently, this endpoint creates access tokens only. The created token is not issued with a refresh token and
         cannot be refreshed. The token value is only returned once in the creation response.
@@ -4996,13 +4984,7 @@ paths:
 
         Requires the `accountAdmin` role.
       parameters:
-        - name: userID
-          description: ID of the user whose app grant token is created.
-          in: path
-          required: true
-          schema:
-            $ref: "#/components/schemas/Model/properties/id"
-        - name: grantID
+        - name: appGrantID
           description: ID of the app grant whose token is created.
           in: path
           required: true
@@ -5028,29 +5010,23 @@ paths:
         "403":
           description: Insufficient permissions to perform this operation.
         "404":
-          description: Account user or app grant not found.
+          description: Account app grant not found.
 
-  /admin/account/users/{userID}/grants/{grantID}/tokens/{tokenID}:
+  /admin/account/app-grants/{appGrantID}/tokens/{tokenID}:
     delete:
-      operationId: revokeAdminAccountUserGrantToken
+      operationId: deleteAdminAccountAppGrantToken
       tags:
         - Account Admin
       summary: Revoke account app grant token as admin
       description: |
-        Revoke an Account-issued OAuth token associated with an account user app grant.
+        Revoke an Account-issued OAuth token associated with an account app grant.
 
-        Revocation follows the existing Account OAuth token semantics. Revoking a refresh token revokes the token family;
-        revoking an access token revokes that access token.
+        Revocation follows the existing Account OAuth token semantics. Revoking a refresh token follows refresh-token
+        rotation semantics; revoking an access token revokes that access token.
 
         Requires the `accountAdmin` role.
       parameters:
-        - name: userID
-          description: ID of the user whose app grant token is revoked.
-          in: path
-          required: true
-          schema:
-            $ref: "#/components/schemas/Model/properties/id"
-        - name: grantID
+        - name: appGrantID
           description: ID of the app grant whose token is revoked.
           in: path
           required: true
@@ -5070,7 +5046,7 @@ paths:
         "403":
           description: Insufficient permissions to perform this operation.
         "404":
-          description: Account user, app grant, or token not found.
+          description: Account app grant or token not found.
 
   /admin/account/sessions/{sessionID}:
     delete:
@@ -6227,9 +6203,8 @@ components:
         - updatedAt
         - grantID
         - tokenType
-        - tokenFamilyID
         - scope
-        - remark
+        - name
         - expiresAt
       properties:
         id:
@@ -6249,22 +6224,16 @@ components:
             - refreshToken
           examples:
             - accessToken
-        tokenFamilyID:
-          description: |
-            Token family identifier.
-
-            All token types are assigned a family ID. For refresh tokens, the family ID groups refresh token rotations.
-          type: string
-          minLength: 1
         scope:
           description: Account OAuth scope associated with the token.
           $ref: "#/components/schemas/OAuthScope"
-        remark:
-          description: Human-readable remark describing the token. Empty when no remark is set.
+        name:
+          description: Human-readable token name.
           type: string
-          maxLength: 200
+          minLength: 1
+          maxLength: 100
           examples:
-            - Used for SPX API testing
+            - SPX API testing
         expiresAt:
           description: Expiration timestamp.
           type: string
@@ -6304,6 +6273,7 @@ components:
         The token scope is inherited from the associated app grant and cannot be overridden.
       required:
         - tokenType
+        - name
         - expiresAt
       properties:
         tokenType:
@@ -6316,12 +6286,13 @@ components:
             - accessToken
           examples:
             - accessToken
-        remark:
-          description: Human-readable remark describing the token. When omitted, an empty remark is used.
+        name:
+          description: Human-readable token name.
           type: string
-          maxLength: 200
+          minLength: 1
+          maxLength: 100
           examples:
-            - Used for SPX API testing
+            - SPX API testing
         expiresAt:
           description: |
             Expiration timestamp of the created token.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -4989,8 +4989,8 @@ paths:
       description: |
         Create an Account-issued OAuth token associated with an account user app grant.
 
-        For the first version, this endpoint creates an access token only. The created token is not issued with a
-        refresh token and cannot be refreshed. The token value is only returned once in the creation response.
+        Currently, this endpoint creates access tokens only. The created token is not issued with a refresh token and
+        cannot be refreshed. The token value is only returned once in the creation response.
 
         The token scope is an Account OAuth scope inherited from the app grant. It does not necessarily describe the
         downstream product API capability that will be exercised with the token. Product API usage is valid only for
@@ -6257,6 +6257,14 @@ components:
         scope:
           description: Account OAuth scope associated with the token.
           $ref: "#/components/schemas/OAuthScope"
+        remark:
+          description: Administrator-provided remark for maintaining the token.
+          type:
+            - string
+            - "null"
+          maxLength: 200
+          examples:
+            - Used for SPX API testing
         expiresAt:
           description: Expiration timestamp.
           type: string
@@ -6292,30 +6300,30 @@ components:
       type: object
       description: Request to create an Account-issued OAuth token for an app grant.
       required:
+        - tokenType
         - expiresAt
       properties:
         tokenType:
           description: |
             OAuth token type to create.
 
-            The first version supports creating access tokens only.
+            Currently, only `accessToken` is supported.
           type: string
           enum:
             - accessToken
-          default: accessToken
           examples:
             - accessToken
-        scope:
-          description: |
-            Account OAuth scope of the created token.
-
-            The requested scope must be covered by the app grant scope. When omitted, the app grant scope is used.
-          $ref: "#/components/schemas/OAuthScope"
+        remark:
+          description: Administrator-provided remark for maintaining the token.
+          type: string
+          maxLength: 200
+          examples:
+            - Used for SPX API testing
         expiresAt:
           description: |
             Expiration timestamp of the created token.
 
-            The server must enforce a maximum token lifetime, for example 365 days from creation.
+            The server must reject expiration timestamps later than 365 days from creation.
           type: string
           format: date-time
           examples:

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -4992,6 +4992,8 @@ paths:
         Currently, this endpoint creates access tokens only. The created token is not issued with a refresh token and
         cannot be refreshed. The token value is only returned once in the creation response.
 
+        The token scope is an Account OAuth scope inherited from the app grant.
+
         Requires the `accountAdmin` role.
       parameters:
         - name: userID

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -4992,10 +4992,6 @@ paths:
         Currently, this endpoint creates access tokens only. The created token is not issued with a refresh token and
         cannot be refreshed. The token value is only returned once in the creation response.
 
-        The token scope is an Account OAuth scope inherited from the app grant. It does not necessarily describe the
-        downstream product API capability that will be exercised with the token. Product API usage is valid only for
-        apps integrated through the Account-issued token model.
-
         Requires the `accountAdmin` role.
       parameters:
         - name: userID
@@ -6231,6 +6227,7 @@ components:
         - tokenType
         - tokenFamilyID
         - scope
+        - remark
         - expiresAt
       properties:
         id:
@@ -6259,9 +6256,7 @@ components:
           $ref: "#/components/schemas/OAuthScope"
         remark:
           description: Administrator-provided remark for maintaining the token.
-          type:
-            - string
-            - "null"
+          type: string
           maxLength: 200
           examples:
             - Used for SPX API testing
@@ -6341,6 +6336,8 @@ components:
               description: One-time token value. This value is not returned again after creation.
               type: string
               minLength: 1
+              examples:
+                - xb_at_2L5f8xQy...
 
     CreatedAccountAppSecret:
       description: OAuth client secret created response including the one-time secret value.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -4822,6 +4822,258 @@ paths:
         "404":
           description: Account user not found.
 
+  /admin/account/users/{userID}/grants:
+    get:
+      operationId: listAdminAccountUserGrants
+      tags:
+        - Account Admin
+      summary: List account user app grants as admin
+      description: |
+        Retrieve a list of app grants of an account user.
+
+        Requires the `accountAdmin` role.
+      parameters:
+        - name: userID
+          description: ID of the user whose app grants are listed.
+          in: path
+          required: true
+          schema:
+            $ref: "#/components/schemas/Model/properties/id"
+        - name: orderBy
+          description: Field by which to order the results.
+          in: query
+          schema:
+            type: string
+            enum:
+              - createdAt
+              - updatedAt
+              - lastUsedAt
+            default: createdAt
+            examples:
+              - createdAt
+        - $ref: "#/components/parameters/SortOrder"
+        - $ref: "#/components/parameters/PageIndex"
+        - $ref: "#/components/parameters/PageSize"
+      responses:
+        "200":
+          description: Successful response.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - total
+                  - data
+                properties:
+                  total:
+                    $ref: "#/components/schemas/ByPage/properties/total"
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/AccountAppGrant"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          description: Insufficient permissions to perform this operation.
+        "404":
+          description: Account user not found.
+
+  /admin/account/users/{userID}/grants/{grantID}:
+    get:
+      operationId: getAdminAccountUserGrant
+      tags:
+        - Account Admin
+      summary: Get account user app grant as admin
+      description: |
+        Retrieve an app grant of an account user.
+
+        Requires the `accountAdmin` role.
+      parameters:
+        - name: userID
+          description: ID of the user whose app grant is retrieved.
+          in: path
+          required: true
+          schema:
+            $ref: "#/components/schemas/Model/properties/id"
+        - name: grantID
+          description: ID of the app grant to get.
+          in: path
+          required: true
+          schema:
+            $ref: "#/components/schemas/Model/properties/id"
+      responses:
+        "200":
+          description: Successful response.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AccountAppGrant"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          description: Insufficient permissions to perform this operation.
+        "404":
+          description: Account user or app grant not found.
+
+  /admin/account/users/{userID}/grants/{grantID}/tokens:
+    get:
+      operationId: listAdminAccountUserGrantTokens
+      tags:
+        - Account Admin
+      summary: List account app grant tokens as admin
+      description: |
+        Retrieve active Account-issued OAuth tokens associated with an account user app grant.
+
+        Tokens are active only when they are not expired, not revoked, and, for refresh tokens, not consumed.
+
+        Requires the `accountAdmin` role.
+      parameters:
+        - name: userID
+          description: ID of the user whose app grant tokens are listed.
+          in: path
+          required: true
+          schema:
+            $ref: "#/components/schemas/Model/properties/id"
+        - name: grantID
+          description: ID of the app grant whose tokens are listed.
+          in: path
+          required: true
+          schema:
+            $ref: "#/components/schemas/Model/properties/id"
+        - name: tokenType
+          description: Filter tokens by OAuth token type.
+          in: query
+          schema:
+            $ref: "#/components/schemas/AccountAppToken/properties/tokenType"
+        - name: orderBy
+          description: Field by which to order the results.
+          in: query
+          schema:
+            type: string
+            enum:
+              - createdAt
+            default: createdAt
+            examples:
+              - createdAt
+        - $ref: "#/components/parameters/SortOrder"
+        - $ref: "#/components/parameters/PageIndex"
+        - $ref: "#/components/parameters/PageSize"
+      responses:
+        "200":
+          description: Successful response.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - total
+                  - data
+                properties:
+                  total:
+                    $ref: "#/components/schemas/ByPage/properties/total"
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/AccountAppToken"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          description: Insufficient permissions to perform this operation.
+        "404":
+          description: Account user or app grant not found.
+    post:
+      operationId: createAdminAccountUserGrantToken
+      tags:
+        - Account Admin
+      summary: Create account app grant token as admin
+      description: |
+        Create an Account-issued OAuth token associated with an account user app grant.
+
+        For the first version, this endpoint creates an access token only. The created token is not issued with a
+        refresh token and cannot be refreshed. The token value is only returned once in the creation response.
+
+        The token scope is an Account OAuth scope inherited from the app grant. It does not necessarily describe the
+        downstream product API capability that will be exercised with the token. Product API usage is valid only for
+        apps integrated through the Account-issued token model.
+
+        Requires the `accountAdmin` role.
+      parameters:
+        - name: userID
+          description: ID of the user whose app grant token is created.
+          in: path
+          required: true
+          schema:
+            $ref: "#/components/schemas/Model/properties/id"
+        - name: grantID
+          description: ID of the app grant whose token is created.
+          in: path
+          required: true
+          schema:
+            $ref: "#/components/schemas/Model/properties/id"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateAccountAppTokenRequest"
+      responses:
+        "201":
+          description: Account app grant token created.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CreatedAccountAppToken"
+        "400":
+          description: Invalid request parameters.
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          description: Insufficient permissions to perform this operation.
+        "404":
+          description: Account user or app grant not found.
+
+  /admin/account/users/{userID}/grants/{grantID}/tokens/{tokenID}:
+    delete:
+      operationId: deleteAdminAccountUserGrantToken
+      tags:
+        - Account Admin
+      summary: Delete account app grant token as admin
+      description: |
+        Revoke an Account-issued OAuth token associated with an account user app grant.
+
+        Revocation follows the existing Account OAuth token semantics. Revoking a refresh token revokes the token family;
+        revoking an access token revokes that access token.
+
+        Requires the `accountAdmin` role.
+      parameters:
+        - name: userID
+          description: ID of the user whose app grant token is deleted.
+          in: path
+          required: true
+          schema:
+            $ref: "#/components/schemas/Model/properties/id"
+        - name: grantID
+          description: ID of the app grant whose token is deleted.
+          in: path
+          required: true
+          schema:
+            $ref: "#/components/schemas/Model/properties/id"
+        - name: tokenID
+          description: ID of the app grant token to delete.
+          in: path
+          required: true
+          schema:
+            $ref: "#/components/schemas/Model/properties/id"
+      responses:
+        "204":
+          description: Account app grant token deleted.
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          description: Insufficient permissions to perform this operation.
+        "404":
+          description: Account user, app grant, or token not found.
+
   /admin/account/sessions/{sessionID}:
     delete:
       operationId: deleteAdminAccountSession
@@ -5920,6 +6172,167 @@ components:
           maxLength: 100
           examples:
             - production
+
+    AccountAppGrant:
+      type: object
+      description: Authorization grant from an account user to an account app.
+      required:
+        - id
+        - createdAt
+        - updatedAt
+        - appID
+        - userID
+        - scope
+        - app
+      properties:
+        id:
+          $ref: "#/components/schemas/Model/properties/id"
+        createdAt:
+          $ref: "#/components/schemas/Model/properties/createdAt"
+        updatedAt:
+          $ref: "#/components/schemas/Model/properties/updatedAt"
+        appID:
+          description: ID of the app authorized by the user.
+          $ref: "#/components/schemas/Model/properties/id"
+        userID:
+          description: ID of the user who authorized the app.
+          $ref: "#/components/schemas/Model/properties/id"
+        scope:
+          description: Account OAuth scope granted to the app.
+          $ref: "#/components/schemas/OAuthScope"
+        app:
+          description: App authorized by the user.
+          $ref: "#/components/schemas/AccountApp"
+        lastUsedAt:
+          description: Timestamp when the app grant was last used.
+          type:
+            - string
+            - "null"
+          format: date-time
+          examples:
+            - 2006-01-02T15:04:05+07:00
+        revokedAt:
+          description: Timestamp when the app grant was revoked.
+          type:
+            - string
+            - "null"
+          format: date-time
+          examples:
+            - null
+
+    AccountAppToken:
+      type: object
+      description: Account-issued app-scoped OAuth token metadata.
+      required:
+        - id
+        - createdAt
+        - updatedAt
+        - grantID
+        - tokenType
+        - tokenFamilyID
+        - scope
+        - expiresAt
+      properties:
+        id:
+          $ref: "#/components/schemas/Model/properties/id"
+        createdAt:
+          $ref: "#/components/schemas/Model/properties/createdAt"
+        updatedAt:
+          $ref: "#/components/schemas/Model/properties/updatedAt"
+        grantID:
+          description: ID of the app grant associated with the token.
+          $ref: "#/components/schemas/Model/properties/id"
+        tokenType:
+          description: OAuth token type.
+          type: string
+          enum:
+            - accessToken
+            - refreshToken
+          examples:
+            - accessToken
+        tokenFamilyID:
+          description: Token family identifier used to group refresh token rotations.
+          type: string
+          minLength: 1
+        scope:
+          description: Account OAuth scope associated with the token.
+          $ref: "#/components/schemas/OAuthScope"
+        expiresAt:
+          description: Expiration timestamp.
+          type: string
+          format: date-time
+          examples:
+            - 2006-01-02T15:04:05+07:00
+        lastUsedAt:
+          description: Timestamp when the token was last used.
+          type:
+            - string
+            - "null"
+          format: date-time
+          examples:
+            - 2006-01-02T15:04:05+07:00
+        consumedAt:
+          description: Timestamp when the refresh token was consumed during rotation.
+          type:
+            - string
+            - "null"
+          format: date-time
+          examples:
+            - null
+        revokedAt:
+          description: Timestamp when the token was revoked.
+          type:
+            - string
+            - "null"
+          format: date-time
+          examples:
+            - null
+
+    CreateAccountAppTokenRequest:
+      type: object
+      description: Request to create an Account-issued OAuth token for an app grant.
+      required:
+        - expiresAt
+      properties:
+        tokenType:
+          description: |
+            OAuth token type to create.
+
+            The first version supports creating access tokens only.
+          type: string
+          enum:
+            - accessToken
+          default: accessToken
+          examples:
+            - accessToken
+        scope:
+          description: |
+            Account OAuth scope of the created token.
+
+            The requested scope must be covered by the app grant scope. When omitted, the app grant scope is used.
+          $ref: "#/components/schemas/OAuthScope"
+        expiresAt:
+          description: |
+            Expiration timestamp of the created token.
+
+            The server must enforce a maximum token lifetime, for example 365 days from creation.
+          type: string
+          format: date-time
+          examples:
+            - 2006-07-01T00:00:00+07:00
+
+    CreatedAccountAppToken:
+      description: Account app token created response including the one-time token value.
+      allOf:
+        - $ref: "#/components/schemas/AccountAppToken"
+        - type: object
+          required:
+            - value
+          properties:
+            value:
+              description: One-time token value. This value is not returned again after creation.
+              type: string
+              minLength: 1
 
     CreatedAccountAppSecret:
       description: OAuth client secret created response including the one-time secret value.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -6216,6 +6216,12 @@ components:
         grantID:
           description: ID of the app grant associated with the token.
           $ref: "#/components/schemas/Model/properties/id"
+        name:
+          description: Human-readable token name.
+          type: string
+          maxLength: 100
+          examples:
+            - SPX API testing
         tokenType:
           description: OAuth token type.
           type: string
@@ -6227,13 +6233,6 @@ components:
         scope:
           description: Account OAuth scope associated with the token.
           $ref: "#/components/schemas/OAuthScope"
-        name:
-          description: Human-readable token name.
-          type: string
-          minLength: 1
-          maxLength: 100
-          examples:
-            - SPX API testing
         expiresAt:
           description: Expiration timestamp.
           type: string
@@ -6276,6 +6275,13 @@ components:
         - name
         - expiresAt
       properties:
+        name:
+          description: Human-readable token name.
+          type: string
+          minLength: 1
+          maxLength: 100
+          examples:
+            - SPX API testing
         tokenType:
           description: |
             OAuth token type to create.
@@ -6286,13 +6292,6 @@ components:
             - accessToken
           examples:
             - accessToken
-        name:
-          description: Human-readable token name.
-          type: string
-          minLength: 1
-          maxLength: 100
-          examples:
-            - SPX API testing
         expiresAt:
           description: |
             Expiration timestamp of the created token.


### PR DESCRIPTION
Refs #3275

## Summary

- Add admin APIs for listing account user app grants and retrieving grant details.
- Add admin APIs for listing, creating, and revoking tokens under a user app grant.
- Add OpenAPI schemas for account app grants, account app token metadata, and one-time token creation responses.

## Notes

This PR only defines the API contract. Backend and Admin UI implementation will follow separately.

The token creation API intentionally stays generic under grant tokens. Currently it creates access tokens only, with explicit expiration, no refresh token, and a one-time returned token value.

## Checks

- Parsed `docs/openapi.yaml` as YAML
- `git diff --check`
