### PR TITLE
Build config for mainland China deployment in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,10 @@ jobs:
           package-name: builder_account
           package-dir: ${{ github.workspace }}/spx-gui/dist
 
+      - name: Build account frontend for mainland China deployment
+        working-directory: spx-gui
+        run: NODE_ENV=production.cn npm run build:account
+
       - name: Deploy builder_account_cn
         uses: ./.github/actions/deploy
         with:

--- a/spx-gui/.env.production.cn
+++ b/spx-gui/.env.production.cn
@@ -1,0 +1,13 @@
+VITE_API_BASE_URL="https://xbuilder-api.qiniu.com"
+
+VITE_USERCONTENT_BASE_URL="https://qn-xbuilder-usercontent.gopluscdn.com"
+VITE_USERCONTENT_BUCKET="xbuilder-usercontent"
+VITE_USERCONTENT_UPLOAD_BASE_URL="https://upload.qiniup.com"
+
+VITE_SENTRY_DSN="https://3b532e8d49bece95a4ad2d14c73c2e0b@o4509472134987776.ingest.us.sentry.io/4509868940263424"
+
+VITE_SHOW_LICENSE="true"
+VITE_SHOW_TUTORIALS_ENTRY="true"
+VITE_DEFAULT_LANG="zh"
+
+VITE_ACCOUNT_OAUTH_CLIENT_ID="1"


### PR DESCRIPTION
This pull request adds support for a mainland China-specific production build and deployment of the account frontend. It introduces a new build step in the GitHub Actions workflow and provides a dedicated environment configuration for the China deployment.

**Mainland China deployment support:**

* Added a new build step in the `.github/workflows/release.yml` workflow to generate a production build of the account frontend specifically for mainland China using the `production.cn` environment.
* Introduced a new environment file `spx-gui/.env.production.cn` containing China-specific configuration variables such as API endpoints, user content URLs, Sentry DSN, and default language settings.