### PR TITLE
Fix DotLottie WASM 404 on project detail pages

### DIFF
--- a/spx-gui/package.json
+++ b/spx-gui/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "@floating-ui/dom": "^1.7.6",
     "@jridgewell/resolve-uri": "^3.1.2",
+    "@lottiefiles/dotlottie-web": "0.41.0",
     "@lottiefiles/dotlottie-vue": "^0.5.8",
     "@nighca/fflate": "^0.8.3",
     "@scalar/api-reference": "^1.40.0",

--- a/spx-gui/pnpm-lock.yaml
+++ b/spx-gui/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@lottiefiles/dotlottie-vue':
         specifier: ^0.5.8
         version: 0.5.8(vue@3.5.25(typescript@5.9.3))
+      '@lottiefiles/dotlottie-web':
+        specifier: 0.41.0
+        version: 0.41.0
       '@nighca/fflate':
         specifier: ^0.8.3
         version: 0.8.3


### PR DESCRIPTION
Closes #3372

## Summary

- declare `@lottiefiles/dotlottie-web` as a direct dependency
- preserve Vite's existing `new URL(..., import.meta.url)` handling for the emitted, hashed local asset

## Root Cause

`@lottiefiles/dotlottie-web` was only a transitive dependency of `@lottiefiles/dotlottie-vue`. Before the pnpm migration, npm hoisting made the WASM package path available at the application level. pnpm does not provide that implicit hoisting, so Vite could not resolve the existing WASM URL during the build and left it for the browser to request as a missing `/assets/@lottiefiles/...` path.

Declaring the package directly makes the WASM path resolvable to Vite again. The existing `new URL(..., import.meta.url)` expression is then transformed to the generated, hashed local asset URL.

## Verification

- `pnpm run lint`
- `pnpm run build`
- confirmed that the production output contains `dist/assets/dotlottie-player-*.wasm` and no unresolved DotLottie package path
