### PR TITLE
docs(product): add feedback documentation

### DIFF
--- a/docs/product/feedback.md
+++ b/docs/product/feedback.md
@@ -1,33 +1,46 @@
 # Feedback
 
-Users may encounter broken features, unexpected runtime results, or situations where they do not know how to continue while using XBuilder. Feedback allows users to describe a problem directly in XBuilder. With the user's consent, the Feedback includes Context to help administrators investigate it.
+Users may encounter broken features, unexpected runtime results, or situations where they do not know how to continue
+while using XBuilder. Feedback lets users describe a problem in XBuilder. With the user's consent, a Feedback can
+include Context that helps administrators investigate the problem.
 
 ## Background
 
-User feedback often consists of a short description. Administrators then need to ask where the user was, what the project looked like, and which errors occurred before they can start investigating.
+User feedback often consists of a short description. Administrators then need to ask where the user was, what the
+project looked like, and which errors occurred before they can start investigating.
 
-Feedback therefore stores the user's Title and Description, and the Context the user agrees to share. Administrators can review and process the problem from one shared list.
+Feedback combines the user's description with the Context the user agrees to share, so administrators can investigate
+and process the problem from one record.
 
 ## Goals
 
 * Users can submit Feedback from within XBuilder.
-* Feedback can include Context.
+* Feedback can include Context captured at submission time.
 * Copilot can help users prepare Feedback, but the user confirms and submits the final content.
 * Users can still access Feedback when Copilot is temporarily unavailable or its quota is exhausted.
 * Administrators can review, process, and reply to Feedback.
 * Users can receive administrator replies within XBuilder.
 
-## Basic Concepts
+## Basic Concepts and Rules
+
+This section defines the Feedback record, its Context, and the states used by the processing flow.
 
 ### Feedback
 
-A Feedback item has three parts:
+User-submitted Feedback content has three parts:
 
 * Title
 * Description
 * Context
 
 Context may be empty.
+
+The Feedback record also contains these system fields:
+
+* User
+* Status
+* CreatedAt
+* Reply
 
 Title is limited to 100 characters. Description is limited to 2000 characters.
 
@@ -52,20 +65,29 @@ new -> handled
 
 Context is the information in a Feedback item used to investigate the reported problem. It includes:
 
+* Source: the page and entry point that triggered the Feedback
 * The current page, language, and capture time
 * The current project's identifier, type, name, and resource structure
 * The selected sprite and its basic state
 * The current code file, cursor, selection, and nearby source
 * Code errors and warnings in the current project
-* The latest 50 runtime outputs
+* Runtime outputs from the current project
 * The Project Snapshot
 * The current page screenshot
 
-Context is captured when the user confirms submission, rather than when the form is opened. It is not updated when the project or page changes after submission.
+Context contains inline diagnostics and references to larger artifacts:
 
-Users can turn off "Share diagnostic information." When it is off, Context is empty. Some contextual details may be omitted when unavailable, but this must not prevent Feedback from being submitted.
+* Inline diagnostics use the existing sampling rules: the latest 50 runtime outputs and at most 21 source-code lines around the current cursor are included.
+* The Feedback API defines the maximum serialized size for inline Context, and both client and server enforce the same limit.
+* The Project Snapshot is the `files` collection returned by the current project's `exportFiles()`. At submission time, the JSON representation is stored in Kodo, and Context stores its Kodo object reference instead of embedding the collection in the Feedback record.
+* The current page screenshot is stored in Kodo, and Context stores its Kodo object reference instead of embedding the image in the Feedback record. The screenshot uses the existing Upload Session `maxSize` limit.
+* If an inline diagnostic or artifact cannot be captured, or exceeds its API or upload limit, that Context item is omitted and marked unavailable. Feedback submission continues with the remaining content.
 
-Context in a Feedback item is not a public resource. Only the submitting user and administrators with the `feedbackAdmin` role can access it.
+Context is captured when the user confirms submission, rather than when the form is opened. It is not updated when the
+project or page changes after submission.
+
+Users can turn off "Share diagnostic information." When it is off, Context is empty. Some contextual details may be
+omitted when unavailable, but this must not prevent Feedback from being submitted.
 
 ### Reply
 
@@ -73,39 +95,18 @@ A Reply is an administrator's written response to a Feedback item.
 
 ### In-Product Notification
 
-An In-Product Notification delivers an administrator's reply to the user.
+An In-Product Notification delivers an administrator's Reply to the user.
 
-It contains the reply and reply time. Users can view the unread count, notification list, and notification details from the navigation bar.
+It contains the Reply and reply time. Users can view the unread count, notification list, and notification details from
+the navigation bar.
 
-## Core Mechanisms
-
-### Submission and Capture
-
-Users open "Send feedback" from the profile menu in the top-right corner, enter a Title and Description, and decide whether to share Context.
-
-When the user agrees, the Feedback includes the Context captured at confirmation. The form shows an in-progress state while submitting to prevent repeated actions. It closes and shows a completion state after the server confirms that the Feedback was created. When submission fails, the form keeps the user's input and allows a retry.
-
-The same submission uses a stable Submission ID:
-
-* The same Submission ID and the same content return the existing Feedback.
-* The same Submission ID with different content causes a conflict.
-* The same content with a different Submission ID is not merged automatically.
-
-### Viewing a Project Snapshot
-
-From Feedback details, administrators select "Open project snapshot" to open the Project Snapshot included in Feedback in the editor.
-
-### Copilot Assistance
-
-After the user explicitly asks for Feedback, or accepts Copilot's suggestion, Copilot may generate a Title and Description draft and open the Feedback form.
-
-The user can edit the draft and decide whether to share Context. Copilot cannot submit Feedback directly or open the form without the user's confirmation.
-
-The quota-exhausted message may provide a direct action to open the Feedback form. Users can always open Feedback from the profile menu.
-
-### Permissions
+## Permissions
 
 The feedback administrator role is `feedbackAdmin`, with the derived `canManageFeedback` capability.
+
+User-facing Feedback reads are limited to Feedback submitted by the current user. The `feedbackAdmin` role can read all
+Feedback records, including the Context shared by users. Context artifacts use the same ownership check and are not
+public download resources.
 
 `feedbackAdmin` can:
 
@@ -115,31 +116,80 @@ The feedback administrator role is `feedbackAdmin`, with the derived `canManageF
 * Reply to Feedback in the `new` state
 * Mark Feedback as `handled`
 
-`authorizationAdmin` can assign `feedbackAdmin`. Feedback management operations require the `feedbackAdmin` role; other administrator roles do not include this permission.
+`authorizationAdmin` can assign `feedbackAdmin`. Feedback management operations require the `feedbackAdmin` role; other
+administrator roles do not include this permission.
+
+The frontend uses `canManageFeedback` to control the management entry point. Feedback management APIs must still check
+`feedbackAdmin` on the server.
+
+Feedback lists return lightweight record fields and Context availability only. The detail view loads inline Context on
+demand; the Project Snapshot JSON and screenshot bytes are fetched only when an authorized reader opens or previews them.
+
+## Core Mechanisms
+
+### Submission and Capture
+
+Users open the Feedback form from the profile menu in the top-right corner, enter a Title and Description, and decide
+whether to share Context.
+
+When the user agrees, the system captures Context when submission is confirmed. The form shows an in-progress state
+while submitting to prevent repeated actions. It closes and shows a completion state after the server confirms that the
+Feedback was created. When submission fails, the form keeps the user's input and allows a retry.
+
+The same submission uses a stable Submission ID. The Submission ID is scoped to the submitting user; the same value
+submitted by different users is treated as a different submission.
+
+* The same Submission ID and the same content return the existing Feedback.
+* The same Submission ID with different content causes a conflict.
+* The same content with a different Submission ID is not merged automatically.
+
+### Copilot Assistance
+
+After the user explicitly asks for Feedback, or accepts Copilot's suggestion, Copilot may generate a Title and
+Description draft and open the Feedback form.
+
+The user can edit the draft and decide whether to share Context. Copilot cannot submit Feedback directly or open the
+form without the user's confirmation.
+
+Copilot's draft does not replace Feedback Context. When the user confirms submission, Feedback captures Context using the
+rules defined above.
+
+When Copilot is temporarily unavailable or its quota is exhausted, the message may provide a direct action to open the
+Feedback form. Users can always open Feedback from the profile menu.
+
+### Viewing a Project Snapshot
+
+From Feedback details, an administrator selects "Open project snapshot". The client fetches the referenced JSON from
+Kodo, passes its `files` collection to the editor's local loading capability, and opens the snapshot locally. This does
+not create or save a new SPX Project.
 
 ### Processing Feedback
 
-When administrators process the same Feedback, the first successful operation wins:
+When administrators process the same Feedback concurrently, the server accepts the first valid state transition:
 
-* The first successful operation takes effect.
-* Later operations do not overwrite the result that has already taken effect.
+* The accepted transition determines the final status and any Reply.
+* Later operations do not overwrite the accepted result.
 * The frontend reloads the Feedback and shows its final state.
 
-After Feedback enters a terminal state, it no longer accepts processing requests. If an administrator repeats a request after a network timeout, the server rejects the duplicate operation based on the current state and does not create another Reply or Notification.
+After Feedback enters a terminal state, it no longer accepts processing requests. If an administrator repeats a request
+after a network timeout, the server rejects the duplicate operation based on the current state and does not create
+another Reply or Notification.
 
 ### Reply and Notification
 
 The Reply, Feedback status change, and In-Product Notification are saved as one complete operation.
 
-If any step fails:
+If saving the Reply or creating the notification record fails:
 
 * The Feedback remains `new`.
 * No partial Reply is saved.
 * No user notification is created.
-* The administrator's reply remains available.
+* The administrator's unsent reply remains in the form for a retry.
 * The interface reports the failure and allows a retry.
 
-The interface shows "Reply sent" after the complete operation succeeds. After the notification record has been saved, a failure to refresh the navigation badge does not affect the notification. Users can still view it the next time they open the notification center.
+The interface shows "Reply sent" after the complete operation succeeds. After the notification record has been saved, a
+failure to refresh the navigation badge does not affect the notification. Users can still view it the next time they
+open the notification list.
 
 Marking Feedback as `handled` does not create a Notification.
 
@@ -147,16 +197,22 @@ Marking Feedback as `handled` does not create a Notification.
 
 ### User Submits Feedback
 
-When users encounter broken behavior, unexpected runtime results, or do not know how to continue, they can submit Feedback from the profile menu. They decide whether to share Context; if submission fails, the form keeps their input for retry.
+When users encounter broken behavior, unexpected runtime results, or do not know how to continue, they can submit
+Feedback from the profile menu. They decide whether to share Context and can retry with the original content if
+submission fails.
 
 ### User Asks Copilot to Prepare Feedback
 
-The user asks for Feedback in a Copilot conversation. Copilot prepares a draft and opens the Feedback form, and the user reviews and edits it before submission.
+The user asks for Feedback in a Copilot conversation. Copilot prepares a draft and opens the Feedback form, and the user
+reviews and edits it before submission.
 
 ### Administrator Processes Feedback
 
-An administrator with `feedbackAdmin` opens the Feedback details and uses Context to investigate the problem. When needed, the administrator opens the Project Snapshot in the editor; after processing, the administrator replies to the user or marks the Feedback as requiring no reply.
+An administrator with `feedbackAdmin` opens the Feedback details and uses Context to investigate the problem. When
+needed, the administrator opens the Project Snapshot in the editor; after processing, the administrator replies to the
+user or marks the Feedback as requiring no reply.
 
 ### User Views a Reply
 
-After an administrator replies, the user sees an unread notification in the navigation bar and opens its details to view the reply.
+After an administrator replies, the user sees an unread notification in the navigation bar and opens its details to view
+the Reply.

--- a/docs/product/feedback.md
+++ b/docs/product/feedback.md
@@ -1,29 +1,26 @@
 # Feedback
 
-Users may encounter broken features, unexpected runtime results, or situations where they do not know how to continue
-while using XBuilder. Feedback lets users describe a problem in XBuilder. With the user's consent, a Feedback can
-include Context that helps administrators investigate the problem.
+Feedback lets users describe a problem they encounter in XBuilder and, with their consent, share Context that helps
+administrators investigate it.
 
 ## Background
 
-User feedback often consists of a short description. Administrators then need to ask where the user was, what the
-project looked like, and which errors occurred before they can start investigating.
+A short description rarely contains enough information to reproduce a problem. Administrators may also need the page,
+project state, code, diagnostics, and runtime output from when the problem occurred.
 
-Feedback combines the user's description with the Context the user agrees to share, so administrators can investigate
-and process the problem from one record.
+Feedback keeps the user's description and the Context they agree to share in one record, so administrators can understand
+and process the problem with fewer follow-up questions.
 
 ## Goals
 
-* Users can submit Feedback from within XBuilder.
-* Feedback can include Context captured at submission time.
-* Copilot can help users prepare Feedback, but the user confirms and submits the final content.
-* Users can still access Feedback when Copilot is temporarily unavailable or its quota is exhausted.
-* Administrators can review, process, and reply to Feedback.
+* Users can submit Feedback within XBuilder.
+* Users can include Context captured at submission time.
+* Copilot can prepare a Feedback draft for the user to review and submit.
+* Supported AI features can provide a Feedback entry when a feature or quota issue occurs.
+* Administrators can investigate, process, and reply to Feedback.
 * Users can receive administrator replies within XBuilder.
 
 ## Basic Concepts and Rules
-
-This section defines the Feedback record, its Context, and the states used by the processing flow.
 
 ### Feedback
 
@@ -33,9 +30,9 @@ User-submitted Feedback content has three parts:
 * Description
 * Context
 
-Context may be empty.
+Context is optional.
 
-The Feedback record also contains these system fields:
+A Feedback record also contains these system fields:
 
 * User
 * Status
@@ -48,9 +45,9 @@ Feedback has three statuses:
 
 | Status | Meaning |
 | - | - |
-| `new` | Not processed yet |
-| `replied` | An administrator has replied |
-| `handled` | Processed without a reply |
+| `new` | Awaiting administrator processing |
+| `replied` | Completed with an administrator Reply |
+| `handled` | Completed through the administrator's "Mark as handled" action |
 
 The allowed status transitions are:
 
@@ -59,160 +56,114 @@ new -> replied
 new -> handled
 ```
 
-`replied` and `handled` are terminal states. A Feedback item can have at most one Reply.
+`replied` and `handled` are terminal states. A Feedback item stores one administrator Reply when it reaches `replied`.
 
 ### Context
 
-Context is the information in a Feedback item used to investigate the reported problem. It includes:
+Context is the diagnostic information shared with a Feedback item. It includes available information from the following
+categories:
 
-* Source: the page and entry point that triggered the Feedback
-* The current page, language, and capture time
-* The current project's identifier, type, name, and resource structure
-* The selected sprite and its basic state
-* The current code file, cursor, selection, and nearby source
+* Source: the page and entry point from which Feedback was opened
+* Current page, language, and capture time
+* Current project's identifier, type, name, and resource structure
+* Selected sprite and its basic state
+* Current code file, cursor, selection, and nearby source
 * Code errors and warnings in the current project
-* Runtime outputs from the current project
-* The Project Snapshot
-* The current page screenshot
+* Runtime output from the current project
+* Project Snapshot
+* Current page screenshot
 
-Context contains inline diagnostics and references to larger artifacts:
+For diagnostic items also used by Copilot, Feedback follows the existing Copilot context collection and sampling rules.
+Context is captured when the user confirms submission and remains fixed after submission.
 
-* Inline diagnostics use the existing sampling rules: the latest 50 runtime outputs and at most 21 source-code lines around the current cursor are included.
-* The Feedback API defines the maximum serialized size for inline Context, and both client and server enforce the same limit.
-* The Project Snapshot is the `files` collection returned by the current project's `exportFiles()`. At submission time, the JSON representation is stored in Kodo, and Context stores its Kodo object reference instead of embedding the collection in the Feedback record.
-* The current page screenshot is stored in Kodo, and Context stores its Kodo object reference instead of embedding the image in the Feedback record. The screenshot uses the existing Upload Session `maxSize` limit.
-* If an inline diagnostic or artifact cannot be captured, or exceeds its API or upload limit, that Context item is omitted and marked unavailable. Feedback submission continues with the remaining content.
+Users control Context sharing through "Share diagnostic information." When enabled, the available Context is included in
+Feedback.
 
-Context is captured when the user confirms submission, rather than when the form is opened. It is not updated when the
-project or page changes after submission.
+### Project Snapshot
 
-Users can turn off "Share diagnostic information." When it is off, Context is empty. Some contextual details may be
-omitted when unavailable, but this must not prevent Feedback from being submitted.
+A Project Snapshot preserves the current project files at the time of submission. It is part of Context and can be opened
+in the editor by an authorized administrator investigating the Feedback.
 
 ### Reply
 
 A Reply is an administrator's written response to a Feedback item.
 
-### In-Product Notification
-
-An In-Product Notification delivers an administrator's Reply to the user.
-
-It contains the Reply and reply time. Users can view the unread count, notification list, and notification details from
-the navigation bar.
-
 ## Permissions
 
 The feedback administrator role is `feedbackAdmin`, with the derived `canManageFeedback` capability.
 
-User-facing Feedback reads are limited to Feedback submitted by the current user. The `feedbackAdmin` role can read all
-Feedback records, including the Context shared by users. Context artifacts use the same ownership check and are not
-public download resources.
-
-`feedbackAdmin` can:
+Users can read the Feedback they submitted. `feedbackAdmin` can:
 
 * View Feedback lists and details
-* View user-shared Context in Feedback details
-* Open the Project Snapshot included in Feedback in the editor
+* View the Context shared with a Feedback item
+* Open its Project Snapshot in the editor
 * Reply to Feedback in the `new` state
-* Mark Feedback as `handled`
+* Mark Feedback in the `new` state as `handled`
 
-`authorizationAdmin` can assign `feedbackAdmin`. Feedback management operations require the `feedbackAdmin` role; other
-administrator roles do not include this permission.
-
-The frontend uses `canManageFeedback` to control the management entry point. Feedback management APIs must still check
-`feedbackAdmin` on the server.
-
-Feedback lists return lightweight record fields and Context availability only. The detail view loads inline Context on
-demand; the Project Snapshot JSON and screenshot bytes are fetched only when an authorized reader opens or previews them.
+Context follows the authorization of its Feedback item. `authorizationAdmin` can assign the `feedbackAdmin` role.
 
 ## Core Mechanisms
 
 ### Submission and Capture
 
-Users open the Feedback form from the profile menu in the top-right corner, enter a Title and Description, and decide
-whether to share Context.
+Users open the Feedback form from the profile menu, enter a Title and Description, and decide whether to share Context.
+The system captures Context after the user confirms submission.
 
-When the user agrees, the system captures Context when submission is confirmed. The form shows an in-progress state
-while submitting to prevent repeated actions. It closes and shows a completion state after the server confirms that the
-Feedback was created. When submission fails, the form keeps the user's input and allows a retry.
-
-The same submission uses a stable Submission ID. The Submission ID is scoped to the submitting user; the same value
-submitted by different users is treated as a different submission.
-
-* The same Submission ID and the same content return the existing Feedback.
-* The same Submission ID with different content causes a conflict.
-* The same content with a different Submission ID is not merged automatically.
+The form indicates progress while Feedback is being submitted. If submission fails, the form keeps the entered content
+and provides an action to try again.
 
 ### Copilot Assistance
 
-After the user explicitly asks for Feedback, or accepts Copilot's suggestion, Copilot may generate a Title and
-Description draft and open the Feedback form.
+When a user asks to submit Feedback or accepts Copilot's suggestion, Copilot can prepare a Title and Description draft.
+After the user confirms opening the Feedback form, they can review the draft, decide whether to share Context, and submit
+the Feedback.
 
-The user can edit the draft and decide whether to share Context. Copilot cannot submit Feedback directly or open the
-form without the user's confirmation.
+### Feedback for AI Feature and Quota Issues
 
-Copilot's draft does not replace Feedback Context. When the user confirms submission, Feedback captures Context using the
-rules defined above.
-
-When Copilot is temporarily unavailable or its quota is exhausted, the message may provide a direct action to open the
-Feedback form. Users can always open Feedback from the profile menu.
+Copilot, Costume Generation, and Animation Generation each present messages for their corresponding feature and quota
+issues. A message can provide an action that opens the Feedback form, with Source identifying the affected feature and
+entry point.
 
 ### Viewing a Project Snapshot
 
-From Feedback details, an administrator selects "Open project snapshot". The client fetches the referenced JSON from
-Kodo, passes its `files` collection to the editor's local loading capability, and opens the snapshot locally. This does
-not create or save a new SPX Project.
+From Feedback details, an administrator can open the Project Snapshot through the editor's reusable local project-loading
+capability and inspect the project as it was when the Feedback was submitted.
 
 ### Processing Feedback
 
-When administrators process the same Feedback concurrently, the server accepts the first valid state transition:
-
-* The accepted transition determines the final status and any Reply.
-* Later operations do not overwrite the accepted result.
-* The frontend reloads the Feedback and shows its final state.
-
-After Feedback enters a terminal state, it no longer accepts processing requests. If an administrator repeats a request
-after a network timeout, the server rejects the duplicate operation based on the current state and does not create
-another Reply or Notification.
+An administrator completes Feedback in the `new` state by replying or selecting "Mark as handled." When administrators
+process the same Feedback concurrently, the first successful action determines its terminal state, and the other
+administrators see the resulting state.
 
 ### Reply and Notification
 
-The Reply, Feedback status change, and In-Product Notification are saved as one complete operation.
-
-If saving the Reply or creating the notification record fails:
-
-* The Feedback remains `new`.
-* No partial Reply is saved.
-* No user notification is created.
-* The administrator's unsent reply remains in the form for a retry.
-* The interface reports the failure and allows a retry.
-
-The interface shows "Reply sent" after the complete operation succeeds. After the notification record has been saved, a
-failure to refresh the navigation badge does not affect the notification. Users can still view it the next time they
-open the notification list.
-
-Marking Feedback as `handled` does not create a Notification.
+After an administrator successfully sends a Reply, Feedback enters the `replied` state and creates an
+[In-Product Notification](./in-product-notification.md) for the submitting user. If the operation fails, the Reply draft
+remains available and the administrator can try again.
 
 ## User Story
 
-### User Submits Feedback
+### User Reports a Project Problem
 
-When users encounter broken behavior, unexpected runtime results, or do not know how to continue, they can submit
-Feedback from the profile menu. They decide whether to share Context and can retry with the original content if
-submission fails.
+While testing a project, a user encounters an unexpected result. The user opens Feedback from the profile menu, describes
+the problem, chooses to share Context, and submits it. The resulting Feedback gives an administrator the description and
+the project state from when the problem occurred.
 
 ### User Asks Copilot to Prepare Feedback
 
-The user asks for Feedback in a Copilot conversation. Copilot prepares a draft and opens the Feedback form, and the user
-reviews and edits it before submission.
+The user asks to submit Feedback during a Copilot conversation. Copilot prepares a draft and, after confirmation, opens
+the Feedback form. The user reviews the draft, chooses whether to share Context, and submits it.
+
+### User Reports an AI Feature or Quota Issue
+
+The user encounters a feature or quota issue in Copilot, Costume Generation, or Animation Generation. The corresponding
+message opens Feedback for that feature, where the user reviews and submits the report.
 
 ### Administrator Processes Feedback
 
-An administrator with `feedbackAdmin` opens the Feedback details and uses Context to investigate the problem. When
-needed, the administrator opens the Project Snapshot in the editor; after processing, the administrator replies to the
-user or marks the Feedback as requiring no reply.
+An administrator opens Feedback in the `new` state and uses its Context to investigate the problem. The administrator can
+open the Project Snapshot in the editor, then reply to the user or mark the Feedback as `handled`.
 
 ### User Views a Reply
 
-After an administrator replies, the user sees an unread notification in the navigation bar and opens its details to view
-the Reply.
+After an administrator replies, the user receives an In-Product Notification and opens it to read the Reply.

--- a/docs/product/feedback.md
+++ b/docs/product/feedback.md
@@ -1,6 +1,6 @@
 # Feedback
 
-Users may encounter broken features, unexpected runtime results, or situations where they do not know how to continue while using XBuilder. Feedback allows users to describe a problem directly in XBuilder and, with their consent, attach Context captured at submission time to help administrators investigate it.
+Users may encounter broken features, unexpected runtime results, or situations where they do not know how to continue while using XBuilder. Feedback allows users to describe a problem directly in XBuilder. With the user's consent, the Feedback includes Context to help administrators investigate it.
 
 ## Background
 
@@ -11,21 +11,23 @@ Feedback therefore stores the user's Title and Description, and the Context the 
 ## Goals
 
 * Users can submit Feedback from within XBuilder.
-* Feedback can include Context captured when it is submitted.
+* Feedback can include Context.
 * Copilot can help users prepare Feedback, but the user confirms and submits the final content.
 * Users can still access Feedback when Copilot is temporarily unavailable or its quota is exhausted.
-* Administrators can review, process, and reply to Feedback, and view the shared Context.
+* Administrators can review, process, and reply to Feedback.
 * Users can receive administrator replies within XBuilder.
 
 ## Basic Concepts
 
 ### Feedback
 
-A Feedback has three parts:
+A Feedback item has three parts:
 
 * Title
 * Description
 * Context
+
+Context may be empty.
 
 Title is limited to 100 characters. Description is limited to 2000 characters.
 
@@ -44,11 +46,11 @@ new -> replied
 new -> handled
 ```
 
-`replied` and `handled` are terminal states. A Feedback can have at most one Reply.
+`replied` and `handled` are terminal states. A Feedback item can have at most one Reply.
 
 ### Context
 
-Context is diagnostic information collected when the user confirms Feedback submission. It includes:
+Context is the information in a Feedback item used to investigate the reported problem. It includes:
 
 * The current page, language, and capture time
 * The current project's identifier, type, name, and resource structure
@@ -61,15 +63,13 @@ Context is diagnostic information collected when the user confirms Feedback subm
 
 Context is captured when the user confirms submission, rather than when the form is opened. It is not updated when the project or page changes after submission.
 
-Users can turn off "Share diagnostic information." When it is off, XBuilder does not capture Context. Some contextual details may be omitted when unavailable, but this must not prevent Feedback from being submitted.
+Users can turn off "Share diagnostic information." When it is off, Context is empty. Some contextual details may be omitted when unavailable, but this must not prevent Feedback from being submitted.
 
-Context is not a public resource. Only the submitting user and administrators with the `feedbackAdmin` role can access it.
+Context in a Feedback item is not a public resource. Only the submitting user and administrators with the `feedbackAdmin` role can access it.
 
 ### Reply
 
-A Reply is an administrator's written response to a Feedback.
-
-After a Reply is saved, the Feedback changes to `replied` and the submitting user receives an In-Product Notification.
+A Reply is an administrator's written response to a Feedback item.
 
 ### In-Product Notification
 
@@ -83,7 +83,7 @@ It contains the reply and reply time. Users can view the unread count, notificat
 
 Users open "Send feedback" from the profile menu in the top-right corner, enter a Title and Description, and decide whether to share Context.
 
-When the user agrees, the system captures Context when submission is confirmed. The form shows an in-progress state while submitting to prevent repeated actions. It closes and shows a completion state after the server confirms that the Feedback was created. When submission fails, the form keeps the user's input and allows a retry.
+When the user agrees, the Feedback includes the Context captured at confirmation. The form shows an in-progress state while submitting to prevent repeated actions. It closes and shows a completion state after the server confirms that the Feedback was created. When submission fails, the form keeps the user's input and allows a retry.
 
 The same submission uses a stable Submission ID:
 
@@ -93,7 +93,7 @@ The same submission uses a stable Submission ID:
 
 ### Viewing a Project Snapshot
 
-From Feedback details, administrators select "Open project snapshot" to open the Project Snapshot from Context in the editor.
+From Feedback details, administrators select "Open project snapshot" to open the Project Snapshot included in Feedback in the editor.
 
 ### Copilot Assistance
 
@@ -110,14 +110,12 @@ The feedback administrator role is `feedbackAdmin`, with the derived `canManageF
 `feedbackAdmin` can:
 
 * View Feedback lists and details
-* View the Context shared by users
-* Open the Project Snapshot from Context in the editor
+* View user-shared Context in Feedback details
+* Open the Project Snapshot included in Feedback in the editor
 * Reply to Feedback in the `new` state
 * Mark Feedback as `handled`
 
-`authorizationAdmin` can assign `feedbackAdmin`. Other administrator roles do not include Feedback management permissions.
-
-The frontend uses `canManageFeedback` to control the management entry point. Admin APIs must still check `feedbackAdmin` on the server.
+`authorizationAdmin` can assign `feedbackAdmin`. Feedback management operations require the `feedbackAdmin` role; other administrator roles do not include this permission.
 
 ### Processing Feedback
 
@@ -149,16 +147,16 @@ Marking Feedback as `handled` does not create a Notification.
 
 ### User Submits Feedback
 
-The user enters a Title and Description, decides whether to share Context, and submits Feedback. On success, the user sees a clear completion state. On failure, the user can retry with the original content.
+When users encounter broken behavior, unexpected runtime results, or do not know how to continue, they can submit Feedback from the profile menu. They decide whether to share Context; if submission fails, the form keeps their input for retry.
 
 ### User Asks Copilot to Prepare Feedback
 
-Copilot prepares a Title and Description draft after the user explicitly asks for it. The user reviews and edits the content, decides whether to share Context, and submits Feedback.
+The user asks for Feedback in a Copilot conversation. Copilot prepares a draft and opens the Feedback form, and the user reviews and edits it before submission.
 
 ### Administrator Processes Feedback
 
-An administrator with `feedbackAdmin` opens the Feedback details, views the shared Context, and opens the Project Snapshot in the editor when needed. The administrator can reply to the user or mark the Feedback as requiring no reply. When concurrent processing occurs, the interface shows the result that has already taken effect.
+An administrator with `feedbackAdmin` opens the Feedback details and uses Context to investigate the problem. When needed, the administrator opens the Project Snapshot in the editor; after processing, the administrator replies to the user or marks the Feedback as requiring no reply.
 
 ### User Views a Reply
 
-After an administrator replies, the user sees an unread notification in the navigation bar and can view the reply.
+After an administrator replies, the user sees an unread notification in the navigation bar and opens its details to view the reply.

--- a/docs/product/feedback.md
+++ b/docs/product/feedback.md
@@ -1,0 +1,159 @@
+# Feedback
+
+Users may encounter broken features, unexpected runtime results, or situations where they do not know how to continue while using XBuilder. Feedback allows users to describe a problem directly in XBuilder and, with their consent, attach Context captured at submission time to help administrators investigate it.
+
+## Background
+
+User feedback often consists of a short description. Administrators then need to ask where the user was, what the project looked like, and which errors occurred before they can start investigating.
+
+Feedback therefore stores the user's Title and Description, and the Context the user agrees to share. Administrators can review and process the problem from one shared list.
+
+## Goals
+
+* Users can submit Feedback from within XBuilder.
+* Feedback can include Context captured when it is submitted.
+* Copilot can help users prepare Feedback, but the user confirms and submits the final content.
+* Users can still access Feedback when Copilot is temporarily unavailable or its quota is exhausted.
+* Administrators can review, process, and reply to Feedback, and view the shared Context.
+* Users can receive administrator replies within XBuilder.
+
+## Basic Concepts
+
+### Feedback
+
+A Feedback has three parts:
+
+* Title
+* Description
+* Context
+
+Title is limited to 100 characters. Description is limited to 2000 characters.
+
+Feedback has three statuses:
+
+| Status | Meaning |
+| - | - |
+| `new` | Not processed yet |
+| `replied` | An administrator has replied |
+| `handled` | Processed without a reply |
+
+The allowed status transitions are:
+
+```text
+new -> replied
+new -> handled
+```
+
+`replied` and `handled` are terminal states. A Feedback can have at most one Reply.
+
+### Context
+
+Context is diagnostic information collected when the user confirms Feedback submission. It includes:
+
+* The current page, language, and capture time
+* The current project's identifier, type, name, and resource structure
+* The selected sprite and its basic state
+* The current code file, cursor, selection, and nearby source
+* Code errors and warnings in the current project
+* The latest 50 runtime outputs
+* The Project Snapshot
+* The current page screenshot
+
+Context is captured when the user confirms submission, rather than when the form is opened. It is not updated when the project or page changes after submission.
+
+Users can turn off "Share diagnostic information." When it is off, XBuilder does not capture Context. Some contextual details may be omitted when unavailable, but this must not prevent Feedback from being submitted.
+
+Context is not a public resource. Only the submitting user and administrators with the `feedbackAdmin` role can access it.
+
+### Reply
+
+A Reply is an administrator's written response to a Feedback.
+
+After a Reply is saved, the Feedback changes to `replied` and the submitting user receives an In-Product Notification.
+
+### In-Product Notification
+
+An In-Product Notification delivers an administrator's reply to the user.
+
+It contains the reply and reply time. Users can view the unread count, notification list, and notification details from the navigation bar.
+
+## Core Mechanisms
+
+### Submission and Capture
+
+Users open "Send feedback" from the profile menu in the top-right corner, enter a Title and Description, and decide whether to share Context.
+
+When the user agrees, the system captures Context when submission is confirmed. The form shows an in-progress state while submitting to prevent repeated actions. It closes and shows a completion state after the server confirms that the Feedback was created. When submission fails, the form keeps the user's input and allows a retry.
+
+The same submission uses a stable Submission ID:
+
+* The same Submission ID and the same content return the existing Feedback.
+* The same Submission ID with different content causes a conflict.
+* The same content with a different Submission ID is not merged automatically.
+
+### Copilot Assistance
+
+After the user explicitly asks for Feedback, or accepts Copilot's suggestion, Copilot may generate a Title and Description draft and open the Feedback form.
+
+The user can edit the draft and decide whether to share Context. Copilot cannot submit Feedback directly or open the form without the user's confirmation.
+
+The quota-exhausted message may provide a direct action to open the Feedback form. Users can always open Feedback from the profile menu.
+
+### Permissions
+
+The feedback administrator role is `feedbackAdmin`, with the derived `canManageFeedback` capability.
+
+`feedbackAdmin` can:
+
+* View Feedback lists and details
+* View the Context shared by users
+* Reply to Feedback in the `new` state
+* Mark Feedback as `handled`
+
+`authorizationAdmin` can assign `feedbackAdmin`. Other administrator roles do not include Feedback management permissions.
+
+The frontend uses `canManageFeedback` to control the management entry point. Admin APIs must still check `feedbackAdmin` on the server.
+
+### Processing Feedback
+
+When administrators process the same Feedback, the first successful operation wins:
+
+* The first successful operation takes effect.
+* Later operations do not overwrite the result that has already taken effect.
+* The frontend reloads the Feedback and shows its final state.
+
+After Feedback enters a terminal state, it no longer accepts processing requests. If an administrator repeats a request after a network timeout, the server rejects the duplicate operation based on the current state and does not create another Reply or Notification.
+
+### Reply and Notification
+
+The Reply, Feedback status change, and In-Product Notification are saved as one complete operation.
+
+If any step fails:
+
+* The Feedback remains `new`.
+* No partial Reply is saved.
+* No user notification is created.
+* The administrator's reply remains available.
+* The interface reports the failure and allows a retry.
+
+The interface shows "Reply sent" after the complete operation succeeds. After the notification record has been saved, a failure to refresh the navigation badge does not affect the notification. Users can still view it the next time they open the notification center.
+
+Marking Feedback as `handled` does not create a Notification.
+
+## User Story
+
+### User Submits Feedback
+
+The user enters a Title and Description, decides whether to share Context, and submits Feedback. On success, the user sees a clear completion state. On failure, the user can retry with the original content.
+
+### User Asks Copilot to Prepare Feedback
+
+Copilot prepares a Title and Description draft after the user explicitly asks for it. The user reviews and edits the content, decides whether to share Context, and submits Feedback.
+
+### Administrator Processes Feedback
+
+An administrator with `feedbackAdmin` opens the Feedback details, views the shared Context, replies to the user, or marks the Feedback as requiring no reply. When concurrent processing occurs, the interface shows the result that has already taken effect.
+
+### User Views a Reply
+
+After an administrator replies, the user sees an unread notification in the navigation bar and can view the reply.

--- a/docs/product/feedback.md
+++ b/docs/product/feedback.md
@@ -1,15 +1,12 @@
 # Feedback
 
-Feedback lets users describe a problem they encounter in XBuilder and, with their consent, share Context that helps
-administrators investigate it.
+Feedback lets users describe a problem they encounter in XBuilder and, with their consent, share Context that helps administrators investigate it.
 
 ## Background
 
-A short description rarely contains enough information to reproduce a problem. Administrators may also need the page,
-project state, code, diagnostics, and runtime output from when the problem occurred.
+A short description rarely contains enough information to reproduce a problem. Administrators may also need the page, project state, code, diagnostics, and runtime output from when the problem occurred.
 
-Feedback keeps the user's description and the Context they agree to share in one record, so administrators can understand
-and process the problem with fewer follow-up questions.
+Feedback keeps the user's description and the Context they agree to share in one record, so administrators can understand and process the problem with fewer follow-up questions.
 
 ## Goals
 
@@ -24,22 +21,15 @@ and process the problem with fewer follow-up questions.
 
 ### Feedback
 
-User-submitted Feedback content has three parts:
+A Feedback item contains:
 
-* Title
-* Description
-* Context
-
-Context is optional.
-
-A Feedback record also contains these system fields:
-
-* User
-* Status
-* CreatedAt
-* Reply
-
-Title is limited to 100 characters. Description is limited to 2000 characters.
+* User: the user who submitted the Feedback
+* Title: a summary of the problem, limited to 100 characters
+* Description: details about the problem, limited to 2000 characters
+* Context: optional diagnostic information the user chooses to share
+* Status: the processing state
+* CreatedAt: the submission time
+* Reply: one administrator response, stored when the Feedback enters `replied`
 
 Feedback has three statuses:
 
@@ -49,21 +39,13 @@ Feedback has three statuses:
 | `replied` | Completed with an administrator Reply |
 | `handled` | Completed through the administrator's "Mark as handled" action |
 
-The allowed status transitions are:
-
-```text
-new -> replied
-new -> handled
-```
-
-`replied` and `handled` are terminal states. A Feedback item stores one administrator Reply when it reaches `replied`.
+A Feedback item is created in `new`. It can move from `new` to `replied` or `handled`; both are terminal states.
 
 ### Context
 
-Context is the diagnostic information shared with a Feedback item. It includes available information from the following
-categories:
+Context is the diagnostic information shared with a Feedback item. It includes available information from the following categories:
 
-* Source: the page and entry point from which Feedback was opened
+* Source: the feature and entry point from which Feedback was opened
 * Current page, language, and capture time
 * Current project's identifier, type, name, and resource structure
 * Selected sprite and its basic state
@@ -73,20 +55,17 @@ categories:
 * Project Snapshot
 * Current page screenshot
 
-For diagnostic items also used by Copilot, Feedback follows the existing Copilot context collection and sampling rules.
-Context is captured when the user confirms submission and remains fixed after submission.
+Context follows these rules:
 
-Users control Context sharing through "Share diagnostic information." When enabled, the available Context is included in
-Feedback.
+* Enabling "Share diagnostic information" includes the available Context in Feedback.
+* Context is captured when the user confirms submission and remains fixed after submission.
+* Nearby source includes up to 21 lines around the current cursor. Runtime output includes the latest 50 entries.
+* The Project Snapshot and current page screenshot are stored separately, and Feedback stores references to them. Both follow the existing upload size limit.
+* If an item is unavailable or exceeds its limit, Feedback includes the remaining Context and can still be submitted.
 
 ### Project Snapshot
 
-A Project Snapshot preserves the current project files at the time of submission. It is part of Context and can be opened
-in the editor by an authorized administrator investigating the Feedback.
-
-### Reply
-
-A Reply is an administrator's written response to a Feedback item.
+A Project Snapshot is the complete project file content captured when the user submits Feedback, represented as the `Files` collection used by the editor.
 
 ## Permissions
 
@@ -95,75 +74,46 @@ The feedback administrator role is `feedbackAdmin`, with the derived `canManageF
 Users can read the Feedback they submitted. `feedbackAdmin` can:
 
 * View Feedback lists and details
-* View the Context shared with a Feedback item
 * Open its Project Snapshot in the editor
 * Reply to Feedback in the `new` state
 * Mark Feedback in the `new` state as `handled`
 
-Context follows the authorization of its Feedback item. `authorizationAdmin` can assign the `feedbackAdmin` role.
+`authorizationAdmin` can assign the `feedbackAdmin` role.
 
 ## Core Mechanisms
 
 ### Submission and Capture
 
-Users open the Feedback form from the profile menu, enter a Title and Description, and decide whether to share Context.
-The system captures Context after the user confirms submission.
+Users open the Feedback form from the profile menu, enter a Title and Description, and submit the Feedback.
 
-The form indicates progress while Feedback is being submitted. If submission fails, the form keeps the entered content
-and provides an action to try again.
+The form indicates progress while Feedback is being submitted. If submission fails, the form keeps the entered content and provides an action to try again.
 
 ### Copilot Assistance
 
-When a user asks to submit Feedback or accepts Copilot's suggestion, Copilot can prepare a Title and Description draft.
-After the user confirms opening the Feedback form, they can review the draft, decide whether to share Context, and submit
-the Feedback.
+When a user asks to submit Feedback or accepts Copilot's suggestion, Copilot can prepare a Title and Description draft. After the user confirms opening the Feedback form, they can review the draft, decide whether to share Context, and submit the Feedback.
 
 ### Feedback for AI Feature and Quota Issues
 
-Copilot, Costume Generation, and Animation Generation each present messages for their corresponding feature and quota
-issues. A message can provide an action that opens the Feedback form, with Source identifying the affected feature and
-entry point.
+Copilot, Costume Generation, and Animation Generation each present messages for their corresponding feature and quota issues. A message can provide an action that opens the Feedback form, with Source identifying the affected feature and entry point.
 
 ### Viewing a Project Snapshot
 
-From Feedback details, an administrator can open the Project Snapshot through the editor's reusable local project-loading
-capability and inspect the project as it was when the Feedback was submitted.
+From Feedback details, an administrator can open the Project Snapshot through the editor's reusable local project-loading capability. The editor loads the captured `Files` into a local session where the administrator can inspect and run the project as it was when the Feedback was submitted.
 
 ### Processing Feedback
 
-An administrator completes Feedback in the `new` state by replying or selecting "Mark as handled." When administrators
-process the same Feedback concurrently, the first successful action determines its terminal state, and the other
-administrators see the resulting state.
+When administrators process the same Feedback in the `new` state concurrently, the first successful action determines its terminal state, and the other administrators see the resulting state.
 
 ### Reply and Notification
 
-After an administrator successfully sends a Reply, Feedback enters the `replied` state and creates an
-[In-Product Notification](./in-product-notification.md) for the submitting user. If the operation fails, the Reply draft
-remains available and the administrator can try again.
+After an administrator successfully sends a Reply, Feedback enters the `replied` state and creates an [In-Product Notification](./in-product-notification.md) for the submitting user. If sending the Reply fails, the draft remains available and the administrator can try again.
 
 ## User Story
 
-### User Reports a Project Problem
+### Submitting Feedback
 
-While testing a project, a user encounters an unexpected result. The user opens Feedback from the profile menu, describes
-the problem, chooses to share Context, and submits it. The resulting Feedback gives an administrator the description and
-the project state from when the problem occurred.
+A user opens the Feedback form from the profile menu, after asking Copilot to prepare a draft, or from an AI feature or quota message. The user reviews the Title and Description, chooses whether to share Context, and submits the Feedback. A successful submission creates a Feedback item in `new`; if submission fails, the form keeps the entered content so the user can try again.
 
-### User Asks Copilot to Prepare Feedback
+### Processing Feedback
 
-The user asks to submit Feedback during a Copilot conversation. Copilot prepares a draft and, after confirmation, opens
-the Feedback form. The user reviews the draft, chooses whether to share Context, and submits it.
-
-### User Reports an AI Feature or Quota Issue
-
-The user encounters a feature or quota issue in Copilot, Costume Generation, or Animation Generation. The corresponding
-message opens Feedback for that feature, where the user reviews and submits the report.
-
-### Administrator Processes Feedback
-
-An administrator opens Feedback in the `new` state and uses its Context to investigate the problem. The administrator can
-open the Project Snapshot in the editor, then reply to the user or mark the Feedback as `handled`.
-
-### User Views a Reply
-
-After an administrator replies, the user receives an In-Product Notification and opens it to read the Reply.
+A `feedbackAdmin` opens a Feedback item in `new` and uses its Title, Description, and available Context to investigate the problem. The administrator can open the Project Snapshot in a local editor session, then send a Reply or mark the Feedback as `handled`. A successful Reply moves the Feedback to `replied` and creates an In-Product Notification for the submitting user. If sending the Reply fails, the draft remains available for another attempt. If another administrator completes the Feedback first, the interface shows the resulting terminal state.

--- a/docs/product/feedback.md
+++ b/docs/product/feedback.md
@@ -91,6 +91,10 @@ The same submission uses a stable Submission ID:
 * The same Submission ID with different content causes a conflict.
 * The same content with a different Submission ID is not merged automatically.
 
+### Viewing a Project Snapshot
+
+From Feedback details, administrators select "Open project snapshot" to open the Project Snapshot from Context in the editor.
+
 ### Copilot Assistance
 
 After the user explicitly asks for Feedback, or accepts Copilot's suggestion, Copilot may generate a Title and Description draft and open the Feedback form.
@@ -107,6 +111,7 @@ The feedback administrator role is `feedbackAdmin`, with the derived `canManageF
 
 * View Feedback lists and details
 * View the Context shared by users
+* Open the Project Snapshot from Context in the editor
 * Reply to Feedback in the `new` state
 * Mark Feedback as `handled`
 
@@ -152,7 +157,7 @@ Copilot prepares a Title and Description draft after the user explicitly asks fo
 
 ### Administrator Processes Feedback
 
-An administrator with `feedbackAdmin` opens the Feedback details, views the shared Context, replies to the user, or marks the Feedback as requiring no reply. When concurrent processing occurs, the interface shows the result that has already taken effect.
+An administrator with `feedbackAdmin` opens the Feedback details, views the shared Context, and opens the Project Snapshot in the editor when needed. The administrator can reply to the user or mark the Feedback as requiring no reply. When concurrent processing occurs, the interface shows the result that has already taken effect.
 
 ### User Views a Reply
 

--- a/docs/product/feedback.zh.md
+++ b/docs/product/feedback.zh.md
@@ -91,6 +91,10 @@ In-product Notification 用于把管理员回复交给用户。
 * Submission ID 相同但内容不同，请求发生冲突。
 * 内容相同但 Submission ID 不同，不自动合并。
 
+### 查看 Project Snapshot
+
+管理员从 Feedback 详情选择“打开项目快照”，在编辑器中打开 Context 中的 Project Snapshot。
+
 ### Copilot 辅助
 
 当用户明确提出需要反馈，或接受 Copilot 的建议后，Copilot 可以生成 Title 和 Description 草稿并打开 Feedback 表单。
@@ -107,6 +111,7 @@ Copilot 额度耗尽时，提示中可以提供直接打开 Feedback 表单的�
 
 * 查看 Feedback 列表和详情
 * 查看用户同意分享的 Context
+* 在编辑器中打开 Context 中的 Project Snapshot
 * 回复 `new` 状态的 Feedback
 * 将 Feedback 标记为 `handled`
 
@@ -152,7 +157,7 @@ Copilot 根据用户明确的请求生成 Title 和 Description 草稿。用户�
 
 ### 管理员处理反馈
 
-拥有 `feedbackAdmin` 的管理员查看 Feedback 详情和用户分享的 Context，回复用户或将 Feedback 标记为无需回复。并发处理时，界面展示已经生效的处理结果。
+拥有 `feedbackAdmin` 的管理员查看 Feedback 详情和用户分享的 Context，并在需要时从 Feedback 详情进入编辑器打开 Project Snapshot。管理员可以回复用户或将 Feedback 标记为无需回复。并发处理时，界面展示已经生效的处理结果。
 
 ### 用户查看回复
 

--- a/docs/product/feedback.zh.md
+++ b/docs/product/feedback.zh.md
@@ -21,22 +21,15 @@ Feedback 将用户填写的内容与其同意分享的 Context 保存在同一�
 
 ### 反馈 Feedback
 
-用户提交的 Feedback 内容由三部分组成：
+一条 Feedback 包含：
 
-* Title
-* Description
-* Context
-
-Context 为可选内容。
-
-Feedback 记录还包含以下系统字段：
-
-* User
-* Status
-* CreatedAt
-* Reply
-
-Title 最多 100 个字符，Description 最多 2000 个字符。
+* User：提交 Feedback 的用户
+* Title：问题概述，最多 100 个字符
+* Description：问题描述，最多 2000 个字符
+* Context：用户选择分享的诊断信息，可选
+* Status：处理状态
+* CreatedAt：提交时间
+* Reply：一条管理员回复，在 Feedback 进入 `replied` 时保存
 
 Feedback 有三种状态：
 
@@ -46,20 +39,13 @@ Feedback 有三种状态：
 | `replied` | 管理员已完成回复 |
 | `handled` | 管理员通过“标记为已处理”完成处理 |
 
-状态按以下方向变化：
-
-```text
-new -> replied
-new -> handled
-```
-
-`replied` 与 `handled` 是终态。Feedback 进入 `replied` 时保存一条管理员 Reply。
+Feedback 创建时为 `new`，可以从 `new` 进入 `replied` 或 `handled`；两者均为终态。
 
 ### 上下文 Context
 
 Context 是随 Feedback 分享的诊断信息，包括以下类别中的可用信息：
 
-* Source：打开 Feedback 的页面和入口
+* Source：打开 Feedback 的功能和入口
 * 当前页面、语言和采集时间
 * 当前工程的标识、类型、名称和资源结构
 * 当前选中的角色及其基本状态
@@ -69,19 +55,17 @@ Context 是随 Feedback 分享的诊断信息，包括以下类别中的可用�
 * Project Snapshot
 * 当前页面截图
 
-对于 Copilot 同样使用的诊断信息，Feedback 沿用现有的 Copilot 上下文采集和采样规则。Context 在用户确认提交时
-采集，并在提交后保持固定。
+Context 遵循以下规则：
 
-用户通过“分享诊断信息”控制 Context 分享。开启后，Feedback 包含当时可用的 Context。
+* 开启“分享诊断信息”后，Feedback 包含当时可用的 Context。
+* Context 在用户确认提交时采集，并在提交后保持固定。
+* 附近代码包含当前光标附近最多 21 行，运行输出包含最近 50 条。
+* Project Snapshot 和当前页面截图单独保存，Feedback 保存它们的引用。两者沿用现有的上传大小限制。
+* 单项内容不可用或超过限制时，Feedback 包含其余 Context，并可以继续提交。
 
 ### 项目快照 Project Snapshot
 
-Project Snapshot 保存提交时的工程文件内容。它属于 Context，获得授权的管理员可以在编辑器中打开快照并排查
-Feedback。
-
-### 回复 Reply
-
-Reply 是管理员针对 Feedback 给出的文字回复。
+Project Snapshot 是用户提交 Feedback 时捕获的完整工程文件内容，以编辑器使用的 `Files` 集合表示。
 
 ## 权限管理
 
@@ -90,69 +74,46 @@ Reply 是管理员针对 Feedback 给出的文字回复。
 用户可以读取自己提交的 Feedback。`feedbackAdmin` 可以：
 
 * 查看 Feedback 列表和详情
-* 查看随 Feedback 分享的 Context
 * 在编辑器中打开其中的 Project Snapshot
 * 回复 `new` 状态的 Feedback
 * 将 `new` 状态的 Feedback 标记为 `handled`
 
-Context 沿用所属 Feedback 的访问权限。`authorizationAdmin` 可以配置 `feedbackAdmin` 角色。
+`authorizationAdmin` 可以配置 `feedbackAdmin` 角色。
 
 ## 核心机制
 
 ### 提交与采集
 
-用户从头像菜单打开 Feedback 表单，填写 Title 和 Description，并决定是否分享 Context。用户确认提交后，系统采集
-Context。
+用户从头像菜单打开 Feedback 表单，填写 Title 和 Description，并提交 Feedback。
 
 提交过程中，表单显示进行中状态。提交失败时，表单保留已填写的内容，并提供重试操作。
 
 ### Copilot 辅助
 
-当用户提出需要提交 Feedback，或接受 Copilot 的建议后，Copilot 可以准备 Title 和 Description 草稿。用户确认打开
-Feedback 表单后，可以检查草稿、决定是否分享 Context，然后提交 Feedback。
+当用户提出需要提交 Feedback，或接受 Copilot 的建议后，Copilot 可以准备 Title 和 Description 草稿。用户确认打开 Feedback 表单后，可以检查草稿、决定是否分享 Context，然后提交 Feedback。
 
 ### AI 功能与额度问题反馈
 
-Copilot、Costume 生成和 Animation 生成分别展示对应的功能与额度问题提示。提示可以提供打开 Feedback 表单的操作，
-Source 记录对应的功能和入口。
+Copilot、Costume 生成和 Animation 生成分别展示对应的功能与额度问题提示。提示可以提供打开 Feedback 表单的操作，Source 记录对应的功能和入口。
 
 ### 查看 Project Snapshot
 
-管理员可以从 Feedback 详情通过编辑器可复用的本地工程加载能力打开 Project Snapshot，查看 Feedback 提交时的工程
-内容。
+管理员可以从 Feedback 详情通过编辑器可复用的本地工程加载能力打开 Project Snapshot。编辑器将快照中的 `Files` 加载到本地会话中，供管理员查看和运行 Feedback 提交时的工程。
 
 ### 处理 Feedback
 
-管理员通过回复或“标记为已处理”完成 `new` 状态的 Feedback。多名管理员并发处理同一条 Feedback 时，第一个成功的
-操作决定其终态，其他管理员看到最终生效的状态。
+多名管理员并发处理同一条 `new` 状态的 Feedback 时，第一个成功的操作决定其终态，其他管理员看到最终生效的状态。
 
 ### 回复与通知
 
-管理员成功发送 Reply 后，Feedback 进入 `replied` 状态，并为提交用户创建
-[In-Product Notification](./in-product-notification.zh.md)。操作失败时，表单保留 Reply 草稿，管理员可以重试。
+管理员成功发送 Reply 后，Feedback 进入 `replied` 状态，并为提交用户创建 [In-Product Notification](./in-product-notification.zh.md)。发送 Reply 失败时，表单保留草稿，管理员可以重试。
 
 ## User Story
 
-### 用户反馈工程问题
+### 提交 Feedback
 
-用户测试工程时遇到与预期不符的结果。用户从头像菜单打开 Feedback，描述问题，选择分享 Context 并提交。管理员可以
-从这条 Feedback 中了解问题描述和问题发生时的工程状态。
+用户可以从头像菜单打开 Feedback 表单，也可以在请 Copilot 准备草稿后，或通过 AI 功能与额度问题提示打开表单。用户检查 Title 和 Description，选择是否分享 Context，然后提交 Feedback。提交成功后创建一条 `new` 状态的 Feedback；提交失败时，表单保留已填写的内容，供用户重试。
 
-### 用户请求 Copilot 整理反馈
+### 处理 Feedback
 
-用户在 Copilot 对话中提出需要提交 Feedback。Copilot 准备草稿，并在用户确认后打开 Feedback 表单。用户检查草稿、
-选择是否分享 Context，然后提交 Feedback。
-
-### 用户反馈 AI 功能或额度问题
-
-用户在 Copilot、Costume 生成或 Animation 生成中遇到功能或额度问题。对应提示为该功能打开 Feedback，用户检查并
-提交反馈内容。
-
-### 管理员处理 Feedback
-
-管理员打开 `new` 状态的 Feedback，并根据 Context 排查问题。管理员可以在编辑器中打开 Project Snapshot，然后回复
-用户或将 Feedback 标记为 `handled`。
-
-### 用户查看回复
-
-管理员回复后，用户收到 In-Product Notification，并从通知中查看 Reply。
+`feedbackAdmin` 打开一条 `new` 状态的 Feedback，根据 Title、Description 和可用的 Context 排查问题。管理员可以在本地编辑器会话中打开 Project Snapshot，然后发送 Reply 或将 Feedback 标记为 `handled`。成功发送 Reply 后，Feedback 进入 `replied`，并为提交用户创建 In-Product Notification。发送 Reply 失败时，草稿保留，供管理员重试。其他管理员先完成处理时，界面显示最终生效的终态。

--- a/docs/product/feedback.zh.md
+++ b/docs/product/feedback.zh.md
@@ -1,0 +1,159 @@
+# 用户反馈 Feedback
+
+用户在使用 XBuilder 时可能遇到功能异常、运行结果不符合预期，或不知道如何继续操作。Feedback 允许用户直接描述问题，并在同意后附带提交时的 Context，帮助管理员定位问题。
+
+## 背景
+
+用户反馈通常只包含一段文字，管理员还需要询问用户所在页面、工程状态和错误信息，才能开始排查。
+
+因此，Feedback 保存用户填写的 Title 和 Description，以及用户同意分享的 Context。管理员通过统一的反馈列表查看和处理问题。
+
+## 目标
+
+* 用户可以在 XBuilder 内提交反馈。
+* Feedback 可以附带提交时采集的 Context。
+* Copilot 可以帮助用户整理反馈，但最终内容由用户确认和提交。
+* Copilot 暂时不可用或额度耗尽时，用户仍然可以使用反馈入口。
+* 管理员可以查看、处理并回复 Feedback，也可以查看用户分享的 Context。
+* 用户可以在 XBuilder 内收到管理员回复。
+
+## 基本概念
+
+### 反馈 Feedback
+
+一条 Feedback 由三部分组成：
+
+* Title
+* Description
+* Context
+
+Title 最多 100 个字符，Description 最多 2000 个字符。
+
+Feedback 有三种状态：
+
+| 状态 | 含义 |
+| - | - |
+| `new` | 尚未处理 |
+| `replied` | 管理员已经回复 |
+| `handled` | 管理员已处理，不需要回复 |
+
+状态按以下方向变化：
+
+```text
+new -> replied
+new -> handled
+```
+
+`replied` 与 `handled` 是终态。一条 Feedback 最多包含一条 Reply。
+
+### 上下文 Context
+
+Context 是用户确认提交 Feedback 时采集的诊断信息，包括：
+
+* 当前页面、语言和采集时间
+* 当前工程的标识、类型、名称和资源结构
+* 当前选中的角色及其基本状态
+* 当前代码文件、光标、选区和附近代码
+* 当前工程中的代码错误和警告
+* 最近 50 条运行输出
+* Project Snapshot
+* 页面截图
+
+Context 在用户确认提交时采集，而不是在打开表单时采集。工程和页面在提交后继续发生变化，不会更新已经保存的 Context。
+
+用户可以关闭“分享诊断信息”。关闭后不采集 Context。部分上下文信息不可用时可以省略对应内容，但不能因此阻止 Feedback 提交。
+
+Context 不是公开资源。只有 Feedback 提交用户和拥有 `feedbackAdmin` 角色的管理员可以访问。
+
+### 回复 Reply
+
+Reply 是管理员针对 Feedback 给出的文字处理结果。
+
+Reply 保存成功后，Feedback 状态变为 `replied`，并为原提交用户创建一条站内通知。
+
+### 站内通知 In-product Notification
+
+In-product Notification 用于把管理员回复交给用户。
+
+通知包含回复内容和回复时间。用户可以从导航栏查看未读数量、通知列表和通知详情。
+
+## 核心机制
+
+### 提交与采集
+
+用户从右上角头像菜单打开“提交反馈”，填写 Title 和 Description，并决定是否分享 Context。
+
+用户同意分享时，系统在确认提交时采集 Context。提交过程中显示进行中状态，避免用户重复操作。服务端确认 Feedback 创建成功后，界面显示完成状态并关闭表单；提交失败时保留用户输入并允许重试。
+
+同一次提交使用稳定的 Submission ID：
+
+* Submission ID 与内容均相同，返回已经创建的 Feedback。
+* Submission ID 相同但内容不同，请求发生冲突。
+* 内容相同但 Submission ID 不同，不自动合并。
+
+### Copilot 辅助
+
+当用户明确提出需要反馈，或接受 Copilot 的建议后，Copilot 可以生成 Title 和 Description 草稿并打开 Feedback 表单。
+
+用户可以修改草稿并决定是否分享 Context。Copilot 不能直接提交 Feedback，也不能在用户未确认时打开表单。
+
+Copilot 额度耗尽时，提示中可以提供直接打开 Feedback 表单的操作。用户也始终可以从头像菜单进入 Feedback。
+
+### 权限管理
+
+反馈管理员对应的角色为 `feedbackAdmin`，并派生 `canManageFeedback` capability。
+
+`feedbackAdmin` 可以：
+
+* 查看 Feedback 列表和详情
+* 查看用户同意分享的 Context
+* 回复 `new` 状态的 Feedback
+* 将 Feedback 标记为 `handled`
+
+`authorizationAdmin` 可以为用户配置 `feedbackAdmin`。其他管理员角色不包含反馈管理权限。
+
+前端通过 `canManageFeedback` 控制管理入口，后端 Admin API 仍必须独立检查 `feedbackAdmin`。
+
+### 处理 Feedback
+
+管理员处理同一条 Feedback 时采用先到先得：
+
+* 第一个成功的处理操作生效。
+* 后续操作不会覆盖已经生效的处理结果。
+* 前端重新加载 Feedback，并展示最终状态。
+
+Feedback 进入终态后不再接受处理请求。管理员因网络超时重复发送请求时，服务端根据当前状态拒绝重复处理，不重复创建 Reply 或 Notification。
+
+### Reply 与 Notification
+
+Reply、Feedback 状态变化和 In-product Notification 作为一次完整操作保存。
+
+如果任一步骤失败：
+
+* Feedback 保持 `new`。
+* 不保存不完整的 Reply。
+* 不创建用户通知。
+* 管理员填写的回复继续保留。
+* 界面提示回复失败，并允许重试。
+
+整个操作成功后，界面显示“回复已发送”。通知记录保存后，即使导航栏角标刷新失败，用户下次打开通知中心时仍然可以查看通知。
+
+将 Feedback 标记为 `handled` 时不创建 Notification。
+
+## User Story
+
+### 用户提交反馈
+
+用户填写 Title 和 Description，并决定是否分享 Context。提交成功时用户看到明确的完成状态；提交失败时可以在原内容基础上重试。
+
+### 用户请 Copilot 整理反馈
+
+Copilot 根据用户明确的请求生成 Title 和 Description 草稿。用户检查和修改内容、决定是否分享 Context，然后自行提交 Feedback。
+
+### 管理员处理反馈
+
+拥有 `feedbackAdmin` 的管理员查看 Feedback 详情和用户分享的 Context，回复用户或将 Feedback 标记为无需回复。并发处理时，界面展示已经生效的处理结果。
+
+### 用户查看回复
+
+管理员回复后，用户在导航栏看到未读通知，并可以查看回复内容。

--- a/docs/product/feedback.zh.md
+++ b/docs/product/feedback.zh.md
@@ -1,33 +1,43 @@
 # 用户反馈 Feedback
 
-用户在使用 XBuilder 时可能遇到功能异常、运行结果不符合预期，或不知道如何继续操作。Feedback 允许用户直接描述问题；用户同意后，Feedback 会包含用于定位问题的 Context。
+用户在使用 XBuilder 时可能遇到功能异常、运行结果不符合预期，或不知道如何继续操作。Feedback 允许用户在
+XBuilder 内描述问题。用户同意后，Feedback 可以包含帮助管理员排查问题的 Context。
 
 ## 背景
 
 用户反馈通常只包含一段文字，管理员还需要询问用户所在页面、工程状态和错误信息，才能开始排查。
 
-因此，Feedback 保存用户填写的 Title 和 Description，以及用户同意分享的 Context。管理员通过统一的反馈列表查看和处理问题。
+因此，Feedback 将用户填写的内容和用户同意分享的 Context 组合到同一条记录中，供管理员排查和处理。
 
 ## 目标
 
 * 用户可以在 XBuilder 内提交反馈。
-* Feedback 可以包含 Context。
+* Feedback 可以包含提交时采集的 Context。
 * Copilot 可以帮助用户整理反馈，但最终内容由用户确认和提交。
 * Copilot 暂时不可用或额度耗尽时，用户仍然可以使用反馈入口。
 * 管理员可以查看、处理并回复 Feedback。
 * 用户可以在 XBuilder 内收到管理员回复。
 
-## 基本概念
+## 基本概念与规则
+
+本节定义 Feedback 记录、Context 以及处理流程使用的状态。
 
 ### 反馈 Feedback
 
-一条 Feedback 由三部分组成：
+用户提交的 Feedback 内容由三部分组成：
 
 * Title
 * Description
 * Context
 
 Context 可以为空。
+
+Feedback 记录还包含以下系统字段：
+
+* User
+* Status
+* CreatedAt
+* Reply
 
 Title 最多 100 个字符，Description 最多 2000 个字符。
 
@@ -52,60 +62,44 @@ new -> handled
 
 Context 是 Feedback 中用于定位问题的信息，包括：
 
+* Source：触发 Feedback 的页面和入口
 * 当前页面、语言和采集时间
 * 当前工程的标识、类型、名称和资源结构
 * 当前选中的角色及其基本状态
 * 当前代码文件、光标、选区和附近代码
 * 当前工程中的代码错误和警告
-* 最近 50 条运行输出
+* 当前工程的运行输出
 * Project Snapshot
 * 页面截图
+
+Context 由内联诊断信息和较大内容的引用组成：
+
+* 内联诊断信息沿用现有采集规则：包含最近 50 条运行输出，以及当前光标前后最多 21 行代码。
+* Feedback API 定义内联 Context 序列化后的最大尺寸，客户端和服务端使用同一限制进行校验。
+* Project Snapshot 是当前工程 `exportFiles()` 返回的 `files` 集合。提交时将其 JSON 内容保存到 Kodo，Context 只保存 Kodo 对象引用，不把整个集合嵌入 Feedback 记录。
+* 页面截图保存到 Kodo，Context 只保存 Kodo 对象引用，不把图片嵌入 Feedback 记录。截图遵循现有 Upload Session 返回的 `maxSize` 限制。
+* 内联诊断信息或较大内容无法采集，或超出 API/上传限制时，省略对应 Context 项并标记为不可用；剩余内容仍可提交。
 
 Context 在用户确认提交时采集，而不是在打开表单时采集。工程和页面在提交后继续发生变化，不会更新已经保存的 Context。
 
 用户可以关闭“分享诊断信息”。关闭后 Context 为空。部分上下文信息不可用时可以省略对应内容，但不能因此阻止 Feedback 提交。
 
-Feedback 中的 Context 不是公开资源。只有 Feedback 提交用户和拥有 `feedbackAdmin` 角色的管理员可以访问。
-
 ### 回复 Reply
 
-Reply 是管理员针对 Feedback 给出的文字处理结果。
+Reply 是管理员针对 Feedback 给出的文字回复。
 
 ### 站内通知 In-Product Notification
 
-In-Product Notification 用于把管理员回复交给用户。
+In-Product Notification 用于把管理员的 Reply 交给用户。
 
 通知包含回复内容和回复时间。用户可以从导航栏查看未读数量、通知列表和通知详情。
 
-## 核心机制
-
-### 提交与采集
-
-用户从右上角头像菜单打开“提交反馈”，填写 Title 和 Description，并决定是否分享 Context。
-
-用户同意分享时，Feedback 包含确认提交时采集的 Context。提交过程中显示进行中状态，避免用户重复操作。服务端确认 Feedback 创建成功后，界面显示完成状态并关闭表单；提交失败时保留用户输入并允许重试。
-
-同一次提交使用稳定的 Submission ID：
-
-* Submission ID 与内容均相同，返回已经创建的 Feedback。
-* Submission ID 相同但内容不同，请求发生冲突。
-* 内容相同但 Submission ID 不同，不自动合并。
-
-### 查看 Project Snapshot
-
-管理员从 Feedback 详情选择“打开项目快照”，在编辑器中打开 Feedback 中的 Project Snapshot。
-
-### Copilot 辅助
-
-当用户明确提出需要反馈，或接受 Copilot 的建议后，Copilot 可以生成 Title 和 Description 草稿并打开 Feedback 表单。
-
-用户可以修改草稿并决定是否分享 Context。Copilot 不能直接提交 Feedback，也不能在用户未确认时打开表单。
-
-Copilot 额度耗尽时，提示中可以提供直接打开 Feedback 表单的操作。用户也始终可以从头像菜单进入 Feedback。
-
-### 权限管理
+## 权限管理
 
 反馈管理员对应的角色为 `feedbackAdmin`，并派生 `canManageFeedback` capability。
+
+用户侧的 Feedback 读取范围限定为当前用户提交的 Feedback。拥有 `feedbackAdmin` 角色的管理员可以读取全部
+Feedback 记录，包括用户分享的 Context。Context 中的快照和截图引用遵循同一归属校验，不提供公开下载资源。
 
 `feedbackAdmin` 可以：
 
@@ -115,31 +109,71 @@ Copilot 额度耗尽时，提示中可以提供直接打开 Feedback 表单的�
 * 回复 `new` 状态的 Feedback
 * 将 Feedback 标记为 `handled`
 
-`authorizationAdmin` 可以为用户配置 `feedbackAdmin`。Feedback 管理操作必须由 `feedbackAdmin` 执行，其他管理员角色不包含该权限。
+`authorizationAdmin` 可以为用户配置 `feedbackAdmin`。Feedback 管理操作必须由 `feedbackAdmin` 执行，其他管理员
+角色不包含该权限。
+
+前端通过 `canManageFeedback` 控制管理入口，Feedback 管理 API 仍必须在服务端检查 `feedbackAdmin`。
+
+Feedback 列表只返回轻量的记录字段和 Context 是否可用。详情页按需加载内联 Context；通过归属校验的用户或管理员
+打开、预览时，才获取 Project Snapshot 的 JSON 和截图内容。
+
+## 核心机制
+
+### 提交与采集
+
+用户从右上角头像菜单打开反馈表单，填写 Title 和 Description，并决定是否分享 Context。
+
+用户同意分享时，系统在确认提交时采集 Context。提交过程中显示进行中状态，避免用户重复操作。服务端确认
+Feedback 创建成功后，界面显示完成状态并关闭表单；提交失败时保留用户输入并允许重试。
+
+同一次提交使用稳定的 Submission ID。Submission ID 以提交用户为作用域，不同用户使用相同值时视为不同提交：
+
+* Submission ID 与内容均相同，返回已经创建的 Feedback。
+* Submission ID 相同但内容不同，请求发生冲突。
+* 内容相同但 Submission ID 不同，不自动合并。
+
+### Copilot 辅助
+
+当用户明确提出需要反馈，或接受 Copilot 的建议后，Copilot 可以生成 Title 和 Description 草稿并打开 Feedback
+表单。
+
+用户可以修改草稿并决定是否分享 Context。Copilot 不能直接提交 Feedback，也不能在用户未确认时打开表单。
+
+Copilot 生成的草稿不替代 Feedback 的 Context。用户确认提交时，Feedback 按上述规则采集 Context。
+
+Copilot 暂时不可用或额度耗尽时，提示中可以提供直接打开 Feedback 表单的操作。用户也始终可以从头像菜单进入
+Feedback。
+
+### 查看 Project Snapshot
+
+管理员从 Feedback 详情选择“打开项目快照”。客户端从 Kodo 获取引用的 JSON，将其中的 `files` 集合交给编辑器的
+本地加载能力，在本地打开快照；此过程不会创建或保存新的 SPX Project。
 
 ### 处理 Feedback
 
-管理员处理同一条 Feedback 时采用先到先得：
+管理员并发处理同一条 Feedback 时，服务端接受第一个有效的状态迁移：
 
-* 第一个成功的处理操作生效。
-* 后续操作不会覆盖已经生效的处理结果。
+* 被接受的迁移决定最终状态和 Reply。
+* 后续操作不会覆盖已接受的处理结果。
 * 前端重新加载 Feedback，并展示最终状态。
 
-Feedback 进入终态后不再接受处理请求。管理员因网络超时重复发送请求时，服务端根据当前状态拒绝重复处理，不重复创建 Reply 或 Notification。
+Feedback 进入终态后不再接受处理请求。管理员因网络超时重复发送请求时，服务端根据当前状态拒绝重复处理，不重复
+创建 Reply 或 Notification。
 
-### Reply 与 Notification
+### 回复与通知
 
 Reply、Feedback 状态变化和 In-Product Notification 作为一次完整操作保存。
 
-如果任一步骤失败：
+如果保存 Reply 或创建通知记录失败：
 
 * Feedback 保持 `new`。
 * 不保存不完整的 Reply。
 * 不创建用户通知。
-* 管理员填写的回复继续保留。
-* 界面提示回复失败，并允许重试。
+* 管理员未发送的回复继续保留在表单中，可以重试。
+* 界面提示操作失败，并允许重试。
 
-整个操作成功后，界面显示“回复已发送”。通知记录保存后，即使导航栏角标刷新失败，用户下次打开通知中心时仍然可以查看通知。
+完整操作成功后，界面显示“回复已发送”。通知记录保存后，即使导航栏角标刷新失败，也不影响通知；用户下次打开
+通知列表时仍然可以查看通知。
 
 将 Feedback 标记为 `handled` 时不创建 Notification。
 
@@ -147,16 +181,18 @@ Reply、Feedback 状态变化和 In-Product Notification 作为一次完整操�
 
 ### 用户提交反馈
 
-用户遇到功能异常、运行结果不符合预期或不知道如何继续时，可以从头像菜单提交 Feedback。用户决定是否分享 Context；提交失败时，界面保留填写内容以供重试。
+用户遇到功能异常、运行结果不符合预期或不知道如何继续时，可以从头像菜单提交 Feedback。用户决定是否分享
+Context；提交失败时，可以在原内容基础上重试。
 
-### 用户请 Copilot 整理反馈
+### 用户请求 Copilot 整理反馈
 
 用户在 Copilot 对话中提出需要反馈。Copilot 生成草稿并打开 Feedback 表单，用户检查和修改后提交。
 
 ### 管理员处理反馈
 
-拥有 `feedbackAdmin` 的管理员查看 Feedback 详情，并根据 Context 排查问题。需要时，管理员可以在编辑器中打开 Project Snapshot；处理完成后回复用户或将 Feedback 标记为无需回复。
+拥有 `feedbackAdmin` 的管理员查看 Feedback 详情，并根据 Context 排查问题。需要时，管理员可以在编辑器中打开
+Project Snapshot；处理完成后回复用户或将 Feedback 标记为无需回复。
 
 ### 用户查看回复
 
-管理员回复后，用户在导航栏看到未读通知，并从通知详情查看回复内容。
+管理员回复后，用户在导航栏看到未读通知，并从通知详情查看 Reply。

--- a/docs/product/feedback.zh.md
+++ b/docs/product/feedback.zh.md
@@ -1,6 +1,6 @@
 # 用户反馈 Feedback
 
-用户在使用 XBuilder 时可能遇到功能异常、运行结果不符合预期，或不知道如何继续操作。Feedback 允许用户直接描述问题，并在同意后附带提交时的 Context，帮助管理员定位问题。
+用户在使用 XBuilder 时可能遇到功能异常、运行结果不符合预期，或不知道如何继续操作。Feedback 允许用户直接描述问题；用户同意后，Feedback 会包含用于定位问题的 Context。
 
 ## 背景
 
@@ -11,10 +11,10 @@
 ## 目标
 
 * 用户可以在 XBuilder 内提交反馈。
-* Feedback 可以附带提交时采集的 Context。
+* Feedback 可以包含 Context。
 * Copilot 可以帮助用户整理反馈，但最终内容由用户确认和提交。
 * Copilot 暂时不可用或额度耗尽时，用户仍然可以使用反馈入口。
-* 管理员可以查看、处理并回复 Feedback，也可以查看用户分享的 Context。
+* 管理员可以查看、处理并回复 Feedback。
 * 用户可以在 XBuilder 内收到管理员回复。
 
 ## 基本概念
@@ -26,6 +26,8 @@
 * Title
 * Description
 * Context
+
+Context 可以为空。
 
 Title 最多 100 个字符，Description 最多 2000 个字符。
 
@@ -48,7 +50,7 @@ new -> handled
 
 ### 上下文 Context
 
-Context 是用户确认提交 Feedback 时采集的诊断信息，包括：
+Context 是 Feedback 中用于定位问题的信息，包括：
 
 * 当前页面、语言和采集时间
 * 当前工程的标识、类型、名称和资源结构
@@ -61,19 +63,17 @@ Context 是用户确认提交 Feedback 时采集的诊断信息，包括：
 
 Context 在用户确认提交时采集，而不是在打开表单时采集。工程和页面在提交后继续发生变化，不会更新已经保存的 Context。
 
-用户可以关闭“分享诊断信息”。关闭后不采集 Context。部分上下文信息不可用时可以省略对应内容，但不能因此阻止 Feedback 提交。
+用户可以关闭“分享诊断信息”。关闭后 Context 为空。部分上下文信息不可用时可以省略对应内容，但不能因此阻止 Feedback 提交。
 
-Context 不是公开资源。只有 Feedback 提交用户和拥有 `feedbackAdmin` 角色的管理员可以访问。
+Feedback 中的 Context 不是公开资源。只有 Feedback 提交用户和拥有 `feedbackAdmin` 角色的管理员可以访问。
 
 ### 回复 Reply
 
 Reply 是管理员针对 Feedback 给出的文字处理结果。
 
-Reply 保存成功后，Feedback 状态变为 `replied`，并为原提交用户创建一条站内通知。
+### 站内通知 In-Product Notification
 
-### 站内通知 In-product Notification
-
-In-product Notification 用于把管理员回复交给用户。
+In-Product Notification 用于把管理员回复交给用户。
 
 通知包含回复内容和回复时间。用户可以从导航栏查看未读数量、通知列表和通知详情。
 
@@ -83,7 +83,7 @@ In-product Notification 用于把管理员回复交给用户。
 
 用户从右上角头像菜单打开“提交反馈”，填写 Title 和 Description，并决定是否分享 Context。
 
-用户同意分享时，系统在确认提交时采集 Context。提交过程中显示进行中状态，避免用户重复操作。服务端确认 Feedback 创建成功后，界面显示完成状态并关闭表单；提交失败时保留用户输入并允许重试。
+用户同意分享时，Feedback 包含确认提交时采集的 Context。提交过程中显示进行中状态，避免用户重复操作。服务端确认 Feedback 创建成功后，界面显示完成状态并关闭表单；提交失败时保留用户输入并允许重试。
 
 同一次提交使用稳定的 Submission ID：
 
@@ -93,7 +93,7 @@ In-product Notification 用于把管理员回复交给用户。
 
 ### 查看 Project Snapshot
 
-管理员从 Feedback 详情选择“打开项目快照”，在编辑器中打开 Context 中的 Project Snapshot。
+管理员从 Feedback 详情选择“打开项目快照”，在编辑器中打开 Feedback 中的 Project Snapshot。
 
 ### Copilot 辅助
 
@@ -110,14 +110,12 @@ Copilot 额度耗尽时，提示中可以提供直接打开 Feedback 表单的�
 `feedbackAdmin` 可以：
 
 * 查看 Feedback 列表和详情
-* 查看用户同意分享的 Context
-* 在编辑器中打开 Context 中的 Project Snapshot
+* 查看 Feedback 详情中用户同意分享的 Context
+* 在编辑器中打开 Feedback 中的 Project Snapshot
 * 回复 `new` 状态的 Feedback
 * 将 Feedback 标记为 `handled`
 
-`authorizationAdmin` 可以为用户配置 `feedbackAdmin`。其他管理员角色不包含反馈管理权限。
-
-前端通过 `canManageFeedback` 控制管理入口，后端 Admin API 仍必须独立检查 `feedbackAdmin`。
+`authorizationAdmin` 可以为用户配置 `feedbackAdmin`。Feedback 管理操作必须由 `feedbackAdmin` 执行，其他管理员角色不包含该权限。
 
 ### 处理 Feedback
 
@@ -131,7 +129,7 @@ Feedback 进入终态后不再接受处理请求。管理员因网络超时重�
 
 ### Reply 与 Notification
 
-Reply、Feedback 状态变化和 In-product Notification 作为一次完整操作保存。
+Reply、Feedback 状态变化和 In-Product Notification 作为一次完整操作保存。
 
 如果任一步骤失败：
 
@@ -149,16 +147,16 @@ Reply、Feedback 状态变化和 In-product Notification 作为一次完整操�
 
 ### 用户提交反馈
 
-用户填写 Title 和 Description，并决定是否分享 Context。提交成功时用户看到明确的完成状态；提交失败时可以在原内容基础上重试。
+用户遇到功能异常、运行结果不符合预期或不知道如何继续时，可以从头像菜单提交 Feedback。用户决定是否分享 Context；提交失败时，界面保留填写内容以供重试。
 
 ### 用户请 Copilot 整理反馈
 
-Copilot 根据用户明确的请求生成 Title 和 Description 草稿。用户检查和修改内容、决定是否分享 Context，然后自行提交 Feedback。
+用户在 Copilot 对话中提出需要反馈。Copilot 生成草稿并打开 Feedback 表单，用户检查和修改后提交。
 
 ### 管理员处理反馈
 
-拥有 `feedbackAdmin` 的管理员查看 Feedback 详情和用户分享的 Context，并在需要时从 Feedback 详情进入编辑器打开 Project Snapshot。管理员可以回复用户或将 Feedback 标记为无需回复。并发处理时，界面展示已经生效的处理结果。
+拥有 `feedbackAdmin` 的管理员查看 Feedback 详情，并根据 Context 排查问题。需要时，管理员可以在编辑器中打开 Project Snapshot；处理完成后回复用户或将 Feedback 标记为无需回复。
 
 ### 用户查看回复
 
-管理员回复后，用户在导航栏看到未读通知，并可以查看回复内容。
+管理员回复后，用户在导航栏看到未读通知，并从通知详情查看回复内容。

--- a/docs/product/feedback.zh.md
+++ b/docs/product/feedback.zh.md
@@ -1,26 +1,23 @@
 # 用户反馈 Feedback
 
-用户在使用 XBuilder 时可能遇到功能异常、运行结果不符合预期，或不知道如何继续操作。Feedback 允许用户在
-XBuilder 内描述问题。用户同意后，Feedback 可以包含帮助管理员排查问题的 Context。
+Feedback 允许用户描述在 XBuilder 中遇到的问题，并在用户同意后分享帮助管理员排查问题的 Context。
 
 ## 背景
 
-用户反馈通常只包含一段文字，管理员还需要询问用户所在页面、工程状态和错误信息，才能开始排查。
+简短的问题描述通常不足以复现问题。管理员还可能需要了解问题发生时的页面、工程状态、代码、诊断信息和运行输出。
 
-因此，Feedback 将用户填写的内容和用户同意分享的 Context 组合到同一条记录中，供管理员排查和处理。
+Feedback 将用户填写的内容与其同意分享的 Context 保存在同一条记录中，帮助管理员减少追问并开始处理问题。
 
 ## 目标
 
-* 用户可以在 XBuilder 内提交反馈。
-* Feedback 可以包含提交时采集的 Context。
-* Copilot 可以帮助用户整理反馈，但最终内容由用户确认和提交。
-* Copilot 暂时不可用或额度耗尽时，用户仍然可以使用反馈入口。
-* 管理员可以查看、处理并回复 Feedback。
+* 用户可以在 XBuilder 内提交 Feedback。
+* 用户可以在 Feedback 中包含提交时采集的 Context。
+* Copilot 可以准备 Feedback 草稿，交由用户检查和提交。
+* 支持的 AI 功能可以在出现功能或额度问题时提供 Feedback 入口。
+* 管理员可以排查、处理并回复 Feedback。
 * 用户可以在 XBuilder 内收到管理员回复。
 
 ## 基本概念与规则
-
-本节定义 Feedback 记录、Context 以及处理流程使用的状态。
 
 ### 反馈 Feedback
 
@@ -30,7 +27,7 @@ XBuilder 内描述问题。用户同意后，Feedback 可以包含帮助管理�
 * Description
 * Context
 
-Context 可以为空。
+Context 为可选内容。
 
 Feedback 记录还包含以下系统字段：
 
@@ -45,9 +42,9 @@ Feedback 有三种状态：
 
 | 状态 | 含义 |
 | - | - |
-| `new` | 尚未处理 |
-| `replied` | 管理员已经回复 |
-| `handled` | 管理员已处理，不需要回复 |
+| `new` | 等待管理员处理 |
+| `replied` | 管理员已完成回复 |
+| `handled` | 管理员通过“标记为已处理”完成处理 |
 
 状态按以下方向变化：
 
@@ -56,13 +53,13 @@ new -> replied
 new -> handled
 ```
 
-`replied` 与 `handled` 是终态。一条 Feedback 最多包含一条 Reply。
+`replied` 与 `handled` 是终态。Feedback 进入 `replied` 时保存一条管理员 Reply。
 
 ### 上下文 Context
 
-Context 是 Feedback 中用于定位问题的信息，包括：
+Context 是随 Feedback 分享的诊断信息，包括以下类别中的可用信息：
 
-* Source：触发 Feedback 的页面和入口
+* Source：打开 Feedback 的页面和入口
 * 当前页面、语言和采集时间
 * 当前工程的标识、类型、名称和资源结构
 * 当前选中的角色及其基本状态
@@ -70,129 +67,92 @@ Context 是 Feedback 中用于定位问题的信息，包括：
 * 当前工程中的代码错误和警告
 * 当前工程的运行输出
 * Project Snapshot
-* 页面截图
+* 当前页面截图
 
-Context 由内联诊断信息和较大内容的引用组成：
+对于 Copilot 同样使用的诊断信息，Feedback 沿用现有的 Copilot 上下文采集和采样规则。Context 在用户确认提交时
+采集，并在提交后保持固定。
 
-* 内联诊断信息沿用现有采集规则：包含最近 50 条运行输出，以及当前光标前后最多 21 行代码。
-* Feedback API 定义内联 Context 序列化后的最大尺寸，客户端和服务端使用同一限制进行校验。
-* Project Snapshot 是当前工程 `exportFiles()` 返回的 `files` 集合。提交时将其 JSON 内容保存到 Kodo，Context 只保存 Kodo 对象引用，不把整个集合嵌入 Feedback 记录。
-* 页面截图保存到 Kodo，Context 只保存 Kodo 对象引用，不把图片嵌入 Feedback 记录。截图遵循现有 Upload Session 返回的 `maxSize` 限制。
-* 内联诊断信息或较大内容无法采集，或超出 API/上传限制时，省略对应 Context 项并标记为不可用；剩余内容仍可提交。
+用户通过“分享诊断信息”控制 Context 分享。开启后，Feedback 包含当时可用的 Context。
 
-Context 在用户确认提交时采集，而不是在打开表单时采集。工程和页面在提交后继续发生变化，不会更新已经保存的 Context。
+### 项目快照 Project Snapshot
 
-用户可以关闭“分享诊断信息”。关闭后 Context 为空。部分上下文信息不可用时可以省略对应内容，但不能因此阻止 Feedback 提交。
+Project Snapshot 保存提交时的工程文件内容。它属于 Context，获得授权的管理员可以在编辑器中打开快照并排查
+Feedback。
 
 ### 回复 Reply
 
 Reply 是管理员针对 Feedback 给出的文字回复。
 
-### 站内通知 In-Product Notification
-
-In-Product Notification 用于把管理员的 Reply 交给用户。
-
-通知包含回复内容和回复时间。用户可以从导航栏查看未读数量、通知列表和通知详情。
-
 ## 权限管理
 
 反馈管理员对应的角色为 `feedbackAdmin`，并派生 `canManageFeedback` capability。
 
-用户侧的 Feedback 读取范围限定为当前用户提交的 Feedback。拥有 `feedbackAdmin` 角色的管理员可以读取全部
-Feedback 记录，包括用户分享的 Context。Context 中的快照和截图引用遵循同一归属校验，不提供公开下载资源。
-
-`feedbackAdmin` 可以：
+用户可以读取自己提交的 Feedback。`feedbackAdmin` 可以：
 
 * 查看 Feedback 列表和详情
-* 查看 Feedback 详情中用户同意分享的 Context
-* 在编辑器中打开 Feedback 中的 Project Snapshot
+* 查看随 Feedback 分享的 Context
+* 在编辑器中打开其中的 Project Snapshot
 * 回复 `new` 状态的 Feedback
-* 将 Feedback 标记为 `handled`
+* 将 `new` 状态的 Feedback 标记为 `handled`
 
-`authorizationAdmin` 可以为用户配置 `feedbackAdmin`。Feedback 管理操作必须由 `feedbackAdmin` 执行，其他管理员
-角色不包含该权限。
-
-前端通过 `canManageFeedback` 控制管理入口，Feedback 管理 API 仍必须在服务端检查 `feedbackAdmin`。
-
-Feedback 列表只返回轻量的记录字段和 Context 是否可用。详情页按需加载内联 Context；通过归属校验的用户或管理员
-打开、预览时，才获取 Project Snapshot 的 JSON 和截图内容。
+Context 沿用所属 Feedback 的访问权限。`authorizationAdmin` 可以配置 `feedbackAdmin` 角色。
 
 ## 核心机制
 
 ### 提交与采集
 
-用户从右上角头像菜单打开反馈表单，填写 Title 和 Description，并决定是否分享 Context。
+用户从头像菜单打开 Feedback 表单，填写 Title 和 Description，并决定是否分享 Context。用户确认提交后，系统采集
+Context。
 
-用户同意分享时，系统在确认提交时采集 Context。提交过程中显示进行中状态，避免用户重复操作。服务端确认
-Feedback 创建成功后，界面显示完成状态并关闭表单；提交失败时保留用户输入并允许重试。
-
-同一次提交使用稳定的 Submission ID。Submission ID 以提交用户为作用域，不同用户使用相同值时视为不同提交：
-
-* Submission ID 与内容均相同，返回已经创建的 Feedback。
-* Submission ID 相同但内容不同，请求发生冲突。
-* 内容相同但 Submission ID 不同，不自动合并。
+提交过程中，表单显示进行中状态。提交失败时，表单保留已填写的内容，并提供重试操作。
 
 ### Copilot 辅助
 
-当用户明确提出需要反馈，或接受 Copilot 的建议后，Copilot 可以生成 Title 和 Description 草稿并打开 Feedback
-表单。
+当用户提出需要提交 Feedback，或接受 Copilot 的建议后，Copilot 可以准备 Title 和 Description 草稿。用户确认打开
+Feedback 表单后，可以检查草稿、决定是否分享 Context，然后提交 Feedback。
 
-用户可以修改草稿并决定是否分享 Context。Copilot 不能直接提交 Feedback，也不能在用户未确认时打开表单。
+### AI 功能与额度问题反馈
 
-Copilot 生成的草稿不替代 Feedback 的 Context。用户确认提交时，Feedback 按上述规则采集 Context。
-
-Copilot 暂时不可用或额度耗尽时，提示中可以提供直接打开 Feedback 表单的操作。用户也始终可以从头像菜单进入
-Feedback。
+Copilot、Costume 生成和 Animation 生成分别展示对应的功能与额度问题提示。提示可以提供打开 Feedback 表单的操作，
+Source 记录对应的功能和入口。
 
 ### 查看 Project Snapshot
 
-管理员从 Feedback 详情选择“打开项目快照”。客户端从 Kodo 获取引用的 JSON，将其中的 `files` 集合交给编辑器的
-本地加载能力，在本地打开快照；此过程不会创建或保存新的 SPX Project。
+管理员可以从 Feedback 详情通过编辑器可复用的本地工程加载能力打开 Project Snapshot，查看 Feedback 提交时的工程
+内容。
 
 ### 处理 Feedback
 
-管理员并发处理同一条 Feedback 时，服务端接受第一个有效的状态迁移：
-
-* 被接受的迁移决定最终状态和 Reply。
-* 后续操作不会覆盖已接受的处理结果。
-* 前端重新加载 Feedback，并展示最终状态。
-
-Feedback 进入终态后不再接受处理请求。管理员因网络超时重复发送请求时，服务端根据当前状态拒绝重复处理，不重复
-创建 Reply 或 Notification。
+管理员通过回复或“标记为已处理”完成 `new` 状态的 Feedback。多名管理员并发处理同一条 Feedback 时，第一个成功的
+操作决定其终态，其他管理员看到最终生效的状态。
 
 ### 回复与通知
 
-Reply、Feedback 状态变化和 In-Product Notification 作为一次完整操作保存。
-
-如果保存 Reply 或创建通知记录失败：
-
-* Feedback 保持 `new`。
-* 不保存不完整的 Reply。
-* 不创建用户通知。
-* 管理员未发送的回复继续保留在表单中，可以重试。
-* 界面提示操作失败，并允许重试。
-
-完整操作成功后，界面显示“回复已发送”。通知记录保存后，即使导航栏角标刷新失败，也不影响通知；用户下次打开
-通知列表时仍然可以查看通知。
-
-将 Feedback 标记为 `handled` 时不创建 Notification。
+管理员成功发送 Reply 后，Feedback 进入 `replied` 状态，并为提交用户创建
+[In-Product Notification](./in-product-notification.zh.md)。操作失败时，表单保留 Reply 草稿，管理员可以重试。
 
 ## User Story
 
-### 用户提交反馈
+### 用户反馈工程问题
 
-用户遇到功能异常、运行结果不符合预期或不知道如何继续时，可以从头像菜单提交 Feedback。用户决定是否分享
-Context；提交失败时，可以在原内容基础上重试。
+用户测试工程时遇到与预期不符的结果。用户从头像菜单打开 Feedback，描述问题，选择分享 Context 并提交。管理员可以
+从这条 Feedback 中了解问题描述和问题发生时的工程状态。
 
 ### 用户请求 Copilot 整理反馈
 
-用户在 Copilot 对话中提出需要反馈。Copilot 生成草稿并打开 Feedback 表单，用户检查和修改后提交。
+用户在 Copilot 对话中提出需要提交 Feedback。Copilot 准备草稿，并在用户确认后打开 Feedback 表单。用户检查草稿、
+选择是否分享 Context，然后提交 Feedback。
 
-### 管理员处理反馈
+### 用户反馈 AI 功能或额度问题
 
-拥有 `feedbackAdmin` 的管理员查看 Feedback 详情，并根据 Context 排查问题。需要时，管理员可以在编辑器中打开
-Project Snapshot；处理完成后回复用户或将 Feedback 标记为无需回复。
+用户在 Copilot、Costume 生成或 Animation 生成中遇到功能或额度问题。对应提示为该功能打开 Feedback，用户检查并
+提交反馈内容。
+
+### 管理员处理 Feedback
+
+管理员打开 `new` 状态的 Feedback，并根据 Context 排查问题。管理员可以在编辑器中打开 Project Snapshot，然后回复
+用户或将 Feedback 标记为 `handled`。
 
 ### 用户查看回复
 
-管理员回复后，用户在导航栏看到未读通知，并从通知详情查看 Reply。
+管理员回复后，用户收到 In-Product Notification，并从通知中查看 Reply。

--- a/docs/product/in-product-notification.md
+++ b/docs/product/in-product-notification.md
@@ -1,12 +1,10 @@
 # In-Product Notification
 
-XBuilder uses In-Product Notification to deliver asynchronous product updates to users inside XBuilder. A Notification is
-a reusable delivery mechanism; the product feature that creates it defines the event and content.
+XBuilder uses In-Product Notification to deliver asynchronous product updates to users inside XBuilder. A Notification is a reusable delivery mechanism; the product feature that creates it defines the event and content.
 
 ## Background
 
-Some product operations finish after the user has left the page where they started. A persistent entry in XBuilder keeps
-the result available after the user leaves the original page.
+Some product operations finish after the user has left the page where they started. A persistent entry in XBuilder keeps the result available after the user leaves the original page.
 
 ## Goals
 
@@ -22,48 +20,22 @@ A Notification is a message addressed to one User about a product event.
 
 A Notification contains:
 
-* Recipient
-* Title
-* Body
-* CreatedAt
-* ReadAt
-
-`ReadAt` is empty for an unread Notification and contains the time at which the user read it after it has been read.
+* Recipient: the User who can read the Notification
+* Title: a summary of the update
+* Body: the complete message
+* CreatedAt: the creation time
+* ReadAt: the time the Recipient read the Notification; empty while unread
 
 ### Notification List
 
-The Notification List is the current user's collection of Notifications. It provides the unread count and the
-Notifications ordered from newest to oldest.
-
-The Recipient can read a Notification. The server validates the Recipient for list, detail, and read-state operations.
+The Notification List is the current user's collection of Notifications. It provides the unread count and the Notifications ordered from newest to oldest.
 
 ## Core Mechanisms
 
 ### Creating a Notification
 
-The originating product feature creates a Notification as part of its user-facing operation. The feature defines when the
-operation succeeds, its transaction behavior, and the Notification's Title and Body.
-
-For Feedback, a successful administrator Reply creates an In-Product Notification for the submitting user. The Feedback
-document defines the transaction and failure behavior for this integration.
+A product feature creates a Notification for its Recipient. A new Notification is unread and appears in the Notification List according to its CreatedAt.
 
 ### Reading Notifications
 
-Users open the Notification List from the navigation bar. Opening a Notification shows its details and records the read
-time. The unread count updates after the read state changes.
-
-### Failure Handling
-
-Notification creation follows the transaction rules of its originating feature. A saved Notification remains available
-when the navigation badge refresh is delayed or fails.
-
-## User Story
-
-### User Receives a Notification
-
-The user can return to XBuilder later and find an update addressed to them, even after leaving the page where the update
-was created.
-
-### User Reads a Notification
-
-The user opens the Notification List, selects a Notification, and reads the complete message.
+Users open the Notification List from the navigation bar. Opening a Notification shows its details and records the read time. The unread count updates after the read state changes.

--- a/docs/product/in-product-notification.md
+++ b/docs/product/in-product-notification.md
@@ -1,0 +1,69 @@
+# In-Product Notification
+
+XBuilder uses In-Product Notification to deliver asynchronous product updates to users inside XBuilder. A Notification is
+a reusable delivery mechanism; the product feature that creates it defines the event and content.
+
+## Background
+
+Some product operations finish after the user has left the page where they started. A persistent entry in XBuilder keeps
+the result available after the user leaves the original page.
+
+## Goals
+
+* Users can find product updates addressed to them in XBuilder.
+* Users can distinguish unread notifications from notifications they have read.
+* Product features share one Notification List and read-state behavior.
+
+## Basic Concepts
+
+### Notification
+
+A Notification is a message addressed to one User about a product event.
+
+A Notification contains:
+
+* Recipient
+* Title
+* Body
+* CreatedAt
+* ReadAt
+
+`ReadAt` is empty for an unread Notification and contains the time at which the user read it after it has been read.
+
+### Notification List
+
+The Notification List is the current user's collection of Notifications. It provides the unread count and the
+Notifications ordered from newest to oldest.
+
+The Recipient can read a Notification. The server validates the Recipient for list, detail, and read-state operations.
+
+## Core Mechanisms
+
+### Creating a Notification
+
+The originating product feature creates a Notification as part of its user-facing operation. The feature defines when the
+operation succeeds, its transaction behavior, and the Notification's Title and Body.
+
+For Feedback, a successful administrator Reply creates an In-Product Notification for the submitting user. The Feedback
+document defines the transaction and failure behavior for this integration.
+
+### Reading Notifications
+
+Users open the Notification List from the navigation bar. Opening a Notification shows its details and records the read
+time. The unread count updates after the read state changes.
+
+### Failure Handling
+
+Notification creation follows the transaction rules of its originating feature. A saved Notification remains available
+when the navigation badge refresh is delayed or fails.
+
+## User Story
+
+### User Receives a Notification
+
+The user can return to XBuilder later and find an update addressed to them, even after leaving the page where the update
+was created.
+
+### User Reads a Notification
+
+The user opens the Notification List, selects a Notification, and reads the complete message.

--- a/docs/product/in-product-notification.zh.md
+++ b/docs/product/in-product-notification.zh.md
@@ -1,0 +1,63 @@
+# 站内通知 In-Product Notification
+
+XBuilder 使用 In-Product Notification 在站内向用户传递异步的产品更新。Notification 是可复用的传递机制；创建通知的
+产品功能负责定义触发事件和通知内容。
+
+## 背景
+
+部分产品操作会在用户离开起始页面后完成。XBuilder 提供持久入口，让用户离开原页面后仍可查看结果。
+
+## 目标
+
+* 用户可以在 XBuilder 内找到发送给自己的产品更新。
+* 用户可以区分未读和已读通知。
+* 各产品功能共用 Notification List 和已读状态行为。
+
+## 基本概念
+
+### Notification
+
+Notification 是针对一个 User、用于传递某个产品事件的消息。
+
+一个 Notification 包含：
+
+* Recipient
+* Title
+* Body
+* CreatedAt
+* ReadAt
+
+未读 Notification 的 `ReadAt` 为空；用户阅读后，`ReadAt` 记录阅读时间。
+
+### 通知列表 Notification List
+
+Notification List 是当前用户收到的 Notification 集合，提供未读数量，并按最新到最早的顺序展示通知。
+
+Recipient 可以读取对应的 Notification。服务端对列表、详情和已读状态操作执行 Recipient 校验。
+
+## 核心机制
+
+### 创建 Notification
+
+发起功能在面向用户的操作中创建 Notification，并定义操作何时成功、事务行为，以及 Notification 的 Title 和 Body。
+
+对于 Feedback，管理员成功回复后，系统为提交用户创建一条 In-Product Notification。Feedback 文档定义这一集成的事务和
+失败处理规则。
+
+### 查看 Notification
+
+用户从导航栏打开 Notification List。打开某条 Notification 时展示详情并记录阅读时间；已读状态变化后更新未读数量。
+
+### 失败处理
+
+Notification 的创建遵循发起功能的事务规则。导航栏角标延迟刷新或刷新失败时，已保存的 Notification 仍可查看。
+
+## User Story
+
+### 用户收到通知
+
+用户离开产生更新的页面后，仍然可以回到 XBuilder 查看发送给自己的更新。
+
+### 用户查看通知
+
+用户打开 Notification List，选择某条 Notification，查看完整消息。

--- a/docs/product/in-product-notification.zh.md
+++ b/docs/product/in-product-notification.zh.md
@@ -1,7 +1,6 @@
 # 站内通知 In-Product Notification
 
-XBuilder 使用 In-Product Notification 在站内向用户传递异步的产品更新。Notification 是可复用的传递机制；创建通知的
-产品功能负责定义触发事件和通知内容。
+XBuilder 使用 In-Product Notification 在站内向用户传递异步的产品更新。Notification 是可复用的传递机制；创建通知的产品功能负责定义触发事件和通知内容。
 
 ## 背景
 
@@ -21,43 +20,22 @@ Notification 是针对一个 User、用于传递某个产品事件的消息。
 
 一个 Notification 包含：
 
-* Recipient
-* Title
-* Body
-* CreatedAt
-* ReadAt
-
-未读 Notification 的 `ReadAt` 为空；用户阅读后，`ReadAt` 记录阅读时间。
+* Recipient：可以查看 Notification 的 User
+* Title：更新摘要
+* Body：完整消息
+* CreatedAt：创建时间
+* ReadAt：Recipient 查看 Notification 的时间，未读时为空
 
 ### 通知列表 Notification List
 
 Notification List 是当前用户收到的 Notification 集合，提供未读数量，并按最新到最早的顺序展示通知。
 
-Recipient 可以读取对应的 Notification。服务端对列表、详情和已读状态操作执行 Recipient 校验。
-
 ## 核心机制
 
 ### 创建 Notification
 
-发起功能在面向用户的操作中创建 Notification，并定义操作何时成功、事务行为，以及 Notification 的 Title 和 Body。
-
-对于 Feedback，管理员成功回复后，系统为提交用户创建一条 In-Product Notification。Feedback 文档定义这一集成的事务和
-失败处理规则。
+产品功能为 Recipient 创建 Notification。新 Notification 为未读状态，并根据 CreatedAt 显示在 Notification List 中。
 
 ### 查看 Notification
 
 用户从导航栏打开 Notification List。打开某条 Notification 时展示详情并记录阅读时间；已读状态变化后更新未读数量。
-
-### 失败处理
-
-Notification 的创建遵循发起功能的事务规则。导航栏角标延迟刷新或刷新失败时，已保存的 Notification 仍可查看。
-
-## User Story
-
-### 用户收到通知
-
-用户离开产生更新的页面后，仍然可以回到 XBuilder 查看发送给自己的更新。
-
-### 用户查看通知
-
-用户打开 Notification List，选择某条 Notification，查看完整消息。


### PR DESCRIPTION
## What

Add the Chinese and English Feedback product documents for #1789.

The documents define the Feedback submission content as Title, Description, and Context. Context covers diagnostic details, the Project Snapshot, and the page screenshot captured at submission time. They also define the Feedback-details action and `feedbackAdmin` permission for opening the Project Snapshot in the editor, while keeping `FileCollection` import and storage mechanics outside the Feedback document.

The remaining sections document submission idempotency, Copilot assistance, administrator permissions, status transitions, repeated processing, reply and notification failure handling, and text-based administrator replies.

## Why

Feedback behavior was previously mixed with implementation-specific editor and storage details, which made the ownership boundary unclear and left the Context model and reply behavior inconsistent. This PR gives the Feedback feature its own product definition while preserving the administrator workflow for inspecting the submitted project state.

## Verification

- `git diff --check`
- Confirmed the branch diff contains `docs/product/feedback.md` and `docs/product/feedback.zh.md`.
- `index.md` and `index.zh.md` are not changed.

Refs #1789
