### PR TITLE
Improve Account admin page titles and list URLs

### DIFF
--- a/spx-gui/src/apis/admin/account.ts
+++ b/spx-gui/src/apis/admin/account.ts
@@ -1,4 +1,4 @@
-import { client, type ByPage, type PaginationParams } from '@/apis/common'
+import { client, SortOrder, type ByPage, type PaginationParams } from '@/apis/common'
 import type {
   AccountApp,
   AccountAppClientType,
@@ -26,8 +26,6 @@ export type {
   CreatedAccountAppSecret,
   CreatedAccountAppToken
 } from '@/apis/account/common'
-
-type SortOrder = 'asc' | 'desc'
 
 /** Maximum allowed length for an app token name. */
 export const accountAppTokenNameMaxLength = 100

--- a/spx-gui/src/apis/admin/audit.ts
+++ b/spx-gui/src/apis/admin/audit.ts
@@ -1,6 +1,4 @@
-import { client, type ByPage, type PaginationParams } from '@/apis/common'
-
-type SortOrder = 'asc' | 'desc'
+import { client, SortOrder, type ByPage, type PaginationParams } from '@/apis/common'
 
 export type AuditLog = {
   /** Unique identifier */

--- a/spx-gui/src/apis/common/index.ts
+++ b/spx-gui/src/apis/common/index.ts
@@ -6,6 +6,11 @@ export type PaginationParams = {
   pageIndex?: number
 }
 
+export enum SortOrder {
+  Asc = 'asc',
+  Desc = 'desc'
+}
+
 export type ByPage<T> = {
   total: number
   data: T[]

--- a/spx-gui/src/apps/xbuilder/pages/admin/app.vue
+++ b/spx-gui/src/apps/xbuilder/pages/admin/app.vue
@@ -5,6 +5,7 @@ import { RouterLink } from 'vue-router'
 import { useMessageHandle } from '@/utils/exception'
 import { useI18n } from '@/utils/i18n'
 import { useQuery } from '@/utils/query'
+import { usePageTitle } from '@/utils/utils'
 import { useSignedInStateQuery } from '@/stores/user'
 import { UIButton, UIError, UILoading, UISwitch, UITextInput } from '@/components/ui'
 import CopyButton from '@/components/common/CopyButton.vue'
@@ -39,6 +40,14 @@ const appQuery = useQuery(
   }
 )
 const app = computed(() => appQuery.data.value)
+usePageTitle(() =>
+  app.value == null
+    ? { en: 'OAuth app', zh: 'OAuth 应用' }
+    : [
+        { en: app.value.displayName, zh: app.value.displayName },
+        { en: 'OAuth app', zh: 'OAuth 应用' }
+      ]
+)
 
 const displayName = ref('')
 const status = ref<accountAdminApis.AccountApp['status']>('active')

--- a/spx-gui/src/apps/xbuilder/pages/admin/apps.vue
+++ b/spx-gui/src/apps/xbuilder/pages/admin/apps.vue
@@ -1,9 +1,12 @@
 <script setup lang="ts">
-import { computed, reactive, ref, watch } from 'vue'
+import { computed, reactive, ref } from 'vue'
 import { RouterLink, useRouter } from 'vue-router'
 
 import { useMessageHandle } from '@/utils/exception'
 import { useQuery } from '@/utils/query'
+import { useRouteQueryParamInt, useRouteQueryParamStrEnum } from '@/utils/route'
+import { usePageTitle } from '@/utils/utils'
+import { SortOrder } from '@/apis/common'
 import { useSignedInStateQuery } from '@/stores/user'
 import { UIButton, UIError, UILoading, UIPagination, UISelect, UISelectOption, UITextInput } from '@/components/ui'
 import * as accountAdminApis from '@/apis/admin/account'
@@ -21,8 +24,9 @@ const router = useRouter()
 const canManageAccount = computed(() => signedInStateQuery.data.value?.user?.capabilities.canManageAccount === true)
 
 const pageSize = 20
-const page = ref(1)
-const sortOrder = ref<'asc' | 'desc'>('desc')
+const page = useRouteQueryParamInt('p', 1)
+const resetPage = (query: Partial<Record<string, string | null>>) => ({ ...query, p: null })
+const sortOrder = useRouteQueryParamStrEnum('order', SortOrder, SortOrder.Desc, resetPage)
 const showCreateForm = ref(false)
 
 const createForm = reactive({
@@ -48,9 +52,7 @@ const appsQuery = useQuery(
 
 const pageTotal = computed(() => Math.ceil((appsQuery.data.value?.total ?? 0) / pageSize))
 
-watch(sortOrder, () => {
-  page.value = 1
-})
+usePageTitle({ en: 'OAuth apps', zh: 'OAuth 应用' })
 
 const handleCreateApp = useMessageHandle(
   async () => {

--- a/spx-gui/src/apps/xbuilder/pages/admin/audit-logs.vue
+++ b/spx-gui/src/apps/xbuilder/pages/admin/audit-logs.vue
@@ -1,25 +1,20 @@
 <script setup lang="ts">
-import { computed, ref, watch } from 'vue'
+import { computed } from 'vue'
 
 import { useQuery } from '@/utils/query'
+import { useRouteQueryParamInt, useRouteQueryParamStr, useRouteQueryParamStrEnum } from '@/utils/route'
+import { usePageTitle } from '@/utils/utils'
+import { SortOrder } from '@/apis/common'
 import { UIButton, UIError, UILoading, UIPagination, UISelect, UISelectOption } from '@/components/ui'
 import * as auditApis from '@/apis/admin/audit'
 import { formatJSON, formatTime } from './common'
 
 const pageSize = 20
-const page = ref(1)
-const sortOrder = ref<'asc' | 'desc'>('desc')
-const createdAfter = ref('')
-const createdBefore = ref('')
-
-watch([sortOrder, createdAfter, createdBefore], () => {
-  page.value = 1
-})
-
-function clearFilters() {
-  createdAfter.value = ''
-  createdBefore.value = ''
-}
+const page = useRouteQueryParamInt('p', 1)
+const resetPage = (query: Partial<Record<string, string | null>>) => ({ ...query, p: null })
+const sortOrder = useRouteQueryParamStrEnum('order', SortOrder, SortOrder.Desc, resetPage)
+const createdAfter = useRouteQueryParamStr('from', '', resetPage)
+const createdBefore = useRouteQueryParamStr('to', '', resetPage)
 
 function hasMetadata(value: unknown) {
   return value != null && typeof value === 'object' && Object.keys(value).length > 0
@@ -27,7 +22,9 @@ function hasMetadata(value: unknown) {
 
 function toISOString(value: string) {
   if (value === '') return undefined
-  return new Date(value).toISOString()
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return undefined
+  return date.toISOString()
 }
 
 const auditLogsQuery = useQuery(
@@ -44,6 +41,8 @@ const auditLogsQuery = useQuery(
 )
 
 const pageTotal = computed(() => Math.ceil((auditLogsQuery.data.value?.total ?? 0) / pageSize))
+
+usePageTitle({ en: 'Audit logs', zh: '审计日志' })
 </script>
 
 <template>
@@ -62,7 +61,7 @@ const pageTotal = computed(() => Math.ceil((auditLogsQuery.data.value?.total ?? 
 
     <div class="overflow-hidden rounded-lg border border-grey-400 bg-white">
       <div
-        class="grid grid-cols-1 gap-3 border-b border-grey-300 bg-grey-100 px-5 py-4 tablet:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_128px_auto]"
+        class="grid grid-cols-1 gap-3 border-b border-grey-300 bg-grey-100 px-5 py-4 tablet:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_128px]"
       >
         <label class="flex flex-col gap-1 text-sm text-grey-900">
           {{ $t({ en: 'Created after', zh: '开始时间' }) }}
@@ -84,14 +83,6 @@ const pageTotal = computed(() => Math.ceil((auditLogsQuery.data.value?.total ?? 
           <UISelectOption value="desc">{{ $t({ en: 'Newest', zh: '最新' }) }}</UISelectOption>
           <UISelectOption value="asc">{{ $t({ en: 'Oldest', zh: '最早' }) }}</UISelectOption>
         </UISelect>
-        <UIButton
-          type="white"
-          class="self-end"
-          :disabled="createdAfter === '' && createdBefore === ''"
-          @click="clearFilters"
-        >
-          {{ $t({ en: 'Clear', zh: '清空' }) }}
-        </UIButton>
       </div>
 
       <UILoading v-if="auditLogsQuery.isLoading.value" class="my-16" />

--- a/spx-gui/src/apps/xbuilder/pages/admin/grant.vue
+++ b/spx-gui/src/apps/xbuilder/pages/admin/grant.vue
@@ -6,6 +6,8 @@ import { RouterLink } from 'vue-router'
 import { useMessageHandle } from '@/utils/exception'
 import { useI18n } from '@/utils/i18n'
 import { useQuery } from '@/utils/query'
+import { usePageTitle } from '@/utils/utils'
+import { SortOrder } from '@/apis/common'
 import { useSignedInStateQuery } from '@/stores/user'
 import {
   UIButton,
@@ -51,6 +53,17 @@ const grantQuery = useQuery(
 const grant = computed(() => grantQuery.data.value)
 const app = computed(() => grant.value?.app ?? null)
 const appFallbackText = computed(() => app.value?.displayName.trim().charAt(0).toUpperCase() || '?')
+usePageTitle(() =>
+  app.value == null || user.value == null
+    ? { en: 'App grant', zh: '应用授权' }
+    : [
+        {
+          en: `${user.value.displayName} -> ${app.value.displayName}`,
+          zh: `${user.value.displayName} -> ${app.value.displayName}`
+        },
+        { en: 'App grant', zh: '应用授权' }
+      ]
+)
 
 const tokensPageSize = 20
 const tokensPage = ref(1)
@@ -62,7 +75,7 @@ const tokensQuery = useQuery(
       pageIndex: tokensPage.value,
       pageSize: tokensPageSize,
       orderBy: 'createdAt',
-      sortOrder: 'desc',
+      sortOrder: SortOrder.Desc,
       tokenType: tokenTypeFilter.value === 'all' ? undefined : tokenTypeFilter.value
     })
   },

--- a/spx-gui/src/apps/xbuilder/pages/admin/index.vue
+++ b/spx-gui/src/apps/xbuilder/pages/admin/index.vue
@@ -2,11 +2,14 @@
 import { computed } from 'vue'
 import { RouterView, useRoute, useRouter } from 'vue-router'
 
+import { usePageTitle } from '@/utils/utils'
 import { useSignedInStateQuery } from '@/stores/user'
 import { UIError, UILoading, UIMenu, UIMenuGroup, UIMenuItem } from '@/components/ui'
 import CenteredWrapper from '@/components/common/CenteredWrapper.vue'
 import NavbarDropdown from '@/components/navbar/NavbarDropdown.vue'
 import NavbarWrapper from '@/components/navbar/NavbarWrapper.vue'
+
+usePageTitle({ en: 'Account admin', zh: '账号管理' })
 
 const route = useRoute()
 const router = useRouter()

--- a/spx-gui/src/apps/xbuilder/pages/admin/user.vue
+++ b/spx-gui/src/apps/xbuilder/pages/admin/user.vue
@@ -30,6 +30,8 @@ import { RouterLink } from 'vue-router'
 import { useMessageHandle } from '@/utils/exception'
 import { useI18n } from '@/utils/i18n'
 import { useQuery } from '@/utils/query'
+import { usePageTitle } from '@/utils/utils'
+import { SortOrder } from '@/apis/common'
 import { useSignedInStateQuery } from '@/stores/user'
 import {
   UIButton,
@@ -71,6 +73,14 @@ const userQuery = useQuery(
 )
 const user = computed(() => userQuery.data.value)
 const avatarFallbackText = computed(() => user.value?.displayName.trim().charAt(0).toUpperCase() || '?')
+usePageTitle(() =>
+  user.value == null
+    ? { en: 'User', zh: '用户' }
+    : [
+        { en: user.value.displayName, zh: user.value.displayName },
+        { en: 'User', zh: '用户' }
+      ]
+)
 
 const displayName = ref('')
 watch(
@@ -111,7 +121,7 @@ const grantsQuery = useQuery(
       pageIndex: grantsPage.value,
       pageSize: grantsPageSize,
       orderBy: 'lastUsedAt',
-      sortOrder: 'desc'
+      sortOrder: SortOrder.Desc
     })
   },
   { en: 'Failed to load Account user app grants', zh: '加载账号用户应用授权失败' }

--- a/spx-gui/src/apps/xbuilder/pages/admin/users.vue
+++ b/spx-gui/src/apps/xbuilder/pages/admin/users.vue
@@ -5,6 +5,9 @@ import { RouterLink, useRouter } from 'vue-router'
 
 import { useMessageHandle } from '@/utils/exception'
 import { useQuery } from '@/utils/query'
+import { useRouteQueryParamInt, useRouteQueryParamStr, useRouteQueryParamStrEnum } from '@/utils/route'
+import { usePageTitle } from '@/utils/utils'
+import { SortOrder } from '@/apis/common'
 import { useSignedInStateQuery } from '@/stores/user'
 import { UIButton, UIError, UILoading, UIPagination, UISelect, UISelectOption, UITextInput } from '@/components/ui'
 import * as accountAdminApis from '@/apis/admin/account'
@@ -15,10 +18,11 @@ const router = useRouter()
 const canManageAccount = computed(() => signedInStateQuery.data.value?.user?.capabilities.canManageAccount === true)
 
 const pageSize = 20
-const page = ref(1)
-const sortOrder = ref<'asc' | 'desc'>('desc')
-const keywordInput = ref('')
-const keyword = ref('')
+const page = useRouteQueryParamInt('p', 1)
+const resetPage = (query: Partial<Record<string, string | null>>) => ({ ...query, p: null })
+const sortOrder = useRouteQueryParamStrEnum('order', SortOrder, SortOrder.Desc, resetPage)
+const keyword = useRouteQueryParamStr('q', '', resetPage)
+const keywordInput = ref(keyword.value)
 const showCreateForm = ref(false)
 
 const createForm = reactive({
@@ -54,20 +58,20 @@ const usersQuery = useQuery(
 
 const pageTotal = computed(() => Math.ceil((usersQuery.data.value?.total ?? 0) / pageSize))
 
-watch(sortOrder, () => {
-  page.value = 1
-})
-
 const updateKeyword = debounce(() => {
   const nextKeyword = keywordInput.value.trim()
   if (keyword.value === nextKeyword) return
   keyword.value = nextKeyword
-  page.value = 1
 }, 300)
 
+watch(keyword, (value) => {
+  if (keywordInput.value !== value) keywordInput.value = value
+})
 watch(keywordInput, updateKeyword)
 
 onUnmounted(() => updateKeyword.cancel())
+
+usePageTitle({ en: 'Users', zh: '用户' })
 
 const handleCreateUser = useMessageHandle(
   async () => {


### PR DESCRIPTION
Closes #3313

## Changes
- Add Account admin page titles for the admin shell, list pages, and detail pages.
- Sync Account admin list pagination, sorting, and filters to route query params.
- Reset list pagination when sorting or filters change while keeping default URLs clean.

## Checks
- npm run type-check
- npm run lint
- git diff --check

## Notes
- Attempted browser verification in the in-app browser, but browser automation timed out while navigating the local admin page. Static checks passed.