### PR TITLE
Improve Account sign-in redirect feedback

### DIFF
--- a/spx-gui/src/apps/account/pages/home.vue
+++ b/spx-gui/src/apps/account/pages/home.vue
@@ -1,7 +1,7 @@
 <template>
   <main class="flex min-h-screen items-center justify-center bg-grey-100 px-6 py-10">
     <section class="w-full max-w-120 rounded-lg border border-grey-300 bg-white px-8 py-7 shadow-sm">
-      <h1 class="m-0 text-2xl font-semibold text-title">{{ $t({ en: 'Account', zh: '账号' }) }}</h1>
+      <h1 class="m-0 text-2xl font-semibold text-title">{{ $t({ en: 'XBuilder Account', zh: 'XBuilder 账号' }) }}</h1>
 
       <div v-if="isLoading" class="mt-8 flex flex-col items-center gap-4 py-10 text-grey-800">
         <UILoading />
@@ -17,8 +17,8 @@
         <p class="mt-2 mb-0 text-grey-800">
           {{
             $t({
-              en: 'There is no active account session in this browser.',
-              zh: '当前浏览器中没有有效的账号登录状态。'
+              en: 'There is no active account session.',
+              zh: '没有有效的账号登录状态。'
             })
           }}
         </p>
@@ -70,5 +70,5 @@ const initial = computed(() =>
   session.value == null ? '?' : session.value.user.displayName.trim().charAt(0).toUpperCase() || '?'
 )
 
-usePageTitle({ en: 'Account', zh: '账号' })
+usePageTitle({ en: 'XBuilder Account', zh: 'XBuilder 账号' })
 </script>

--- a/spx-gui/src/components/account/sign-in/SignInForm.vue
+++ b/spx-gui/src/components/account/sign-in/SignInForm.vue
@@ -109,14 +109,14 @@ const { fn: handleSignInWithPasswordSubmit, isLoading: isSubmittingSignInWithPas
     >
       <UILoading />
       <p class="m-0 text-grey-800">
-        <template v-if="isInitializing">
-          {{ $t({ en: 'Loading sign-in options…', zh: '正在加载登录选项…' }) }}
-        </template>
-        <template v-else-if="isRedirectingToProvider">
+        <template v-if="isRedirectingToProvider">
           {{ $t({ en: 'Redirecting…', zh: '正在跳转…' }) }}
         </template>
         <template v-else-if="isRedirectingToApp">
           {{ $t({ en: 'Signing in…', zh: '正在登录…' }) }}
+        </template>
+        <template v-else-if="isInitializing">
+          {{ $t({ en: 'Loading sign-in options…', zh: '正在加载登录选项…' }) }}
         </template>
       </p>
     </div>

--- a/spx-gui/src/components/account/sign-in/SignInForm.vue
+++ b/spx-gui/src/components/account/sign-in/SignInForm.vue
@@ -64,7 +64,11 @@ const idpsQuery = useQuery(() => getIdentityProviders(props.request), {
   en: 'Failed to get identity providers',
   zh: '获取身份提供商列表失败'
 })
-const { isLoading: isInitializing, error: initializationError, refetch: reinitialize } = useQuery((ctx) => Promise.all([composeQuery(ctx, sessionQuery), composeQuery(ctx, idpsQuery)]), {
+const {
+  isLoading: isInitializing,
+  error: initializationError,
+  refetch: reinitialize
+} = useQuery((ctx) => Promise.all([composeQuery(ctx, sessionQuery), composeQuery(ctx, idpsQuery)]), {
   en: 'Failed to initialize sign-in form',
   zh: '初始化登录表单失败'
 })
@@ -108,24 +112,14 @@ const { fn: handleSignInWithPasswordSubmit, isLoading: isSubmittingSignInWithPas
       class="min-h-45 self-stretch flex flex-col items-center justify-center gap-6"
     >
       <UILoading />
-      <p
-        v-if="isRedirectingToProvider || isRedirectingToApp"
-        class="m-0 text-grey-800"
-      >
-        <template v-if="isRedirectingToProvider">
-          {{ $t({ en: 'Redirecting…', zh: '正在跳转…' }) }}
-        </template>
-        <template v-else-if="isRedirectingToApp">
+      <p class="m-0 text-grey-800">
+        <template v-if="isRedirectingToProvider || isRedirectingToApp">
           {{ $t({ en: 'Redirecting…', zh: '正在跳转…' }) }}
         </template>
       </p>
     </div>
 
-    <UIError
-      v-else-if="initializationError != null"
-      class="mb-2 min-h-50 rounded-lg px-6"
-      :retry="reinitialize"
-    >
+    <UIError v-else-if="initializationError != null" class="mb-2 min-h-50 rounded-lg px-6" :retry="reinitialize">
       {{ $t(initializationError.userMessage) }}
     </UIError>
 

--- a/spx-gui/src/components/account/sign-in/SignInForm.vue
+++ b/spx-gui/src/components/account/sign-in/SignInForm.vue
@@ -47,12 +47,15 @@ function handleSignInWithPassword() {
   showPasswordForm.value = true
 }
 
+const isRedirectingToApp = ref(false)
+
 function completeSignInWithCurrentAccount() {
   clearPendingAuthorization(props.request)
   const authorizeUrl = accountOAuthApis.buildAuthorizeUrl({
     client_id: props.request.clientId,
     request_uri: props.request.requestUri
   })
+  isRedirectingToApp.value = true
   window.location.assign(authorizeUrl)
 }
 
@@ -61,7 +64,7 @@ const idpsQuery = useQuery(() => getIdentityProviders(props.request), {
   en: 'Failed to get identity providers',
   zh: '获取身份提供商列表失败'
 })
-const initialization = useQuery((ctx) => Promise.all([composeQuery(ctx, sessionQuery), composeQuery(ctx, idpsQuery)]), {
+const { isLoading: isInitializing, error: initializationError, refetch: reinitialize } = useQuery((ctx) => Promise.all([composeQuery(ctx, sessionQuery), composeQuery(ctx, idpsQuery)]), {
   en: 'Failed to initialize sign-in form',
   zh: '初始化登录表单失败'
 })
@@ -81,8 +84,11 @@ const { fn: handleSwitchAccount, isLoading: isSwitchingAccount } = useMessageHan
   { en: 'Failed to switch account', zh: '切换账号失败' }
 )
 
+const isRedirectingToProvider = ref(false)
+
 function handleSignInWithProvider(provider: IdentityProvider) {
   markPendingAuthorization(props.request)
+  isRedirectingToProvider.value = true
   window.location.assign(buildIdentityProviderAuthorizeUrl(provider.name, props.request))
 }
 
@@ -98,21 +104,29 @@ const { fn: handleSignInWithPasswordSubmit, isLoading: isSubmittingSignInWithPas
 <template>
   <div class="self-stretch">
     <div
-      v-if="initialization.isLoading.value"
+      v-if="isInitializing || isRedirectingToProvider || isRedirectingToApp"
       class="min-h-45 self-stretch flex flex-col items-center justify-center gap-6"
     >
       <UILoading />
       <p class="m-0 text-grey-800">
-        {{ $t({ en: 'Loading sign-in options…', zh: '正在加载登录选项…' }) }}
+        <template v-if="isInitializing">
+          {{ $t({ en: 'Loading sign-in options…', zh: '正在加载登录选项…' }) }}
+        </template>
+        <template v-else-if="isRedirectingToProvider">
+          {{ $t({ en: 'Redirecting…', zh: '正在跳转…' }) }}
+        </template>
+        <template v-else-if="isRedirectingToApp">
+          {{ $t({ en: 'Signing in…', zh: '正在登录…' }) }}
+        </template>
       </p>
     </div>
 
     <UIError
-      v-else-if="initialization.error.value != null"
+      v-else-if="initializationError != null"
       class="mb-2 min-h-50 rounded-lg px-6"
-      :retry="initialization.refetch"
+      :retry="reinitialize"
     >
-      {{ $t(initialization.error.value.userMessage) }}
+      {{ $t(initializationError.userMessage) }}
     </UIError>
 
     <template v-else>

--- a/spx-gui/src/components/account/sign-in/SignInForm.vue
+++ b/spx-gui/src/components/account/sign-in/SignInForm.vue
@@ -108,15 +108,15 @@ const { fn: handleSignInWithPasswordSubmit, isLoading: isSubmittingSignInWithPas
       class="min-h-45 self-stretch flex flex-col items-center justify-center gap-6"
     >
       <UILoading />
-      <p class="m-0 text-grey-800">
+      <p
+        v-if="isRedirectingToProvider || isRedirectingToApp"
+        class="m-0 text-grey-800"
+      >
         <template v-if="isRedirectingToProvider">
           {{ $t({ en: 'Redirecting…', zh: '正在跳转…' }) }}
         </template>
         <template v-else-if="isRedirectingToApp">
-          {{ $t({ en: 'Signing in…', zh: '正在登录…' }) }}
-        </template>
-        <template v-else-if="isInitializing">
-          {{ $t({ en: 'Loading sign-in options…', zh: '正在加载登录选项…' }) }}
+          {{ $t({ en: 'Redirecting…', zh: '正在跳转…' }) }}
         </template>
       </p>
     </div>


### PR DESCRIPTION
Summary
- Show loading feedback while Account sign-in is redirecting to an identity provider or back to the app.
- Update the Account home page title and empty-session copy to use XBuilder Account naming.

Review
- No blocking issues found in the reviewed diff.

Checks
- npm run type-check
- npm run lint

Refs #3112