### PR TITLE
fix(api): count exact frontend string budgets as code points

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -592,7 +592,7 @@ paths:
                   description: |
                     Avatar image file.
 
-                    Maximum size is 5 MiB (5242880 bytes).
+                    Maximum size is 5 MiB.
                   type: string
                   format: binary
             encoding:
@@ -871,7 +871,7 @@ paths:
                   description: |
                     Avatar image file.
 
-                    Maximum size is 5 MiB (5242880 bytes).
+                    Maximum size is 5 MiB.
                   type: string
                   format: binary
             encoding:
@@ -3985,7 +3985,7 @@ paths:
         Image requirements:
 
         - Format: PNG only (`image/png`)
-        - Maximum image size: 5 MiB (5242880 bytes) after decoding the base64 content
+        - Maximum image size: 5 MiB after decoding the base64 content
         - Images must be provided as base64-encoded data URLs
         - Other formats must be converted to PNG before sending
 
@@ -4432,7 +4432,7 @@ paths:
                   description: |
                     Scratch project file, such as .sb2, .sb3, or project zip. Form field name must be `file`.
 
-                    Maximum size is 64 MiB (67108864 bytes).
+                    Maximum size is 64 MiB.
                   type: string
                   format: binary
       responses:
@@ -4641,7 +4641,7 @@ paths:
                   description: |
                     Avatar image file.
 
-                    Maximum size is 5 MiB (5242880 bytes).
+                    Maximum size is 5 MiB.
                   type: string
                   format: binary
             encoding:
@@ -7876,7 +7876,7 @@ components:
             All images must be provided as PNG format. If you have images in other formats (SVG, JPEG, WebP),
             convert them to PNG before sending.
 
-            Maximum image size: 5 MiB (5242880 bytes) after decoding the base64 content.
+            Maximum image size: 5 MiB after decoding the base64 content.
 
             Format: `data:image/png;base64,<base64_data>`
           type: string

--- a/spx-gui/AGENTS.md
+++ b/spx-gui/AGENTS.md
@@ -26,6 +26,15 @@ Keep import statements in order:
 2. Internal libraries: from base to specific, e.g., from `utils` to `models` to `components`
 3. Local files: relative paths starting with `./` or `../`
 
+### String Length Validation
+
+* Use native `string.length`, browser input constraints, and `z.string().max()` for ordinary frontend input validation,
+  following the app's existing validation and feedback patterns.
+* Use `getStringLengthInCodePoints` only when frontend logic must exactly match backend/OpenAPI Unicode code point
+  semantics, or when slicing, truncating, or constructing hard-budget strings such as LLM/API payloads.
+* Count after submission-time normalization such as `trim()`. Use byte or source-file-size checks for explicit byte or
+  payload-size limits.
+
 ### Asset URLs
 
 * For widget-safe full asset URLs, use `new URL('...', import.meta.url).href` instead of `import x from './file.ext?url'`.

--- a/spx-gui/src/apis/admin/account.ts
+++ b/spx-gui/src/apis/admin/account.ts
@@ -27,7 +27,13 @@ export type {
   CreatedAccountAppToken
 } from '@/apis/account/common'
 
-/** Maximum allowed length for an app token name. */
+export const accountUsersKeywordMaxLength = 100
+export const accountUserUsernameMaxLength = 100
+export const accountUserDisplayNameMaxLength = 100
+export const accountUserPasswordMinLength = 8
+export const accountUserPasswordMaxLength = 128
+export const accountAppDisplayNameMaxLength = 100
+export const accountAppSecretNameMaxLength = 100
 export const accountAppTokenNameMaxLength = 100
 
 export type ListAccountUsersParams = PaginationParams & {
@@ -149,7 +155,7 @@ export function listAccountAppGrantTokens(appGrantID: string, params?: ListAccou
 export type CreateAccountAppGrantTokenParams = {
   /** OAuth token type to create */
   tokenType: 'accessToken'
-  /** Human-readable token name. Maximum length: accountAppTokenNameMaxLength. */
+  /** Human-readable token name */
   name: string
   /** Expiration timestamp */
   expiresAt: string

--- a/spx-gui/src/apis/asset.ts
+++ b/spx-gui/src/apis/asset.ts
@@ -13,6 +13,8 @@ import { client, Visibility } from './common'
 
 export { Visibility }
 
+export const assetDisplayNameMaxLength = 100
+
 export enum AssetType {
   Sprite = 'sprite',
   Backdrop = 'backdrop',

--- a/spx-gui/src/apis/copilot.ts
+++ b/spx-gui/src/apis/copilot.ts
@@ -5,6 +5,8 @@
 import type { JsonSchema7Type } from 'zod-to-json-schema'
 import { client } from './common'
 
+export const copilotMessageContentMaxLength = 40000
+
 export enum ToolType {
   Function = 'function'
 }

--- a/spx-gui/src/apis/project.ts
+++ b/spx-gui/src/apis/project.ts
@@ -7,6 +7,7 @@ import type { Prettify } from '@/utils/types'
 
 export { Visibility }
 
+export const projectNameMaxLength = 100
 export const projectDisplayNameMaxLength = 100
 export const projectDescriptionMaxLength = 400
 export const projectInstructionsMaxLength = 400

--- a/spx-gui/src/apis/user.ts
+++ b/spx-gui/src/apis/user.ts
@@ -1,6 +1,7 @@
 import { client, type ByPage, type PaginationParams } from './common'
 import { ApiException, ApiExceptionCode } from './common/exception'
 
+export const usernameMaxLength = 100
 export const userDisplayNameMaxLength = 100
 export const userDescriptionMaxLength = 200
 

--- a/spx-gui/src/apps/xbuilder/pages/admin/app.vue
+++ b/spx-gui/src/apps/xbuilder/pages/admin/app.vue
@@ -59,6 +59,7 @@ const savedRedirectURIs = ref<string[]>([])
 const savedAllowedOrigins = ref<string[]>([])
 const appUpdatedAt = ref('')
 const appFallbackText = computed(() => displayName.value.trim().charAt(0).toUpperCase() || '?')
+const trimmedDisplayName = computed(() => displayName.value.trim())
 
 watch(
   app,
@@ -81,7 +82,7 @@ const parsedRedirectURIs = computed(() => parseLines(redirectURIs.value))
 const parsedAllowedOrigins = computed(() => parseLines(allowedOrigins.value))
 const isActive = computed(() => status.value === 'active')
 const isIdentityChanged = computed(
-  () => displayName.value.trim() !== '' && displayName.value.trim() !== savedDisplayName.value
+  () => trimmedDisplayName.value !== '' && trimmedDisplayName.value !== savedDisplayName.value
 )
 const isStatusChanged = computed(() => status.value !== savedStatus.value)
 const areEndpointsChanged = computed(
@@ -114,7 +115,7 @@ function refetchAll() {
 
 const handleUpdateIdentity = useMessageHandle(
   async () => {
-    const updated = await accountAdminApis.updateAccountApp(props.appID, { displayName: displayName.value.trim() })
+    const updated = await accountAdminApis.updateAccountApp(props.appID, { displayName: trimmedDisplayName.value })
     savedDisplayName.value = updated.displayName
     appUpdatedAt.value = updated.updatedAt
   },
@@ -148,10 +149,12 @@ const handleUpdateStatus = useMessageHandle(
 
 const secretName = ref('')
 const createdSecret = ref<accountAdminApis.CreatedAccountAppSecret | null>(null)
+const trimmedSecretName = computed(() => secretName.value.trim())
+const isSecretNameValid = computed(() => trimmedSecretName.value !== '')
 
 const handleCreateSecret = useMessageHandle(
   async () => {
-    const secret = await accountAdminApis.createAccountAppSecret(props.appID, { name: secretName.value.trim() })
+    const secret = await accountAdminApis.createAccountAppSecret(props.appID, { name: trimmedSecretName.value })
     createdSecret.value = secret
     secretName.value = ''
     secretsQuery.refetch()
@@ -247,7 +250,6 @@ function deleteSecret(secretID: string) {
           icon="reload"
           shape="square"
           type="white"
-          :aria-label="$t({ en: 'Refresh app details', zh: '刷新应用详情' })"
           @click="refetchAll"
         />
       </header>
@@ -277,7 +279,10 @@ function deleteSecret(secretID: string) {
                 </div>
                 <label class="flex flex-col gap-1 text-sm text-grey-900">
                   {{ $t({ en: 'Display name', zh: '显示名称' }) }}
-                  <UITextInput v-model:value="displayName" maxlength="100" />
+                  <UITextInput
+                    v-model:value="displayName"
+                    :maxlength="accountAdminApis.accountAppDisplayNameMaxLength"
+                  />
                 </label>
                 <div class="text-sm">
                   <div class="text-grey-800">{{ $t({ en: 'Client ID', zh: '客户端 ID' }) }}</div>
@@ -399,7 +404,6 @@ function deleteSecret(secretID: string) {
                   desc: 'Enable or disable OAuth flows for this app'
                 }"
                 :value="isActive"
-                :aria-label="$t({ en: 'App availability', zh: '应用可用状态' })"
                 @update:value="handleActiveChange"
               />
             </div>
@@ -464,7 +468,7 @@ function deleteSecret(secretID: string) {
               <form class="mb-4 flex flex-col gap-3" @submit.prevent="handleCreateSecret.fn">
                 <label class="flex flex-col gap-1 text-sm text-grey-900">
                   {{ $t({ en: 'New secret name', zh: '新密钥名称' }) }}
-                  <UITextInput v-model:value="secretName" maxlength="100" />
+                  <UITextInput v-model:value="secretName" :maxlength="accountAdminApis.accountAppSecretNameMaxLength" />
                   <span class="text-xs text-grey-700">
                     {{
                       $t({
@@ -477,7 +481,7 @@ function deleteSecret(secretID: string) {
                 <UIButton
                   html-type="submit"
                   type="primary"
-                  :disabled="secretName.trim() === ''"
+                  :disabled="!isSecretNameValid"
                   :loading="handleCreateSecret.isLoading.value"
                 >
                   {{ $t({ en: 'Create secret', zh: '创建密钥' }) }}

--- a/spx-gui/src/apps/xbuilder/pages/admin/grant.vue
+++ b/spx-gui/src/apps/xbuilder/pages/admin/grant.vue
@@ -66,6 +66,7 @@ usePageTitle(() =>
 )
 
 const tokensPageSize = 20
+const maxTokenLifetimeDays = 365
 const tokensPage = ref(1)
 const tokenTypeFilter = ref<'all' | accountAdminApis.AccountAppTokenType>('accessToken')
 const tokensQuery = useQuery(
@@ -88,17 +89,12 @@ watch(tokenTypeFilter, () => {
 
 const showCreateForm = ref(false)
 const tokenName = ref('')
+const trimmedTokenName = computed(() => tokenName.value.trim())
 const createdToken = ref<accountAdminApis.CreatedAccountAppToken | null>(null)
 const minExpiresAtInput = ref(formatDateTimeLocal(dayjs()))
-const maxExpiresAtInput = ref(formatDateTimeLocal(dayjs().add(365, 'day')))
+const maxExpiresAtInput = ref(formatDateTimeLocal(dayjs().add(maxTokenLifetimeDays, 'day')))
 const expiresAtInput = ref(formatDateTimeLocal(defaultTokenExpiresAt()))
-const isCreateTokenValid = computed(
-  () =>
-    tokenName.value.trim() !== '' &&
-    tokenName.value.length <= accountAdminApis.accountAppTokenNameMaxLength &&
-    expiresAtInput.value !== ''
-)
-const maxTokenLifetimeDays = 365
+const isCreateTokenValid = computed(() => trimmedTokenName.value !== '' && expiresAtInput.value !== '')
 
 function formatDateTimeLocal(value: dayjs.Dayjs) {
   return value.format('YYYY-MM-DDTHH:mm')
@@ -147,7 +143,7 @@ const handleCreateToken = useMessageHandle(
   async () => {
     const token = await accountAdminApis.createAccountAppGrantToken(props.grantID, {
       tokenType: 'accessToken',
-      name: tokenName.value.trim(),
+      name: trimmedTokenName.value,
       expiresAt: dayjs(expiresAtInput.value).toISOString()
     })
     createdToken.value = token
@@ -176,7 +172,7 @@ const handleRevokeToken = useMessageHandle(
     tokensQuery.refetch()
   },
   { en: 'Failed to revoke token', zh: '撤销 token 失败' },
-  { en: 'Token revoked', zh: 'token 已撤销' }
+  { en: 'Token revoked', zh: '已撤销 token' }
 ).fn
 
 function dismissCreatedToken() {
@@ -266,7 +262,6 @@ function dismissCreatedToken() {
           icon="reload"
           shape="square"
           type="white"
-          :aria-label="$t({ en: 'Refresh grant details', zh: '刷新授权详情' })"
           @click="refetchAll"
         />
       </header>
@@ -337,7 +332,7 @@ function dismissCreatedToken() {
                   {{
                     $t({
                       en: 'Creates an Access token under this grant. The token value is shown only once.',
-                      zh: '基于此授权创建 Access token。token 值只会展示一次。'
+                      zh: '基于此授权创建 Access token。该 token 值只会展示一次。'
                     })
                   }}
                 </p>

--- a/spx-gui/src/apps/xbuilder/pages/admin/users.vue
+++ b/spx-gui/src/apps/xbuilder/pages/admin/users.vue
@@ -92,6 +92,12 @@ const handleCreateUser = useMessageHandle(
     const displayName = createForm.displayName.trim() || username
     const password = createForm.password.trim()
     if (password === '') throw new DefaultException({ en: 'Password is required', zh: '密码不能为空' })
+    if (password.length < accountAdminApis.accountUserPasswordMinLength) {
+      throw new DefaultException({
+        en: `The password must be at least ${accountAdminApis.accountUserPasswordMinLength} characters`,
+        zh: `密码长度不能少于 ${accountAdminApis.accountUserPasswordMinLength} 个字符`
+      })
+    }
 
     const user = await accountAdminApis.createAccountUser({ username, displayName, password })
     await router.push(`/admin/users/${encodeURIComponent(user.id)}`)
@@ -142,18 +148,30 @@ async function handleImportUsers() {
       <div class="grid grid-cols-1 gap-4 tablet:grid-cols-3">
         <label class="flex flex-col gap-1 text-sm text-grey-900">
           {{ $t({ en: 'Username', zh: '用户名' }) }}
-          <UITextInput v-model:value="createForm.username" required />
+          <UITextInput
+            v-model:value="createForm.username"
+            required
+            :maxlength="accountAdminApis.accountUserUsernameMaxLength"
+          />
         </label>
         <label class="flex flex-col gap-1 text-sm text-grey-900">
           {{ $t({ en: 'Display name', zh: '显示名称' }) }}
-          <UITextInput v-model:value="createForm.displayName" />
+          <UITextInput
+            v-model:value="createForm.displayName"
+            :maxlength="accountAdminApis.accountUserDisplayNameMaxLength"
+          />
           <span class="text-xs text-grey-700">
             {{ $t({ en: 'Leave empty to use username.', zh: '留空则使用用户名。' }) }}
           </span>
         </label>
         <label class="flex flex-col gap-1 text-sm text-grey-900">
           {{ $t({ en: 'Initial password', zh: '初始密码' }) }}
-          <UITextInput v-model:value="createForm.password" type="password" required />
+          <UITextInput
+            v-model:value="createForm.password"
+            type="password"
+            required
+            :maxlength="accountAdminApis.accountUserPasswordMaxLength"
+          />
         </label>
       </div>
       <div class="mt-4 flex justify-end">
@@ -190,6 +208,7 @@ async function handleImportUsers() {
             v-model:value="keywordInput"
             clearable
             class="w-64 max-w-full"
+            :maxlength="accountAdminApis.accountUsersKeywordMaxLength"
             :placeholder="$t({ en: 'Username or display name', zh: '用户名或显示名称' })"
           />
           <UISelect v-model:value="sortOrder" class="w-32">

--- a/spx-gui/src/apps/xbuilder/pages/sign-in/token.vue
+++ b/spx-gui/src/apps/xbuilder/pages/sign-in/token.vue
@@ -8,7 +8,7 @@
           v-radar="{ name: 'Token input', desc: 'Input field for authentication token' }"
           class="justify-self-stretch h-40"
           type="textarea"
-          :placeholder="$t({ en: 'Paste token here', zh: '在此粘贴 Token' })"
+          :placeholder="$t({ en: 'Paste token here', zh: '在此粘贴 token' })"
         />
       </UIFormItem>
       <footer class="mt-4 flex justify-center gap-4">
@@ -41,7 +41,7 @@ import { UIForm, UIFormItem, UITextInput, UIButton, useForm } from '@/components
 
 const title = {
   en: 'Sign in with token',
-  zh: '使用 Token 登录'
+  zh: '使用 token 登录'
 }
 
 usePageTitle(title)
@@ -58,7 +58,7 @@ function validateToken(token: string) {
   if (token === '')
     return i18n.t({
       en: 'Token is required',
-      zh: '请提供 Token'
+      zh: '请提供 token'
     })
 }
 

--- a/spx-gui/src/components/account/admin/account-user-import/csv.test.ts
+++ b/spx-gui/src/components/account/admin/account-user-import/csv.test.ts
@@ -1,28 +1,29 @@
 import { describe, expect, it } from 'vitest'
 
+import * as accountAdminApis from '@/apis/admin/account'
 import { parseAccountUserImportCsv } from './csv'
 
 describe('parseAccountUserImportCsv', () => {
   it('parses account users from CSV', () => {
     const result = parseAccountUserImportCsv(`username,displayName,password
-alice,Alice,pass123
-bob,Bob,pass456
+alice,Alice,pass1234
+bob,Bob,pass4567
 `)
 
     expect(result.errors).toEqual([])
     expect(result.rows).toEqual([
-      { line: 2, username: 'alice', displayName: 'Alice', password: 'pass123' },
-      { line: 3, username: 'bob', displayName: 'Bob', password: 'pass456' }
+      { line: 2, username: 'alice', displayName: 'Alice', password: 'pass1234' },
+      { line: 3, username: 'bob', displayName: 'Bob', password: 'pass4567' }
     ])
   })
 
   it('trims cells and supports quoted CSV values', () => {
     const result = parseAccountUserImportCsv(` username , displayName , password
- "alice" ,"Alice, A."," pass123 "
+ "alice" ,"Alice, A."," pass1234 "
 `)
 
     expect(result.errors).toEqual([])
-    expect(result.rows).toEqual([{ line: 2, username: 'alice', displayName: 'Alice, A.', password: 'pass123' }])
+    expect(result.rows).toEqual([{ line: 2, username: 'alice', displayName: 'Alice, A.', password: 'pass1234' }])
   })
 
   it('requires all required headers', () => {
@@ -38,20 +39,20 @@ alice,Alice
 
   it('uses username as display name when display name is empty or absent', () => {
     const result = parseAccountUserImportCsv(`username,password
-alice,pass123
-bob,pass456
+alice,pass1234
+bob,pass4567
 `)
 
     expect(result.errors).toEqual([])
     expect(result.rows).toEqual([
-      { line: 2, username: 'alice', displayName: 'alice', password: 'pass123' },
-      { line: 3, username: 'bob', displayName: 'bob', password: 'pass456' }
+      { line: 2, username: 'alice', displayName: 'alice', password: 'pass1234' },
+      { line: 3, username: 'bob', displayName: 'bob', password: 'pass4567' }
     ])
   })
 
   it('validates required fields', () => {
     const result = parseAccountUserImportCsv(`username,displayName,password
-,,pass123
+,,pass1234
 bob,Bob,
 `)
 
@@ -60,15 +61,72 @@ bob,Bob,
       { line: 3, message: { en: 'Password is required', zh: '密码不能为空' } }
     ])
     expect(result.rows).toEqual([
-      { line: 2, username: '', displayName: '', password: 'pass123' },
+      { line: 2, username: '', displayName: '', password: 'pass1234' },
       { line: 3, username: 'bob', displayName: 'Bob', password: '' }
     ])
   })
 
+  it('validates field lengths', () => {
+    const longUsername = 'a'.repeat(accountAdminApis.accountUserUsernameMaxLength + 1)
+    const longDisplayName = 'n'.repeat(accountAdminApis.accountUserDisplayNameMaxLength + 1)
+    const shortPassword = 'p'.repeat(accountAdminApis.accountUserPasswordMinLength - 1)
+    const longPassword = 'p'.repeat(accountAdminApis.accountUserPasswordMaxLength + 1)
+
+    const result = parseAccountUserImportCsv(`username,displayName,password
+${longUsername},Alice,validpass
+bob,${longDisplayName},validpass
+carl,Carl,${shortPassword}
+dave,Dave,${longPassword}
+`)
+
+    expect(result.errors).toEqual([
+      {
+        line: 2,
+        message: {
+          en: `The username is too long (maximum is ${accountAdminApis.accountUserUsernameMaxLength} characters)`,
+          zh: `用户名长度超出限制（最多 ${accountAdminApis.accountUserUsernameMaxLength} 个字符）`
+        }
+      },
+      {
+        line: 3,
+        message: {
+          en: `The display name is too long (maximum is ${accountAdminApis.accountUserDisplayNameMaxLength} characters)`,
+          zh: `显示名称长度超出限制（最多 ${accountAdminApis.accountUserDisplayNameMaxLength} 个字符）`
+        }
+      },
+      {
+        line: 4,
+        message: {
+          en: `The password must be at least ${accountAdminApis.accountUserPasswordMinLength} characters`,
+          zh: `密码长度不能少于 ${accountAdminApis.accountUserPasswordMinLength} 个字符`
+        }
+      },
+      {
+        line: 5,
+        message: {
+          en: `The password is too long (maximum is ${accountAdminApis.accountUserPasswordMaxLength} characters)`,
+          zh: `密码长度超出限制（最多 ${accountAdminApis.accountUserPasswordMaxLength} 个字符）`
+        }
+      }
+    ])
+  })
+
+  it('counts Unicode code points when validating field lengths', () => {
+    const displayName = '\u{1f600}'.repeat(accountAdminApis.accountUserDisplayNameMaxLength)
+    const password = '\u{1f600}'.repeat(accountAdminApis.accountUserPasswordMinLength)
+
+    const result = parseAccountUserImportCsv(`username,displayName,password
+emoji,${displayName},${password}
+`)
+
+    expect(result.errors).toEqual([])
+    expect(result.rows).toEqual([{ line: 2, username: 'emoji', displayName, password }])
+  })
+
   it('validates duplicate usernames', () => {
     const result = parseAccountUserImportCsv(`username,displayName,password
-alice,Alice,pass123
-alice,Alice 2,pass456
+alice,Alice,pass1234
+alice,Alice 2,pass4567
 `)
 
     expect(result.errors).toEqual([
@@ -79,15 +137,15 @@ alice,Alice 2,pass456
   it('keeps source line numbers when CSV contains empty lines', () => {
     const result = parseAccountUserImportCsv(`username,displayName,password
 
-alice,Alice,pass123
+alice,Alice,pass1234
 
-alice,Alice 2,pass456
+alice,Alice 2,pass4567
 bob,Bob,
 `)
 
     expect(result.rows).toEqual([
-      { line: 3, username: 'alice', displayName: 'Alice', password: 'pass123' },
-      { line: 5, username: 'alice', displayName: 'Alice 2', password: 'pass456' },
+      { line: 3, username: 'alice', displayName: 'Alice', password: 'pass1234' },
+      { line: 5, username: 'alice', displayName: 'Alice 2', password: 'pass4567' },
       { line: 6, username: 'bob', displayName: 'Bob', password: '' }
     ])
     expect(result.errors).toEqual([

--- a/spx-gui/src/components/account/admin/account-user-import/csv.ts
+++ b/spx-gui/src/components/account/admin/account-user-import/csv.ts
@@ -1,5 +1,8 @@
 import { parse, type InfoRecord } from 'csv-parse/browser/esm/sync'
+
 import type { LocaleMessage } from '@/utils/i18n'
+import { getStringLengthInCodePoints } from '@/utils/utils'
+import * as accountAdminApis from '@/apis/admin/account'
 
 export type AccountUserImportRow = {
   line: number
@@ -77,9 +80,47 @@ export function parseAccountUserImportCsv(csv: string): AccountUserImportParseRe
     const username = readCell(record, headerIndex.username)
     const displayName = readCell(record, headerIndex.displayName) || username
     const password = readCell(record, headerIndex.password)
+    const usernameLength = getStringLengthInCodePoints(username)
+    const displayNameLength = getStringLengthInCodePoints(displayName)
+    const passwordLength = getStringLengthInCodePoints(password)
 
     if (username === '') errors.push({ line, message: { en: 'Username is required', zh: '用户名不能为空' } })
+    else if (usernameLength > accountAdminApis.accountUserUsernameMaxLength) {
+      errors.push({
+        line,
+        message: {
+          en: `The username is too long (maximum is ${accountAdminApis.accountUserUsernameMaxLength} characters)`,
+          zh: `用户名长度超出限制（最多 ${accountAdminApis.accountUserUsernameMaxLength} 个字符）`
+        }
+      })
+    }
+    if (displayNameLength > accountAdminApis.accountUserDisplayNameMaxLength) {
+      errors.push({
+        line,
+        message: {
+          en: `The display name is too long (maximum is ${accountAdminApis.accountUserDisplayNameMaxLength} characters)`,
+          zh: `显示名称长度超出限制（最多 ${accountAdminApis.accountUserDisplayNameMaxLength} 个字符）`
+        }
+      })
+    }
     if (password === '') errors.push({ line, message: { en: 'Password is required', zh: '密码不能为空' } })
+    else if (passwordLength < accountAdminApis.accountUserPasswordMinLength) {
+      errors.push({
+        line,
+        message: {
+          en: `The password must be at least ${accountAdminApis.accountUserPasswordMinLength} characters`,
+          zh: `密码长度不能少于 ${accountAdminApis.accountUserPasswordMinLength} 个字符`
+        }
+      })
+    } else if (passwordLength > accountAdminApis.accountUserPasswordMaxLength) {
+      errors.push({
+        line,
+        message: {
+          en: `The password is too long (maximum is ${accountAdminApis.accountUserPasswordMaxLength} characters)`,
+          zh: `密码长度超出限制（最多 ${accountAdminApis.accountUserPasswordMaxLength} 个字符）`
+        }
+      })
+    }
 
     const previousLine = usernameLines.get(username)
     if (username !== '' && previousLine != null) {

--- a/spx-gui/src/components/community/user/ModifyUsernameModal.vue
+++ b/spx-gui/src/components/community/user/ModifyUsernameModal.vue
@@ -9,7 +9,7 @@ import {
   useForm,
   type FormValidationResult
 } from '@/components/ui'
-import { isUsernameTaken } from '@/apis/user'
+import { isUsernameTaken, usernameMaxLength } from '@/apis/user'
 import { useModifySignedInUsername } from '@/stores/user'
 import { useMessageHandle } from '@/utils/exception'
 import { useI18n } from '@/utils/i18n'
@@ -40,10 +40,10 @@ async function validateUsername(val: string): Promise<FormValidationResult> {
       en: 'The username can only contain letters, digits, and the characters - and _.',
       zh: '用户名仅可包含字母、数字以及字符 - 和 _。'
     })
-  if (trimmed.length > 100)
+  if (trimmed.length > usernameMaxLength)
     return t({
-      en: 'The username is too long (maximum is 100 characters)',
-      zh: '用户名长度超出限制（最多 100 个字符）'
+      en: `The username is too long (maximum is ${usernameMaxLength} characters)`,
+      zh: `用户名长度超出限制（最多 ${usernameMaxLength} 个字符）`
     })
 
   if (await isUsernameTaken(trimmed))

--- a/spx-gui/src/components/copilot/CopilotInput.vue
+++ b/spx-gui/src/components/copilot/CopilotInput.vue
@@ -1,5 +1,9 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue'
+import { copilotMessageContentMaxLength } from '@/apis/copilot'
+import { useI18n } from '@/utils/i18n'
+import { getStringLengthInCodePoints } from '@/utils/utils'
+import { useMessage } from '@/components/ui'
 import { RoundState, type Copilot } from './copilot'
 
 const props = defineProps<{
@@ -8,6 +12,8 @@ const props = defineProps<{
 
 const inputStr = ref('')
 const textareaRef = ref<HTMLTextAreaElement>()
+const i18n = useI18n()
+const message = useMessage()
 const round = computed(() => props.copilot.currentSession?.currentRound ?? null)
 const loading = computed(() => {
   return round.value != null && [RoundState.Loading, RoundState.InProgress].includes(round.value.state)
@@ -24,6 +30,15 @@ const placeholder = computed(() => {
 function handleSubmit() {
   const problem = inputStr.value.trim()
   if (problem === '') return
+  if (getStringLengthInCodePoints(problem) > copilotMessageContentMaxLength) {
+    message.error(
+      i18n.t({
+        en: `The input must be ${copilotMessageContentMaxLength} characters or fewer`,
+        zh: `输入不能超过 ${copilotMessageContentMaxLength} 字`
+      })
+    )
+    return
+  }
   inputStr.value = ''
   props.copilot.addUserTextMessage(problem)
 }

--- a/spx-gui/src/components/copilot/CopilotRoot.vue
+++ b/spx-gui/src/components/copilot/CopilotRoot.vue
@@ -5,7 +5,7 @@ import { onBeforeUnmount, onUnmounted, toValue, watch, type WatchSource } from '
 import { useRouter, type Router } from 'vue-router'
 import { useRadar, type Radar, type RadarNodeInfo } from '@/utils/radar'
 import { useI18n, type I18n } from '@/utils/i18n'
-import { escapeHTML, unicodeSafeSlice, until } from '@/utils/utils'
+import { escapeHTML, getStringLengthInCodePoints, unicodeSafeSlice, until } from '@/utils/utils'
 import { useIsRouteLoaded } from '@/utils/route-loading'
 import * as projectApis from '@/apis/project'
 import { projectSearchKeywordMaxLength } from '@/apis/project'
@@ -30,7 +30,9 @@ const listProjectsParamsSchema = z.object({
     .describe('List projects visible to the current session across all users. Do not use this with owner'),
   keyword: z
     .string()
-    .max(projectSearchKeywordMaxLength)
+    .refine((value) => getStringLengthInCodePoints(value) <= projectSearchKeywordMaxLength, {
+      message: `Must be ${projectSearchKeywordMaxLength} characters or fewer`
+    })
     .optional()
     .describe('Keyword in the project display name or project name'),
   pageSize: z.number().describe('Number of projects to return per page'),
@@ -73,7 +75,8 @@ class GetUINodeTextContentTool implements ToolDefinition {
     const nodeInfo = this.radar.getNodeById(targetId)
     if (nodeInfo == null) throw new Error(`Radar node with ID ${targetId} not found.`)
     const textContent = nodeInfo.getElement()?.textContent ?? ''
-    return textContent.length > 500 ? unicodeSafeSlice(textContent, 0, 500) + '...' : textContent
+    const textContentPreview = unicodeSafeSlice(textContent, 0, 500)
+    return textContentPreview === textContent ? textContent : textContentPreview + '...'
   }
 }
 

--- a/spx-gui/src/components/editor/navbar/EditorProjectDisplayName.vue
+++ b/spx-gui/src/components/editor/navbar/EditorProjectDisplayName.vue
@@ -145,6 +145,7 @@ function handleInputEsc() {
           v-model:value="displayName"
           v-radar="{ name: 'Project display name input', desc: 'Input field for project display name' }"
           class="w-62 text-xl"
+          :maxlength="projectDisplayNameMaxLength"
           @keydown.esc.prevent="handleInputEsc"
           @blur="handleInputBlur"
         />

--- a/spx-gui/src/components/project/ProjectCreateModal.vue
+++ b/spx-gui/src/components/project/ProjectCreateModal.vue
@@ -48,7 +48,14 @@ import {
   useForm,
   type FormValidationResult
 } from '@/components/ui'
-import { addProject, isProjectNameTaken, ProjectType, Visibility, parseRemixSource } from '@/apis/project'
+import {
+  addProject,
+  isProjectNameTaken,
+  ProjectType,
+  projectNameMaxLength,
+  Visibility,
+  parseRemixSource
+} from '@/apis/project'
 import { useI18n } from '@/utils/i18n'
 import { useMessageHandle } from '@/utils/exception'
 import { untilLoaded } from '@/utils/query'
@@ -131,10 +138,10 @@ async function validateName(name: string): Promise<FormValidationResult> {
       zh: '项目名仅可包含字母、数字以及字符 - 和 _。'
     })
 
-  if (name.length > 100)
+  if (name.length > projectNameMaxLength)
     return t({
-      en: 'The project name is too long (maximum is 100 characters)',
-      zh: '项目名长度超出限制（最多 100 个字符）'
+      en: `The project name is too long (maximum is ${projectNameMaxLength} characters)`,
+      zh: `项目名长度超出限制（最多 ${projectNameMaxLength} 个字符）`
     })
 
   // check naming conflict

--- a/spx-gui/src/components/project/ProjectModifyNameModal.vue
+++ b/spx-gui/src/components/project/ProjectModifyNameModal.vue
@@ -9,7 +9,7 @@ import {
   useForm,
   type FormValidationResult
 } from '@/components/ui'
-import { isProjectNameTaken, updateProject } from '@/apis/project'
+import { isProjectNameTaken, projectNameMaxLength, updateProject } from '@/apis/project'
 import type { SpxProject } from '@/models/spx/project'
 import { useMessageHandle } from '@/utils/exception'
 import { useI18n } from '@/utils/i18n'
@@ -64,10 +64,10 @@ async function validateName(name: string): Promise<FormValidationResult> {
       zh: '项目名仅可包含字母、数字以及字符 - 和 _。'
     })
 
-  if (name.length > 100)
+  if (name.length > projectNameMaxLength)
     return t({
-      en: 'The project name is too long (maximum is 100 characters)',
-      zh: '项目名长度超出限制（最多 100 个字符）'
+      en: `The project name is too long (maximum is ${projectNameMaxLength} characters)`,
+      zh: `项目名长度超出限制（最多 ${projectNameMaxLength} 个字符）`
     })
 
   if (name.toLowerCase() === currentName.value.toLowerCase()) return

--- a/spx-gui/src/components/ui/input/UITextInput.test.ts
+++ b/spx-gui/src/components/ui/input/UITextInput.test.ts
@@ -38,4 +38,23 @@ describe('UITextInput', () => {
     expect(wrapper.emitted('focus')).toHaveLength(1)
     expect(wrapper.emitted('blur')).toHaveLength(1)
   })
+
+  it('passes maxlength to the native text control', () => {
+    const inputWrapper = mount(UITextInput, {
+      props: {
+        value: '',
+        maxlength: 100
+      }
+    })
+    expect(inputWrapper.get('input').attributes('maxlength')).toBe('100')
+
+    const textareaWrapper = mount(UITextInput, {
+      props: {
+        value: '',
+        type: 'textarea',
+        maxlength: 200
+      }
+    })
+    expect(textareaWrapper.get('textarea').attributes('maxlength')).toBe('200')
+  })
 })

--- a/spx-gui/src/components/ui/input/UITextInput.vue
+++ b/spx-gui/src/components/ui/input/UITextInput.vue
@@ -20,6 +20,7 @@
       :disabled="props.disabled"
       :readonly="props.readonly"
       :rows="props.rows"
+      :maxlength="props.maxlength"
       @input="handleTextInput"
       @focus="handleFocus"
       @blur="handleBlur"
@@ -36,6 +37,7 @@
       :type="inputType"
       :disabled="props.disabled"
       :readonly="props.readonly"
+      :maxlength="props.maxlength"
       @input="handleTextInput"
       @focus="handleFocus"
       @blur="handleBlur"
@@ -102,6 +104,7 @@ const props = withDefaults(
     placeholder?: string
     autofocus?: boolean
     rows?: number
+    maxlength?: number
   }>(),
   {
     type: undefined,
@@ -112,7 +115,8 @@ const props = withDefaults(
     readonly: false,
     placeholder: undefined,
     autofocus: false,
-    rows: 3
+    rows: 3,
+    maxlength: undefined
   }
 )
 

--- a/spx-gui/src/models/spx/common/asset-name.ts
+++ b/spx-gui/src/models/spx/common/asset-name.ts
@@ -1,5 +1,6 @@
 import type { LocaleMessage } from '@/utils/i18n'
-import { lowFirst, unicodeSafeSlice, upFirst } from '@/utils/utils'
+import { assetDisplayNameMaxLength } from '@/apis/asset'
+import { getStringLengthInCodePoints, lowFirst, unicodeSafeSlice, upFirst } from '@/utils/utils'
 import { getXGoIdentifierNameTip, normalizeXGoIdentifierAssetName, validateXGoIdentifierName } from '@/utils/xgo'
 import {
   resourceAnimationName,
@@ -10,29 +11,31 @@ import {
   resourceWidgetName
 } from './resource'
 
+const assetNameMaxLength = 100
+
 function validateAssetName(name: string) {
   if (name === '') return { en: 'The name must not be blank', zh: '名字不可为空' }
-  if (name.length > 100)
+  if (getStringLengthInCodePoints(name) > assetNameMaxLength)
     return {
-      en: 'The name is too long (maximum is 100 characters)',
-      zh: '名字长度超出限制（最多 100 个字符）'
+      en: `The name is too long (maximum is ${assetNameMaxLength} characters)`,
+      zh: `名字长度超出限制（最多 ${assetNameMaxLength} 个字符）`
     }
 }
 
 function getAssetNameTip(asset: LocaleMessage) {
   return {
-    en: `The ${asset.en} name should be non-empty string with length no longer than 100.`,
-    zh: `${asset.zh}名称不可为空，长度不超过 100`
+    en: `The ${asset.en} name should be non-empty string with length no longer than ${assetNameMaxLength}.`,
+    zh: `${asset.zh}名称不可为空，长度不超过 ${assetNameMaxLength}`
   }
 }
 
 export function validateAssetDisplayName(name: string) {
   name = name.trim()
   if (name === '') return { en: 'The asset name must not be blank', zh: '名称不可为空' }
-  if (name.length > 100)
+  if (getStringLengthInCodePoints(name) > assetDisplayNameMaxLength)
     return {
-      en: 'The name is too long (maximum is 100 characters)',
-      zh: '名字长度超出限制（最多 100 个字符）'
+      en: `The name is too long (maximum is ${assetDisplayNameMaxLength} characters)`,
+      zh: `名字长度超出限制（最多 ${assetDisplayNameMaxLength} 个字符）`
     }
 }
 

--- a/spx-gui/src/models/spx/project.ts
+++ b/spx-gui/src/models/spx/project.ts
@@ -11,6 +11,7 @@ import { Disposable, getCleanupSignal, getTimeoutSignal, mergeSignals, promiseFo
 import Mutex from '@/utils/mutex'
 import { Cancelled, capture } from '@/utils/exception'
 import { getSpxProjectKnowledge } from '@/utils/spx'
+import { getStringLengthInCodePoints, unicodeSafeSlice } from '@/utils/utils'
 import { ProjectType, Visibility, type ProjectExtraSettings } from '@/apis/project'
 import { generateProjectDescription } from '@/apis/aigc'
 import { toConfig, type Files, fromConfig, File, toText, getImageSize } from '../common/file'
@@ -37,6 +38,7 @@ export const projectConfigFilePath = join(assetsDir, projectConfigFileName)
 
 const aiDescriptionMaxContentLength = 150_000 // Keep in sync with maxContentLength in spx-backend/internal/controller/aidescription.go
 const aiDescriptionTruncationNotice = '\n[TRUNCATED]\n'
+const aiDescriptionTruncationNoticeLength = getStringLengthInCodePoints(aiDescriptionTruncationNotice)
 const mainFileMaxLength = 60_000
 const spriteFileMaxLength = 20_000
 const projectConfigMaxLength = 15_000
@@ -572,29 +574,32 @@ export class SpxProject extends Disposable implements IProject {
     let result = ''
     const skippedSections: string[] = []
 
-    const append = (value: string) => {
-      if (value.length === 0 || remaining <= 0) return remaining > 0
-      const toWrite = Math.min(value.length, remaining)
-      result += value.slice(0, toWrite)
+    const appendKnownLength = (value: string, valueLength: number) => {
+      if (remaining <= 0) return false
+      if (valueLength === 0) return true
+      const toWrite = Math.min(valueLength, remaining)
+      result += unicodeSafeSlice(value, 0, toWrite)
       remaining -= toWrite
-      return toWrite === value.length
+      return toWrite === valueLength
     }
+    const append = (value: string) => appendKnownLength(value, getStringLengthInCodePoints(value))
     const appendLine = (line: string) => append(`${line}\n`)
     const appendBlankLine = () => append('\n')
 
     const appendBody = (body: string) => {
-      if (body.length === 0) return true
-      if (body.length <= remaining) {
-        return append(body)
+      const bodyLength = getStringLengthInCodePoints(body)
+      if (bodyLength === 0) return true
+      if (bodyLength <= remaining) {
+        return appendKnownLength(body, bodyLength)
       }
-      if (remaining < aiDescriptionTruncationNotice.length) {
+      if (remaining < aiDescriptionTruncationNoticeLength) {
         return false
       }
-      const allowedLength = remaining - aiDescriptionTruncationNotice.length
+      const allowedLength = remaining - aiDescriptionTruncationNoticeLength
       if (allowedLength > 0) {
-        append(body.slice(0, allowedLength))
+        appendKnownLength(unicodeSafeSlice(body, 0, allowedLength), allowedLength)
       }
-      append(aiDescriptionTruncationNotice)
+      appendKnownLength(aiDescriptionTruncationNotice, aiDescriptionTruncationNoticeLength)
       return false
     }
 
@@ -605,13 +610,15 @@ export class SpxProject extends Disposable implements IProject {
       }
 
       const header = `=== ${title} ===`
-      const headerLength = header.length + 1
+      const headerLine = `${header}\n`
+      const headerLength = getStringLengthInCodePoints(headerLine)
       if (remaining <= headerLength) {
         skippedSections.push(title)
         return
       }
 
       const body = await toText(file)
+      const bodyLength = getStringLengthInCodePoints(body)
       let sectionBudget = remaining - headerLength
       if (maxBodyLength != null) sectionBudget = Math.min(sectionBudget, maxBodyLength)
       if (sectionBudget <= 0) {
@@ -619,17 +626,19 @@ export class SpxProject extends Disposable implements IProject {
         return
       }
       let bodyToAppend = body
-      if (body.length > sectionBudget) {
-        const sliceLength = sectionBudget - aiDescriptionTruncationNotice.length
+      let bodyToAppendLength = bodyLength
+      if (bodyLength > sectionBudget) {
+        const sliceLength = sectionBudget - aiDescriptionTruncationNoticeLength
         if (sliceLength <= 0) {
           skippedSections.push(title)
           return
         }
-        bodyToAppend = body.slice(0, sliceLength) + aiDescriptionTruncationNotice
+        bodyToAppend = unicodeSafeSlice(body, 0, sliceLength) + aiDescriptionTruncationNotice
+        bodyToAppendLength = sliceLength + aiDescriptionTruncationNoticeLength
       }
 
-      appendLine(header)
-      append(bodyToAppend)
+      appendKnownLength(headerLine, headerLength)
+      appendKnownLength(bodyToAppend, bodyToAppendLength)
       if (remaining > 0) appendBlankLine()
     }
 
@@ -675,7 +684,7 @@ export class SpxProject extends Disposable implements IProject {
 
     if (skippedSections.length > 0 && remaining > 0) {
       const header = '=== Skipped Sections ==='
-      if (remaining > header.length + 1) {
+      if (remaining > getStringLengthInCodePoints(`${header}\n`)) {
         appendLine(header)
         for (const name of skippedSections) {
           if (remaining <= 0) break

--- a/spx-gui/src/utils/utils.test.ts
+++ b/spx-gui/src/utils/utils.test.ts
@@ -4,6 +4,7 @@ import {
   isImage,
   isSound,
   normalizeDegree,
+  getStringLengthInCodePoints,
   memoizeAsync,
   localStorageRef,
   humanizeListWithLimit,
@@ -88,6 +89,17 @@ describe('normalizeDegree', () => {
     expect(normalizeDegree(-360)).toBe(0)
     expect(normalizeDegree(-450)).toBe(-90)
     expect(normalizeDegree(-720)).toBe(0)
+  })
+})
+
+describe('getStringLengthInCodePoints', () => {
+  it('should count Unicode code points', () => {
+    expect(getStringLengthInCodePoints('abc')).toBe(3)
+    expect(getStringLengthInCodePoints('\u4f60\u597d')).toBe(2)
+    expect(getStringLengthInCodePoints('\u{1f600}')).toBe(1)
+    expect(getStringLengthInCodePoints('\u00e9')).toBe(1)
+    // Precomposed and decomposed forms render the same but have different code point counts.
+    expect(getStringLengthInCodePoints('e\u0301')).toBe(2)
   })
 })
 

--- a/spx-gui/src/utils/utils.ts
+++ b/spx-gui/src/utils/utils.ts
@@ -498,9 +498,15 @@ export function assertNever(input: never): never {
   throw new Error(`Unreachable code reached with input: ${input}`)
 }
 
+/** Return the string length in Unicode code points. */
+export function getStringLengthInCodePoints(value: string) {
+  return Array.from(value).length
+}
+
 /**
  * Safely slice a string by Unicode code points.
- * This prevents breaking surrogate pairs and combining characters.
+ * This prevents breaking surrogate pairs.
+ * Grapheme-cluster boundaries are not preserved.
  * Use this instead of `str.slice(start, end)` when these conditions are met:
  * - The string may include non-BMP characters (e.g., emojis), especially when it is provided by the user
  * - And you are not sure if slicing positions (start / end) are at valid code point boundaries, especially when they are fixed numbers


### PR DESCRIPTION
Use `getStringLengthInCodePoints` for frontend logic that must preserve exact Unicode code point budgets, such as Copilot inputs, AI description payload construction, and spx model string validation.

Keep ordinary form validation on native JavaScript and browser string length behavior, while keeping shared API limits in API modules.

Document when frontend code should use native string length and when it should count Unicode code points.
