### PR TITLE
Add Account user CSV import

### DIFF
--- a/spx-gui/package-lock.json
+++ b/spx-gui/package-lock.json
@@ -34,6 +34,7 @@
         "browserslist": "^4.28.0",
         "browserslist-to-esbuild": "^2.1.1",
         "cropperjs": "^2.1.0",
+        "csv-parse": "^6.2.1",
         "csv-stringify": "^6.5.2",
         "dayjs": "^1.11.10",
         "diff": "^7.0.0",
@@ -4090,6 +4091,12 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
+    },
+    "node_modules/csv-parse": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-6.2.1.tgz",
+      "integrity": "sha512-LRLMV+UCyfMokp8Wb411duBf1gaBKJfOfBWU9eHMJ+b+cJYZsNu3AFmjJf3+yPGd59Exz1TsMjaSFyxnYB9+IQ==",
+      "license": "MIT"
     },
     "node_modules/csv-stringify": {
       "version": "6.5.2",

--- a/spx-gui/package.json
+++ b/spx-gui/package.json
@@ -42,6 +42,7 @@
     "browserslist": "^4.28.0",
     "browserslist-to-esbuild": "^2.1.1",
     "cropperjs": "^2.1.0",
+    "csv-parse": "^6.2.1",
     "csv-stringify": "^6.5.2",
     "dayjs": "^1.11.10",
     "diff": "^7.0.0",

--- a/spx-gui/src/apis/common/exception.ts
+++ b/spx-gui/src/apis/common/exception.ts
@@ -27,6 +27,7 @@ export enum ApiExceptionCode {
   errorForbidden = 40300,
   errorQuotaExceeded = 40301,
   errorNotFound = 40400,
+  errorConflict = 40900,
   errorResourceMoved = 40901,
   errorTooManyRequests = 42900,
   errorRateLimitExceeded = 42901,
@@ -71,6 +72,10 @@ const codeMessages: Record<ApiExceptionCode, LocaleMessage> = {
   [ApiExceptionCode.errorNotFound]: {
     en: 'resource not exist',
     zh: '资源不存在'
+  },
+  [ApiExceptionCode.errorConflict]: {
+    en: 'resource conflict',
+    zh: '资源冲突'
   },
   [ApiExceptionCode.errorResourceMoved]: {
     en: 'resource moved',

--- a/spx-gui/src/apps/xbuilder/pages/admin/users.vue
+++ b/spx-gui/src/apps/xbuilder/pages/admin/users.vue
@@ -3,14 +3,24 @@ import { debounce } from 'lodash'
 import { computed, onUnmounted, reactive, ref, watch } from 'vue'
 import { RouterLink, useRouter } from 'vue-router'
 
-import { useMessageHandle } from '@/utils/exception'
+import { DefaultException, useMessageHandle } from '@/utils/exception'
 import { useQuery } from '@/utils/query'
 import { useRouteQueryParamInt, useRouteQueryParamStr, useRouteQueryParamStrEnum } from '@/utils/route'
 import { usePageTitle } from '@/utils/utils'
 import { SortOrder } from '@/apis/common'
 import { useSignedInStateQuery } from '@/stores/user'
-import { UIButton, UIError, UILoading, UIPagination, UISelect, UISelectOption, UITextInput } from '@/components/ui'
+import {
+  UIButton,
+  UIError,
+  UILoading,
+  UIPagination,
+  UISelect,
+  UISelectOption,
+  UITextInput,
+  useModal
+} from '@/components/ui'
 import * as accountAdminApis from '@/apis/admin/account'
+import AccountUserImportModal from '@/components/account/admin/account-user-import/AccountUserImportModal.vue'
 import { formatTime } from './common'
 
 const signedInStateQuery = useSignedInStateQuery()
@@ -24,6 +34,7 @@ const sortOrder = useRouteQueryParamStrEnum('order', SortOrder, SortOrder.Desc, 
 const keyword = useRouteQueryParamStr('q', '', resetPage)
 const keywordInput = ref(keyword.value)
 const showCreateForm = ref(false)
+const invokeAccountUserImportModal = useModal(AccountUserImportModal)
 
 const createForm = reactive({
   username: '',
@@ -75,15 +86,26 @@ usePageTitle({ en: 'Users', zh: '用户' })
 
 const handleCreateUser = useMessageHandle(
   async () => {
-    const user = await accountAdminApis.createAccountUser({
-      username: createForm.username.trim(),
-      displayName: createForm.displayName.trim(),
-      ...(createForm.password.trim() === '' ? {} : { password: createForm.password })
-    })
+    const username = createForm.username.trim()
+    const displayName = createForm.displayName.trim() || username
+    const password = createForm.password.trim()
+    if (username === '') throw new DefaultException({ en: 'Username is required', zh: '用户名不能为空' })
+    if (displayName === '') throw new DefaultException({ en: 'Display name is required', zh: '显示名称不能为空' })
+    if (password === '') throw new DefaultException({ en: 'Password is required', zh: '密码不能为空' })
+
+    const user = await accountAdminApis.createAccountUser({ username, displayName, password })
     await router.push(`/admin/users/${encodeURIComponent(user.id)}`)
   },
   { en: 'Failed to create Account user', zh: '创建账号用户失败' },
   { en: 'Account user created', zh: '账号用户已创建' }
+)
+
+const handleImportUsers = useMessageHandle(
+  async () => {
+    await invokeAccountUserImportModal({})
+    void usersQuery.refetch()
+  },
+  { en: 'Failed to import Account users', zh: '导入账号用户失败' }
 )
 </script>
 
@@ -96,14 +118,18 @@ const handleCreateUser = useMessageHandle(
           {{ $t({ en: 'Browse and create Account users.', zh: '浏览和创建账号用户。' }) }}
         </p>
       </div>
-      <UIButton
-        v-if="canManageAccount"
-        :icon="showCreateForm ? 'close' : 'plus'"
-        :type="showCreateForm ? 'white' : 'primary'"
-        @click="showCreateForm = !showCreateForm"
-      >
-        {{ showCreateForm ? $t({ en: 'Cancel', zh: '取消' }) : $t({ en: 'Create user', zh: '创建用户' }) }}
-      </UIButton>
+      <div v-if="canManageAccount" class="flex flex-wrap justify-end gap-2">
+        <UIButton type="white" icon="file" :loading="handleImportUsers.isLoading.value" @click="handleImportUsers.fn">
+          {{ $t({ en: 'Import users', zh: '导入用户' }) }}
+        </UIButton>
+        <UIButton
+          :icon="showCreateForm ? 'close' : 'plus'"
+          :type="showCreateForm ? 'white' : 'primary'"
+          @click="showCreateForm = !showCreateForm"
+        >
+          {{ showCreateForm ? $t({ en: 'Cancel', zh: '取消' }) : $t({ en: 'Create user', zh: '创建用户' }) }}
+        </UIButton>
+      </div>
     </div>
 
     <form
@@ -118,11 +144,14 @@ const handleCreateUser = useMessageHandle(
         </label>
         <label class="flex flex-col gap-1 text-sm text-grey-900">
           {{ $t({ en: 'Display name', zh: '显示名称' }) }}
-          <UITextInput v-model:value="createForm.displayName" required />
+          <UITextInput v-model:value="createForm.displayName" />
+          <span class="text-xs text-grey-700">
+            {{ $t({ en: 'Leave empty to use username.', zh: '留空则使用用户名。' }) }}
+          </span>
         </label>
         <label class="flex flex-col gap-1 text-sm text-grey-900">
           {{ $t({ en: 'Initial password', zh: '初始密码' }) }}
-          <UITextInput v-model:value="createForm.password" type="password" />
+          <UITextInput v-model:value="createForm.password" type="password" required />
         </label>
       </div>
       <div class="mt-4 flex justify-end">

--- a/spx-gui/src/apps/xbuilder/pages/admin/users.vue
+++ b/spx-gui/src/apps/xbuilder/pages/admin/users.vue
@@ -3,7 +3,7 @@ import { debounce } from 'lodash'
 import { computed, onUnmounted, reactive, ref, watch } from 'vue'
 import { RouterLink, useRouter } from 'vue-router'
 
-import { DefaultException, useMessageHandle } from '@/utils/exception'
+import { Cancelled, DefaultException, useMessageHandle } from '@/utils/exception'
 import { useQuery } from '@/utils/query'
 import { useRouteQueryParamInt, useRouteQueryParamStr, useRouteQueryParamStrEnum } from '@/utils/route'
 import { usePageTitle } from '@/utils/utils'
@@ -87,10 +87,10 @@ usePageTitle({ en: 'Users', zh: '用户' })
 const handleCreateUser = useMessageHandle(
   async () => {
     const username = createForm.username.trim()
+    if (username === '') throw new DefaultException({ en: 'Username is required', zh: '用户名不能为空' })
+
     const displayName = createForm.displayName.trim() || username
     const password = createForm.password.trim()
-    if (username === '') throw new DefaultException({ en: 'Username is required', zh: '用户名不能为空' })
-    if (displayName === '') throw new DefaultException({ en: 'Display name is required', zh: '显示名称不能为空' })
     if (password === '') throw new DefaultException({ en: 'Password is required', zh: '密码不能为空' })
 
     const user = await accountAdminApis.createAccountUser({ username, displayName, password })
@@ -100,13 +100,15 @@ const handleCreateUser = useMessageHandle(
   { en: 'Account user created', zh: '账号用户已创建' }
 )
 
-const handleImportUsers = useMessageHandle(
-  async () => {
+async function handleImportUsers() {
+  try {
     await invokeAccountUserImportModal({})
+  } catch (e) {
+    if (!(e instanceof Cancelled)) throw e
+  } finally {
     void usersQuery.refetch()
-  },
-  { en: 'Failed to import Account users', zh: '导入账号用户失败' }
-)
+  }
+}
 </script>
 
 <template>
@@ -119,7 +121,7 @@ const handleImportUsers = useMessageHandle(
         </p>
       </div>
       <div v-if="canManageAccount" class="flex flex-wrap justify-end gap-2">
-        <UIButton type="white" icon="file" :loading="handleImportUsers.isLoading.value" @click="handleImportUsers.fn">
+        <UIButton type="white" icon="file" @click="handleImportUsers">
           {{ $t({ en: 'Import users', zh: '导入用户' }) }}
         </UIButton>
         <UIButton

--- a/spx-gui/src/components/account/admin/account-user-import/AccountUserImportModal.vue
+++ b/spx-gui/src/components/account/admin/account-user-import/AccountUserImportModal.vue
@@ -6,7 +6,7 @@ import { useI18n } from '@/utils/i18n'
 import { useQuery } from '@/utils/query'
 import { UIButton, UIError, UIIcon, UILoading, UIModal, UIModalClose } from '@/components/ui'
 import * as accountAdminApis from '@/apis/admin/account'
-import { parseAccountUserImportCsv, type AccountUserImportRow } from './csv'
+import { parseAccountUserImportCsv, type AccountUserImportError, type AccountUserImportRow } from './csv'
 
 type ImportStatus = 'pending' | 'creating' | 'created' | 'failed'
 
@@ -128,6 +128,14 @@ function getErrorMessage(e: unknown) {
   if (e instanceof Error) return e.message
   return String(e)
 }
+
+function formatImportError(error: AccountUserImportError) {
+  if (error.line == null) return error.message
+  return {
+    en: `Line ${error.line}: ${error.message.en}`,
+    zh: `第 ${error.line} 行：${error.message.zh}`
+  }
+}
 </script>
 
 <template>
@@ -190,11 +198,7 @@ function getErrorMessage(e: unknown) {
         <template #sub-message>
           <div class="mt-3 space-y-1 text-left">
             <div v-for="(error, index) in parseErrors" :key="index">
-              {{
-                error.line == null
-                  ? error.message
-                  : $t({ en: `Line ${error.line}: ${error.message}`, zh: `第 ${error.line} 行：${error.message}` })
-              }}
+              {{ $t(formatImportError(error)) }}
             </div>
           </div>
         </template>

--- a/spx-gui/src/components/account/admin/account-user-import/AccountUserImportModal.vue
+++ b/spx-gui/src/components/account/admin/account-user-import/AccountUserImportModal.vue
@@ -62,7 +62,7 @@ function chooseFile() {
 }
 
 function downloadExampleCsv() {
-  const csv = 'username,displayName,password\nsample-user,Sample User,ChangeMe123!\n'
+  const csv = 'username,displayName,password\nsample-user,Sample User,YOUR_PASSWORD_HERE\n'
   const url = URL.createObjectURL(new Blob([csv], { type: 'text/csv;charset=utf-8' }))
   const link = document.createElement('a')
   link.href = url
@@ -70,7 +70,7 @@ function downloadExampleCsv() {
   document.body.append(link)
   link.click()
   link.remove()
-  window.setTimeout(() => URL.revokeObjectURL(url))
+  window.setTimeout(() => URL.revokeObjectURL(url), 1000)
 }
 
 function handleFileChange(event: Event) {

--- a/spx-gui/src/components/account/admin/account-user-import/AccountUserImportModal.vue
+++ b/spx-gui/src/components/account/admin/account-user-import/AccountUserImportModal.vue
@@ -92,7 +92,7 @@ async function createRows(targetRows: ImportRowState[]) {
         })
         row.status = 'created'
       } catch (e) {
-        if (isConflictError(e)) {
+        if (e instanceof ApiException && e.code === ApiExceptionCode.errorConflict) {
           row.status = 'skipped'
           row.error = t({ en: 'Already exists', zh: '已存在' })
           continue
@@ -128,10 +128,6 @@ function getErrorMessage(e: unknown) {
   if (e instanceof Exception && e.userMessage != null) return t(e.userMessage)
   if (e instanceof Error) return e.message
   return String(e)
-}
-
-function isConflictError(e: unknown) {
-  return e instanceof ApiException && e.code === ApiExceptionCode.errorConflict
 }
 
 function formatImportError(error: AccountUserImportError) {

--- a/spx-gui/src/components/account/admin/account-user-import/AccountUserImportModal.vue
+++ b/spx-gui/src/components/account/admin/account-user-import/AccountUserImportModal.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import saveAs from 'file-saver'
 import { computed, ref, watch } from 'vue'
 
 import { Exception, capture } from '@/utils/exception'
@@ -63,14 +64,7 @@ function chooseFile() {
 
 function downloadExampleCsv() {
   const csv = 'username,displayName,password\nsample-user,Sample User,YOUR_PASSWORD_HERE\n'
-  const url = URL.createObjectURL(new Blob([csv], { type: 'text/csv;charset=utf-8' }))
-  const link = document.createElement('a')
-  link.href = url
-  link.download = 'account-users-example.csv'
-  document.body.append(link)
-  link.click()
-  link.remove()
-  window.setTimeout(() => URL.revokeObjectURL(url), 1000)
+  saveAs(new Blob([csv], { type: 'text/csv;charset=utf-8' }), 'account-users-example.csv')
 }
 
 function handleFileChange(event: Event) {

--- a/spx-gui/src/components/account/admin/account-user-import/AccountUserImportModal.vue
+++ b/spx-gui/src/components/account/admin/account-user-import/AccountUserImportModal.vue
@@ -1,0 +1,287 @@
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+
+import { Exception, capture } from '@/utils/exception'
+import { useI18n } from '@/utils/i18n'
+import { useQuery } from '@/utils/query'
+import { UIButton, UIError, UIIcon, UILoading, UIModal, UIModalClose } from '@/components/ui'
+import * as accountAdminApis from '@/apis/admin/account'
+import { parseAccountUserImportCsv, type AccountUserImportRow } from './csv'
+
+type ImportStatus = 'pending' | 'creating' | 'created' | 'failed'
+
+type ImportRowState = AccountUserImportRow & {
+  status: ImportStatus
+  error: string | null
+}
+
+defineProps<{
+  visible: boolean
+}>()
+
+const emit = defineEmits<{
+  resolved: [void]
+  cancelled: []
+}>()
+
+const { t } = useI18n()
+
+const selectedFile = ref<File | null>(null)
+const fileInputRef = ref<HTMLInputElement | null>(null)
+const rows = ref<ImportRowState[]>([])
+const isCreating = ref(false)
+
+const parseResultQuery = useQuery(
+  async () => {
+    if (selectedFile.value == null) return null
+    const text = await selectedFile.value.text()
+    return parseAccountUserImportCsv(text)
+  },
+  { en: 'Failed to read CSV file', zh: '读取 CSV 文件失败' }
+)
+
+const fileName = computed(() => selectedFile.value?.name ?? '')
+const hasSelectedFile = computed(() => selectedFile.value != null)
+const parseErrors = computed(() => parseResultQuery.data.value?.errors ?? [])
+const validRows = computed(() => rows.value.length > 0 && parseErrors.value.length === 0)
+const createdCount = computed(() => rows.value.filter((row) => row.status === 'created').length)
+const failedRows = computed(() => rows.value.filter((row) => row.status === 'failed'))
+const pendingRows = computed(() => rows.value.filter((row) => row.status === 'pending'))
+const canCreate = computed(() => validRows.value && !isCreating.value && pendingRows.value.length > 0)
+const canRetry = computed(() => validRows.value && !isCreating.value && failedRows.value.length > 0)
+
+watch(
+  () => parseResultQuery.data.value,
+  (result) => {
+    rows.value = result?.rows.map((row) => ({ ...row, status: 'pending', error: null })) ?? []
+  }
+)
+
+function chooseFile() {
+  fileInputRef.value?.click()
+}
+
+function downloadExampleCsv() {
+  const csv = 'username,displayName,password\nsample-user,Sample User,ChangeMe123!\n'
+  const url = URL.createObjectURL(new Blob([csv], { type: 'text/csv;charset=utf-8' }))
+  const link = document.createElement('a')
+  link.href = url
+  link.download = 'account-users-example.csv'
+  document.body.append(link)
+  link.click()
+  link.remove()
+  window.setTimeout(() => URL.revokeObjectURL(url))
+}
+
+function handleFileChange(event: Event) {
+  const input = event.currentTarget as HTMLInputElement
+  const file = input.files?.[0] ?? null
+  input.value = ''
+  if (file == null) return
+  selectedFile.value = file
+}
+
+async function createRows(targetRows: ImportRowState[]) {
+  if (isCreating.value) return
+  isCreating.value = true
+  try {
+    for (const row of targetRows) {
+      row.status = 'creating'
+      row.error = null
+      try {
+        await accountAdminApis.createAccountUser({
+          username: row.username,
+          displayName: row.displayName,
+          password: row.password
+        })
+        row.status = 'created'
+      } catch (e) {
+        row.status = 'failed'
+        row.error = getErrorMessage(e)
+        capture(e)
+      }
+    }
+  } finally {
+    isCreating.value = false
+  }
+}
+
+function handleCreate() {
+  void createRows(pendingRows.value)
+}
+
+function handleRetryFailed() {
+  void createRows(failedRows.value)
+}
+
+function handleClose() {
+  if (isCreating.value) return
+  emit('cancelled')
+}
+
+function handleDone() {
+  emit('resolved')
+}
+
+function getErrorMessage(e: unknown) {
+  if (e instanceof Exception && e.userMessage != null) return t(e.userMessage)
+  if (e instanceof Error) return e.message
+  return String(e)
+}
+</script>
+
+<template>
+  <UIModal
+    :radar="{ name: 'Account user import modal', desc: 'Modal for importing Account users from CSV' }"
+    style="width: 900px; max-height: calc(100vh - 32px)"
+    :visible="visible"
+    :mask-closable="!isCreating"
+    @update:visible="handleClose"
+  >
+    <header class="h-14 flex items-center justify-between border-b border-grey-400 px-6">
+      <h2 class="m-0 text-xl font-semibold text-title">{{ $t({ en: 'Import users', zh: '导入用户' }) }}</h2>
+      <UIModalClose @click="handleClose" />
+    </header>
+
+    <main class="min-h-0 flex-1 overflow-y-auto px-6 py-5">
+      <section class="rounded-lg border border-grey-400 bg-grey-100 p-4">
+        <div class="flex flex-wrap items-center justify-between gap-3">
+          <div class="min-w-0">
+            <div class="font-medium text-title">{{ fileName || $t({ en: 'CSV file', zh: 'CSV 文件' }) }}</div>
+            <div class="mt-1 text-sm text-grey-800">
+              {{
+                $t({
+                  en: 'Required columns: username, password. displayName is optional and defaults to username.',
+                  zh: '必需列：username、password；displayName 可选，留空则使用 username。'
+                })
+              }}
+              <button
+                v-if="!hasSelectedFile"
+                type="button"
+                class="cursor-pointer border-none bg-transparent p-0 text-primary-main underline hover:text-primary-600"
+                @click="downloadExampleCsv"
+              >
+                {{ $t({ en: 'Download example CSV', zh: '下载示例 CSV' }) }}
+              </button>
+            </div>
+          </div>
+          <input
+            ref="fileInputRef"
+            class="hidden"
+            type="file"
+            accept=".csv,text/csv"
+            :disabled="isCreating"
+            @change="handleFileChange"
+          />
+          <UIButton type="white" icon="file" :disabled="isCreating" @click="chooseFile">
+            {{ $t({ en: 'Choose file', zh: '选择文件' }) }}
+          </UIButton>
+        </div>
+      </section>
+
+      <UILoading v-if="parseResultQuery.isLoading.value" class="my-12" />
+
+      <UIError v-else-if="parseResultQuery.error.value != null" class="py-10">
+        {{ $t(parseResultQuery.error.value.userMessage) }}
+      </UIError>
+
+      <UIError v-else-if="parseErrors.length > 0" class="py-10">
+        {{ $t({ en: 'CSV validation failed', zh: 'CSV 校验失败' }) }}
+        <template #sub-message>
+          <div class="mt-3 space-y-1 text-left">
+            <div v-for="(error, index) in parseErrors" :key="index">
+              {{
+                error.line == null
+                  ? error.message
+                  : $t({ en: `Line ${error.line}: ${error.message}`, zh: `第 ${error.line} 行：${error.message}` })
+              }}
+            </div>
+          </div>
+        </template>
+      </UIError>
+
+      <div v-else-if="rows.length > 0" class="mt-5 overflow-hidden rounded-lg border border-grey-400 bg-white">
+        <div class="flex flex-wrap items-center justify-between gap-3 border-b border-grey-300 bg-grey-100 px-5 py-3">
+          <div class="text-sm text-grey-800">
+            {{
+              $t({
+                en: `${rows.length} users, ${createdCount} created, ${failedRows.length} failed`,
+                zh: `共 ${rows.length} 位用户，已创建 ${createdCount} 位，失败 ${failedRows.length} 位`
+              })
+            }}
+          </div>
+        </div>
+        <div class="max-h-[420px] overflow-auto">
+          <table class="w-full min-w-[760px] border-collapse text-left text-sm">
+            <thead class="sticky top-0 bg-grey-200 text-grey-800">
+              <tr class="border-b border-grey-300">
+                <th class="px-5 py-3 font-medium">{{ $t({ en: 'Line', zh: '行' }) }}</th>
+                <th class="px-5 py-3 font-medium">{{ $t({ en: 'Username', zh: '用户名' }) }}</th>
+                <th class="px-5 py-3 font-medium">{{ $t({ en: 'Display name', zh: '显示名称' }) }}</th>
+                <th class="px-5 py-3 font-medium">{{ $t({ en: 'Status', zh: '状态' }) }}</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="row in rows" :key="row.line" class="border-b border-grey-200 last:border-b-0">
+                <td class="px-5 py-3 font-mono text-xs text-grey-800">{{ row.line }}</td>
+                <td class="px-5 py-3">{{ row.username }}</td>
+                <td class="px-5 py-3">{{ row.displayName }}</td>
+                <td class="px-5 py-3">
+                  <div class="flex items-start gap-2">
+                    <UIIcon
+                      v-if="row.status === 'creating'"
+                      class="mt-0.5 h-4 w-4 shrink-0 text-primary-main"
+                      type="loading"
+                    />
+                    <UIIcon
+                      v-else-if="row.status === 'created'"
+                      class="mt-0.5 h-4 w-4 shrink-0 text-green-600"
+                      type="success"
+                    />
+                    <UIIcon
+                      v-else-if="row.status === 'failed'"
+                      class="mt-0.5 h-4 w-4 shrink-0 text-red-500"
+                      type="error"
+                    />
+                    <span>
+                      <template v-if="row.status === 'pending'">{{ $t({ en: 'Pending', zh: '待创建' }) }}</template>
+                      <template v-else-if="row.status === 'creating'">{{
+                        $t({ en: 'Creating', zh: '创建中' })
+                      }}</template>
+                      <template v-else-if="row.status === 'created'">{{
+                        $t({ en: 'Created', zh: '已创建' })
+                      }}</template>
+                      <template v-else>
+                        {{ row.error ?? $t({ en: 'Failed', zh: '失败' }) }}
+                      </template>
+                    </span>
+                  </div>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </main>
+
+    <footer class="flex items-center justify-end gap-3 border-t border-grey-400 px-6 py-4">
+      <UIButton type="white" :disabled="isCreating" @click="handleClose">
+        {{ $t({ en: 'Cancel', zh: '取消' }) }}
+      </UIButton>
+      <UIButton v-if="canRetry" type="primary" icon="reload" :loading="isCreating" @click="handleRetryFailed">
+        {{ $t({ en: 'Retry failed', zh: '重试失败项' }) }}
+      </UIButton>
+      <UIButton v-else-if="canCreate" type="primary" :loading="isCreating" @click="handleCreate">
+        {{ $t({ en: 'Create users', zh: '创建用户' }) }}
+      </UIButton>
+      <UIButton
+        v-else-if="validRows && pendingRows.length === 0"
+        type="primary"
+        :disabled="isCreating"
+        @click="handleDone"
+      >
+        {{ $t({ en: 'Done', zh: '完成' }) }}
+      </UIButton>
+    </footer>
+  </UIModal>
+</template>

--- a/spx-gui/src/components/account/admin/account-user-import/AccountUserImportModal.vue
+++ b/spx-gui/src/components/account/admin/account-user-import/AccountUserImportModal.vue
@@ -8,7 +8,12 @@ import { useQuery } from '@/utils/query'
 import { UIButton, UIError, UIIcon, UILoading, UIModal, UIModalClose } from '@/components/ui'
 import { ApiException, ApiExceptionCode } from '@/apis/common/exception'
 import * as accountAdminApis from '@/apis/admin/account'
-import { parseAccountUserImportCsv, type AccountUserImportError, type AccountUserImportRow } from './csv'
+import {
+  accountUserImportExampleCsv,
+  parseAccountUserImportCsv,
+  type AccountUserImportError,
+  type AccountUserImportRow
+} from './csv'
 
 type ImportStatus = 'pending' | 'creating' | 'created' | 'skipped' | 'failed'
 
@@ -42,8 +47,6 @@ const parseResultQuery = useQuery(
   { en: 'Failed to read CSV file', zh: '读取 CSV 文件失败' }
 )
 
-const fileName = computed(() => selectedFile.value?.name ?? '')
-const hasSelectedFile = computed(() => selectedFile.value != null)
 const parseErrors = computed(() => parseResultQuery.data.value?.errors ?? [])
 const validRows = computed(() => rows.value.length > 0 && parseErrors.value.length === 0)
 const createdCount = computed(() => rows.value.filter((row) => row.status === 'created').length)
@@ -65,8 +68,7 @@ function chooseFile() {
 }
 
 function downloadExampleCsv() {
-  const csv = 'username,displayName,password\nsample-user,Sample User,YOUR_PASSWORD_HERE\n'
-  saveAs(new Blob([csv], { type: 'text/csv;charset=utf-8' }), 'account-users-example.csv')
+  saveAs(new Blob([accountUserImportExampleCsv], { type: 'text/csv;charset=utf-8' }), 'account-users-example.csv')
 }
 
 function handleFileChange(event: Event) {
@@ -156,7 +158,9 @@ function formatImportError(error: AccountUserImportError) {
       <section class="rounded-lg border border-grey-400 bg-grey-100 p-4">
         <div class="flex flex-wrap items-center justify-between gap-3">
           <div class="min-w-0">
-            <div class="font-medium text-title">{{ fileName || $t({ en: 'CSV file', zh: 'CSV 文件' }) }}</div>
+            <div class="font-medium text-title">
+              {{ selectedFile?.name ?? $t({ en: 'CSV file', zh: 'CSV 文件' }) }}
+            </div>
             <div class="mt-1 text-sm text-grey-800">
               {{
                 $t({
@@ -165,7 +169,7 @@ function formatImportError(error: AccountUserImportError) {
                 })
               }}
               <button
-                v-if="!hasSelectedFile"
+                v-if="selectedFile == null"
                 type="button"
                 class="cursor-pointer border-none bg-transparent p-0 text-primary-main underline hover:text-primary-600"
                 @click="downloadExampleCsv"

--- a/spx-gui/src/components/account/admin/account-user-import/AccountUserImportModal.vue
+++ b/spx-gui/src/components/account/admin/account-user-import/AccountUserImportModal.vue
@@ -6,10 +6,11 @@ import { Exception, capture } from '@/utils/exception'
 import { useI18n } from '@/utils/i18n'
 import { useQuery } from '@/utils/query'
 import { UIButton, UIError, UIIcon, UILoading, UIModal, UIModalClose } from '@/components/ui'
+import { ApiException, ApiExceptionCode } from '@/apis/common/exception'
 import * as accountAdminApis from '@/apis/admin/account'
 import { parseAccountUserImportCsv, type AccountUserImportError, type AccountUserImportRow } from './csv'
 
-type ImportStatus = 'pending' | 'creating' | 'created' | 'failed'
+type ImportStatus = 'pending' | 'creating' | 'created' | 'skipped' | 'failed'
 
 type ImportRowState = AccountUserImportRow & {
   status: ImportStatus
@@ -46,6 +47,7 @@ const hasSelectedFile = computed(() => selectedFile.value != null)
 const parseErrors = computed(() => parseResultQuery.data.value?.errors ?? [])
 const validRows = computed(() => rows.value.length > 0 && parseErrors.value.length === 0)
 const createdCount = computed(() => rows.value.filter((row) => row.status === 'created').length)
+const skippedCount = computed(() => rows.value.filter((row) => row.status === 'skipped').length)
 const failedRows = computed(() => rows.value.filter((row) => row.status === 'failed'))
 const pendingRows = computed(() => rows.value.filter((row) => row.status === 'pending'))
 const canCreate = computed(() => validRows.value && !isCreating.value && pendingRows.value.length > 0)
@@ -90,6 +92,11 @@ async function createRows(targetRows: ImportRowState[]) {
         })
         row.status = 'created'
       } catch (e) {
+        if (isConflictError(e)) {
+          row.status = 'skipped'
+          row.error = t({ en: 'Already exists', zh: '已存在' })
+          continue
+        }
         row.status = 'failed'
         row.error = getErrorMessage(e)
         capture(e)
@@ -121,6 +128,10 @@ function getErrorMessage(e: unknown) {
   if (e instanceof Exception && e.userMessage != null) return t(e.userMessage)
   if (e instanceof Error) return e.message
   return String(e)
+}
+
+function isConflictError(e: unknown) {
+  return e instanceof ApiException && e.code === ApiExceptionCode.errorConflict
 }
 
 function formatImportError(error: AccountUserImportError) {
@@ -203,8 +214,8 @@ function formatImportError(error: AccountUserImportError) {
           <div class="text-sm text-grey-800">
             {{
               $t({
-                en: `${rows.length} users, ${createdCount} created, ${failedRows.length} failed`,
-                zh: `共 ${rows.length} 位用户，已创建 ${createdCount} 位，失败 ${failedRows.length} 位`
+                en: `${rows.length} users, ${createdCount} created, ${skippedCount} skipped, ${failedRows.length} failed`,
+                zh: `共 ${rows.length} 位用户，已创建 ${createdCount} 位，已跳过 ${skippedCount} 位，失败 ${failedRows.length} 位`
               })
             }}
           </div>
@@ -237,6 +248,11 @@ function formatImportError(error: AccountUserImportError) {
                       type="success"
                     />
                     <UIIcon
+                      v-else-if="row.status === 'skipped'"
+                      class="mt-0.5 h-4 w-4 shrink-0 text-yellow-main"
+                      type="warning"
+                    />
+                    <UIIcon
                       v-else-if="row.status === 'failed'"
                       class="mt-0.5 h-4 w-4 shrink-0 text-red-500"
                       type="error"
@@ -249,6 +265,9 @@ function formatImportError(error: AccountUserImportError) {
                       <template v-else-if="row.status === 'created'">{{
                         $t({ en: 'Created', zh: '已创建' })
                       }}</template>
+                      <template v-else-if="row.status === 'skipped'">
+                        {{ row.error ?? $t({ en: 'Skipped', zh: '已跳过' }) }}
+                      </template>
                       <template v-else>
                         {{ row.error ?? $t({ en: 'Failed', zh: '失败' }) }}
                       </template>

--- a/spx-gui/src/components/account/admin/account-user-import/csv.test.ts
+++ b/spx-gui/src/components/account/admin/account-user-import/csv.test.ts
@@ -59,6 +59,10 @@ bob,Bob,
       { line: 2, message: { en: 'Username is required', zh: '用户名不能为空' } },
       { line: 3, message: { en: 'Password is required', zh: '密码不能为空' } }
     ])
+    expect(result.rows).toEqual([
+      { line: 2, username: '', displayName: '', password: 'pass123' },
+      { line: 3, username: 'bob', displayName: 'Bob', password: '' }
+    ])
   })
 
   it('validates duplicate usernames', () => {

--- a/spx-gui/src/components/account/admin/account-user-import/csv.test.ts
+++ b/spx-gui/src/components/account/admin/account-user-import/csv.test.ts
@@ -75,4 +75,24 @@ alice,Alice 2,pass456
       { line: 3, message: { en: 'Duplicate username with line 2', zh: '用户名与第 2 行重复' } }
     ])
   })
+
+  it('keeps source line numbers when CSV contains empty lines', () => {
+    const result = parseAccountUserImportCsv(`username,displayName,password
+
+alice,Alice,pass123
+
+alice,Alice 2,pass456
+bob,Bob,
+`)
+
+    expect(result.rows).toEqual([
+      { line: 3, username: 'alice', displayName: 'Alice', password: 'pass123' },
+      { line: 5, username: 'alice', displayName: 'Alice 2', password: 'pass456' },
+      { line: 6, username: 'bob', displayName: 'Bob', password: '' }
+    ])
+    expect(result.errors).toEqual([
+      { line: 5, message: { en: 'Duplicate username with line 3', zh: '用户名与第 3 行重复' } },
+      { line: 6, message: { en: 'Password is required', zh: '密码不能为空' } }
+    ])
+  })
 })

--- a/spx-gui/src/components/account/admin/account-user-import/csv.test.ts
+++ b/spx-gui/src/components/account/admin/account-user-import/csv.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest'
+
+import { parseAccountUserImportCsv } from './csv'
+
+describe('parseAccountUserImportCsv', () => {
+  it('parses account users from CSV', () => {
+    const result = parseAccountUserImportCsv(`username,displayName,password
+alice,Alice,pass123
+bob,Bob,pass456
+`)
+
+    expect(result.errors).toEqual([])
+    expect(result.rows).toEqual([
+      { line: 2, username: 'alice', displayName: 'Alice', password: 'pass123' },
+      { line: 3, username: 'bob', displayName: 'Bob', password: 'pass456' }
+    ])
+  })
+
+  it('trims cells and supports quoted CSV values', () => {
+    const result = parseAccountUserImportCsv(` username , displayName , password
+ "alice" ,"Alice, A."," pass123 "
+`)
+
+    expect(result.errors).toEqual([])
+    expect(result.rows).toEqual([{ line: 2, username: 'alice', displayName: 'Alice, A.', password: 'pass123' }])
+  })
+
+  it('requires all required headers', () => {
+    const result = parseAccountUserImportCsv(`username,displayName
+alice,Alice
+`)
+
+    expect(result.rows).toEqual([])
+    expect(result.errors).toEqual([{ line: 1, message: 'Missing required column: password' }])
+  })
+
+  it('uses username as display name when display name is empty or absent', () => {
+    const result = parseAccountUserImportCsv(`username,password
+alice,pass123
+bob,pass456
+`)
+
+    expect(result.errors).toEqual([])
+    expect(result.rows).toEqual([
+      { line: 2, username: 'alice', displayName: 'alice', password: 'pass123' },
+      { line: 3, username: 'bob', displayName: 'bob', password: 'pass456' }
+    ])
+  })
+
+  it('validates required fields', () => {
+    const result = parseAccountUserImportCsv(`username,displayName,password
+,,pass123
+bob,Bob,
+`)
+
+    expect(result.errors).toEqual([
+      { line: 2, message: 'Username is required' },
+      { line: 2, message: 'Display name is required' },
+      { line: 3, message: 'Password is required' }
+    ])
+  })
+
+  it('validates duplicate usernames', () => {
+    const result = parseAccountUserImportCsv(`username,displayName,password
+alice,Alice,pass123
+alice,Alice 2,pass456
+`)
+
+    expect(result.errors).toEqual([{ line: 3, message: 'Duplicate username with line 2' }])
+  })
+})

--- a/spx-gui/src/components/account/admin/account-user-import/csv.test.ts
+++ b/spx-gui/src/components/account/admin/account-user-import/csv.test.ts
@@ -31,7 +31,9 @@ alice,Alice
 `)
 
     expect(result.rows).toEqual([])
-    expect(result.errors).toEqual([{ line: 1, message: 'Missing required column: password' }])
+    expect(result.errors).toEqual([
+      { line: 1, message: { en: 'Missing required column: password', zh: '缺少必需列：password' } }
+    ])
   })
 
   it('uses username as display name when display name is empty or absent', () => {
@@ -54,9 +56,8 @@ bob,Bob,
 `)
 
     expect(result.errors).toEqual([
-      { line: 2, message: 'Username is required' },
-      { line: 2, message: 'Display name is required' },
-      { line: 3, message: 'Password is required' }
+      { line: 2, message: { en: 'Username is required', zh: '用户名不能为空' } },
+      { line: 3, message: { en: 'Password is required', zh: '密码不能为空' } }
     ])
   })
 
@@ -66,6 +67,8 @@ alice,Alice,pass123
 alice,Alice 2,pass456
 `)
 
-    expect(result.errors).toEqual([{ line: 3, message: 'Duplicate username with line 2' }])
+    expect(result.errors).toEqual([
+      { line: 3, message: { en: 'Duplicate username with line 2', zh: '用户名与第 2 行重复' } }
+    ])
   })
 })

--- a/spx-gui/src/components/account/admin/account-user-import/csv.ts
+++ b/spx-gui/src/components/account/admin/account-user-import/csv.ts
@@ -1,0 +1,79 @@
+import { parse } from 'csv-parse/browser/esm/sync'
+
+export type AccountUserImportRow = {
+  line: number
+  username: string
+  displayName: string
+  password: string
+}
+
+export type AccountUserImportError = {
+  line: number | null
+  message: string
+}
+
+export type AccountUserImportParseResult = {
+  rows: AccountUserImportRow[]
+  errors: AccountUserImportError[]
+}
+
+const requiredHeaders = ['username', 'password'] as const
+
+export function parseAccountUserImportCsv(csv: string): AccountUserImportParseResult {
+  let records: string[][]
+  try {
+    records = parse(csv, { bom: true, skip_empty_lines: true, ltrim: true, rtrim: true })
+  } catch (e) {
+    return {
+      rows: [],
+      errors: [{ line: null, message: e instanceof Error ? e.message : 'Invalid CSV file' }]
+    }
+  }
+
+  if (records.length === 0) {
+    return { rows: [], errors: [{ line: null, message: 'CSV file is empty' }] }
+  }
+
+  const headers = records[0].map((header) => header.trim())
+  const headerIndex = Object.fromEntries(headers.map((header, index) => [header, index]))
+  const missingHeaders = requiredHeaders.filter((header) => headerIndex[header] == null)
+  if (missingHeaders.length > 0) {
+    return {
+      rows: [],
+      errors: [{ line: 1, message: `Missing required column: ${missingHeaders.join(', ')}` }]
+    }
+  }
+
+  const rows: AccountUserImportRow[] = []
+  const errors: AccountUserImportError[] = []
+  const usernameLines = new Map<string, number>()
+
+  records.slice(1).forEach((record, index) => {
+    const line = index + 2
+    const username = readCell(record, headerIndex.username)
+    const displayName = readCell(record, headerIndex.displayName) || username
+    const password = readCell(record, headerIndex.password)
+
+    if (username === '') errors.push({ line, message: 'Username is required' })
+    if (displayName === '') errors.push({ line, message: 'Display name is required' })
+    if (password === '') errors.push({ line, message: 'Password is required' })
+
+    const previousLine = usernameLines.get(username)
+    if (username !== '' && previousLine != null) {
+      errors.push({ line, message: `Duplicate username with line ${previousLine}` })
+    }
+    if (username !== '') usernameLines.set(username, line)
+
+    rows.push({ line, username, displayName, password })
+  })
+
+  if (rows.length === 0) {
+    errors.push({ line: null, message: 'CSV file has no user rows' })
+  }
+
+  return { rows, errors }
+}
+
+function readCell(record: string[], index: number) {
+  return (record[index] ?? '').trim()
+}

--- a/spx-gui/src/components/account/admin/account-user-import/csv.ts
+++ b/spx-gui/src/components/account/admin/account-user-import/csv.ts
@@ -19,6 +19,7 @@ export type AccountUserImportParseResult = {
 }
 
 const requiredHeaders = ['username', 'password'] as const
+export const accountUserImportExampleCsv = 'username,displayName,password\nsample-user,Sample User,YOUR_PASSWORD_HERE\n'
 
 export function parseAccountUserImportCsv(csv: string): AccountUserImportParseResult {
   let records: string[][]

--- a/spx-gui/src/components/account/admin/account-user-import/csv.ts
+++ b/spx-gui/src/components/account/admin/account-user-import/csv.ts
@@ -1,4 +1,4 @@
-import { parse } from 'csv-parse/browser/esm/sync'
+import { parse, type InfoRecord } from 'csv-parse/browser/esm/sync'
 import type { LocaleMessage } from '@/utils/i18n'
 
 export type AccountUserImportRow = {
@@ -18,13 +18,24 @@ export type AccountUserImportParseResult = {
   errors: AccountUserImportError[]
 }
 
+type ParsedRecord = {
+  record: string[]
+  info: InfoRecord
+}
+
 const requiredHeaders = ['username', 'password'] as const
 export const accountUserImportExampleCsv = 'username,displayName,password\nsample-user,Sample User,YOUR_PASSWORD_HERE\n'
 
 export function parseAccountUserImportCsv(csv: string): AccountUserImportParseResult {
-  let records: string[][]
+  let records: ParsedRecord[]
   try {
-    records = parse(csv, { bom: true, skip_empty_lines: true, ltrim: true, rtrim: true })
+    records = parse(csv, {
+      bom: true,
+      skip_empty_lines: true,
+      ltrim: true,
+      rtrim: true,
+      info: true
+    }) as unknown as ParsedRecord[]
   } catch (e) {
     return {
       rows: [],
@@ -38,7 +49,8 @@ export function parseAccountUserImportCsv(csv: string): AccountUserImportParseRe
     return { rows: [], errors: [{ line: null, message: { en: 'CSV file is empty', zh: 'CSV 文件为空' } }] }
   }
 
-  const headers = records[0].map((header) => header.trim())
+  const headerRecord = records[0]
+  const headers = headerRecord.record.map((header) => header.trim())
   const headerIndex = Object.fromEntries(headers.map((header, index) => [header, index]))
   const missingHeaders = requiredHeaders.filter((header) => headerIndex[header] == null)
   if (missingHeaders.length > 0) {
@@ -46,7 +58,7 @@ export function parseAccountUserImportCsv(csv: string): AccountUserImportParseRe
       rows: [],
       errors: [
         {
-          line: 1,
+          line: headerRecord.info.lines,
           message: {
             en: `Missing required column: ${missingHeaders.join(', ')}`,
             zh: `缺少必需列：${missingHeaders.join(', ')}`
@@ -60,8 +72,8 @@ export function parseAccountUserImportCsv(csv: string): AccountUserImportParseRe
   const errors: AccountUserImportError[] = []
   const usernameLines = new Map<string, number>()
 
-  records.slice(1).forEach((record, index) => {
-    const line = index + 2
+  records.slice(1).forEach(({ record, info }) => {
+    const line = info.lines
     const username = readCell(record, headerIndex.username)
     const displayName = readCell(record, headerIndex.displayName) || username
     const password = readCell(record, headerIndex.password)

--- a/spx-gui/src/components/account/admin/account-user-import/csv.ts
+++ b/spx-gui/src/components/account/admin/account-user-import/csv.ts
@@ -1,4 +1,5 @@
 import { parse } from 'csv-parse/browser/esm/sync'
+import type { LocaleMessage } from '@/utils/i18n'
 
 export type AccountUserImportRow = {
   line: number
@@ -9,7 +10,7 @@ export type AccountUserImportRow = {
 
 export type AccountUserImportError = {
   line: number | null
-  message: string
+  message: LocaleMessage
 }
 
 export type AccountUserImportParseResult = {
@@ -26,12 +27,14 @@ export function parseAccountUserImportCsv(csv: string): AccountUserImportParseRe
   } catch (e) {
     return {
       rows: [],
-      errors: [{ line: null, message: e instanceof Error ? e.message : 'Invalid CSV file' }]
+      errors: [
+        { line: null, message: { en: e instanceof Error ? e.message : 'Invalid CSV file', zh: 'CSV 文件格式错误' } }
+      ]
     }
   }
 
   if (records.length === 0) {
-    return { rows: [], errors: [{ line: null, message: 'CSV file is empty' }] }
+    return { rows: [], errors: [{ line: null, message: { en: 'CSV file is empty', zh: 'CSV 文件为空' } }] }
   }
 
   const headers = records[0].map((header) => header.trim())
@@ -40,7 +43,15 @@ export function parseAccountUserImportCsv(csv: string): AccountUserImportParseRe
   if (missingHeaders.length > 0) {
     return {
       rows: [],
-      errors: [{ line: 1, message: `Missing required column: ${missingHeaders.join(', ')}` }]
+      errors: [
+        {
+          line: 1,
+          message: {
+            en: `Missing required column: ${missingHeaders.join(', ')}`,
+            zh: `缺少必需列：${missingHeaders.join(', ')}`
+          }
+        }
+      ]
     }
   }
 
@@ -54,13 +65,18 @@ export function parseAccountUserImportCsv(csv: string): AccountUserImportParseRe
     const displayName = readCell(record, headerIndex.displayName) || username
     const password = readCell(record, headerIndex.password)
 
-    if (username === '') errors.push({ line, message: 'Username is required' })
-    if (displayName === '') errors.push({ line, message: 'Display name is required' })
-    if (password === '') errors.push({ line, message: 'Password is required' })
+    if (username === '') errors.push({ line, message: { en: 'Username is required', zh: '用户名不能为空' } })
+    if (password === '') errors.push({ line, message: { en: 'Password is required', zh: '密码不能为空' } })
 
     const previousLine = usernameLines.get(username)
     if (username !== '' && previousLine != null) {
-      errors.push({ line, message: `Duplicate username with line ${previousLine}` })
+      errors.push({
+        line,
+        message: {
+          en: `Duplicate username with line ${previousLine}`,
+          zh: `用户名与第 ${previousLine} 行重复`
+        }
+      })
     }
     if (username !== '') usernameLines.set(username, line)
 
@@ -68,12 +84,13 @@ export function parseAccountUserImportCsv(csv: string): AccountUserImportParseRe
   })
 
   if (rows.length === 0) {
-    errors.push({ line: null, message: 'CSV file has no user rows' })
+    errors.push({ line: null, message: { en: 'CSV file has no user rows', zh: 'CSV 文件没有用户行' } })
   }
 
   return { rows, errors }
 }
 
-function readCell(record: string[], index: number) {
+function readCell(record: string[], index: number | undefined) {
+  if (index == null) return ''
   return (record[index] ?? '').trim()
 }


### PR DESCRIPTION
Closes #3290

## Summary
- add CSV import flow for Account users in the admin users page
- reuse the existing single-user create API for each imported row
- support CSV validation, preview, per-row status, and retrying failed rows
- allow downloading an example CSV file from the import modal

## Checks
- npm test -- csv.test.ts --run
- npm run lint -- src/apps/xbuilder/pages/admin/users.vue src/components/account/admin/account-user-import/AccountUserImportModal.vue src/components/account/admin/account-user-import/csv.ts src/components/account/admin/account-user-import/csv.test.ts
- npm run type-check
