### PR TITLE
refactor(lifecycle)!: align resource lifecycle semantics

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -476,10 +476,10 @@ paths:
         "401":
           $ref: "#/components/responses/Unauthorized"
     delete:
-      operationId: deleteAccountSession
+      operationId: revokeAccountSession
       tags:
         - Account
-      summary: Delete the current account session
+      summary: Revoke the current account session
       description: |
         Revoke the current account session.
 
@@ -488,7 +488,7 @@ paths:
         - accountSessionCookie: []
       responses:
         "204":
-          description: Account session deleted.
+          description: Account session revoked.
           headers:
             Set-Cookie:
               description: Clears the `__Host-xbuilder-account-session` cookie.
@@ -533,10 +533,10 @@ paths:
         "401":
           $ref: "#/components/responses/Unauthorized"
     delete:
-      operationId: deleteAccountSessions
+      operationId: revokeAccountSessions
       tags:
         - Account
-      summary: Delete current account sessions
+      summary: Revoke all current account sessions
       description: |
         Revoke all account sessions of the current user.
 
@@ -545,7 +545,7 @@ paths:
         - accountSessionCookie: []
       responses:
         "204":
-          description: Account sessions deleted.
+          description: Account sessions revoked.
           headers:
             Set-Cookie:
               description: Clears the `__Host-xbuilder-account-session` cookie.
@@ -558,10 +558,10 @@ paths:
 
   /account/sessions/{sessionID}:
     delete:
-      operationId: deleteAccountSessionByID
+      operationId: revokeAccountSessionByID
       tags:
         - Account
-      summary: Delete an account session of the current user
+      summary: Revoke an account session of the current user
       description: |
         Revoke an account session owned by the current user.
 
@@ -570,17 +570,17 @@ paths:
         - accountSessionCookie: []
       parameters:
         - name: sessionID
-          description: ID of the account session to delete.
+          description: ID of the account session to revoke.
           in: path
           required: true
           schema:
             $ref: "#/components/schemas/Model/properties/id"
       responses:
         "204":
-          description: Account session deleted.
+          description: Account session revoked.
           headers:
             Set-Cookie:
-              description: Clears the `__Host-xbuilder-account-session` cookie when the deleted session is current.
+              description: Clears the `__Host-xbuilder-account-session` cookie when the revoked session is current.
               schema:
                 type: string
         "400":
@@ -1691,7 +1691,7 @@ paths:
         "404":
           $ref: "#/components/responses/NotFound"
         "409":
-          $ref: "#/components/responses/ResourceMoved"
+          $ref: "#/components/responses/ProjectUpdateConflict"
     delete:
       operationId: deleteProject
       tags:
@@ -3174,6 +3174,8 @@ paths:
           $ref: "#/components/responses/Unauthorized"
         "403":
           $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
 
   /course-series/{courseSeriesID}:
     get:
@@ -5038,24 +5040,24 @@ paths:
         "404":
           $ref: "#/components/responses/NotFound"
     delete:
-      operationId: deleteAdminAccountUserSessions
+      operationId: revokeAdminAccountUserSessions
       tags:
         - Account Admin
-      summary: Delete account user sessions as admin
+      summary: Revoke all account user sessions as admin
       description: |
         Revoke all account sessions of an account user.
 
         Requires the `accountAdmin` role.
       parameters:
         - name: userID
-          description: ID of the user whose account sessions are deleted.
+          description: ID of the user whose account sessions are revoked.
           in: path
           required: true
           schema:
             $ref: "#/components/schemas/Model/properties/id"
       responses:
         "204":
-          description: Account user sessions deleted.
+          description: Account user sessions revoked.
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":
@@ -5067,24 +5069,24 @@ paths:
 
   /admin/account/sessions/{sessionID}:
     delete:
-      operationId: deleteAdminAccountSession
+      operationId: revokeAdminAccountSession
       tags:
         - Account Admin
-      summary: Delete an account session as admin
+      summary: Revoke an account session as admin
       description: |
         Revoke an account session.
 
         Requires the `accountAdmin` role.
       parameters:
         - name: sessionID
-          description: ID of the account session to delete.
+          description: ID of the account session to revoke.
           in: path
           required: true
           schema:
             $ref: "#/components/schemas/Model/properties/id"
       responses:
         "204":
-          description: Account session deleted.
+          description: Account session revoked.
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":
@@ -5356,30 +5358,33 @@ paths:
 
   /admin/account/apps/{appID}/secrets/{secretID}:
     delete:
-      operationId: deleteAdminAccountAppSecret
+      operationId: revokeAdminAccountAppSecret
       tags:
         - Account Admin
-      summary: Delete an account app secret as admin
+      summary: Revoke an account app secret as admin
       description: |
-        Delete a secret from a confidential account app.
+        Permanently revoke a secret from a confidential account app. The secret can no longer authenticate the client
+        and cannot be restored.
+
+        Existing grants and tokens issued before revocation remain valid. This operation does not revoke them.
 
         Requires the `accountAdmin` role.
       parameters:
         - name: appID
-          description: ID of the app whose secret is deleted.
+          description: ID of the app whose secret is revoked.
           in: path
           required: true
           schema:
             $ref: "#/components/schemas/Model/properties/id"
         - name: secretID
-          description: ID of the secret to delete.
+          description: ID of the secret to revoke.
           in: path
           required: true
           schema:
             $ref: "#/components/schemas/Model/properties/id"
       responses:
         "204":
-          description: Account app secret deleted.
+          description: Account app secret revoked.
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":
@@ -5589,10 +5594,10 @@ paths:
 
   /admin/account/app-grants/{appGrantID}/tokens/{tokenID}:
     delete:
-      operationId: deleteAdminAccountAppGrantToken
+      operationId: revokeAdminAccountAppGrantToken
       tags:
         - Account Admin
-      summary: Delete an account app grant token as admin
+      summary: Revoke an account app grant token as admin
       description: |
         Revoke an Account-issued OAuth token for an account app grant.
 
@@ -5815,6 +5820,16 @@ components:
         application/json:
           schema:
             $ref: "#/components/schemas/MovedResourceError"
+    ProjectUpdateConflict:
+      description: |
+        The update conflicts with current project state because the requested project route moved or the requested name
+        is unavailable.
+      content:
+        application/json:
+          schema:
+            oneOf:
+              - $ref: "#/components/schemas/ConflictError"
+              - $ref: "#/components/schemas/MovedResourceError"
     BadRequest:
       description: Invalid request syntax, parameters, or body.
       content:
@@ -6194,6 +6209,23 @@ components:
         - 50101
       examples:
         - 40001
+
+    ConflictError:
+      description: Error payload for a generic resource conflict.
+      type: object
+      required:
+        - code
+        - msg
+      properties:
+        code:
+          type: integer
+          format: int32
+          enum:
+            - 40900
+        msg:
+          type: string
+          enum:
+            - Conflict
 
     MovedResourceError:
       description: |
@@ -7214,7 +7246,6 @@ components:
           type: boolean
           examples:
             - true
-
 
     Project:
       type: object

--- a/spx-gui/src/apis/account/index.ts
+++ b/spx-gui/src/apis/account/index.ts
@@ -24,7 +24,7 @@ export async function getSession(): Promise<CurrentAccountSession | null> {
   }
 }
 
-export async function deleteSession(): Promise<void> {
+export async function revokeSession(): Promise<void> {
   await accountClient.delete('/session')
 }
 

--- a/spx-gui/src/apis/admin/account.ts
+++ b/spx-gui/src/apis/admin/account.ts
@@ -112,11 +112,11 @@ export function listAccountUserSessions(userID: string, params?: PaginationParam
   >
 }
 
-export function deleteAccountUserSessions(userID: string) {
+export function revokeAccountUserSessions(userID: string) {
   return client.delete(`/admin/account/users/${encodeURIComponent(userID)}/sessions`) as Promise<void>
 }
 
-export function deleteAccountSession(sessionID: string) {
+export function revokeAccountSession(sessionID: string) {
   return client.delete(`/admin/account/sessions/${encodeURIComponent(sessionID)}`) as Promise<void>
 }
 
@@ -168,7 +168,7 @@ export function createAccountAppGrantToken(appGrantID: string, params: CreateAcc
   ) as Promise<CreatedAccountAppToken>
 }
 
-export function deleteAccountAppGrantToken(appGrantID: string, tokenID: string) {
+export function revokeAccountAppGrantToken(appGrantID: string, tokenID: string) {
   return client.delete(
     `/admin/account/app-grants/${encodeURIComponent(appGrantID)}/tokens/${encodeURIComponent(tokenID)}`
   ) as Promise<void>
@@ -235,7 +235,7 @@ export function createAccountAppSecret(appID: string, params: CreateAccountAppSe
   ) as Promise<CreatedAccountAppSecret>
 }
 
-export function deleteAccountAppSecret(appID: string, secretID: string) {
+export function revokeAccountAppSecret(appID: string, secretID: string) {
   return client.delete(
     `/admin/account/apps/${encodeURIComponent(appID)}/secrets/${encodeURIComponent(secretID)}`
   ) as Promise<void>

--- a/spx-gui/src/apps/xbuilder/pages/admin/app.vue
+++ b/spx-gui/src/apps/xbuilder/pages/admin/app.vue
@@ -158,19 +158,25 @@ const handleCopySecret = useMessageHandle(
   { en: 'App secret copied', zh: '应用密钥已复制' }
 )
 
-const handleDeleteSecret = useMessageHandle(
+const handleRevokeSecret = useMessageHandle(
   async (secretID: string) => {
-    await accountAdminApis.deleteAccountAppSecret(props.appID, secretID)
+    await accountAdminApis.revokeAccountAppSecret(props.appID, secretID)
     if (createdSecret.value?.id === secretID) createdSecret.value = null
     secretsQuery.refetch()
   },
-  { en: 'Failed to delete Account app secret', zh: '删除账号应用密钥失败' },
-  { en: 'Account app secret deleted', zh: '账号应用密钥已删除' }
+  { en: 'Failed to revoke Account app secret', zh: '撤销账号应用密钥失败' },
+  { en: 'Account app secret revoked', zh: '账号应用密钥已撤销' }
 )
 
-function deleteSecret(secretID: string) {
-  if (!window.confirm(i18n.t({ en: 'Delete this secret?', zh: '删除此密钥？' }))) return
-  handleDeleteSecret.fn(secretID)
+function revokeSecret(secretID: string) {
+  const confirmed = window.confirm(
+    i18n.t({
+      en: 'Revoke this secret permanently? It will no longer authenticate the app. Existing grants and tokens will remain valid unless revoked separately or the app is disabled.',
+      zh: '确定永久撤销此密钥吗？撤销后它将无法再用于应用认证。现有授权和令牌仍然有效，除非另行撤销或停用该应用。'
+    })
+  )
+  if (!confirmed) return
+  handleRevokeSecret.fn(secretID)
 }
 </script>
 
@@ -524,8 +530,8 @@ function deleteSecret(secretID: string) {
                       {{ $t({ en: 'Created', zh: '创建时间' }) }}: {{ formatTime(secret.createdAt) }}
                     </div>
                   </div>
-                  <UIButton type="red" size="small" @click="deleteSecret(secret.id)">
-                    {{ $t({ en: 'Delete', zh: '删除' }) }}
+                  <UIButton type="red" size="small" @click="revokeSecret(secret.id)">
+                    {{ $t({ en: 'Revoke', zh: '撤销' }) }}
                   </UIButton>
                 </div>
                 <div v-if="(secretsQuery.data.value?.data.length ?? 0) === 0" class="py-8 text-center text-grey-800">

--- a/spx-gui/src/apps/xbuilder/pages/admin/grant.vue
+++ b/spx-gui/src/apps/xbuilder/pages/admin/grant.vue
@@ -167,7 +167,7 @@ const handleRevokeToken = useMessageHandle(
       content: i18n.t({ en: 'Are you sure to revoke this token?', zh: '确定要撤销此 token 吗？' }),
       confirmText: i18n.t({ en: 'Revoke', zh: '撤销' })
     })
-    await accountAdminApis.deleteAccountAppGrantToken(props.grantID, tokenID)
+    await accountAdminApis.revokeAccountAppGrantToken(props.grantID, tokenID)
     if (createdToken.value?.id === tokenID) createdToken.value = null
     tokensQuery.refetch()
   },

--- a/spx-gui/src/apps/xbuilder/pages/admin/user.vue
+++ b/spx-gui/src/apps/xbuilder/pages/admin/user.vue
@@ -335,32 +335,32 @@ function deleteIdentity(identityID: string) {
   handleDeleteIdentity.fn(identityID)
 }
 
-const handleDeleteSession = useMessageHandle(
+const handleRevokeSession = useMessageHandle(
   async (sessionID: string) => {
-    await accountAdminApis.deleteAccountSession(sessionID)
+    await accountAdminApis.revokeAccountSession(sessionID)
     sessionsQuery.refetch()
   },
-  { en: 'Failed to delete session', zh: '删除会话失败' },
-  { en: 'Session deleted', zh: '会话已删除' }
+  { en: 'Failed to revoke session', zh: '撤销会话失败' },
+  { en: 'Session revoked', zh: '会话已撤销' }
 )
 
-function deleteSession(sessionID: string) {
-  if (!window.confirm(i18n.t({ en: 'Delete this session?', zh: '删除此会话？' }))) return
-  handleDeleteSession.fn(sessionID)
+function revokeSession(sessionID: string) {
+  if (!window.confirm(i18n.t({ en: 'Revoke this session?', zh: '撤销此会话？' }))) return
+  handleRevokeSession.fn(sessionID)
 }
 
-const handleDeleteAllSessions = useMessageHandle(
+const handleRevokeAllSessions = useMessageHandle(
   async () => {
-    await accountAdminApis.deleteAccountUserSessions(props.userID)
+    await accountAdminApis.revokeAccountUserSessions(props.userID)
     sessionsQuery.refetch()
   },
-  { en: 'Failed to delete sessions', zh: '删除会话失败' },
-  { en: 'Sessions deleted', zh: '会话已删除' }
+  { en: 'Failed to revoke sessions', zh: '撤销会话失败' },
+  { en: 'Sessions revoked', zh: '会话已撤销' }
 )
 
-function deleteAllSessions() {
-  if (!window.confirm(i18n.t({ en: 'Delete all sessions for this user?', zh: '删除此用户的全部会话？' }))) return
-  handleDeleteAllSessions.fn()
+function revokeAllSessions() {
+  if (!window.confirm(i18n.t({ en: 'Revoke all sessions for this user?', zh: '撤销此用户的全部会话？' }))) return
+  handleRevokeAllSessions.fn()
 }
 </script>
 
@@ -859,9 +859,9 @@ function deleteAllSessions() {
               type="red"
               size="small"
               :disabled="(sessionsQuery.data.value?.data.length ?? 0) === 0"
-              @click="deleteAllSessions"
+              @click="revokeAllSessions"
             >
-              {{ $t({ en: 'Delete all sessions', zh: '删除全部会话' }) }}
+              {{ $t({ en: 'Revoke all sessions', zh: '撤销全部会话' }) }}
             </UIButton>
           </div>
         </div>
@@ -916,8 +916,8 @@ function deleteAllSessions() {
                 <td class="whitespace-nowrap px-4 py-3 text-grey-900">{{ formatTime(session.lastUsedAt) }}</td>
                 <td class="whitespace-nowrap px-4 py-3 text-grey-900">{{ formatTime(session.expiresAt) }}</td>
                 <td class="px-4 py-3 text-right">
-                  <UIButton type="red" size="small" @click="deleteSession(session.id)">
-                    {{ $t({ en: 'Delete', zh: '删除' }) }}
+                  <UIButton type="red" size="small" @click="revokeSession(session.id)">
+                    {{ $t({ en: 'Revoke', zh: '撤销' }) }}
                   </UIButton>
                 </td>
               </tr>

--- a/spx-gui/src/components/account/sign-in/SignInForm.vue
+++ b/spx-gui/src/components/account/sign-in/SignInForm.vue
@@ -22,7 +22,7 @@ import { ref, watch } from 'vue'
 import {
   buildIdentityProviderAuthorizeUrl,
   createSessionWithPassword,
-  deleteSession,
+  revokeSession,
   getIdentityProviders,
   getPasswordSignInRetryAfter,
   getSession
@@ -82,7 +82,7 @@ watch(sessionQuery.data, (session) => {
 
 const { fn: handleSwitchAccount, isLoading: isSwitchingAccount } = useMessageHandle(
   async () => {
-    await deleteSession()
+    await revokeSession()
     showPasswordForm.value = false
     sessionQuery.refetch()
   },


### PR DESCRIPTION
Use revoke terminology for Account sessions, app grant tokens, and app secrets across OpenAPI, client adapters, and admin actions. Document app secret revocation as permanent without invalidating existing grants or tokens.

Require Course Series member IDs to reference existing courses. Document not-found responses and project update conflicts for unavailable names and historical routes.

BREAKING CHANGE: Account revoke operations use new OpenAPI operation IDs.
