### PR TITLE
feat(project)!: create releases from saved revisions

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -2211,7 +2211,10 @@ paths:
       tags:
         - Project Releases
       summary: Create a project release
-      description: Create a new release for a specific project.
+      description: |
+        Create a new release for a specific project.
+
+        The request fails with a conflict if the current project revision does not match `projectRevision`.
       parameters:
         - name: owner
           description: Username of the project's owner.
@@ -2234,6 +2237,7 @@ paths:
               required:
                 - name
                 - description
+                - projectRevision
               properties:
                 name:
                   $ref: "#/components/schemas/ProjectRelease/properties/name"
@@ -2241,6 +2245,15 @@ paths:
                   $ref: "#/components/schemas/ProjectRelease/properties/description"
                 thumbnail:
                   $ref: "#/components/schemas/ProjectRelease/properties/thumbnail"
+                projectRevision:
+                  description: |
+                    Expected revision of the project state from which to create the release. The request fails with a
+                    conflict if the current project revision does not match this value.
+                  type: integer
+                  format: int64
+                  minimum: 1
+                  examples:
+                    - 1
       responses:
         "201":
           description: Successfully created the project release.
@@ -2266,7 +2279,7 @@ paths:
         "404":
           $ref: "#/components/responses/NotFound"
         "409":
-          $ref: "#/components/responses/ResourceMoved"
+          $ref: "#/components/responses/ProjectReleaseCreateConflict"
 
   /projects/{owner}/{project}/releases/{release}:
     get:
@@ -5830,6 +5843,16 @@ components:
             oneOf:
               - $ref: "#/components/schemas/ConflictError"
               - $ref: "#/components/schemas/MovedResourceError"
+    ProjectReleaseCreateConflict:
+      description: |
+        The release creation conflicts with current project state because `projectRevision` does not match the current
+        project revision or the requested project route moved.
+      content:
+        application/json:
+          schema:
+            oneOf:
+              - $ref: "#/components/schemas/ConflictError"
+              - $ref: "#/components/schemas/MovedResourceError"
     BadRequest:
       description: Invalid request syntax, parameters, or body.
       content:
@@ -7258,7 +7281,7 @@ components:
         - name
         - type
         - displayName
-        - version
+        - revision
         - files
         - visibility
         - description
@@ -7306,10 +7329,16 @@ components:
           maxLength: 100
           examples:
             - Niu Xiao Qi
-        version:
-          description: Version number of the project.
+        revision:
+          description: |
+            Monotonically increasing identifier of the project's editable state.
+
+            Changes to editable project content or metadata advance this revision. Creating releases and updating
+            activity counters such as views, likes, and remixes do not.
           type: integer
-          format: int32
+          format: int64
+          minimum: 1
+          readOnly: true
           examples:
             - 1
         files:

--- a/spx-gui/src/apis/project-release.ts
+++ b/spx-gui/src/apis/project-release.ts
@@ -23,7 +23,10 @@ export type ProjectRelease = {
   remixCount: number
 }
 
-export type CreateProjectReleaseParams = Pick<ProjectRelease, 'name' | 'description' | 'thumbnail'>
+export type CreateProjectReleaseParams = Pick<ProjectRelease, 'name' | 'description' | 'thumbnail'> & {
+  /** Expected revision of the project state from which to create the release. */
+  projectRevision: number
+}
 
 export function createProjectRelease(
   owner: string,

--- a/spx-gui/src/apis/project.ts
+++ b/spx-gui/src/apis/project.ts
@@ -61,8 +61,8 @@ export type ProjectData = {
   type: ProjectType
   /** Display name of the project */
   displayName: string
-  /** Version number of the project */
-  version: number
+  /** Monotonically increasing identifier of the project's editable state */
+  revision: number
   /** File paths and their corresponding universal URLs associated with the project */
   files: FileCollection
   /** Visibility of the project */

--- a/spx-gui/src/components/course/management/course-series-file.test.ts
+++ b/spx-gui/src/components/course/management/course-series-file.test.ts
@@ -101,7 +101,7 @@ beforeEach(() => {
         instructions: '',
         createdAt: '2026-01-01T00:00:00Z',
         updatedAt: '2026-01-01T00:00:00Z',
-        version: 1,
+        revision: 1,
         files: {},
         thumbnail: '',
         remixedFrom: null,
@@ -122,7 +122,11 @@ beforeEach(() => {
     } as unknown as Awaited<ReturnType<typeof cloudHelpers.load>>
   })
   vi.mocked(cloudHelpers.save).mockImplementation(
-    async (serialized) => serialized as Awaited<ReturnType<typeof cloudHelpers.save>>
+    async (serialized) =>
+      ({
+        ...serialized,
+        metadata: { ...serialized.metadata, revision: 7 }
+      }) as Awaited<ReturnType<typeof cloudHelpers.save>>
   )
   vi.mocked(xbpHelpers.save).mockImplementation(
     async (serialized) => new File([JSON.stringify(serialized.metadata)], `${serialized.metadata.name}.xbp`)
@@ -165,9 +169,31 @@ beforeEach(() => {
     updatedAt: '2026-01-01T00:00:00Z'
   }))
   vi.mocked(deleteCourse).mockResolvedValue(undefined)
-  vi.mocked(updateProject).mockResolvedValue({} as Awaited<ReturnType<typeof updateProject>>)
+  vi.mocked(updateProject).mockImplementation(
+    async (owner, name) =>
+      ({
+        owner,
+        name,
+        revision: 8
+      }) as Awaited<ReturnType<typeof updateProject>>
+  )
   vi.mocked(createProjectRelease).mockResolvedValue({} as Awaited<ReturnType<typeof createProjectRelease>>)
 })
+
+function mockCloudProjectSave(owner: string, name: string, revision: number) {
+  vi.mocked(cloudHelpers.save).mockImplementationOnce(
+    async (serialized) =>
+      ({
+        ...serialized,
+        metadata: {
+          ...serialized.metadata,
+          owner,
+          name,
+          revision
+        }
+      }) as Awaited<ReturnType<typeof cloudHelpers.save>>
+  )
+}
 
 describe('exportCourseSeriesFile', () => {
   it('exports a self-contained package with entrypoint projects', async () => {
@@ -233,9 +259,81 @@ describe('importCourseSeriesFile', () => {
       'alice',
       'EntryProject',
       expect.objectContaining({
-        description: 'Imported from course series "Imported series"'
+        description: 'Imported from course series "Imported series"',
+        thumbnail: '',
+        projectRevision: 8
       }),
       ctrl.signal
+    )
+  })
+
+  it('uses the canonical project identity returned by the project save', async () => {
+    vi.mocked(xbpHelpers.load).mockResolvedValueOnce({
+      metadata: {
+        displayName: 'Display EntryProject',
+        type: ProjectType.Game,
+        visibility: Visibility.Public
+      },
+      files: {}
+    })
+    mockCloudProjectSave('saved-owner', 'SavedProject', 7)
+
+    await importCourseSeriesFile(
+      existingSeries,
+      await makeCourseSeriesFile('/editor/curator/EntryProject/lesson?tab=code'),
+      'alice'
+    )
+
+    expect(updateProject).not.toHaveBeenCalled()
+    expect(createProjectRelease).toHaveBeenCalledWith(
+      'saved-owner',
+      'SavedProject',
+      expect.objectContaining({ projectRevision: 7 }),
+      undefined
+    )
+    expect(addCourse).toHaveBeenCalledWith(
+      expect.objectContaining({
+        entrypoint: '/editor/saved-owner/SavedProject/lesson?tab=code'
+      }),
+      undefined
+    )
+  })
+
+  it('uses the canonical project identity returned by the metadata update', async () => {
+    mockCloudProjectSave('saved-owner', 'SavedProject', 7)
+    vi.mocked(updateProject).mockResolvedValueOnce({
+      owner: 'final-owner',
+      name: 'FinalProject',
+      revision: 8
+    } as Awaited<ReturnType<typeof updateProject>>)
+
+    await importCourseSeriesFile(
+      existingSeries,
+      await makeCourseSeriesFile('/editor/curator/EntryProject/lesson?tab=code'),
+      'alice'
+    )
+
+    expect(updateProject).toHaveBeenCalledWith(
+      'saved-owner',
+      'SavedProject',
+      {
+        description: 'Description EntryProject',
+        instructions: 'Instructions EntryProject',
+        extraSettings: {}
+      },
+      undefined
+    )
+    expect(createProjectRelease).toHaveBeenCalledWith(
+      'final-owner',
+      'FinalProject',
+      expect.objectContaining({ projectRevision: 8 }),
+      undefined
+    )
+    expect(addCourse).toHaveBeenCalledWith(
+      expect.objectContaining({
+        entrypoint: '/editor/final-owner/FinalProject/lesson?tab=code'
+      }),
+      undefined
     )
   })
 

--- a/spx-gui/src/components/course/management/course-series-file.ts
+++ b/spx-gui/src/components/course/management/course-series-file.ts
@@ -273,31 +273,36 @@ async function importProject(
 ) {
   const serialized = await xbpHelpers.load(new File([getRequiredEntry(unzipped, project.path)], `${project.name}.xbp`))
   const existingProject = await getSignedInUserProject(signedInUsername, project.name, signal)
-  const owner = existingProject?.owner ?? signedInUsername
-  const name = existingProject?.name ?? project.name
   const metadata: PartialMetadata = {
     ...serialized.metadata,
     id: existingProject?.id,
-    owner,
-    name,
+    owner: existingProject?.owner ?? signedInUsername,
+    name: existingProject?.name ?? project.name,
     displayName: serialized.metadata.displayName ?? project.name,
     type: serialized.metadata.type ?? ProjectType.Game,
     visibility: Visibility.Public
   }
 
-  await cloudHelpers.save({ metadata, files: serialized.files }, signal)
+  const saved = await cloudHelpers.save({ metadata, files: serialized.files }, signal)
+  let { owner, name, revision } = saved.metadata
   const metadataUpdates: UpdateProjectParams = {}
   if (serialized.metadata.description != null) metadataUpdates.description = serialized.metadata.description
   if (serialized.metadata.instructions != null) metadataUpdates.instructions = serialized.metadata.instructions
   if (serialized.metadata.extraSettings != null) metadataUpdates.extraSettings = serialized.metadata.extraSettings
-  if (Object.keys(metadataUpdates).length > 0) await updateProject(owner, name, metadataUpdates, signal)
+  if (Object.keys(metadataUpdates).length > 0) {
+    const updated = await updateProject(owner, name, metadataUpdates, signal)
+    owner = updated.owner
+    name = updated.name
+    revision = updated.revision
+  }
   await createProjectRelease(
     owner,
     name,
     {
       name: generateReleaseName(),
       description: `Imported from course series "${manifest.courseSeries.title}"`,
-      thumbnail: ''
+      thumbnail: '',
+      projectRevision: revision
     },
     signal
   )

--- a/spx-gui/src/components/editor/editing.test.ts
+++ b/spx-gui/src/components/editor/editing.test.ts
@@ -41,7 +41,7 @@ function makeProject({
   return new MockProject(owner, name, files)
 }
 
-function makeCloudSerialized(owner: string, name: string, version: number = 1): ProjectSerialized<Metadata> {
+function makeCloudSerialized(owner: string, name: string, revision: number = 1): ProjectSerialized<Metadata> {
   return {
     metadata: {
       id: 'project-id',
@@ -52,7 +52,7 @@ function makeCloudSerialized(owner: string, name: string, version: number = 1): 
       name,
       type: ProjectType.Game,
       displayName: name,
-      version,
+      revision,
       visibility: Visibility.Private,
       description: '',
       instructions: '',
@@ -69,17 +69,31 @@ function makeCloudSerialized(owner: string, name: string, version: number = 1): 
   }
 }
 
-function makeLocalSerialized(owner: string, name: string, version?: number): ProjectSerialized {
+function makeLocalSerialized(owner: string, name: string, revision?: number): ProjectSerialized {
   return {
-    metadata: { owner, name, version },
+    metadata: { owner, name, revision },
     files: { 'main.spx': mockFile('main.spx') }
+  }
+}
+
+function makeSavedSerialized({ metadata, files }: ProjectSerialized) {
+  return {
+    metadata: {
+      ...makeCloudSerialized('owner', 'project').metadata,
+      ...metadata,
+      latestRelease: null,
+      owner: metadata.owner ?? 'owner',
+      name: metadata.name ?? 'project',
+      revision: metadata.revision ?? 1
+    },
+    files
   }
 }
 
 function makeCloudHelpers(): CloudHelpers {
   return {
     load: vi.fn().mockResolvedValue(makeCloudSerialized('owner', 'project')),
-    save: vi.fn().mockResolvedValue({ metadata: {}, files: {} })
+    save: vi.fn().mockImplementation(async (serialized) => makeSavedSerialized(serialized))
   }
 }
 
@@ -138,7 +152,7 @@ describe('Editing', () => {
   it('should do auto-save correctly', async () => {
     const cloudHelpers = makeCloudHelpers()
     vi.mocked(cloudHelpers.save).mockImplementation(({ metadata, files }: ProjectSerialized, signal?: AbortSignal) =>
-      timeout(500, signal).then(() => ({ metadata, files }))
+      timeout(500, signal).then(() => makeSavedSerialized({ metadata, files }))
     )
     const localCacheHelper = makeLocalCache()
     vi.mocked(localCacheHelper.save).mockImplementation((_serialized: ProjectSerialized, signal?: AbortSignal) =>
@@ -180,7 +194,7 @@ describe('Editing', () => {
     vi.mocked(cloudHelpers.save)
       .mockRejectedValueOnce(new Error('Cloud save failed'))
       .mockRejectedValueOnce(new Error('Cloud save failed again'))
-      .mockResolvedValue({ metadata: {}, files: {} })
+      .mockResolvedValue(makeSavedSerialized({ metadata: {}, files: {} }))
     const editing = makeEditing({ project, cloudHelpers })
     editing.startEditing()
 
@@ -343,7 +357,7 @@ describe('Editing', () => {
     const project = makeProject()
     const cloudHelpers = makeCloudHelpers()
     vi.mocked(cloudHelpers.save).mockImplementation(({ metadata, files }: ProjectSerialized, signal?: AbortSignal) =>
-      timeout(500, signal).then(() => ({ metadata, files }))
+      timeout(500, signal).then(() => makeSavedSerialized({ metadata, files }))
     )
     const isOnline = ref(false) // Start offline
     const localCacheHelper = makeLocalCache()
@@ -436,7 +450,7 @@ describe('Editing.loadProject', () => {
     expect(localCacheHelper.clear).toHaveBeenCalled()
   })
 
-  it('should prefer local cache when local version is newer than cloud version', async () => {
+  it('should prefer local cache when local revision is newer than cloud revision', async () => {
     const cloudData = makeCloudSerialized('alice', 'my-project', 1)
     const localData = makeLocalSerialized('alice', 'my-project', 2)
     const cloudHelpers = makeCloudHelpers()
@@ -451,7 +465,7 @@ describe('Editing.loadProject', () => {
     expect(project.load).toHaveBeenCalledWith(localData, expect.anything())
   })
 
-  it('should prefer cloud data and clear cache when cloud version is newer', async () => {
+  it('should prefer cloud data and clear cache when cloud revision is newer', async () => {
     const cloudData = makeCloudSerialized('alice', 'my-project', 3)
     const localData = makeLocalSerialized('alice', 'my-project', 1)
     const cloudHelpers = makeCloudHelpers()
@@ -661,7 +675,7 @@ describe('Editing.loadProject', () => {
     expect(editing.mode).toBe(EditingMode.AutoSave)
   })
 
-  it('should prefer local cache when cloud and local versions are equal', async () => {
+  it('should prefer local cache when cloud and local revisions are equal', async () => {
     const cloudData = makeCloudSerialized('alice', 'my-project', 1)
     const localData = makeLocalSerialized('alice', 'my-project', 1)
     const cloudHelpers = makeCloudHelpers()
@@ -673,7 +687,7 @@ describe('Editing.loadProject', () => {
 
     await editing.loadProject('alice', 'my-project', makeUIHelpers(), makeReporter(), new AbortController().signal)
 
-    // Equal versions keep the local cache to preserve unsaved local work.
+    // Equal revisions keep the local cache to preserve unsaved local work.
     expect(project.load).toHaveBeenCalledWith(localData, expect.anything())
   })
 })

--- a/spx-gui/src/components/editor/editing.ts
+++ b/spx-gui/src/components/editor/editing.ts
@@ -255,10 +255,10 @@ export class Editing extends Disposable {
 
     let finalData: ProjectSerialized = cloudData
     if (localData != null) {
-      const cloudVersion = cloudData?.metadata.version ?? -1
-      const localVersion = localData.metadata.version ?? -1
-      if (cloudVersion > localVersion) {
-        // If cloud version is newer, ignore & clear the cached data to avoid potential conflict
+      const cloudRevision = cloudData?.metadata.revision ?? -1
+      const localRevision = localData.metadata.revision ?? -1
+      if (cloudRevision > localRevision) {
+        // If the cloud revision is newer, ignore and clear the cached data to avoid potential conflict.
         this.localCacheHelper.clear().catch((e) => capture(e, 'Failed to clear local cache'))
       } else {
         finalData = localData

--- a/spx-gui/src/components/editor/editor-state.test.ts
+++ b/spx-gui/src/components/editor/editor-state.test.ts
@@ -19,7 +19,10 @@ import { EditorState, type IRouter, type Selected } from './editor-state'
 function makeCloudHelpers(): editing.CloudHelpers {
   return {
     load: vi.fn().mockResolvedValue({ metadata: { owner: 'test-owner', name: 'test-project' }, files: {} }),
-    save: vi.fn().mockResolvedValue({ metadata: {}, files: {} })
+    save: vi.fn().mockResolvedValue({
+      metadata: { owner: 'test-owner', name: 'test-project', revision: 1 },
+      files: {}
+    })
   }
 }
 

--- a/spx-gui/src/components/project/ProjectPublishModal.test.ts
+++ b/spx-gui/src/components/project/ProjectPublishModal.test.ts
@@ -1,0 +1,190 @@
+import { defineComponent } from 'vue'
+import { flushPromises, mount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { Visibility } from '@/apis/common'
+import type { SpxProject } from '@/models/spx/project'
+import ProjectPublishModal from './ProjectPublishModal.vue'
+
+const mocks = vi.hoisted(() => ({
+  createProjectRelease: vi.fn(),
+  save: vi.fn(),
+  saveFile: vi.fn(),
+  handledError: null as unknown
+}))
+
+vi.mock('dayjs', () => ({
+  default: () => ({
+    tz: () => ({
+      format: () => '20260803000000'
+    })
+  })
+}))
+
+vi.mock('@/utils/exception', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/utils/exception')>()),
+  useMessageHandle: (fn: (...args: unknown[]) => unknown) => ({
+    fn: async (...args: unknown[]) => {
+      try {
+        await fn(...args)
+      } catch (error) {
+        mocks.handledError = error
+      }
+    },
+    isLoading: { value: false }
+  })
+}))
+
+vi.mock('@/utils/i18n', () => ({
+  useI18n: () => ({
+    t: (message: { en: string }) => message.en
+  })
+}))
+
+vi.mock('@/utils/img-rendering', () => ({
+  useRenderableImageUrl: () => ['', false]
+}))
+
+vi.mock('@/utils/project', () => ({
+  isProjectUsingAIInteraction: () => false
+}))
+
+vi.mock('@/apis/project-release', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/apis/project-release')>()),
+  createProjectRelease: mocks.createProjectRelease
+}))
+
+vi.mock('@/models/common/cloud', () => ({
+  cloudHelpers: {
+    save: mocks.save
+  },
+  saveFile: mocks.saveFile
+}))
+
+vi.mock('@/components/ui', () => {
+  const Stub = defineComponent({ template: '<div><slot /></div>' })
+  const FormStub = defineComponent({
+    emits: ['submit'],
+    template: '<form @submit.prevent="$emit(\'submit\')"><slot /></form>'
+  })
+  const TextInputStub = defineComponent({
+    props: {
+      value: { type: String, default: '' },
+      type: { type: String, default: 'text' }
+    },
+    emits: ['update:value'],
+    template:
+      '<textarea v-if="type === \'textarea\'" :value="value" @input="$emit(\'update:value\', $event.target.value)" /><input v-else :value="value" @input="$emit(\'update:value\', $event.target.value)" />'
+  })
+  return {
+    UIButton: Stub,
+    UIForm: FormStub,
+    UIFormItem: Stub,
+    UIFormModal: Stub,
+    UIImg: Stub,
+    UITextInput: TextInputStub,
+    useForm: (fields: Record<string, [unknown]>) => ({
+      value: Object.fromEntries(Object.entries(fields).map(([key, [value]]) => [key, value]))
+    })
+  }
+})
+
+function makeProject() {
+  const project = {
+    owner: 'alice',
+    name: 'project',
+    displayName: 'Project',
+    description: 'Old description',
+    instructions: 'Old instructions',
+    thumbnail: {},
+    visibility: Visibility.Private,
+    revision: 6,
+    releaseCount: 2,
+    ensureAIDescription: vi.fn(),
+    export: vi.fn().mockResolvedValue({ metadata: {}, files: {} }),
+    setDescription: vi.fn((description: string) => {
+      project.description = description
+    }),
+    setInstructions: vi.fn((instructions: string) => {
+      project.instructions = instructions
+    }),
+    setMetadata: vi.fn((metadata: Record<string, unknown>) => {
+      Object.assign(project, metadata)
+    }),
+    setVisibility: vi.fn((visibility: Visibility) => {
+      project.visibility = visibility
+    })
+  }
+  return project as unknown as SpxProject
+}
+
+function mountModal(project: SpxProject) {
+  return mount(ProjectPublishModal, {
+    props: {
+      project,
+      visible: true
+    },
+    global: {
+      directives: {
+        radar: () => {}
+      },
+      mocks: {
+        $t: (message: { en: string }) => message.en
+      }
+    }
+  })
+}
+
+describe('ProjectPublishModal', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    mocks.handledError = null
+    mocks.save.mockResolvedValue({
+      metadata: {
+        owner: 'alice',
+        name: 'project',
+        revision: 7,
+        visibility: Visibility.Public
+      },
+      files: {}
+    })
+    mocks.saveFile.mockResolvedValue('kodo://builder/thumbnails/project.png')
+    mocks.createProjectRelease.mockResolvedValue({ name: 'v1.0.0' })
+  })
+
+  it('creates a release from the saved public project revision', async () => {
+    const project = makeProject()
+    const wrapper = mountModal(project)
+
+    await wrapper.get('textarea').setValue('Release notes')
+    await wrapper.get('form').trigger('submit')
+    await flushPromises()
+
+    expect(project.setVisibility).toHaveBeenCalledWith(Visibility.Public)
+    const saveCallOrder = mocks.save.mock.invocationCallOrder[0]
+    const releaseCallOrder = mocks.createProjectRelease.mock.invocationCallOrder[0]
+    if (saveCallOrder == null || releaseCallOrder == null) throw new Error('Expected save and release calls')
+    expect(saveCallOrder).toBeLessThan(releaseCallOrder)
+    expect(mocks.createProjectRelease).toHaveBeenCalledWith('alice', 'project', {
+      name: expect.stringMatching(/^v0\.0\.0\+/),
+      description: 'Release notes',
+      thumbnail: 'kodo://builder/thumbnails/project.png',
+      projectRevision: 7
+    })
+    expect(wrapper.emitted('resolved')).toHaveLength(1)
+  })
+
+  it('keeps the project public and the modal open when release creation fails', async () => {
+    const project = makeProject()
+    const wrapper = mountModal(project)
+    const error = new Error('release failed')
+    mocks.createProjectRelease.mockRejectedValue(error)
+
+    await wrapper.get('textarea').setValue('Release notes')
+    await wrapper.get('form').trigger('submit')
+    await flushPromises()
+
+    expect(mocks.handledError).toBe(error)
+    expect(project.visibility).toBe(Visibility.Public)
+    expect(wrapper.emitted('resolved')).toBeUndefined()
+  })
+})

--- a/spx-gui/src/components/project/ProjectPublishModal.vue
+++ b/spx-gui/src/components/project/ProjectPublishModal.vue
@@ -81,12 +81,14 @@ const handleSubmit = useMessageHandle(
     if (isProjectUsingAIInteraction(project)) await project.ensureAIDescription(true) // Ensure AI description is available if needed
     const serialized = await project.export()
     const saved = await cloudHelpers.save(serialized)
+    const { owner, name, revision } = saved.metadata
     project.setMetadata(saved.metadata)
-    const thumbnailUniversalUrl = await saveFile(props.project.thumbnail!)
-    await createProjectRelease(project.owner!, project.name!, {
+    const thumbnailUniversalUrl = await saveFile(project.thumbnail!)
+    await createProjectRelease(owner, name, {
       name: generateReleaseName(),
       description: form.value.releaseDescription,
-      thumbnail: thumbnailUniversalUrl
+      thumbnail: thumbnailUniversalUrl,
+      projectRevision: revision
     })
     emit('resolved')
   },

--- a/spx-gui/src/models/common/cloud.ts
+++ b/spx-gui/src/models/common/cloud.ts
@@ -148,8 +148,11 @@ async function save(metadata: PartialMetadata, files: Files, signal?: AbortSigna
       ))
   signal?.throwIfAborted()
 
-  metadata = { ...savedMetadata, thumbnail: metadata.thumbnail }
-  return { metadata, files }
+  const savedProjectMetadata = {
+    ...savedMetadata,
+    thumbnail: metadata.thumbnail
+  }
+  return { metadata: savedProjectMetadata, files }
 }
 
 async function parseProjectData({ files: fileCollection, thumbnail: thumbnailUniversalUrl, ...extra }: ProjectData) {

--- a/spx-gui/src/models/spx/project.ts
+++ b/spx-gui/src/models/spx/project.ts
@@ -111,7 +111,7 @@ export class SpxProject extends Disposable implements IProject {
   name?: string
   type = ProjectType.Game
   displayName = ''
-  version = 0
+  revision = 0
   visibility?: Visibility
   description?: string
   instructions?: string
@@ -399,7 +399,7 @@ export class SpxProject extends Disposable implements IProject {
       name: this.name,
       type: this.type,
       displayName: this.displayName,
-      version: this.version,
+      revision: this.revision,
       visibility: this.visibility,
       description: this.description,
       instructions: this.instructions,


### PR DESCRIPTION
Adopt `Project` revisions in API models, project metadata, and local cache freshness checks. Use the canonical project identity and revision returned by the last successful project save or metadata update when creating a release, including course-series imports.

Preserve the existing public-first publish flow. If release creation fails after the save, the `Project` remains public and the user can retry.

BREAKING CHANGE: Frontend Project data uses `revision` instead of `version`, and release creation requires `projectRevision`.
