### PR TITLE
fix: skip rendering empty backdrop images

### DIFF
--- a/spx-gui/src/components/editor/map-editor/map-viewer/MapViewer.vue
+++ b/spx-gui/src/components/editor/map-editor/map-viewer/MapViewer.vue
@@ -274,6 +274,9 @@ const konvaBackdropRectConfig = computed(() => {
   const stageHeight = mapSize.value.height
   const imageWidth = backdropImg.value.width
   const imageHeight = backdropImg.value.height
+  if (imageWidth <= 0 || imageHeight <= 0) {
+    return null
+  }
 
   if (props.project.stage.mapMode === MapMode.fillRatio) {
     const scaleX = stageWidth / imageWidth

--- a/spx-gui/src/components/editor/preview/stage-viewer/StageViewer.vue
+++ b/spx-gui/src/components/editor/preview/stage-viewer/StageViewer.vue
@@ -343,6 +343,9 @@ const konvaBackdropRectConfig = computed(() => {
   const stageHeight = mapSize.value.height
   const imageWidth = backdropImg.value.width
   const imageHeight = backdropImg.value.height
+  if (imageWidth <= 0 || imageHeight <= 0) {
+    return null
+  }
 
   if (editorCtx.project.stage.mapMode === MapMode.fillRatio) {
     const scaleX = stageWidth / imageWidth


### PR DESCRIPTION
Closes #3357

## Summary

- Skip backdrop-rectangle rendering when the loaded image has a zero width or height.
- Apply the same behavior to `StageViewer` and `MapViewer` so the white stage background remains visible.

## Validation

- `./node_modules/.bin/vue-tsc --build --force`
- `./node_modules/.bin/eslint --max-warnings 0`
- `./node_modules/.bin/prettier --check ./src`
- `git diff --check`
