### PR TITLE
feat(account): add Firefox browser hijacking

### DIFF
--- a/spx-gui/build/vite-plugins/browser-hijack-plugin.ts
+++ b/spx-gui/build/vite-plugins/browser-hijack-plugin.ts
@@ -1,15 +1,12 @@
-import crypto from 'node:crypto'
 import fs from 'node:fs'
-import http from 'node:http'
 import net from 'node:net'
 import path from 'node:path'
-import { Buffer } from 'node:buffer'
 import type { Plugin, ViteDevServer } from 'vite'
 
 // Browser Hijack Plugin redirects selected browser requests during local
-// development by connecting to Chrome DevTools Protocol. The plugin does not
-// launch Chrome itself; it prints a Chrome command with a remote debugging port
-// and then attaches to all page targets exposed by that Chrome instance.
+// development by connecting to Chrome DevTools Protocol or Firefox WebDriver
+// BiDi. The plugin does not launch a browser itself. It prints browser commands
+// with a remote debugging port and waits for the developer to run one of them.
 // Matching requests are fulfilled with a 307 redirect to the current Vite dev
 // server, preserving the original HTTP method and request body.
 
@@ -21,17 +18,15 @@ export interface BrowserHijackPluginOptions {
   /**
    * Path patterns to hijack under `origin`.
    *
-   * Each route should start with `/` and may contain `*` as a wildcard for any
-   * path segment text. Query strings are not part of the pattern; matched
+   * Each route should start with `/` and may contain `*` as a wildcard for a
+   * single path segment. Query strings are not part of the pattern. Matched
    * requests keep their original query when redirected to the Vite dev server.
-   * For example: `/sign-in` or `/api/identity-providers/:provider/callback`
-   * with `:provider` replaced by `*`.
    */
   routes: string[]
-  /** The remote debugging port for Chrome */
+  /** The remote debugging port for Chrome or Firefox */
   remoteDebuggingPort?: number
-  /** The URL to start Chrome with */
-  chromeStartURL: string
+  /** The URL to open when starting the browser */
+  startURL: string
 }
 
 export function createBrowserHijackPlugin(options: BrowserHijackPluginOptions): Plugin {
@@ -44,7 +39,8 @@ export function createBrowserHijackPlugin(options: BrowserHijackPluginOptions): 
       server.httpServer?.once('listening', () => {
         void startBrowserHijack(server, options, () => stopped)
           .then((result) => {
-            browserHijack = result
+            if (stopped) result.close()
+            else browserHijack = result
           })
           .catch((error: unknown) => {
             if (stopped) return
@@ -67,41 +63,72 @@ async function startBrowserHijack(
   isStopped: () => boolean
 ) {
   const devOrigin = server.resolvedUrls?.local[0]?.replace(/\/$/, '') ?? `http://localhost:${server.config.server.port}`
-  const hijackedOrigin = options.origin
   const remoteDebuggingPort = options.remoteDebuggingPort ?? defaultRemoteDebuggingPort
-  const portState = await checkRemoteDebuggingPort(remoteDebuggingPort)
-  if (portState === 'available') {
+  const resolveHijackedRequest = createHijackedRequestResolver(devOrigin, options.origin, options.routes)
+  let browser: RemoteBrowser | null = null
+  if (await checkPortAvailable(remoteDebuggingPort)) {
     server.config.logger.info(
-      `Browser hijack Chrome command:\n${createChromeCommand(options, remoteDebuggingPort, server.config.root)}`
+      [
+        `Browser hijack Chrome command:\n${createChromeCommand(options, remoteDebuggingPort, server.config.root)}`,
+        `Browser hijack Firefox command:\n${createFirefoxCommand(options, remoteDebuggingPort, server.config.root)}`
+      ].join('\n')
     )
   } else {
-    server.config.logger.info(`Browser hijack reusing Chrome remote debugging port ${remoteDebuggingPort}`)
-    if ((await getCDPTargets(remoteDebuggingPort)).length === 0) {
-      server.config.logger.info(
-        `Browser hijack is waiting for a Chrome page target. Open ${options.chromeStartURL} in that Chrome instance.`
-      )
+    browser = await detectRemoteBrowser(remoteDebuggingPort)
+    if (browser == null) {
+      throw new Error(`Remote debugging port ${remoteDebuggingPort} is already in use by an unsupported process`)
     }
+    server.config.logger.info(
+      `Browser hijack reusing ${browser.type === 'chrome' ? 'Chrome' : 'Firefox'} remote debugging port ${remoteDebuggingPort}`
+    )
   }
-  const hijackedURLPatterns = options.routes.map((route) => `${hijackedOrigin.replace(/\/$/, '')}${route}*`)
-  const cdps = new Map<string, CDPWebSocket>()
+
+  browser ??= await waitForRemoteBrowser(remoteDebuggingPort, isStopped)
+  if (browser.type === 'chrome') {
+    return startChromeBrowserHijack(server, options, resolveHijackedRequest, remoteDebuggingPort, isStopped)
+  }
+  return startFirefoxBrowserHijack(server, options, resolveHijackedRequest, browser.webSocket)
+}
+
+async function startChromeBrowserHijack(
+  server: ViteDevServer,
+  options: BrowserHijackPluginOptions,
+  resolveHijackedRequest: ResolveHijackedRequest,
+  remoteDebuggingPort: number,
+  isStopped: () => boolean
+) {
+  const hijackedURLPatterns = options.routes.map((route) => `${options.origin.replace(/\/$/, '')}${route}*`)
+  const cdps = new Map<string, ProtocolConnection>()
   const connectTarget = async (target: CDPTarget) => {
     if (cdps.has(target.id)) return
-    const cdp = await CDPWebSocket.connect(target.webSocketDebuggerUrl)
-    cdps.set(target.id, cdp)
+    const cdp = await ProtocolConnection.connect(target.webSocketDebuggerUrl)
 
-    cdp.send('Fetch.enable', {
-      patterns: hijackedURLPatterns.map((urlPattern) => ({ urlPattern, requestStage: 'Request' }))
+    cdp.setEventListener('Fetch.requestPaused', (params) => {
+      handleCDPPausedRequest(cdp, params, resolveHijackedRequest)
     })
-    cdp.on('Fetch.requestPaused', (params) => {
-      handlePausedBrowserHijackedRequest(cdp, params as unknown as CDPRequestPausedParams, devOrigin, options.routes)
-    })
+    try {
+      await cdp.request('Fetch.enable', {
+        patterns: hijackedURLPatterns.map((urlPattern) => ({ urlPattern, requestStage: 'Request' }))
+      })
+      cdps.set(target.id, cdp)
+    } catch (error) {
+      cdp.close()
+      throw error
+    }
   }
 
   for (const target of await waitForCDPTargets(remoteDebuggingPort, isStopped)) await connectTarget(target)
   const interval = setInterval(() => {
     if (isStopped()) return
     void getCDPTargets(remoteDebuggingPort).then((targets) => {
-      for (const target of targets) void connectTarget(target)
+      for (const target of targets) {
+        void connectTarget(target).catch((error: unknown) => {
+          if (isStopped()) return
+          server.config.logger.error(
+            `Failed to connect browser hijack target: ${error instanceof Error ? error.message : String(error)}`
+          )
+        })
+      }
     })
   }, 1000)
   server.config.logger.info(`Browser hijack enabled for ${hijackedURLPatterns.join(', ')}`)
@@ -113,67 +140,133 @@ async function startBrowserHijack(
   }
 }
 
+async function startFirefoxBrowserHijack(
+  server: ViteDevServer,
+  options: BrowserHijackPluginOptions,
+  resolveHijackedRequest: ResolveHijackedRequest,
+  bidi: ProtocolConnection
+) {
+  const hijackedOrigin = new URL(options.origin)
+  try {
+    await bidi.request('session.new', { capabilities: { alwaysMatch: { browserName: 'firefox' } } })
+    bidi.setEventListener('network.beforeRequestSent', (params) => {
+      handleBiDiBeforeRequestSent(bidi, params, resolveHijackedRequest)
+    })
+    await bidi.request('session.subscribe', { events: ['network.beforeRequestSent'] })
+    // BiDi pathnames match exactly, so wildcard routes are filtered after intercepting the origin.
+    await bidi.request('network.addIntercept', {
+      phases: ['beforeRequestSent'],
+      urlPatterns: [
+        {
+          type: 'pattern',
+          protocol: hijackedOrigin.protocol.slice(0, -1),
+          hostname: hijackedOrigin.hostname,
+          ...(hijackedOrigin.port === '' ? {} : { port: hijackedOrigin.port })
+        }
+      ]
+    })
+  } catch (error) {
+    bidi.close()
+    throw error
+  }
+
+  const hijackedURLPatterns = options.routes.map((route) => `${options.origin.replace(/\/$/, '')}${route}`)
+  server.config.logger.info(`Browser hijack enabled for ${hijackedURLPatterns.join(', ')}`)
+  return { close: () => bidi.close() }
+}
+
 function createChromeCommand(options: BrowserHijackPluginOptions, remoteDebuggingPort: number, projectRoot: string) {
   const executable = findChromeExecutable()
   const userDataDir = path.join(projectRoot, 'node_modules/.cache/browser-hijack-chrome')
   fs.mkdirSync(userDataDir, { recursive: true })
-  const args = [
+  return [
+    executable,
     `--remote-debugging-port=${remoteDebuggingPort}`,
     `--user-data-dir=${userDataDir}`,
     '--no-first-run',
     '--no-default-browser-check',
-    options.chromeStartURL
+    options.startURL
   ]
-  return [executable, ...args].map((arg) => shellQuote(arg)).join(' ')
+    .map((arg) => shellQuote(arg))
+    .join(' ')
+}
+
+function createFirefoxCommand(options: BrowserHijackPluginOptions, remoteDebuggingPort: number, projectRoot: string) {
+  const executable = findFirefoxExecutable()
+  const profileDir = path.join(projectRoot, 'node_modules/.cache/browser-hijack-firefox')
+  fs.mkdirSync(profileDir, { recursive: true })
+  return [
+    executable,
+    `--remote-debugging-port=${remoteDebuggingPort}`,
+    '--profile',
+    profileDir,
+    '--no-remote',
+    options.startURL
+  ]
+    .map((arg) => shellQuote(arg))
+    .join(' ')
 }
 
 function findChromeExecutable() {
-  const candidates = [
-    process.env.CHROME_PATH ?? null,
-    '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
-    '/Applications/Google Chrome Canary.app/Contents/MacOS/Google Chrome Canary',
-    '/Applications/Chromium.app/Contents/MacOS/Chromium',
-    'google-chrome',
-    'chromium',
-    'chromium-browser'
-  ]
-  const executable = candidates.find(
-    (candidate) => candidate != null && (candidate.includes('/') ? fs.existsSync(candidate) : true)
+  return (
+    [
+      process.env.CHROME_PATH ?? null,
+      '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+      '/Applications/Google Chrome Canary.app/Contents/MacOS/Google Chrome Canary',
+      '/Applications/Chromium.app/Contents/MacOS/Chromium'
+    ].find((candidate) => candidate != null && (candidate.includes('/') ? fs.existsSync(candidate) : true)) ??
+    'google-chrome'
   )
-  if (executable == null) throw new Error('Chrome executable not found')
-  return executable
 }
 
-async function checkRemoteDebuggingPort(port: number) {
-  const portCheckResult = await checkPortAvailable(port)
-  if (portCheckResult === 'available') return 'available'
+function findFirefoxExecutable() {
+  return (
+    [
+      process.env.FIREFOX_PATH ?? null,
+      '/Applications/Firefox.app/Contents/MacOS/firefox',
+      '/Applications/Firefox Developer Edition.app/Contents/MacOS/firefox',
+      '/Applications/Firefox Nightly.app/Contents/MacOS/firefox'
+    ].find((candidate) => candidate != null && (candidate.includes('/') ? fs.existsSync(candidate) : true)) ?? 'firefox'
+  )
+}
 
-  const version = await getCDPVersion(port)
-  if (version != null) return 'connected'
+type RemoteBrowser =
+  | { type: 'chrome' }
+  | {
+      type: 'firefox'
+      webSocket: ProtocolConnection
+    }
 
-  throw new Error(`Chrome remote debugging port ${port} is already in use by another process`)
+async function detectRemoteBrowser(port: number): Promise<RemoteBrowser | null> {
+  if ((await getCDPVersion(port)) != null) return { type: 'chrome' }
+  const webSocket = await ProtocolConnection.connect(`ws://127.0.0.1:${port}/session`).catch(() => null)
+  return webSocket == null ? null : { type: 'firefox', webSocket }
+}
+
+async function waitForRemoteBrowser(port: number, isStopped: () => boolean): Promise<RemoteBrowser> {
+  for (let i = 0; i < 1200; i++) {
+    if (isStopped()) throw new Error('Browser hijack stopped')
+    const browser = await detectRemoteBrowser(port)
+    if (browser != null) return browser
+    await new Promise((resolveTimeout) => setTimeout(resolveTimeout, 500))
+  }
+  throw new Error('Timed out waiting for a supported browser remote debugging endpoint')
 }
 
 function checkPortAvailable(port: number) {
-  return new Promise<void>((resolvePort, reject) => {
+  return new Promise<boolean>((resolvePort, reject) => {
     const server = net.createServer()
     server.once('error', (error: NodeJS.ErrnoException) => {
       if (error.code === 'EADDRINUSE') {
-        reject(error)
+        resolvePort(false)
         return
       }
       reject(error)
     })
     server.listen(port, '127.0.0.1', () => {
-      server.close(() => resolvePort())
+      server.close(() => resolvePort(true))
     })
-  }).then(
-    () => 'available' as const,
-    (error: NodeJS.ErrnoException) => {
-      if (error.code === 'EADDRINUSE') return 'occupied' as const
-      throw error
-    }
-  )
+  })
 }
 
 async function waitForCDPTargets(port: number, isStopped: () => boolean) {
@@ -192,217 +285,200 @@ async function getCDPTargets(port: number) {
 }
 
 async function getCDPVersion(port: number) {
-  const version = await readJSON<CDPVersion>(`http://127.0.0.1:${port}/json/version`).catch(() => null)
+  const version = await readJSON<{ Browser?: string }>(`http://127.0.0.1:${port}/json/version`).catch(() => null)
   if (version == null || typeof version.Browser !== 'string') return null
   return version
 }
 
-function readJSON<T>(url: string) {
-  return new Promise<T>((resolveJSON, reject) => {
-    http
-      .get(url, (response) => {
-        const chunks: Buffer[] = []
-        response.on('data', (chunk) => chunks.push(chunk))
-        response.on('end', () => {
-          resolveJSON(JSON.parse(Buffer.concat(chunks).toString()) as T)
-        })
-      })
-      .on('error', reject)
-  })
+async function readJSON<T>(url: string) {
+  const response = await fetch(url, { signal: AbortSignal.timeout(1000) })
+  if (!response.ok) throw new Error(`Request failed with status ${response.status}`)
+  return response.json() as Promise<T>
 }
 
-function handlePausedBrowserHijackedRequest(
-  cdp: CDPWebSocket,
-  params: CDPRequestPausedParams,
-  devOrigin: string,
-  routes: string[]
+function handleCDPPausedRequest(
+  cdp: ProtocolConnection,
+  params: Record<string, unknown>,
+  resolveHijackedRequest: ResolveHijackedRequest
 ) {
-  const requestURL = new URL(params.request.url)
-  const route = routes.find((item) => matchPathPattern(item, requestURL.pathname))
-  if (route == null) {
-    cdp.send('Fetch.continueRequest', { requestId: params.requestId })
+  const requestID = typeof params.requestId === 'string' ? params.requestId : null
+  const request = isRecord(params.request) ? params.request : null
+  const requestURL = request != null && typeof request.url === 'string' ? request.url : null
+  if (requestID == null || requestURL == null) return
+
+  const target = resolveHijackedRequest(requestURL)
+  if (target == null) {
+    cdp.send('Fetch.continueRequest', { requestId: requestID })
     return
   }
-
-  const target = new URL(requestURL.pathname, devOrigin)
-  for (const [key, value] of requestURL.searchParams) target.searchParams.append(key, value)
   cdp.send('Fetch.fulfillRequest', {
-    requestId: params.requestId,
+    requestId: requestID,
     responseCode: 307,
     responseHeaders: [
-      { name: 'Location', value: target.toString() },
+      { name: 'Location', value: target },
       { name: 'Cache-Control', value: 'no-store' }
     ]
   })
 }
 
-function matchPathPattern(pattern: string, pathname: string) {
-  const escaped = pattern.replace(/[.+?^${}()|[\]\\]/g, '\\$&').replace(/\*/g, '.*')
-  return new RegExp(`^${escaped}$`).test(pathname)
+function handleBiDiBeforeRequestSent(
+  bidi: ProtocolConnection,
+  params: Record<string, unknown>,
+  resolveHijackedRequest: ResolveHijackedRequest
+) {
+  const request = isRecord(params.request) ? params.request : null
+  const requestID = request != null && typeof request.request === 'string' ? request.request : null
+  const requestURL = request != null && typeof request.url === 'string' ? request.url : null
+  if (params.isBlocked !== true || requestID == null || requestURL == null) return
+
+  const target = resolveHijackedRequest(requestURL)
+  if (target == null) {
+    bidi.send('network.continueRequest', { request: requestID })
+    return
+  }
+  bidi.send('network.provideResponse', {
+    request: requestID,
+    statusCode: 307,
+    headers: [
+      { name: 'Location', value: { type: 'string', value: target } },
+      { name: 'Cache-Control', value: { type: 'string', value: 'no-store' } }
+    ]
+  })
+}
+
+type ResolveHijackedRequest = (rawURL: string) => string | null
+
+function createHijackedRequestResolver(devOrigin: string, hijackedOrigin: string, routes: string[]) {
+  const origin = new URL(hijackedOrigin).origin
+  const routePatterns = routes.map((route) => {
+    const escaped = route.replace(/[.+?^${}()|[\]\\]/g, '\\$&').replace(/\*/g, '[^/]*')
+    return new RegExp(`^${escaped}$`)
+  })
+
+  return (rawURL: string) => {
+    const requestURL = new URL(rawURL)
+    if (requestURL.origin !== origin) return null
+    if (!routePatterns.some((pattern) => pattern.test(requestURL.pathname))) return null
+
+    const target = new URL(requestURL.pathname, devOrigin)
+    target.search = requestURL.search
+    return target.toString()
+  }
 }
 
 function shellQuote(value: string) {
   return `'${value.replace(/'/g, `'\\''`)}'`
 }
 
-interface CDPCommand {
-  id: number
-  method: string
-  params?: Record<string, unknown>
-}
-
-interface CDPEvent {
-  method: string
-  params?: Record<string, unknown>
-}
-
-interface CDPRequestPausedParams {
-  requestId: string
-  request: {
-    url: string
-    method: string
-    headers: Record<string, string>
-    postData?: string
-  }
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value != null && !Array.isArray(value)
 }
 
 interface CDPTarget {
   id: string
   type: string
-  url?: string
   webSocketDebuggerUrl: string
 }
 
-interface CDPVersion {
-  Browser?: string
-  webSocketDebuggerUrl?: string
+interface PendingProtocolRequest {
+  resolve: (result: Record<string, unknown>) => void
+  reject: (error: Error) => void
 }
 
-class CDPWebSocket {
-  private socket: net.Socket
-  private buffer = Buffer.alloc(0)
+class ProtocolConnection {
   private nextID = 1
-  private eventListeners = new Map<string, Array<(params: Record<string, unknown>) => void>>()
+  private eventListeners = new Map<string, (params: Record<string, unknown>) => void>()
+  private pendingRequests = new Map<number, PendingProtocolRequest>()
 
-  private constructor(socket: net.Socket) {
-    this.socket = socket
-    socket.on('data', (chunk) => this.handleData(chunk))
+  private constructor(private webSocket: WebSocket) {
+    webSocket.addEventListener('message', (event) => {
+      if (typeof event.data === 'string') this.handleMessage(event.data)
+    })
+    webSocket.addEventListener('close', () => {
+      this.rejectPendingRequests(new Error('Browser remote debugging connection closed'))
+    })
+    webSocket.addEventListener('error', () => {
+      this.rejectPendingRequests(new Error('Browser remote debugging connection failed'))
+    })
   }
 
-  static async connect(rawURL: string) {
-    const url = new URL(rawURL)
-    const socket = await connectSocket(url.hostname, Number(url.port || 80))
-    const key = crypto.randomBytes(16).toString('base64')
-    socket.write(
-      [
-        `GET ${url.pathname}${url.search} HTTP/1.1`,
-        `Host: ${url.host}`,
-        'Upgrade: websocket',
-        'Connection: Upgrade',
-        `Sec-WebSocket-Key: ${key}`,
-        'Sec-WebSocket-Version: 13',
-        '',
-        ''
-      ].join('\r\n')
-    )
-
-    await readHandshake(socket)
-    return new CDPWebSocket(socket)
+  static connect(url: string) {
+    return new Promise<ProtocolConnection>((resolve, reject) => {
+      const webSocket = new WebSocket(url)
+      const timeout = setTimeout(() => {
+        cleanup()
+        webSocket.close()
+        reject(new Error(`Timed out connecting to browser remote debugging endpoint ${url}`))
+      }, 1000)
+      const onOpen = () => {
+        cleanup()
+        resolve(new ProtocolConnection(webSocket))
+      }
+      const onError = () => {
+        cleanup()
+        reject(new Error(`Failed to connect to browser remote debugging endpoint ${url}`))
+      }
+      const cleanup = () => {
+        clearTimeout(timeout)
+        webSocket.removeEventListener('open', onOpen)
+        webSocket.removeEventListener('error', onError)
+      }
+      webSocket.addEventListener('open', onOpen)
+      webSocket.addEventListener('error', onError)
+    })
   }
 
-  on(event: string, listener: (params: Record<string, unknown>) => void) {
-    const listeners = this.eventListeners.get(event) ?? []
-    listeners.push(listener)
-    this.eventListeners.set(event, listeners)
+  setEventListener(event: string, listener: (params: Record<string, unknown>) => void) {
+    this.eventListeners.set(event, listener)
   }
 
-  send(method: string, params?: Record<string, unknown>) {
-    const command: CDPCommand = { id: this.nextID++, method, params }
-    this.socket.write(encodeWebSocketFrame(JSON.stringify(command)))
+  send(method: string, params: Record<string, unknown> = {}) {
+    this.writeCommand(this.nextID++, method, params)
+  }
+
+  request(method: string, params: Record<string, unknown> = {}) {
+    const id = this.nextID++
+    const result = new Promise<Record<string, unknown>>((resolve, reject) => {
+      this.pendingRequests.set(id, { resolve, reject })
+    })
+    this.writeCommand(id, method, params)
+    return result
   }
 
   close() {
-    this.socket.end()
+    this.webSocket.close()
   }
 
-  private handleData(chunk: Buffer) {
-    this.buffer = Buffer.concat([this.buffer, chunk])
-    while (this.buffer.length > 0) {
-      const frame = decodeWebSocketFrame(this.buffer)
-      if (frame == null) return
-      this.buffer = this.buffer.subarray(frame.length)
-      const message = JSON.parse(frame.payload.toString()) as CDPEvent
-      if (message.method == null || message.params == null) continue
-      for (const listener of this.eventListeners.get(message.method) ?? []) listener(message.params)
+  private writeCommand(id: number, method: string, params: Record<string, unknown>) {
+    this.webSocket.send(JSON.stringify({ id, method, params }))
+  }
+
+  private handleMessage(payload: string) {
+    const message: unknown = JSON.parse(payload)
+    if (!isRecord(message)) return
+    if (typeof message.id === 'number') {
+      const pending = this.pendingRequests.get(message.id)
+      if (pending == null) return
+      this.pendingRequests.delete(message.id)
+      if (message.type === 'error' || message.error != null) {
+        const description =
+          typeof message.message === 'string'
+            ? message.message
+            : isRecord(message.error) && typeof message.error.message === 'string'
+              ? message.error.message
+              : String(message.error)
+        pending.reject(new Error(description))
+      } else {
+        pending.resolve(isRecord(message.result) ? message.result : {})
+      }
+      return
     }
+    if (typeof message.method !== 'string' || !isRecord(message.params)) return
+    this.eventListeners.get(message.method)?.(message.params)
   }
-}
 
-function connectSocket(host: string, port: number) {
-  return new Promise<net.Socket>((resolveSocket, reject) => {
-    const socket = net.connect(port, host)
-    socket.once('connect', () => resolveSocket(socket))
-    socket.once('error', reject)
-  })
-}
-
-function readHandshake(socket: net.Socket) {
-  return new Promise<void>((resolveHandshake, reject) => {
-    let buffer = Buffer.alloc(0)
-    const onData = (chunk: Buffer) => {
-      buffer = Buffer.concat([buffer, chunk])
-      if (!buffer.includes('\r\n\r\n')) return
-      socket.off('data', onData)
-      resolveHandshake()
-    }
-    socket.on('data', onData)
-    socket.once('error', reject)
-  })
-}
-
-function encodeWebSocketFrame(payload: string) {
-  const payloadBuffer = Buffer.from(payload)
-  const mask = crypto.randomBytes(4)
-  const headerLength = payloadBuffer.length < 126 ? 6 : 8
-  const frame = Buffer.alloc(headerLength + payloadBuffer.length)
-  frame[0] = 0x81
-  if (payloadBuffer.length < 126) {
-    frame[1] = 0x80 | payloadBuffer.length
-    mask.copy(frame, 2)
-  } else {
-    frame[1] = 0x80 | 126
-    frame.writeUInt16BE(payloadBuffer.length, 2)
-    mask.copy(frame, 4)
+  private rejectPendingRequests(error: Error) {
+    for (const pending of this.pendingRequests.values()) pending.reject(error)
+    this.pendingRequests.clear()
   }
-  const maskOffset = headerLength - 4
-  for (let i = 0; i < payloadBuffer.length; i++) {
-    frame[headerLength + i] = payloadBuffer[i] ^ frame[maskOffset + (i % 4)]
-  }
-  return frame
-}
-
-function decodeWebSocketFrame(buffer: Buffer): { length: number; payload: Buffer } | null {
-  if (buffer.length < 2) return null
-  const baseLength = buffer[1] & 0x7f
-  let offset = 2
-  let payloadLength = baseLength
-  if (baseLength === 126) {
-    if (buffer.length < 4) return null
-    payloadLength = buffer.readUInt16BE(2)
-    offset = 4
-  } else if (baseLength === 127) {
-    if (buffer.length < 10) return null
-    payloadLength = Number(buffer.readBigUInt64BE(2))
-    offset = 10
-  }
-  const masked = (buffer[1] & 0x80) !== 0
-  const maskOffset = offset
-  if (masked) offset += 4
-  const length = offset + payloadLength
-  if (buffer.length < length) return null
-  const payload = Buffer.from(buffer.subarray(offset, length))
-  if (masked) {
-    for (let i = 0; i < payload.length; i++) payload[i] ^= buffer[maskOffset + (i % 4)]
-  }
-  return { length, payload }
 }

--- a/spx-gui/vite.config.account.ts
+++ b/spx-gui/vite.config.account.ts
@@ -23,7 +23,7 @@ export default defineConfig(({ mode }) => {
       createBrowserHijackPlugin({
         origin: accountWebOrigin,
         routes: ['/sign-in', '/api/identity-providers/*/callback'],
-        chromeStartURL: 'http://localhost:5173'
+        startURL: 'http://localhost:5173'
       })
     )
   }


### PR DESCRIPTION
Support Firefox WebDriver BiDi alongside Chrome DevTools Protocol for local Account development. Preserve redirects for sign-in and identity provider callbacks across both browsers.