### PR TITLE
fix(account): preserve client IP through trusted proxies

### DIFF
--- a/spx-gui/build/nginx.account.conf
+++ b/spx-gui/build/nginx.account.conf
@@ -2,6 +2,11 @@ server {
     listen 80 default_server;
     server_name _;
 
+    # Ingress controller addresses in the jfcs-k8s-qa1 cluster.
+    set_real_ip_from 10.210.31.52/32;
+    set_real_ip_from 10.210.31.66/32;
+    real_ip_header X-Real-IP;
+
     client_max_body_size 5M;
 
     gzip on;


### PR DESCRIPTION
Trust only the jfcs-k8s-qa1 ingress controller addresses when restoring `X-Real-IP` before proxying Account API requests. This preserves the client address across the hosted sign-in facade for backend IP-based limits.