### PR TITLE
feat(editor): let copilot narrow the API references panel during tutorials

### DIFF
--- a/spx-gui/src/components/editor/copilot/index.ts
+++ b/spx-gui/src/components/editor/copilot/index.ts
@@ -5,6 +5,7 @@ import { useCopilot } from '@/components/copilot/context'
 import { codeFilePathSchema, parseProjectIdentifier, projectIdentifierSchema } from '@/components/copilot/common'
 import { type ICopilotContextProvider, type ToolDefinition } from '@/components/copilot/copilot'
 import { skillSpxProject, skillXgoLanguage } from '@/components/copilot/skills/built-in'
+import { stringifyDefinitionId } from '@/components/xgo-code-editor'
 import { cloudHelpers, type CloudHelpers } from '@/models/common/cloud'
 import { SpxProject } from '@/models/spx/project'
 import type { Sprite } from '@/models/spx/sprite'
@@ -188,6 +189,30 @@ class GetCodeDiagnosticsTool implements ToolDefinition {
   }
 }
 
+const listApiReferenceItemsParamsSchema = z.object({})
+
+class ListApiReferenceItemsTool implements ToolDefinition {
+  name = 'list_api_reference_items'
+  description =
+    'List the available API reference items (definition id and signature) for the code file the user is currently ' +
+    'editing. Use the returned ids with the `api-reference-filter` element to narrow the "API References" panel.'
+  parameters = listApiReferenceItemsParamsSchema
+
+  constructor(private codeEditor: CodeEditor) {}
+
+  async implementation(_: z.infer<typeof listApiReferenceItemsParamsSchema>, signal?: AbortSignal) {
+    const textDocument = this.codeEditor.getAttachedUI()?.activeTextDocument
+    if (textDocument == null) return []
+    const items = await this.codeEditor.apiReferenceProvider.provideAPIReference({
+      textDocument,
+      signal: signal ?? new AbortController().signal
+    })
+    return items
+      .filter((item) => item.hiddenFromList !== true)
+      .map((item) => ({ id: stringifyDefinitionId(item.definition), overview: item.overview }))
+  }
+}
+
 class ProjectContextProvider implements ICopilotContextProvider {
   constructor(private editorCtx: EditorCtx) {}
 
@@ -286,6 +311,7 @@ export function useSpxEditorCopilot(): void {
   d.addDisposer(copilot.registerTool(new GetSpriteContentTool(retriever)))
   d.addDisposer(copilot.registerTool(new GetProjectCodeTool(retriever)))
   d.addDisposer(copilot.registerTool(new GetCodeDiagnosticsTool(codeEditor)))
+  d.addDisposer(copilot.registerTool(new ListApiReferenceItemsTool(codeEditor)))
   d.addDisposer(
     copilot.registerCustomElement({
       tagName: codeLink.tagName,

--- a/spx-gui/src/components/tutorials/TutorialRoot.vue
+++ b/spx-gui/src/components/tutorials/TutorialRoot.vue
@@ -7,15 +7,18 @@ import { useIsRouteLoaded } from '@/utils/route-loading'
 import { isTutorialTopic, provideTutorial, Tutorial } from './tutorial'
 
 import { useCopilot } from '@/components/copilot/context'
+import { useCodeEditorRef } from '@/components/xgo-code-editor'
 import * as tutorialCourseSuccess from './TutorialCourseSuccess.vue'
 import * as tutorialCourseExitLink from './TutorialCourseExitLink'
 import * as tutorialStateIndicator from './TutorialStateIndicator.vue'
+import * as apiReferenceFilter from './api-reference-filter'
 import { tutorialCourseAbandonPrediction, tutorialCourseAbandonDismissal } from './tutorial-course-abandon'
 
 const i18n = useI18n()
 const copilot = useCopilot()
 const router = useRouter()
 const isRouteLoaded = useIsRouteLoaded()
+const codeEditorRef = useCodeEditorRef()
 
 const tutorial = new Tutorial(copilot, router, isRouteLoaded)
 
@@ -44,6 +47,13 @@ watch(
       }),
       copilot.registerCustomElement(tutorialCourseAbandonPrediction),
       copilot.registerCustomElement(tutorialCourseAbandonDismissal),
+      copilot.registerCustomElement({
+        tagName: apiReferenceFilter.tagName,
+        description: apiReferenceFilter.detailedDescription,
+        attributes: apiReferenceFilter.attributes,
+        isRaw: apiReferenceFilter.isRaw,
+        component: apiReferenceFilter.default
+      }),
       copilot.registerStateIndicatorComponent(tutorialStateIndicator.name, tutorialStateIndicator.default),
       copilot.registerQuickInputProvider({
         provideQuickInput(lastCopilotMessage, topic) {
@@ -75,6 +85,8 @@ watch(
       for (const dispose of disposers) {
         dispose()
       }
+      // Reset the API references panel when leaving the course, so the filter never outlives it.
+      codeEditorRef.value?.setAPIReferenceFilter(null)
     })
   },
   {

--- a/spx-gui/src/components/tutorials/api-reference-filter.ts
+++ b/spx-gui/src/components/tutorials/api-reference-filter.ts
@@ -1,0 +1,67 @@
+import { z } from 'zod'
+import { defineComponent, watch } from 'vue'
+import { useCodeEditorRef, stringifyDefinitionId } from '@/components/xgo-code-editor'
+
+export const tagName = 'api-reference-filter'
+
+export const isRaw = false
+
+export const description = 'Narrow the "API References" panel to only the listed APIs.'
+
+export const detailedDescription = `Narrow the "API References" panel (left of the code editor) to only the listed \
+APIs, to focus the user during a guided step. \`ids\` is a comma-separated list of API definition IDs — get the exact \
+IDs from the \`list_api_reference_items\` tool. Use \`ids=""\` to show all APIs again. Re-emit this element with a new \
+list whenever the relevant APIs change or you previously made a mistake — the latest one wins. For example, \
+<${tagName} ids="xgo:github.com/goplus/spx/v2?Sprite.say#0,xgo:github.com/goplus/spx/v2?Game.onStart" /> keeps only \
+those two APIs visible.`
+
+export const attributes = z.object({
+  ids: z
+    .string()
+    .describe(
+      'Comma-separated API definition IDs to keep visible (from list_api_reference_items). Empty string shows all.'
+    )
+})
+
+export type Props = {
+  /** Comma-separated API definition IDs to keep visible. Empty string shows all. */
+  ids: string
+}
+
+export default defineComponent<Props>(
+  (props) => {
+    const codeEditorRef = useCodeEditorRef()
+
+    function apply() {
+      const codeEditor = codeEditorRef.value
+      if (codeEditor == null) return
+      const ids = props.ids
+        .split(',')
+        .map((id) => id.trim())
+        .filter((id) => id !== '')
+      if (ids.length === 0) {
+        codeEditor.setAPIReferenceFilter(null)
+        return
+      }
+      const allow = new Set(ids)
+      codeEditor.setAPIReferenceFilter((item) => allow.has(stringifyDefinitionId(item.definition)))
+    }
+
+    // Re-apply on initial render, when the editor becomes available (it may mount later than this
+    // element), and when the copilot updates the element with a new `ids` prop.
+    watch([codeEditorRef, () => props.ids], apply, { immediate: true })
+
+    return function render() {
+      return null
+    }
+  },
+  {
+    name: 'ApiReferenceFilter',
+    props: {
+      ids: {
+        type: String,
+        default: ''
+      }
+    }
+  }
+)

--- a/spx-gui/src/components/tutorials/tutorial.ts
+++ b/spx-gui/src/components/tutorials/tutorial.ts
@@ -130,6 +130,8 @@ First do some preparation:
 
 * Clearly define the course completion criteria.
 
+* If the course involves writing spx code, proactively narrow the "API References" panel (left of the code editor) at the start, before guiding the first coding step. Keep ALL the APIs the course uses anywhere — the union across every step, decided from the course goal and the reference project's code (the standard answer) — not just the current step's APIs, so the user can always find every API they will need throughout the course. Set this once and keep it stable for the whole course; only change it if the course genuinely needs a different set. This is expected for every coding course — do not wait for the user to ask.
+
 Then guide the user through each step. For each step:
 
 1. If extra information required, use appropriate tool to gather it.
@@ -156,6 +158,7 @@ When coding tasks are involved:
 * Before offering coding suggestions, ensure you understand the current code. If not, use appropriate tools to review it first.
 * Avoid giving complete solution code directly. Instead, guide the user step-by-step with hints and explanations.
 * Prefer to insert code by dragging corresponding items (if available) from "API References" into the code editor over providing manual code snippets.
+* Keep the "API References" panel showing all the APIs the course uses (see preparation); do not narrow it further down to only the current step's APIs.
 
 When tool result received:
 

--- a/spx-gui/src/components/xgo-code-editor/api-reference.ts
+++ b/spx-gui/src/components/xgo-code-editor/api-reference.ts
@@ -7,6 +7,13 @@ import type { BaseContext, DefinitionDocumentationItem } from './common'
 
 export type APIReferenceItem = DefinitionDocumentationItem
 
+/**
+ * Predicate to narrow which API reference items are shown in the panel.
+ * `null` (no filter) means show all items. The editor stays agnostic about how
+ * the predicate is built; consumers decide the rule.
+ */
+export type APIReferenceFilter = (item: APIReferenceItem) => boolean
+
 export type APIReferenceContext = BaseContext
 
 export type APICategoryViewInfo = {

--- a/spx-gui/src/components/xgo-code-editor/code-editor.ts
+++ b/spx-gui/src/components/xgo-code-editor/code-editor.ts
@@ -5,7 +5,7 @@ import type { History } from '@/components/editor/history'
 import type { IXGoProject } from './project'
 import { type IDocumentBase, DocumentBase } from './document-base'
 import type { ILSPClient } from './lsp/types'
-import { EmptyAPIReferenceProvider } from './api-reference'
+import { EmptyAPIReferenceProvider, type APIReferenceFilter } from './api-reference'
 import {
   type ICodeEditorUIController,
   type IDiagnosticsProvider,
@@ -80,6 +80,7 @@ export class CodeEditor extends Disposable {
     this.inlayHintProviderRef = shallowRef(new InlayHintProvider(params.lspClient))
     this.inputHelperProviderRef = shallowRef(new InputHelperProvider(params.lspClient, () => this.resourceAdapter))
     this.apiReferenceProviderRef = shallowRef(new EmptyAPIReferenceProvider())
+    this.apiReferenceFilterRef = shallowRef<APIReferenceFilter | null>(null)
     this.completionProviderRef = shallowRef(
       new CompletionProvider(params.lspClient, documentBase, params.project.classFramework)
     )
@@ -133,6 +134,14 @@ export class CodeEditor extends Disposable {
   }
   registerAPIReferenceProvider(provider: IAPIReferenceProvider) {
     this.apiReferenceProviderRef.value = provider
+  }
+
+  private apiReferenceFilterRef: ShallowRef<APIReferenceFilter | null>
+  get apiReferenceFilter() {
+    return this.apiReferenceFilterRef.value
+  }
+  setAPIReferenceFilter(filter: APIReferenceFilter | null) {
+    this.apiReferenceFilterRef.value = filter
   }
 
   private completionProviderRef: ShallowRef<ICompletionProvider>

--- a/spx-gui/src/components/xgo-code-editor/ui/api-reference/index.ts
+++ b/spx-gui/src/components/xgo-code-editor/ui/api-reference/index.ts
@@ -23,8 +23,24 @@ export class APIReferenceController extends Disposable {
     return provider.provideAPIReference({ textDocument, signal })
   }, true)
 
-  get items() {
+  /** Items as loaded from the provider, before applying the filter. */
+  private get loadedItems() {
     return this.itemsMgr.result.data
+  }
+
+  /**
+   * Items exposed to consumers, after applying `codeEditor.apiReferenceFilter`. Filtering is an
+   * internal concern of the controller: it is a synchronous derivation over the already-loaded items,
+   * so filter changes update the UI reactively without re-running the async provider. Falls back to
+   * the full list when the filter matches nothing, to avoid leaving the panel empty.
+   */
+  get items() {
+    const items = this.loadedItems
+    if (items == null) return null
+    const filter = this.ui.codeEditor.apiReferenceFilter
+    if (filter == null) return items
+    const filtered = items.filter(filter)
+    return filtered.length > 0 ? filtered : items
   }
 
   get error() {


### PR DESCRIPTION
## What & why

During a tutorial course, the left-side **API References** panel shows the full catalog of spx APIs, which can overwhelm a learner. This PR lets the copilot narrow that panel to only the APIs a course actually needs, and restores it automatically when the course ends.

The panel is filtered while the user is being guided through a course, and returns to showing everything once they leave "tutorial mode" (i.e. the copilot session ends).

## How it works (data flow)

```
copilot emits  <api-reference-filter names="onStart, say, move">
      │  (custom element, rendered in the copilot panel)
      ▼
codeEditor.setAPIReferenceFilter(predicate)      ← generic, reactive state on CodeEditor
      ▼
APIReferenceController.filteredItems             ← synchronous derived view over loaded items
      ▼
APIReferenceUI re-renders (empty categories collapse automatically)
```

Clearing: the editor watches `copilot.currentSession` and resets the filter whenever the session ends or switches.

## Changes (by layer)

**Generic editor (`xgo-code-editor`) — no knowledge of copilot/tutorials**
- `api-reference.ts`: new `APIReferenceFilter = (item) => boolean` type.
- `code-editor.ts`: reactive `apiReferenceFilter` + `setAPIReferenceFilter()` .
- `ui/api-reference/index.ts`: `filteredItems` — a synchronous derivation over the already-loaded `items`, so filter changes update the UI reactively **without** re-running the async provider. Falls back to the full list if a filter matches nothing.
- `ui/api-reference/APIReferenceUI.vue`: render `filteredItems` instead of `items`.

**Editor ↔ copilot seam (`editor/copilot`)**
- New `ApiReferenceFilter.ts`: an `api-reference-filter` custom element that reaches the editor via `useCodeEditorRef()` (same mechanism as the existing `CodeLink`/`CodeChange` elements) and sets the filter on mount. APIs are matched **by name** (e.g. `onStart`, `say`) — the vocabulary the model already knows from the `spx-project` skill — so no extra catalog/tool is needed.
- `index.ts`: register the element next to the other editor copilot elements; clear the filter on copilot session change.

**Tutorial**
- `tutorial.ts`: the course prompt now instructs the copilot to narrow the panel to the **union of APIs the whole course uses** (not just the current step), set once at the start and kept stable. The tutorial module holds no filter state and does not depend on the editor.

## Design notes

- The generic `xgo-code-editor` / API Reference layer stays unaware of `tutorial`; the only coupling lives in the two existing connection points (`editor/copilot` and the tutorial prompt), bridged through copilot.
- Filtering is a **synchronous** derivation, so it rides Vue reactivity rather than re-triggering the async API load.
- The filter is a session-scoped transient: cleared on session end, so it can never persist into normal (non-tutorial) editing.

## Testing

- Manual: in the editor, asking the copilot to "show only `onStart` and `say`" narrows the panel; starting a coding course narrows it to the course's APIs; finishing/leaving the course restores the full list.
- `npm run type-check`, `npm run lint`, Prettier — all pass.

