### PR TITLE
feat(spx-gui): preconnect critical resource origins

### DIFF
--- a/spx-gui/src/apps/account/.env
+++ b/spx-gui/src/apps/account/.env
@@ -23,6 +23,9 @@ VITE_API_PROXY_TARGET=""
 #   accordingly.
 VITE_WEB_ORIGIN=""
 
+# Base URL for Account avatar images.
+VITE_AVATAR_BASE_URL=""
+
 # Sentry configuration for app account.
 VITE_SENTRY_DSN=""
 VITE_SENTRY_TRACES_SAMPLE_RATE="0.8"

--- a/spx-gui/src/apps/account/.env.production
+++ b/spx-gui/src/apps/account/.env.production
@@ -1,3 +1,5 @@
 # Config for env production
 
+VITE_AVATAR_BASE_URL="https://xbuilder-account-avatars.gopluscdn.com"
+
 VITE_SENTRY_DSN="https://0d463740215eb87f7e06f6572d64c93e@o4509472134987776.ingest.us.sentry.io/4509472136167424"

--- a/spx-gui/src/apps/account/.env.production-cn
+++ b/spx-gui/src/apps/account/.env.production-cn
@@ -1,4 +1,6 @@
 # Config for env production-cn
 
+VITE_AVATAR_BASE_URL="https://xbuilder-account-avatars-cn.gopluscdn.com"
+
 VITE_SENTRY_DSN="https://3b532e8d49bece95a4ad2d14c73c2e0b@o4509472134987776.ingest.us.sentry.io/4509868940263424"
 VITE_DEFAULT_LANG="zh"

--- a/spx-gui/src/apps/account/.env.staging
+++ b/spx-gui/src/apps/account/.env.staging
@@ -3,4 +3,6 @@
 VITE_API_PROXY_TARGET="https://goplus-builder-account.qiniu.io/api"
 VITE_WEB_ORIGIN="https://goplus-builder-account.qiniu.io"
 
+VITE_AVATAR_BASE_URL="https://xbuilder-account-avatars-test.gopluscdn.com"
+
 VITE_SENTRY_DSN="https://0d463740215eb87f7e06f6572d64c93e@o4509472134987776.ingest.us.sentry.io/4509472136167424"

--- a/spx-gui/src/apps/account/index.html
+++ b/spx-gui/src/apps/account/index.html
@@ -3,6 +3,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+
+    <link rel="preconnect" href="%VITE_AVATAR_BASE_URL%" crossorigin />
+
     <title>XBuilder Account</title>
     <link rel="icon" href="/src/assets/logo.svg" />
 

--- a/spx-gui/src/apps/xbuilder/.env
+++ b/spx-gui/src/apps/xbuilder/.env
@@ -20,6 +20,15 @@ VITE_VERCEL_PROXIED_API_BASE_URL=""
 # Optional. Only used when running `npm run dev`.
 VITE_DEV_PROXIED_API_BASE_URL=""
 
+# Base URL for Account avatar images.
+VITE_ACCOUNT_AVATAR_BASE_URL=""
+
+# Account OAuth configuration used by app xbuilder for the main-site hosted
+# sign-in flow.
+#
+# Required when enabling the new Account OAuth flow.
+VITE_ACCOUNT_OAUTH_CLIENT_ID=""
+
 # Base URL for user-generated content files (e.g. images, audio) used in projects.
 #
 # NOTE: Must be synchronized with `KODO_BASE_URL` in spx-backend `.env` file.
@@ -60,9 +69,3 @@ VITE_SHOW_TUTORIALS_ENTRY="false"
 
 # Default language, e.g. `en`, `zh`.
 VITE_DEFAULT_LANG="en"
-
-# Account OAuth configuration used by app xbuilder for the main-site hosted
-# sign-in flow.
-#
-# Required when enabling the new Account OAuth flow.
-VITE_ACCOUNT_OAUTH_CLIENT_ID=""

--- a/spx-gui/src/apps/xbuilder/.env.production
+++ b/spx-gui/src/apps/xbuilder/.env.production
@@ -9,10 +9,11 @@
 VITE_API_BASE_URL="https://api.xbuilder.com"
 VITE_VERCEL_PROXIED_API_BASE_URL="https://api.xbuilder.com"
 
+VITE_ACCOUNT_AVATAR_BASE_URL="https://xbuilder-account-avatars.gopluscdn.com"
+VITE_ACCOUNT_OAUTH_CLIENT_ID="1"
+
 VITE_USERCONTENT_BASE_URL="https://builder-usercontent.gopluscdn.com"
 VITE_USERCONTENT_BUCKET="goplus-builder-usercontent"
 VITE_USERCONTENT_UPLOAD_BASE_URL="https://upload-na0.qiniup.com"
 
 VITE_SENTRY_DSN="https://0d463740215eb87f7e06f6572d64c93e@o4509472134987776.ingest.us.sentry.io/4509472136167424"
-
-VITE_ACCOUNT_OAUTH_CLIENT_ID="1"

--- a/spx-gui/src/apps/xbuilder/.env.production-cn
+++ b/spx-gui/src/apps/xbuilder/.env.production-cn
@@ -1,5 +1,8 @@
 VITE_API_BASE_URL="https://xbuilder-api.qiniu.com"
 
+VITE_ACCOUNT_AVATAR_BASE_URL="https://xbuilder-account-avatars-cn.gopluscdn.com"
+VITE_ACCOUNT_OAUTH_CLIENT_ID="1"
+
 VITE_USERCONTENT_BASE_URL="https://qn-xbuilder-usercontent.gopluscdn.com"
 VITE_USERCONTENT_BUCKET="xbuilder-usercontent"
 VITE_USERCONTENT_UPLOAD_BASE_URL="https://upload.qiniup.com"
@@ -9,5 +12,3 @@ VITE_SENTRY_DSN="https://3b532e8d49bece95a4ad2d14c73c2e0b@o4509472134987776.inge
 VITE_SHOW_LICENSE="true"
 VITE_SHOW_TUTORIALS_ENTRY="true"
 VITE_DEFAULT_LANG="zh"
-
-VITE_ACCOUNT_OAUTH_CLIENT_ID="1"

--- a/spx-gui/src/apps/xbuilder/.env.staging
+++ b/spx-gui/src/apps/xbuilder/.env.staging
@@ -3,6 +3,9 @@
 VITE_API_BASE_URL="https://goplus-builder-api.qiniu.io"
 VITE_VERCEL_PROXIED_API_BASE_URL="https://goplus-builder-api.qiniu.io"
 
+VITE_ACCOUNT_AVATAR_BASE_URL="https://xbuilder-account-avatars-test.gopluscdn.com"
+VITE_ACCOUNT_OAUTH_CLIENT_ID="1"
+
 VITE_USERCONTENT_BASE_URL="https://xbuilder-usercontent-test.gopluscdn.com"
 VITE_USERCONTENT_BUCKET="xbuilder-usercontent-test"
 VITE_USERCONTENT_UPLOAD_BASE_URL="https://upload.qiniup.com"
@@ -10,5 +13,3 @@ VITE_USERCONTENT_UPLOAD_BASE_URL="https://upload.qiniup.com"
 VITE_SENTRY_DSN="https://0d463740215eb87f7e06f6572d64c93e@o4509472134987776.ingest.us.sentry.io/4509472136167424"
 
 VITE_SHOW_TUTORIALS_ENTRY="true"
-
-VITE_ACCOUNT_OAUTH_CLIENT_ID="1"

--- a/spx-gui/src/apps/xbuilder/index.html
+++ b/spx-gui/src/apps/xbuilder/index.html
@@ -4,9 +4,10 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
 
-    <link rel="dns-prefetch" href="%VITE_USERCONTENT_UPLOAD_BASE_URL%" />
-    <link rel="dns-prefetch" href="%VITE_USERCONTENT_BASE_URL%" />
+    <link rel="preconnect" href="%VITE_API_BASE_URL%" crossorigin />
+    <link rel="preconnect" href="%VITE_ACCOUNT_AVATAR_BASE_URL%" crossorigin />
     <link rel="preconnect" href="%VITE_USERCONTENT_BASE_URL%" crossorigin />
+    <link rel="dns-prefetch" href="%VITE_USERCONTENT_UPLOAD_BASE_URL%" />
 
     <title>XBuilder</title>
     <meta


### PR DESCRIPTION
Preconnect the API, Account avatar CDN, and usercontent CDN so early cross-origin requests can reuse warmed connections.

Configure Account avatar origins for every deployment mode and keep the upload host on DNS-only prefetch to avoid opening an unnecessary connection before user action.