### PR TITLE
fix(api)!: align thumbnail omission semantics

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1524,6 +1524,9 @@ paths:
         Create a new project owned by the authenticated user.
 
         If `remixSource` is provided, the new project will be a remix of an existing project.
+
+        For remixes, omitted `files` and `thumbnail` inherit from the source release, while omitted `description` and
+        `instructions` inherit from the source project. Explicitly provided values are used as-is.
       requestBody:
         required: true
         content:
@@ -2244,7 +2247,10 @@ paths:
                 description:
                   $ref: "#/components/schemas/ProjectRelease/properties/description"
                 thumbnail:
-                  $ref: "#/components/schemas/ProjectRelease/properties/thumbnail"
+                  description: Defaults to the project's thumbnail if not provided.
+                  allOf:
+                    - $ref: "#/components/schemas/ProjectRelease/properties/thumbnail"
+                  minLength: 1
                 projectRevision:
                   description: |
                     Expected revision of the project state from which to create the release. The request fails with a
@@ -3152,6 +3158,7 @@ paths:
               type: object
               required:
                 - title
+                - thumbnail
                 - courseIDs
                 - order
               properties:
@@ -7631,6 +7638,7 @@ components:
           description: Thumbnail reference of the course series.
           type: string
           format: uri-reference
+          minLength: 1
           examples:
             - kodo://xbuilder-usercontent-test/files/FvYyHLNrtx8qFHSwnLjEe57UA2fF-2824936
         description:

--- a/spx-gui/src/apis/project-release.ts
+++ b/spx-gui/src/apis/project-release.ts
@@ -23,7 +23,9 @@ export type ProjectRelease = {
   remixCount: number
 }
 
-export type CreateProjectReleaseParams = Pick<ProjectRelease, 'name' | 'description' | 'thumbnail'> & {
+export type CreateProjectReleaseParams = Pick<ProjectRelease, 'name' | 'description'> & {
+  /** Defaults to the project's thumbnail if not provided. */
+  thumbnail?: ProjectRelease['thumbnail']
   /** Expected revision of the project state from which to create the release. */
   projectRevision: number
 }

--- a/spx-gui/src/components/course/management/course-series-file.test.ts
+++ b/spx-gui/src/components/course/management/course-series-file.test.ts
@@ -11,7 +11,12 @@ import { createProjectRelease } from '@/apis/project-release'
 import { cloudHelpers, createFileWithUniversalUrl, saveFile } from '@/models/common/cloud'
 import { File as LazyFile } from '@/models/common/file'
 import { xbpHelpers } from '@/models/common/xbp'
-import { exportCourseSeriesFile, importCourseSeriesFile, inspectCourseSeriesFileImport } from './course-series-file'
+import {
+  exportCourseSeriesFile,
+  importCourseSeriesFile,
+  importCourseSeriesFileAsNew,
+  inspectCourseSeriesFileImport
+} from './course-series-file'
 
 dayjs.extend(utc)
 dayjs.extend(timezone)
@@ -228,6 +233,29 @@ describe('exportCourseSeriesFile', () => {
 })
 
 describe('importCourseSeriesFile', () => {
+  it('creates a new course series with complete imported content', async () => {
+    const ctrl = new AbortController()
+
+    await importCourseSeriesFileAsNew(
+      await makeCourseSeriesFile('/editor/curator/EntryProject/lesson?tab=code'),
+      'alice',
+      ctrl.signal
+    )
+
+    expect(addCourseSeries).toHaveBeenCalledWith(
+      {
+        title: 'Imported series',
+        thumbnail: 'kodo://imported/thumbnails/course-series.png',
+        description: 'Imported description',
+        order: 1,
+        courseIDs: ['imported-course']
+      },
+      ctrl.signal
+    )
+    expect(updateCourseSeries).not.toHaveBeenCalled()
+    expect(deleteCourse).not.toHaveBeenCalled()
+  })
+
   it('rewrites exact editor project segment and preserves local order', async () => {
     const ctrl = new AbortController()
 
@@ -258,11 +286,11 @@ describe('importCourseSeriesFile', () => {
     expect(createProjectRelease).toHaveBeenCalledWith(
       'alice',
       'EntryProject',
-      expect.objectContaining({
+      {
+        name: expect.stringMatching(/^v0\.0\.0\+/),
         description: 'Imported from course series "Imported series"',
-        thumbnail: '',
         projectRevision: 8
-      }),
+      },
       ctrl.signal
     )
   })

--- a/spx-gui/src/components/course/management/course-series-file.ts
+++ b/spx-gui/src/components/course/management/course-series-file.ts
@@ -116,17 +116,7 @@ export async function importCourseSeriesFileAsNew(
   signal?: AbortSignal
 ) {
   const data = await loadCourseSeriesFile(file, signal)
-  const courseSeries = await addCourseSeries(
-    {
-      title: data.manifest.courseSeries.title,
-      thumbnail: '',
-      description: data.manifest.courseSeries.description,
-      order: 1,
-      courseIDs: []
-    },
-    signal
-  )
-  return importCourseSeriesFileData(courseSeries, data, signedInUsername, signal)
+  return importCourseSeriesFileData(null, data, signedInUsername, signal)
 }
 
 export async function inspectCourseSeriesFileImport(
@@ -165,7 +155,7 @@ async function loadCourseSeriesFile(file: globalThis.File, signal?: AbortSignal)
 }
 
 async function importCourseSeriesFileData(
-  courseSeries: CourseSeries,
+  courseSeries: CourseSeries | null,
   { manifest, unzipped }: Awaited<ReturnType<typeof loadCourseSeriesFile>>,
   signedInUsername: string,
   signal?: AbortSignal
@@ -191,20 +181,20 @@ async function importCourseSeriesFileData(
     )
   }
 
-  const importedCourseSeries = await updateCourseSeries(
-    courseSeries.id,
-    {
-      title: manifest.courseSeries.title,
-      thumbnail: await importThumbnail(manifest.courseSeries.thumbnail, unzipped, signal),
-      description: manifest.courseSeries.description,
-      // Keep the local sort order because it depends on other course series in the current environment.
-      order: courseSeries.order,
-      courseIDs: importedCourses.map((course) => course.id)
-    },
-    signal
-  )
+  const params = {
+    title: manifest.courseSeries.title,
+    thumbnail: await importThumbnail(manifest.courseSeries.thumbnail, unzipped, signal),
+    description: manifest.courseSeries.description,
+    // Keep the local sort order because it depends on other course series in the current environment.
+    order: courseSeries?.order ?? 1,
+    courseIDs: importedCourses.map((course) => course.id)
+  }
+  const importedCourseSeries =
+    courseSeries == null
+      ? await addCourseSeries(params, signal)
+      : await updateCourseSeries(courseSeries.id, params, signal)
 
-  await Promise.all(courseSeries.courseIDs.map((courseID) => deleteCourse(courseID)))
+  if (courseSeries != null) await Promise.all(courseSeries.courseIDs.map((courseID) => deleteCourse(courseID)))
   return importedCourseSeries
 }
 
@@ -301,7 +291,6 @@ async function importProject(
     {
       name: generateReleaseName(),
       description: `Imported from course series "${manifest.courseSeries.title}"`,
-      thumbnail: '',
       projectRevision: revision
     },
     signal

--- a/spx-gui/src/components/project/ProjectPublishModal.test.ts
+++ b/spx-gui/src/components/project/ProjectPublishModal.test.ts
@@ -8,7 +8,6 @@ import ProjectPublishModal from './ProjectPublishModal.vue'
 const mocks = vi.hoisted(() => ({
   createProjectRelease: vi.fn(),
   save: vi.fn(),
-  saveFile: vi.fn(),
   handledError: null as unknown
 }))
 
@@ -56,8 +55,7 @@ vi.mock('@/apis/project-release', async (importOriginal) => ({
 vi.mock('@/models/common/cloud', () => ({
   cloudHelpers: {
     save: mocks.save
-  },
-  saveFile: mocks.saveFile
+  }
 }))
 
 vi.mock('@/components/ui', () => {
@@ -95,7 +93,7 @@ function makeProject() {
     displayName: 'Project',
     description: 'Old description',
     instructions: 'Old instructions',
-    thumbnail: {},
+    thumbnail: null,
     visibility: Visibility.Private,
     revision: 6,
     releaseCount: 2,
@@ -147,7 +145,6 @@ describe('ProjectPublishModal', () => {
       },
       files: {}
     })
-    mocks.saveFile.mockResolvedValue('kodo://builder/thumbnails/project.png')
     mocks.createProjectRelease.mockResolvedValue({ name: 'v1.0.0' })
   })
 
@@ -167,7 +164,6 @@ describe('ProjectPublishModal', () => {
     expect(mocks.createProjectRelease).toHaveBeenCalledWith('alice', 'project', {
       name: expect.stringMatching(/^v0\.0\.0\+/),
       description: 'Release notes',
-      thumbnail: 'kodo://builder/thumbnails/project.png',
       projectRevision: 7
     })
     expect(wrapper.emitted('resolved')).toHaveLength(1)

--- a/spx-gui/src/components/project/ProjectPublishModal.vue
+++ b/spx-gui/src/components/project/ProjectPublishModal.vue
@@ -6,7 +6,7 @@ import { useRenderableImageUrl } from '@/utils/img-rendering'
 import { Visibility } from '@/apis/common'
 import { projectDescriptionMaxLength, projectInstructionsMaxLength } from '@/apis/project'
 import { createProjectRelease, projectReleaseDescriptionMaxLength } from '@/apis/project-release'
-import { cloudHelpers, saveFile } from '@/models/common/cloud'
+import { cloudHelpers } from '@/models/common/cloud'
 import type { SpxProject } from '@/models/spx/project'
 import { isProjectUsingAIInteraction } from '@/utils/project'
 import { UIImg, UIFormModal, UIForm, UIFormItem, UITextInput, UIButton, useForm } from '@/components/ui'
@@ -83,11 +83,9 @@ const handleSubmit = useMessageHandle(
     const saved = await cloudHelpers.save(serialized)
     const { owner, name, revision } = saved.metadata
     project.setMetadata(saved.metadata)
-    const thumbnailUniversalUrl = await saveFile(project.thumbnail!)
     await createProjectRelease(owner, name, {
       name: generateReleaseName(),
       description: form.value.releaseDescription,
-      thumbnail: thumbnailUniversalUrl,
       projectRevision: revision
     })
     emit('resolved')


### PR DESCRIPTION
Let project releases inherit the saved project's thumbnail when the override is omitted, and reject explicit empty overrides. Document remix inheritance while preserving explicitly supplied empty values.

Require non-empty course series thumbnails and create imported series only after their complete content is available.

BREAKING CHANGE: Empty project release thumbnail overrides and empty course series thumbnails are no longer accepted.