### PR TITLE
feat(account): enforce managed password policy

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -4711,10 +4711,7 @@ paths:
                 displayName:
                   $ref: "#/components/schemas/AccountUser/properties/displayName"
                 password:
-                  description: Optional administrator-managed password for the new user.
-                  type: string
-                  minLength: 8
-                  maxLength: 128
+                  $ref: "#/components/schemas/AccountManagedPassword"
       responses:
         "201":
           description: Account user created.
@@ -4884,10 +4881,7 @@ paths:
                 - password
               properties:
                 password:
-                  description: New administrator-managed password.
-                  type: string
-                  minLength: 8
-                  maxLength: 128
+                  $ref: "#/components/schemas/AccountManagedPassword"
       responses:
         "204":
           description: Password credential set.
@@ -6503,6 +6497,15 @@ components:
           examples:
             - https://avatars.example.com/users/10137.png
 
+    AccountManagedPassword:
+      description: Administrator-managed password using printable ASCII characters with no leading or trailing spaces.
+      type: string
+      minLength: 8
+      maxLength: 128
+      pattern: "^[!-~][ -~]*[!-~]$"
+      examples:
+        - 1abc def2
+
     AccountIdentityProvider:
       type: object
       description: Identity provider available for hosted sign-in.
@@ -6623,10 +6626,10 @@ components:
           description: Username for password sign-in.
           $ref: "#/components/schemas/AccountUser/properties/username"
         password:
-          description: Administrator-managed password.
+          description: |
+            Administrator-managed password submitted verbatim for sign-in, up to 128 bytes when encoded as UTF-8.
           type: string
           minLength: 1
-          maxLength: 128
 
     CurrentAccountSession:
       type: object

--- a/spx-gui/src/apis/account/index.ts
+++ b/spx-gui/src/apis/account/index.ts
@@ -36,7 +36,6 @@ export type PasswordSignInPayload = {
 export async function createSessionWithPassword(payload: PasswordSignInPayload): Promise<CurrentAccountSession> {
   return (await accountClient
     .post('/session', {
-      method: 'password',
       username: payload.username,
       password: payload.password
     })

--- a/spx-gui/src/apps/xbuilder/pages/admin/user.vue
+++ b/spx-gui/src/apps/xbuilder/pages/admin/user.vue
@@ -27,7 +27,7 @@ const accountAdminRoleLabels: Record<AccountAdminRole, LocaleMessage> = {
 import { computed, ref, watch } from 'vue'
 import { RouterLink } from 'vue-router'
 
-import { useMessageHandle } from '@/utils/exception'
+import { DefaultException, useMessageHandle } from '@/utils/exception'
 import { useI18n } from '@/utils/i18n'
 import { useQuery } from '@/utils/query'
 import { usePageTitle } from '@/utils/utils'
@@ -48,6 +48,7 @@ import CopyButton from '@/components/common/CopyButton.vue'
 import UIIcon from '@/components/ui/icons/UIIcon.vue'
 import * as accountAdminApis from '@/apis/admin/account'
 import * as authorizationAdminApis from '@/apis/admin/authorization'
+import { validateAccountUserPassword } from '@/components/account/admin/password'
 import { formatJSON, formatTime } from './common'
 
 const props = defineProps<{
@@ -269,6 +270,8 @@ const handleUpdateAvatar = useMessageHandle(
 
 const handleSetPassword = useMessageHandle(
   async () => {
+    const passwordError = validateAccountUserPassword(password.value)
+    if (passwordError != null) throw new DefaultException(passwordError)
     await accountAdminApis.setAccountUserPassword(props.userID, { password: password.value })
     password.value = ''
   },

--- a/spx-gui/src/apps/xbuilder/pages/admin/users.vue
+++ b/spx-gui/src/apps/xbuilder/pages/admin/users.vue
@@ -21,6 +21,7 @@ import {
 } from '@/components/ui'
 import * as accountAdminApis from '@/apis/admin/account'
 import AccountUserImportModal from '@/components/account/admin/account-user-import/AccountUserImportModal.vue'
+import { validateAccountUserPassword } from '@/components/account/admin/password'
 import { formatTime } from './common'
 
 const signedInStateQuery = useSignedInStateQuery()
@@ -90,14 +91,9 @@ const handleCreateUser = useMessageHandle(
     if (username === '') throw new DefaultException({ en: 'Username is required', zh: '用户名不能为空' })
 
     const displayName = createForm.displayName.trim() || username
-    const password = createForm.password.trim()
-    if (password === '') throw new DefaultException({ en: 'Password is required', zh: '密码不能为空' })
-    if (password.length < accountAdminApis.accountUserPasswordMinLength) {
-      throw new DefaultException({
-        en: `The password must be at least ${accountAdminApis.accountUserPasswordMinLength} characters`,
-        zh: `密码长度不能少于 ${accountAdminApis.accountUserPasswordMinLength} 个字符`
-      })
-    }
+    const password = createForm.password
+    const passwordError = validateAccountUserPassword(password)
+    if (passwordError != null) throw new DefaultException(passwordError)
 
     const user = await accountAdminApis.createAccountUser({ username, displayName, password })
     await router.push(`/admin/users/${encodeURIComponent(user.id)}`)
@@ -166,12 +162,7 @@ async function handleImportUsers() {
         </label>
         <label class="flex flex-col gap-1 text-sm text-grey-900">
           {{ $t({ en: 'Initial password', zh: '初始密码' }) }}
-          <UITextInput
-            v-model:value="createForm.password"
-            type="password"
-            required
-            :maxlength="accountAdminApis.accountUserPasswordMaxLength"
-          />
+          <UITextInput v-model:value="createForm.password" type="password" required />
         </label>
       </div>
       <div class="mt-4 flex justify-end">

--- a/spx-gui/src/components/account/admin/account-user-import/AccountUserImportModal.vue
+++ b/spx-gui/src/components/account/admin/account-user-import/AccountUserImportModal.vue
@@ -177,6 +177,14 @@ function formatImportError(error: AccountUserImportError) {
                 {{ $t({ en: 'Download example CSV', zh: '下载示例 CSV' }) }}
               </button>
             </div>
+            <div class="mt-1 text-xs text-grey-700">
+              {{
+                $t({
+                  en: 'Passwords must contain 8 to 128 printable ASCII characters and cannot begin or end with a space.',
+                  zh: '密码必须包含 8 到 128 个可打印 ASCII 字符，且不能以空格开头或结尾。'
+                })
+              }}
+            </div>
           </div>
           <input
             ref="fileInputRef"

--- a/spx-gui/src/components/account/admin/account-user-import/csv.test.ts
+++ b/spx-gui/src/components/account/admin/account-user-import/csv.test.ts
@@ -17,13 +17,48 @@ bob,Bob,pass4567
     ])
   })
 
-  it('trims cells and supports quoted CSV values', () => {
+  it('trims user fields, preserves internal password spaces, and supports quoted CSV values', () => {
     const result = parseAccountUserImportCsv(` username , displayName , password
- "alice" ,"Alice, A."," pass1234 "
+ "alice" , "Alice, A." ,"pass 1234"
+bob, Bob ,pass 4567
 `)
 
     expect(result.errors).toEqual([])
-    expect(result.rows).toEqual([{ line: 2, username: 'alice', displayName: 'Alice, A.', password: 'pass1234' }])
+    expect(result.rows).toEqual([
+      { line: 2, username: 'alice', displayName: 'Alice, A.', password: 'pass 1234' },
+      { line: 3, username: 'bob', displayName: 'Bob', password: 'pass 4567' }
+    ])
+  })
+
+  it('preserves and rejects invalid password characters', () => {
+    const result = parseAccountUserImportCsv(`username,displayName,password
+alice,Alice," pass1234"
+bob,Bob,"pass1234 "
+carl,Carl,password\u00e9
+`)
+
+    expect(result.errors).toEqual([
+      {
+        line: 2,
+        message: { en: 'The password cannot start or end with a space', zh: '密码不能以空格开头或结尾' }
+      },
+      {
+        line: 3,
+        message: { en: 'The password cannot start or end with a space', zh: '密码不能以空格开头或结尾' }
+      },
+      {
+        line: 4,
+        message: {
+          en: 'The password must contain only printable ASCII characters',
+          zh: '密码只能包含可打印 ASCII 字符'
+        }
+      }
+    ])
+    expect(result.rows).toEqual([
+      { line: 2, username: 'alice', displayName: 'Alice', password: ' pass1234' },
+      { line: 3, username: 'bob', displayName: 'Bob', password: 'pass1234 ' },
+      { line: 4, username: 'carl', displayName: 'Carl', password: 'password\u00e9' }
+    ])
   })
 
   it('requires all required headers', () => {
@@ -104,16 +139,16 @@ dave,Dave,${longPassword}
       {
         line: 5,
         message: {
-          en: `The password is too long (maximum is ${accountAdminApis.accountUserPasswordMaxLength} characters)`,
-          zh: `密码长度超出限制（最多 ${accountAdminApis.accountUserPasswordMaxLength} 个字符）`
+          en: `The password must be at most ${accountAdminApis.accountUserPasswordMaxLength} characters`,
+          zh: `密码长度不能超过 ${accountAdminApis.accountUserPasswordMaxLength} 个字符`
         }
       }
     ])
   })
 
-  it('counts Unicode code points when validating field lengths', () => {
+  it('counts Unicode code points when validating non-password field lengths', () => {
     const displayName = '\u{1f600}'.repeat(accountAdminApis.accountUserDisplayNameMaxLength)
-    const password = '\u{1f600}'.repeat(accountAdminApis.accountUserPasswordMinLength)
+    const password = 'validpass'
 
     const result = parseAccountUserImportCsv(`username,displayName,password
 emoji,${displayName},${password}
@@ -135,8 +170,9 @@ alice,Alice 2,pass4567
   })
 
   it('keeps source line numbers when CSV contains empty lines', () => {
+    const whitespaceOnlyLine = '   '
     const result = parseAccountUserImportCsv(`username,displayName,password
-
+${whitespaceOnlyLine}
 alice,Alice,pass1234
 
 alice,Alice 2,pass4567

--- a/spx-gui/src/components/account/admin/account-user-import/csv.ts
+++ b/spx-gui/src/components/account/admin/account-user-import/csv.ts
@@ -3,6 +3,7 @@ import { parse, type InfoRecord } from 'csv-parse/browser/esm/sync'
 import type { LocaleMessage } from '@/utils/i18n'
 import { getStringLengthInCodePoints } from '@/utils/utils'
 import * as accountAdminApis from '@/apis/admin/account'
+import { validateAccountUserPassword } from '@/components/account/admin/password'
 
 export type AccountUserImportRow = {
   line: number
@@ -77,12 +78,11 @@ export function parseAccountUserImportCsv(csv: string): AccountUserImportParseRe
 
   records.slice(1).forEach(({ record, info }) => {
     const line = info.lines
-    const username = readCell(record, headerIndex.username)
-    const displayName = readCell(record, headerIndex.displayName) || username
+    const username = readCell(record, headerIndex.username).trim()
+    const displayName = readCell(record, headerIndex.displayName).trim() || username
     const password = readCell(record, headerIndex.password)
     const usernameLength = getStringLengthInCodePoints(username)
     const displayNameLength = getStringLengthInCodePoints(displayName)
-    const passwordLength = getStringLengthInCodePoints(password)
 
     if (username === '') errors.push({ line, message: { en: 'Username is required', zh: '用户名不能为空' } })
     else if (usernameLength > accountAdminApis.accountUserUsernameMaxLength) {
@@ -103,24 +103,8 @@ export function parseAccountUserImportCsv(csv: string): AccountUserImportParseRe
         }
       })
     }
-    if (password === '') errors.push({ line, message: { en: 'Password is required', zh: '密码不能为空' } })
-    else if (passwordLength < accountAdminApis.accountUserPasswordMinLength) {
-      errors.push({
-        line,
-        message: {
-          en: `The password must be at least ${accountAdminApis.accountUserPasswordMinLength} characters`,
-          zh: `密码长度不能少于 ${accountAdminApis.accountUserPasswordMinLength} 个字符`
-        }
-      })
-    } else if (passwordLength > accountAdminApis.accountUserPasswordMaxLength) {
-      errors.push({
-        line,
-        message: {
-          en: `The password is too long (maximum is ${accountAdminApis.accountUserPasswordMaxLength} characters)`,
-          zh: `密码长度超出限制（最多 ${accountAdminApis.accountUserPasswordMaxLength} 个字符）`
-        }
-      })
-    }
+    const passwordError = validateAccountUserPassword(password)
+    if (passwordError != null) errors.push({ line, message: passwordError })
 
     const previousLine = usernameLines.get(username)
     if (username !== '' && previousLine != null) {
@@ -146,5 +130,5 @@ export function parseAccountUserImportCsv(csv: string): AccountUserImportParseRe
 
 function readCell(record: string[], index: number | undefined) {
   if (index == null) return ''
-  return (record[index] ?? '').trim()
+  return record[index] ?? ''
 }

--- a/spx-gui/src/components/account/admin/password.test.ts
+++ b/spx-gui/src/components/account/admin/password.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest'
+
+import * as accountAdminApis from '@/apis/admin/account'
+import { validateAccountUserPassword } from './password'
+
+describe('validateAccountUserPassword', () => {
+  it('accepts printable ASCII with non-space boundaries', () => {
+    for (const password of [
+      'p'.repeat(8),
+      'p'.repeat(128),
+      '12345678',
+      '1abc def2',
+      '!abcdef?',
+      '!"#$%&\'()*+,-./:;<=>?@[\\]^_`{|}~'
+    ]) {
+      expect(validateAccountUserPassword(password)).toBeNull()
+    }
+  })
+
+  it('rejects values outside the managed password policy', () => {
+    for (const password of [
+      '',
+      'p'.repeat(7),
+      'p'.repeat(129),
+      ' password',
+      'password ',
+      '        ',
+      'pass\tword',
+      'pass\nword',
+      'passwor\x7f',
+      'password\u00e9',
+      'password\u5bc6',
+      'password\u{1f600}'
+    ]) {
+      expect(validateAccountUserPassword(password)).not.toBeNull()
+    }
+  })
+
+  it('returns specific validation messages', () => {
+    expect(validateAccountUserPassword('')).toEqual({ en: 'Password is required', zh: '密码不能为空' })
+    expect(validateAccountUserPassword('password\u00e9')).toEqual({
+      en: 'The password must contain only printable ASCII characters',
+      zh: '密码只能包含可打印 ASCII 字符'
+    })
+    expect(validateAccountUserPassword(' password')).toEqual({
+      en: 'The password cannot start or end with a space',
+      zh: '密码不能以空格开头或结尾'
+    })
+    expect(validateAccountUserPassword('p'.repeat(accountAdminApis.accountUserPasswordMinLength - 1))).toEqual({
+      en: `The password must be at least ${accountAdminApis.accountUserPasswordMinLength} characters`,
+      zh: `密码长度不能少于 ${accountAdminApis.accountUserPasswordMinLength} 个字符`
+    })
+    expect(validateAccountUserPassword('p'.repeat(accountAdminApis.accountUserPasswordMaxLength + 1))).toEqual({
+      en: `The password must be at most ${accountAdminApis.accountUserPasswordMaxLength} characters`,
+      zh: `密码长度不能超过 ${accountAdminApis.accountUserPasswordMaxLength} 个字符`
+    })
+  })
+})

--- a/spx-gui/src/components/account/admin/password.ts
+++ b/spx-gui/src/components/account/admin/password.ts
@@ -1,0 +1,29 @@
+import type { LocaleMessage } from '@/utils/i18n'
+import { accountUserPasswordMaxLength, accountUserPasswordMinLength } from '@/apis/admin/account'
+
+const printableASCIIPattern = /^[\x20-\x7e]+$/
+
+export function validateAccountUserPassword(password: string): LocaleMessage | null {
+  if (password === '') return { en: 'Password is required', zh: '密码不能为空' }
+  if (!printableASCIIPattern.test(password))
+    return {
+      en: 'The password must contain only printable ASCII characters',
+      zh: '密码只能包含可打印 ASCII 字符'
+    }
+  if (password.startsWith(' ') || password.endsWith(' '))
+    return {
+      en: 'The password cannot start or end with a space',
+      zh: '密码不能以空格开头或结尾'
+    }
+  if (password.length < accountUserPasswordMinLength)
+    return {
+      en: `The password must be at least ${accountUserPasswordMinLength} characters`,
+      zh: `密码长度不能少于 ${accountUserPasswordMinLength} 个字符`
+    }
+  if (password.length > accountUserPasswordMaxLength)
+    return {
+      en: `The password must be at most ${accountUserPasswordMaxLength} characters`,
+      zh: `密码长度不能超过 ${accountUserPasswordMaxLength} 个字符`
+    }
+  return null
+}


### PR DESCRIPTION
Apply printable ASCII and boundary-space validation to Account admin password forms and CSV imports. Preserve CSV password cells verbatim so validation matches the API instead of silently changing credentials.

Document the shared managed-password schema and keep password sign-in compatible with existing credentials.