### PR TITLE
feat(user): upload avatars through multipart endpoint

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -589,10 +589,12 @@ paths:
                 - file
               properties:
                 file:
-                  description: Avatar image file.
+                  description: |
+                    Avatar image file.
+
+                    Maximum size is 5 MiB (5242880 bytes).
                   type: string
                   format: binary
-                  maxLength: 5242880
             encoding:
               file:
                 contentType: image/png, image/jpeg
@@ -837,14 +839,6 @@ paths:
                   $ref: "#/components/schemas/User/properties/username"
                 displayName:
                   $ref: "#/components/schemas/User/properties/displayName"
-                avatar:
-                  description: New avatar Kodo universal URL of the authenticated user.
-                  allOf:
-                    - $ref: "#/components/schemas/User/properties/avatar"
-                    - minLength: 1
-                      pattern: "^kodo://[^/?#@:]+/[^?#]+$"
-                      examples:
-                        - kodo://xbuilder-usercontent-test/files/FvYyHLNrtx8qFHSwnLjEe57UA2fF-2824936
                 description:
                   $ref: "#/components/schemas/User/properties/description"
       responses:
@@ -856,6 +850,44 @@ paths:
                 $ref: "#/components/schemas/AuthenticatedUser"
         "401":
           $ref: "#/components/responses/Unauthorized"
+
+  /user/avatar:
+    put:
+      operationId: updateAuthenticatedUserAvatar
+      tags:
+        - Users
+      summary: Update the authenticated user avatar
+      description: Upload and replace the avatar image of the authenticated user.
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required:
+                - file
+              properties:
+                file:
+                  description: |
+                    Avatar image file.
+
+                    Maximum size is 5 MiB (5242880 bytes).
+                  type: string
+                  format: binary
+            encoding:
+              file:
+                contentType: image/png, image/jpeg
+      responses:
+        "204":
+          description: Authenticated user avatar updated.
+        "400":
+          description: Invalid request parameters.
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "413":
+          description: Avatar image file is too large.
+        "415":
+          description: Avatar image file type is not supported.
 
   /user/followers:
     get:
@@ -3953,7 +3985,7 @@ paths:
         Image requirements:
 
         - Format: PNG only (`image/png`)
-        - Maximum image size: 5 MB after decoding the base64 content
+        - Maximum image size: 5 MiB (5242880 bytes) after decoding the base64 content
         - Images must be provided as base64-encoded data URLs
         - Other formats must be converted to PNG before sending
 
@@ -4397,10 +4429,12 @@ paths:
                 - file
               properties:
                 file:
-                  description: Scratch project file, such as .sb2, .sb3, or project zip. Form field name must be `file`. Maximum size is 64 MiB.
+                  description: |
+                    Scratch project file, such as .sb2, .sb3, or project zip. Form field name must be `file`.
+
+                    Maximum size is 64 MiB (67108864 bytes).
                   type: string
                   format: binary
-                  maxLength: 67108864
       responses:
         "200":
           description: Conversion successful. Returns a zip archive containing the XBP project file.
@@ -4604,10 +4638,12 @@ paths:
                 - file
               properties:
                 file:
-                  description: Avatar image file.
+                  description: |
+                    Avatar image file.
+
+                    Maximum size is 5 MiB (5242880 bytes).
                   type: string
                   format: binary
-                  maxLength: 5242880
             encoding:
               file:
                 contentType: image/png, image/jpeg
@@ -7444,7 +7480,7 @@ components:
             All images must be provided as PNG format. If you have images in other formats (SVG, JPEG, WebP),
             convert them to PNG before sending.
 
-            Maximum image size: 5 MB (after decoding the base64 content).
+            Maximum image size: 5 MiB (5242880 bytes) after decoding the base64 content.
 
             Format: `data:image/png;base64,<base64_data>`
           type: string

--- a/spx-gui/src/apis/user.ts
+++ b/spx-gui/src/apis/user.ts
@@ -70,10 +70,16 @@ export function getSignedInUser(
   return client.get(`/user`, undefined, options) as Promise<SignedInUser>
 }
 
-export type UpdateSignedInUserParams = Partial<Pick<User, 'username' | 'displayName' | 'avatar' | 'description'>>
+export type UpdateSignedInUserParams = Partial<Pick<User, 'username' | 'displayName' | 'description'>>
 
 export function updateSignedInUser(params: UpdateSignedInUserParams) {
   return client.patch(`/user`, params) as Promise<SignedInUser>
+}
+
+export async function updateSignedInUserAvatar(file: File) {
+  const form = new FormData()
+  form.append('file', file)
+  await client.putBinary('/user/avatar', form)
 }
 
 type ListUserFollowRelationsParams = PaginationParams & {

--- a/spx-gui/src/apps/xbuilder/pages/admin/user.vue
+++ b/spx-gui/src/apps/xbuilder/pages/admin/user.vue
@@ -413,7 +413,7 @@ function deleteAllSessions() {
                   }}
                   <input class="hidden" type="file" accept="image/png,image/jpeg" @change="handleAvatarFile" />
                 </label>
-                <div class="text-center text-xs text-grey-700">PNG / JPG, ≤ 5 MiB</div>
+                <div class="text-center text-xs text-grey-700">PNG / JPG, ≤ 5 MB</div>
               </div>
               <form class="flex min-w-0 flex-col gap-5" @submit.prevent="handleUpdateUser.fn">
                 <div class="grid grid-cols-1 gap-4 tablet:grid-cols-2">

--- a/spx-gui/src/components/community/user/EditAvatarModal.vue
+++ b/spx-gui/src/components/community/user/EditAvatarModal.vue
@@ -2,11 +2,9 @@
 import { computed, nextTick, onBeforeUnmount, ref, watch } from 'vue'
 import Cropper from 'cropperjs'
 import { type User } from '@/apis/user'
-import { fromBlob } from '@/models/common/file'
-import { saveFile } from '@/models/common/cloud'
 import { UIButton, UIFormModal } from '@/components/ui'
 import { DefaultException, useMessageHandle } from '@/utils/exception'
-import { useUpdateSignedInUser } from '@/stores/user'
+import { useUpdateSignedInUserAvatar } from '@/stores/user'
 import AvatarZoomSlider from './AvatarZoomSlider.vue'
 
 const avatarSize = 512
@@ -326,7 +324,18 @@ function handleWheelZoom(event: WheelEvent) {
   setZoomValue(zoomValueRef.value + zoomDelta)
 }
 
-function canvasToBlob(canvas: HTMLCanvasElement) {
+async function exportAvatarBlob() {
+  const selection = getSelection()
+  let canvas: HTMLCanvasElement
+  try {
+    canvas = await selection.$toCanvas({
+      width: avatarSize,
+      height: avatarSize
+    })
+  } catch {
+    throw new DefaultException({ en: 'Failed to export avatar image', zh: '导出头像图片失败' })
+  }
+
   return new Promise<Blob>((resolve, reject) => {
     canvas.toBlob((blob) => {
       if (blob == null) {
@@ -338,28 +347,21 @@ function canvasToBlob(canvas: HTMLCanvasElement) {
   })
 }
 
-const updateProfile = useUpdateSignedInUser()
+const updateAvatar = useUpdateSignedInUserAvatar()
 
-const handleConfirm = useMessageHandle(
-  async () => {
-    const canvas = await getSelection().$toCanvas({
-      width: avatarSize,
-      height: avatarSize
+const handleConfirm = useMessageHandle(async () => {
+  const blob = await exportAvatarBlob()
+  if (blob.size > maxAvatarFileSize) {
+    throw new DefaultException({
+      en: 'Avatar image must be 5 MB or smaller',
+      zh: '头像图片不能超过 5 MB'
     })
-    const blob = await canvasToBlob(canvas)
-    if (blob.size > maxAvatarFileSize) {
-      throw new DefaultException({
-        en: 'Avatar image must be 5 MiB or smaller',
-        zh: '头像图片不能超过 5 MiB'
-      })
-    }
-    const avatar = await saveFile(fromBlob('avatar.png', blob))
-    const updated = await updateProfile({ avatar })
-    if (!props.visible) return
-    emit('resolved', updated)
-  },
-  { en: 'Failed to update avatar', zh: '更新头像失败' }
-)
+  }
+  const file = new File([blob], 'avatar.png', { type: blob.type })
+  const updated = await updateAvatar(file)
+  if (!props.visible) return
+  emit('resolved', updated)
+})
 
 function handleCancel() {
   if (handleConfirm.isLoading.value) return

--- a/spx-gui/src/components/community/user/EditProfileModal.vue
+++ b/spx-gui/src/components/community/user/EditProfileModal.vue
@@ -80,8 +80,8 @@ function validateAvatarInputFile(file: globalThis.File) {
 
   if (file.size > maxAvatarInputFileSize) {
     throw new DefaultException({
-      en: 'Avatar image must be 50 MiB or smaller',
-      zh: '头像图片不能超过 50 MiB'
+      en: 'Avatar image must be 50 MB or smaller',
+      zh: '头像图片不能超过 50 MB'
     })
   }
 }

--- a/spx-gui/src/stores/user/signed-in.ts
+++ b/spx-gui/src/stores/user/signed-in.ts
@@ -214,9 +214,7 @@ export function useUpdateSignedInUser() {
   const queryCache = useQueryCache()
 
   return useAction(
-    async function updateSignedInUser(
-      params: Pick<userApis.UpdateSignedInUserParams, 'displayName' | 'avatar' | 'description'>
-    ) {
+    async function updateSignedInUser(params: Pick<userApis.UpdateSignedInUserParams, 'displayName' | 'description'>) {
       const unresolvedUsername = getUnresolvedSignedInUsername()
       const updated = await userApis.updateSignedInUser(params)
       if (unresolvedUsername != null) queryCache.invalidate(getUserQueryKey(unresolvedUsername))
@@ -224,6 +222,22 @@ export function useUpdateSignedInUser() {
       return updated
     },
     { en: 'Failed to update profile', zh: '更新个人信息失败' }
+  )
+}
+
+export function useUpdateSignedInUserAvatar() {
+  const queryCache = useQueryCache()
+
+  return useAction(
+    async function updateSignedInUserAvatar(file: File) {
+      const unresolvedUsername = getUnresolvedSignedInUsername()
+      await userApis.updateSignedInUserAvatar(file)
+      const updated = await userApis.getSignedInUser()
+      if (unresolvedUsername != null) queryCache.invalidate(getUserQueryKey(unresolvedUsername))
+      queryCache.invalidate(getUserQueryKey(updated.username))
+      return updated
+    },
+    { en: 'Failed to update avatar', zh: '更新头像失败' }
   )
 }
 


### PR DESCRIPTION
Move signed-in user avatar updates out of profile patch requests and onto the dedicated `/user/avatar` multipart upload endpoint.

Keep profile patches scoped to text fields and refresh the signed-in user after avatar upload so callers receive the updated avatar URL.