### PR TITLE
fix(auth): coordinate token refresh across pages

### DIFF
--- a/spx-gui/src/stores/user/signed-in.test.ts
+++ b/spx-gui/src/stores/user/signed-in.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { accountOAuthApisForXBuilder } from '@/apis/account/oauth'
+import { ensureAccessToken, initUserState } from './signed-in'
+
+const userStateStorageKey = 'builder-user'
+
+describe('ensureAccessToken', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('uses credentials refreshed by another page while waiting for the refresh lock', async () => {
+    localStorage.setItem(
+      userStateStorageKey,
+      JSON.stringify({
+        accessToken: 'expired-access-token',
+        accessTokenExpiresAt: Date.now(),
+        refreshToken: 'old-refresh-token',
+        username: 'alice'
+      })
+    )
+    Object.defineProperty(navigator, 'locks', {
+      configurable: true,
+      value: {
+        request: vi.fn(async (_name: string, callback: () => Promise<void>) => {
+          localStorage.setItem(
+            userStateStorageKey,
+            JSON.stringify({
+              accessToken: 'new-access-token',
+              accessTokenExpiresAt: Date.now() + 60 * 60 * 1000,
+              refreshToken: 'new-refresh-token',
+              username: 'alice'
+            })
+          )
+          await callback()
+        })
+      }
+    })
+    const refreshToken = vi.spyOn(accountOAuthApisForXBuilder, 'refreshToken')
+
+    initUserState('client-id')
+
+    await expect(ensureAccessToken()).resolves.toBe('new-access-token')
+    expect(refreshToken).not.toHaveBeenCalled()
+  })
+})

--- a/spx-gui/src/stores/user/signed-in.test.ts
+++ b/spx-gui/src/stores/user/signed-in.test.ts
@@ -78,4 +78,28 @@ describe('ensureAccessToken', () => {
     await expect(ensureAccessToken()).resolves.toBe('access-token')
     expect(request).not.toHaveBeenCalled()
   })
+
+  it('clears cached state when the shared state is removed', async () => {
+    localStorage.setItem(
+      userStateStorageKey,
+      JSON.stringify({
+        accessToken: 'access-token',
+        accessTokenExpiresAt: Date.now() + 60 * 60 * 1000,
+        refreshToken: 'refresh-token',
+        username: 'alice'
+      })
+    )
+    Object.defineProperty(navigator, 'locks', {
+      configurable: true,
+      value: {
+        request: vi.fn(async (_name: string, callback: () => Promise<void>) => callback())
+      }
+    })
+    initUserState('client-id')
+
+    localStorage.removeItem(userStateStorageKey)
+    window.dispatchEvent(new StorageEvent('storage', { key: userStateStorageKey }))
+
+    await expect(ensureAccessToken()).resolves.toBe(null)
+  })
 })

--- a/spx-gui/src/stores/user/signed-in.test.ts
+++ b/spx-gui/src/stores/user/signed-in.test.ts
@@ -23,21 +23,22 @@ describe('ensureAccessToken', () => {
         username: 'alice'
       })
     )
+    const request = vi.fn(async (_name: string, callback: () => Promise<void>) => {
+      localStorage.setItem(
+        userStateStorageKey,
+        JSON.stringify({
+          accessToken: 'new-access-token',
+          accessTokenExpiresAt: Date.now() + 60 * 60 * 1000,
+          refreshToken: 'new-refresh-token',
+          username: 'alice'
+        })
+      )
+      await callback()
+    })
     Object.defineProperty(navigator, 'locks', {
       configurable: true,
       value: {
-        request: vi.fn(async (_name: string, callback: () => Promise<void>) => {
-          localStorage.setItem(
-            userStateStorageKey,
-            JSON.stringify({
-              accessToken: 'new-access-token',
-              accessTokenExpiresAt: Date.now() + 60 * 60 * 1000,
-              refreshToken: 'new-refresh-token',
-              username: 'alice'
-            })
-          )
-          await callback()
-        })
+        request
       }
     })
     const refreshToken = vi.spyOn(accountOAuthApisForXBuilder, 'refreshToken')
@@ -45,6 +46,31 @@ describe('ensureAccessToken', () => {
     initUserState('client-id')
 
     await expect(ensureAccessToken()).resolves.toBe('new-access-token')
+    expect(request).toHaveBeenCalledWith('builder-user-access-token', expect.any(Function))
     expect(refreshToken).not.toHaveBeenCalled()
+  })
+
+  it('waits for the access token lock when the cached token is valid', async () => {
+    localStorage.setItem(
+      userStateStorageKey,
+      JSON.stringify({
+        accessToken: 'access-token',
+        accessTokenExpiresAt: Date.now() + 60 * 60 * 1000,
+        refreshToken: 'refresh-token',
+        username: 'alice'
+      })
+    )
+    const request = vi.fn(async (_name: string, callback: () => Promise<void>) => callback())
+    Object.defineProperty(navigator, 'locks', {
+      configurable: true,
+      value: {
+        request
+      }
+    })
+
+    initUserState('client-id')
+
+    await expect(ensureAccessToken()).resolves.toBe('access-token')
+    expect(request).toHaveBeenCalledWith('builder-user-access-token', expect.any(Function))
   })
 })

--- a/spx-gui/src/stores/user/signed-in.test.ts
+++ b/spx-gui/src/stores/user/signed-in.test.ts
@@ -1,12 +1,17 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { accountOAuthApisForXBuilder } from '@/apis/account/oauth'
-import { ensureAccessToken, initUserState } from './signed-in'
 
 const userStateStorageKey = 'builder-user'
 
 describe('ensureAccessToken', () => {
-  beforeEach(() => {
+  let ensureAccessToken: typeof import('./signed-in').ensureAccessToken
+  let initUserState: typeof import('./signed-in').initUserState
+  let accountOAuthApisForXBuilder: typeof import('@/apis/account/oauth').accountOAuthApisForXBuilder
+
+  beforeEach(async () => {
+    vi.resetModules()
     localStorage.clear()
+    ;({ ensureAccessToken, initUserState } = await import('./signed-in'))
+    ;({ accountOAuthApisForXBuilder } = await import('@/apis/account/oauth'))
   })
 
   afterEach(() => {
@@ -72,5 +77,40 @@ describe('ensureAccessToken', () => {
 
     await expect(ensureAccessToken()).resolves.toBe('access-token')
     expect(request).toHaveBeenCalledWith('builder-user-access-token', expect.any(Function))
+  })
+
+  it('preserves a session written while a refresh request fails', async () => {
+    localStorage.setItem(
+      userStateStorageKey,
+      JSON.stringify({
+        accessToken: 'expired-access-token',
+        accessTokenExpiresAt: Date.now(),
+        refreshToken: 'old-refresh-token',
+        username: 'alice'
+      })
+    )
+    const request = vi.fn(async (_name: string, callback: () => Promise<void>) => callback())
+    Object.defineProperty(navigator, 'locks', {
+      configurable: true,
+      value: {
+        request
+      }
+    })
+    vi.spyOn(accountOAuthApisForXBuilder, 'refreshToken').mockImplementationOnce(async () => {
+      localStorage.setItem(
+        userStateStorageKey,
+        JSON.stringify({
+          accessToken: 'new-access-token',
+          accessTokenExpiresAt: Date.now() + 60 * 60 * 1000,
+          refreshToken: 'new-refresh-token',
+          username: 'alice'
+        })
+      )
+      throw new Error('Refresh failed')
+    })
+
+    initUserState('client-id')
+
+    await expect(ensureAccessToken()).resolves.toBe('new-access-token')
   })
 })

--- a/spx-gui/src/stores/user/signed-in.test.ts
+++ b/spx-gui/src/stores/user/signed-in.test.ts
@@ -102,4 +102,46 @@ describe('ensureAccessToken', () => {
 
     await expect(ensureAccessToken()).resolves.toBe(null)
   })
+
+  it('clears cached state when the shared storage is cleared', async () => {
+    localStorage.setItem(
+      userStateStorageKey,
+      JSON.stringify({
+        accessToken: 'access-token',
+        accessTokenExpiresAt: Date.now() + 60 * 60 * 1000,
+        refreshToken: 'refresh-token',
+        username: 'alice'
+      })
+    )
+    Object.defineProperty(navigator, 'locks', {
+      configurable: true,
+      value: {
+        request: vi.fn(async (_name: string, callback: () => Promise<void>) => callback())
+      }
+    })
+    initUserState('client-id')
+
+    localStorage.clear()
+    window.dispatchEvent(new StorageEvent('storage', { key: null }))
+
+    await expect(ensureAccessToken()).resolves.toBe(null)
+  })
+
+  it('does not write state back after receiving a storage event', () => {
+    initUserState('client-id')
+    localStorage.setItem(
+      userStateStorageKey,
+      JSON.stringify({
+        accessToken: 'access-token',
+        accessTokenExpiresAt: Date.now() + 60 * 60 * 1000,
+        refreshToken: 'refresh-token',
+        username: 'alice'
+      })
+    )
+    const setItem = vi.spyOn(Storage.prototype, 'setItem')
+
+    window.dispatchEvent(new StorageEvent('storage', { key: userStateStorageKey }))
+
+    expect(setItem).not.toHaveBeenCalled()
+  })
 })

--- a/spx-gui/src/stores/user/signed-in.test.ts
+++ b/spx-gui/src/stores/user/signed-in.test.ts
@@ -78,39 +78,4 @@ describe('ensureAccessToken', () => {
     await expect(ensureAccessToken()).resolves.toBe('access-token')
     expect(request).toHaveBeenCalledWith('builder-user-access-token', expect.any(Function))
   })
-
-  it('preserves a session written while a refresh request fails', async () => {
-    localStorage.setItem(
-      userStateStorageKey,
-      JSON.stringify({
-        accessToken: 'expired-access-token',
-        accessTokenExpiresAt: Date.now(),
-        refreshToken: 'old-refresh-token',
-        username: 'alice'
-      })
-    )
-    const request = vi.fn(async (_name: string, callback: () => Promise<void>) => callback())
-    Object.defineProperty(navigator, 'locks', {
-      configurable: true,
-      value: {
-        request
-      }
-    })
-    vi.spyOn(accountOAuthApisForXBuilder, 'refreshToken').mockImplementationOnce(async () => {
-      localStorage.setItem(
-        userStateStorageKey,
-        JSON.stringify({
-          accessToken: 'new-access-token',
-          accessTokenExpiresAt: Date.now() + 60 * 60 * 1000,
-          refreshToken: 'new-refresh-token',
-          username: 'alice'
-        })
-      )
-      throw new Error('Refresh failed')
-    })
-
-    initUserState('client-id')
-
-    await expect(ensureAccessToken()).resolves.toBe('new-access-token')
-  })
 })

--- a/spx-gui/src/stores/user/signed-in.test.ts
+++ b/spx-gui/src/stores/user/signed-in.test.ts
@@ -55,7 +55,7 @@ describe('ensureAccessToken', () => {
     expect(refreshToken).not.toHaveBeenCalled()
   })
 
-  it('waits for the access token lock when the cached token is valid', async () => {
+  it('returns the cached access token without acquiring the lock', async () => {
     localStorage.setItem(
       userStateStorageKey,
       JSON.stringify({
@@ -76,6 +76,6 @@ describe('ensureAccessToken', () => {
     initUserState('client-id')
 
     await expect(ensureAccessToken()).resolves.toBe('access-token')
-    expect(request).toHaveBeenCalledWith('builder-user-access-token', expect.any(Function))
+    expect(request).not.toHaveBeenCalled()
   })
 })

--- a/spx-gui/src/stores/user/signed-in.ts
+++ b/spx-gui/src/stores/user/signed-in.ts
@@ -112,17 +112,11 @@ export async function ensureAccessToken(): Promise<string | null> {
     }
 
     const refreshTokenBeforeRefresh = userState.refreshToken
-    const storedUserStateBeforeRefresh = localStorage.getItem(userStateStorageKey)
     try {
       await ensureOAuthFlow().refreshToken(refreshTokenBeforeRefresh).then(handleTokenResponse)
     } catch (e) {
       capture(e, 'Failed to refresh access token')
-      if (localStorage.getItem(userStateStorageKey) === storedUserStateBeforeRefresh) {
-        clearUserState()
-      } else {
-        // Preserve a session written by another page while this request was in flight.
-        restoreUserState()
-      }
+      clearUserState()
     }
   })
   return userState.accessToken

--- a/spx-gui/src/stores/user/signed-in.ts
+++ b/spx-gui/src/stores/user/signed-in.ts
@@ -41,11 +41,15 @@ export function initUserState(clientId: string) {
 
 function restoreUserState() {
   const stored = localStorage.getItem(userStateStorageKey)
-  if (stored == null) return
+  if (stored == null) {
+    clearUserState()
+    return
+  }
   try {
     Object.assign(userState, JSON.parse(stored))
   } catch {
     localStorage.removeItem(userStateStorageKey)
+    clearUserState()
   }
 }
 

--- a/spx-gui/src/stores/user/signed-in.ts
+++ b/spx-gui/src/stores/user/signed-in.ts
@@ -34,21 +34,18 @@ export function initUserState(clientId: string) {
 
   restoreUserState()
   window.addEventListener('storage', (event) => {
-    if (event.key === userStateStorageKey) restoreUserState(event.newValue)
+    if (event.key === userStateStorageKey) restoreUserState()
   })
   watchEffect(() => localStorage.setItem(userStateStorageKey, JSON.stringify(userState)))
 }
 
-function restoreUserState(stored: string | null = localStorage.getItem(userStateStorageKey)) {
-  if (stored == null) {
-    clearUserState()
-    return
-  }
+function restoreUserState() {
+  const stored = localStorage.getItem(userStateStorageKey)
+  if (stored == null) return
   try {
     Object.assign(userState, JSON.parse(stored))
   } catch {
     localStorage.removeItem(userStateStorageKey)
-    clearUserState()
   }
 }
 
@@ -115,12 +112,17 @@ export async function ensureAccessToken(): Promise<string | null> {
     }
 
     const refreshTokenBeforeRefresh = userState.refreshToken
+    const storedUserStateBeforeRefresh = localStorage.getItem(userStateStorageKey)
     try {
       await ensureOAuthFlow().refreshToken(refreshTokenBeforeRefresh).then(handleTokenResponse)
     } catch (e) {
       capture(e, 'Failed to refresh access token')
-      restoreUserState()
-      if (userState.refreshToken === refreshTokenBeforeRefresh) clearUserState()
+      if (localStorage.getItem(userStateStorageKey) === storedUserStateBeforeRefresh) {
+        clearUserState()
+      } else {
+        // Preserve a session written by another page while this request was in flight.
+        restoreUserState()
+      }
     }
   })
   return userState.accessToken

--- a/spx-gui/src/stores/user/signed-in.ts
+++ b/spx-gui/src/stores/user/signed-in.ts
@@ -104,38 +104,29 @@ export async function signOut() {
   ).catch((e) => capture(e, 'Failed to revoke tokens during sign out'))
 }
 
-let tokenRefreshPromise: Promise<void> | null = null
-
 export async function ensureAccessToken(): Promise<string | null> {
   if (isAccessTokenValid()) return userState.accessToken
   if (userState.refreshToken == null) {
     clearUserState()
     return null
   }
-  if (tokenRefreshPromise == null) {
-    tokenRefreshPromise = (async () => {
-      await navigator.locks.request('builder-user-token-refresh', async () => {
-        restoreUserState()
-        if (isAccessTokenValid()) return
-        if (userState.refreshToken == null) {
-          clearUserState()
-          return
-        }
+  await navigator.locks.request('builder-user-token-refresh', async () => {
+    restoreUserState()
+    if (isAccessTokenValid()) return
+    if (userState.refreshToken == null) {
+      clearUserState()
+      return
+    }
 
-        const refreshToken = userState.refreshToken
-        try {
-          await ensureOAuthFlow().refreshToken(refreshToken).then(handleTokenResponse)
-        } catch (e) {
-          capture(e, 'Failed to refresh access token')
-          restoreUserState()
-          if (userState.refreshToken === refreshToken) clearUserState()
-        }
-      })
-    })().finally(() => {
-      tokenRefreshPromise = null
-    })
-  }
-  await tokenRefreshPromise
+    const refreshToken = userState.refreshToken
+    try {
+      await ensureOAuthFlow().refreshToken(refreshToken).then(handleTokenResponse)
+    } catch (e) {
+      capture(e, 'Failed to refresh access token')
+      restoreUserState()
+      if (userState.refreshToken === refreshToken) clearUserState()
+    }
+  })
   return userState.accessToken
 }
 

--- a/spx-gui/src/stores/user/signed-in.ts
+++ b/spx-gui/src/stores/user/signed-in.ts
@@ -113,7 +113,8 @@ export async function ensureAccessToken(): Promise<string | null> {
 
     const refreshTokenBeforeRefresh = userState.refreshToken
     try {
-      await ensureOAuthFlow().refreshToken(refreshTokenBeforeRefresh).then(handleTokenResponse)
+      const token = await ensureOAuthFlow().refreshToken(refreshTokenBeforeRefresh)
+      await handleTokenResponse(token)
     } catch (e) {
       capture(e, 'Failed to refresh access token')
       clearUserState()

--- a/spx-gui/src/stores/user/signed-in.ts
+++ b/spx-gui/src/stores/user/signed-in.ts
@@ -1,4 +1,4 @@
-import { reactive, watchEffect, computed } from 'vue'
+import { reactive, computed } from 'vue'
 import { composeQuery, useQuery, useQueryCache, useQueryWithCache } from '@/utils/query'
 import { capture, useAction } from '@/utils/exception'
 import { OAuthFlow, type OAuthTokenResponse } from '@/utils/oauth'
@@ -31,15 +31,27 @@ export function initUserState(clientId: string) {
     redirectUri: `${window.location.origin}/sign-in/callback`
   })
 
-  const stored = localStorage.getItem(userStateStorageKey)
-  if (stored != null) {
-    try {
-      Object.assign(userState, JSON.parse(stored))
-    } catch {
-      localStorage.removeItem(userStateStorageKey)
-    }
+  restoreUserState()
+  window.addEventListener('storage', (event) => {
+    if (event.key === userStateStorageKey) restoreUserState(event.newValue)
+  })
+}
+
+function restoreUserState(stored: string | null = localStorage.getItem(userStateStorageKey)) {
+  if (stored == null) {
+    clearUserState(false)
+    return
   }
-  watchEffect(() => localStorage.setItem(userStateStorageKey, JSON.stringify(userState)))
+  try {
+    Object.assign(userState, JSON.parse(stored))
+  } catch {
+    localStorage.removeItem(userStateStorageKey)
+    clearUserState(false)
+  }
+}
+
+function persistUserState() {
+  localStorage.setItem(userStateStorageKey, JSON.stringify(userState))
 }
 
 async function getSignedInUsernameByAccessToken(accessToken: string) {
@@ -53,6 +65,7 @@ async function handleTokenResponse(resp: OAuthTokenResponse) {
   userState.accessTokenExpiresAt = resp.expires_in != null ? Date.now() + resp.expires_in * 1000 : null
   userState.refreshToken = resp.refresh_token ?? null
   userState.username = username
+  persistUserState()
 }
 
 export function useSignIn() {
@@ -78,13 +91,15 @@ export async function signInWithAccessToken(accessToken: string) {
   userState.accessTokenExpiresAt = null
   userState.refreshToken = null
   userState.username = username
+  persistUserState()
 }
 
-function clearUserState() {
+function clearUserState(persist: boolean = true) {
   userState.accessToken = null
   userState.accessTokenExpiresAt = null
   userState.refreshToken = null
   userState.username = null
+  if (persist) persistUserState()
 }
 
 export async function signOut() {
@@ -104,16 +119,27 @@ export async function ensureAccessToken(): Promise<string | null> {
     return null
   }
   if (tokenRefreshPromise == null) {
-    tokenRefreshPromise = ensureOAuthFlow()
-      .refreshToken(userState.refreshToken)
-      .then(handleTokenResponse)
-      .catch((e) => {
-        capture(e, 'Failed to refresh access token')
-        clearUserState()
+    tokenRefreshPromise = (async () => {
+      await navigator.locks.request('builder-user-token-refresh', async () => {
+        restoreUserState()
+        if (isAccessTokenValid()) return
+        if (userState.refreshToken == null) {
+          clearUserState()
+          return
+        }
+
+        const refreshToken = userState.refreshToken
+        try {
+          await ensureOAuthFlow().refreshToken(refreshToken).then(handleTokenResponse)
+        } catch (e) {
+          capture(e, 'Failed to refresh access token')
+          restoreUserState()
+          if (userState.refreshToken === refreshToken) clearUserState()
+        }
       })
-      .finally(() => {
-        tokenRefreshPromise = null
-      })
+    })().finally(() => {
+      tokenRefreshPromise = null
+    })
   }
   await tokenRefreshPromise
   return userState.accessToken

--- a/spx-gui/src/stores/user/signed-in.ts
+++ b/spx-gui/src/stores/user/signed-in.ts
@@ -114,13 +114,13 @@ export async function ensureAccessToken(): Promise<string | null> {
       return
     }
 
-    const refreshToken = userState.refreshToken
+    const refreshTokenBeforeRefresh = userState.refreshToken
     try {
-      await ensureOAuthFlow().refreshToken(refreshToken).then(handleTokenResponse)
+      await ensureOAuthFlow().refreshToken(refreshTokenBeforeRefresh).then(handleTokenResponse)
     } catch (e) {
       capture(e, 'Failed to refresh access token')
       restoreUserState()
-      if (userState.refreshToken === refreshToken) clearUserState()
+      if (userState.refreshToken === refreshTokenBeforeRefresh) clearUserState()
     }
   })
   return userState.accessToken

--- a/spx-gui/src/stores/user/signed-in.ts
+++ b/spx-gui/src/stores/user/signed-in.ts
@@ -1,4 +1,4 @@
-import { reactive, watchEffect, computed } from 'vue'
+import { reactive, computed } from 'vue'
 import { composeQuery, useQuery, useQueryCache, useQueryWithCache } from '@/utils/query'
 import { capture, useAction } from '@/utils/exception'
 import { OAuthFlow, type OAuthTokenResponse } from '@/utils/oauth'
@@ -12,14 +12,23 @@ export type SignedInUser = userApis.SignedInUser
 const userStateStorageKey = 'builder-user'
 const userAccessTokenLockName = 'builder-user-access-token'
 
+type UserState = {
+  accessToken: string | null
+  accessTokenExpiresAt: number | null
+  refreshToken: string | null
+  username: string | null
+}
+
+const emptyUserState: UserState = {
+  accessToken: null,
+  accessTokenExpiresAt: null,
+  refreshToken: null,
+  username: null
+}
+
 let oauthFlow: OAuthFlow<{ returnTo: string }> | null = null
 
-const userState = reactive({
-  accessToken: null as string | null,
-  accessTokenExpiresAt: null as number | null,
-  refreshToken: null as string | null,
-  username: null as string | null
-})
+const userState = reactive<UserState>({ ...emptyUserState })
 
 function ensureOAuthFlow() {
   if (oauthFlow == null) throw new Error('OAuth flow is not initialized')
@@ -34,23 +43,24 @@ export function initUserState(clientId: string) {
 
   restoreUserState()
   window.addEventListener('storage', (event) => {
-    if (event.key === userStateStorageKey) restoreUserState()
+    if (event.key == null || event.key === userStateStorageKey) restoreUserState()
   })
-  watchEffect(() => localStorage.setItem(userStateStorageKey, JSON.stringify(userState)))
 }
 
 function restoreUserState() {
   const stored = localStorage.getItem(userStateStorageKey)
-  if (stored == null) {
-    clearUserState()
-    return
-  }
   try {
-    Object.assign(userState, JSON.parse(stored))
+    const newState: UserState = stored != null ? JSON.parse(stored) : emptyUserState
+    Object.assign(userState, newState)
   } catch {
     localStorage.removeItem(userStateStorageKey)
-    clearUserState()
+    Object.assign(userState, emptyUserState)
   }
+}
+
+function setUserState(state: UserState) {
+  Object.assign(userState, state)
+  localStorage.setItem(userStateStorageKey, JSON.stringify(state))
 }
 
 async function getSignedInUsernameByAccessToken(accessToken: string) {
@@ -60,10 +70,12 @@ async function getSignedInUsernameByAccessToken(accessToken: string) {
 
 async function handleTokenResponse(resp: OAuthTokenResponse) {
   const username = await getSignedInUsernameByAccessToken(resp.access_token)
-  userState.accessToken = resp.access_token
-  userState.accessTokenExpiresAt = resp.expires_in != null ? Date.now() + resp.expires_in * 1000 : null
-  userState.refreshToken = resp.refresh_token ?? null
-  userState.username = username
+  setUserState({
+    accessToken: resp.access_token,
+    accessTokenExpiresAt: resp.expires_in != null ? Date.now() + resp.expires_in * 1000 : null,
+    refreshToken: resp.refresh_token ?? null,
+    username
+  })
 }
 
 export function useSignIn() {
@@ -85,17 +97,16 @@ export async function completeSignIn(search: string) {
 
 export async function signInWithAccessToken(accessToken: string) {
   const username = await getSignedInUsernameByAccessToken(accessToken)
-  userState.accessToken = accessToken
-  userState.accessTokenExpiresAt = null
-  userState.refreshToken = null
-  userState.username = username
+  setUserState({
+    accessToken,
+    accessTokenExpiresAt: null,
+    refreshToken: null,
+    username
+  })
 }
 
 function clearUserState() {
-  userState.accessToken = null
-  userState.accessTokenExpiresAt = null
-  userState.refreshToken = null
-  userState.username = null
+  setUserState(emptyUserState)
 }
 
 export async function signOut() {

--- a/spx-gui/src/stores/user/signed-in.ts
+++ b/spx-gui/src/stores/user/signed-in.ts
@@ -10,6 +10,7 @@ import { getUserQueryKey } from './query-keys'
 export type SignedInUser = userApis.SignedInUser
 
 const userStateStorageKey = 'builder-user'
+const userAccessTokenLockName = 'builder-user-access-token'
 
 let oauthFlow: OAuthFlow<{ returnTo: string }> | null = null
 
@@ -105,12 +106,7 @@ export async function signOut() {
 }
 
 export async function ensureAccessToken(): Promise<string | null> {
-  if (isAccessTokenValid()) return userState.accessToken
-  if (userState.refreshToken == null) {
-    clearUserState()
-    return null
-  }
-  await navigator.locks.request('builder-user-token-refresh', async () => {
+  await navigator.locks.request(userAccessTokenLockName, async () => {
     restoreUserState()
     if (isAccessTokenValid()) return
     if (userState.refreshToken == null) {

--- a/spx-gui/src/stores/user/signed-in.ts
+++ b/spx-gui/src/stores/user/signed-in.ts
@@ -1,4 +1,4 @@
-import { reactive, computed } from 'vue'
+import { reactive, watchEffect, computed } from 'vue'
 import { composeQuery, useQuery, useQueryCache, useQueryWithCache } from '@/utils/query'
 import { capture, useAction } from '@/utils/exception'
 import { OAuthFlow, type OAuthTokenResponse } from '@/utils/oauth'
@@ -35,23 +35,20 @@ export function initUserState(clientId: string) {
   window.addEventListener('storage', (event) => {
     if (event.key === userStateStorageKey) restoreUserState(event.newValue)
   })
+  watchEffect(() => localStorage.setItem(userStateStorageKey, JSON.stringify(userState)))
 }
 
 function restoreUserState(stored: string | null = localStorage.getItem(userStateStorageKey)) {
   if (stored == null) {
-    clearUserState(false)
+    clearUserState()
     return
   }
   try {
     Object.assign(userState, JSON.parse(stored))
   } catch {
     localStorage.removeItem(userStateStorageKey)
-    clearUserState(false)
+    clearUserState()
   }
-}
-
-function persistUserState() {
-  localStorage.setItem(userStateStorageKey, JSON.stringify(userState))
 }
 
 async function getSignedInUsernameByAccessToken(accessToken: string) {
@@ -65,7 +62,6 @@ async function handleTokenResponse(resp: OAuthTokenResponse) {
   userState.accessTokenExpiresAt = resp.expires_in != null ? Date.now() + resp.expires_in * 1000 : null
   userState.refreshToken = resp.refresh_token ?? null
   userState.username = username
-  persistUserState()
 }
 
 export function useSignIn() {
@@ -91,15 +87,13 @@ export async function signInWithAccessToken(accessToken: string) {
   userState.accessTokenExpiresAt = null
   userState.refreshToken = null
   userState.username = username
-  persistUserState()
 }
 
-function clearUserState(persist: boolean = true) {
+function clearUserState() {
   userState.accessToken = null
   userState.accessTokenExpiresAt = null
   userState.refreshToken = null
   userState.username = null
-  if (persist) persistUserState()
 }
 
 export async function signOut() {

--- a/spx-gui/src/stores/user/signed-in.ts
+++ b/spx-gui/src/stores/user/signed-in.ts
@@ -121,6 +121,7 @@ export async function ensureAccessToken(): Promise<string | null> {
   if (isAccessTokenValid()) return userState.accessToken
 
   await navigator.locks.request(userAccessTokenLockName, async () => {
+    // Another tab may have refreshed the token while this request waited for the lock.
     restoreUserState()
     if (isAccessTokenValid()) return
     if (userState.refreshToken == null) {

--- a/spx-gui/src/stores/user/signed-in.ts
+++ b/spx-gui/src/stores/user/signed-in.ts
@@ -103,6 +103,8 @@ export async function signOut() {
 }
 
 export async function ensureAccessToken(): Promise<string | null> {
+  if (isAccessTokenValid()) return userState.accessToken
+
   await navigator.locks.request(userAccessTokenLockName, async () => {
     restoreUserState()
     if (isAccessTokenValid()) return


### PR DESCRIPTION
Closes #3376

## Changes

- serialize access-token retrieval across browser pages with the Web Locks API
- reload shared credentials after acquiring the lock so waiting pages reuse the refreshed token
- synchronize user state through localStorage

## Verification

- `pnpm exec vitest --run src/stores/user/signed-in.test.ts`
- `pnpm run type-check`
- `pnpm run lint -- src/stores/user/signed-in.ts src/stores/user/signed-in.test.ts`