### PR TITLE
fix(api): raise the course prompt limit to 12000

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -7600,7 +7600,7 @@ components:
         prompt:
           description: Prompt text for the course (used for copilot assistance).
           type: string
-          maxLength: 4000
+          maxLength: 12000
           examples:
             - Learn the basics of XGo programming language
 

--- a/spx-gui/src/apis/course.ts
+++ b/spx-gui/src/apis/course.ts
@@ -1,7 +1,12 @@
 import { client, type ByPage, type PaginationParams } from './common'
 
 export const courseTitleMaxLength = 200
-export const coursePromptMaxLength = 4000
+/**
+ * A prompt carries the lesson text together with its scaffold code, reference answer and
+ * completion rules, so exercise and multi-sprite courses run several times longer than a plain
+ * lesson. Kept in step with the API contract in `docs/openapi.yaml`.
+ */
+export const coursePromptMaxLength = 12000
 
 export type Course = {
   /** Unique identifier */


### PR DESCRIPTION
A course prompt is not just lesson text: it carries the scaffold code the learner starts from, the reference answer, and the rules that decide when the course is complete. Exercise and multi-sprite courses therefore run several times longer than a plain lesson.

Across the 126 courses currently published, 96% sit under 2000 characters, but the multi-sprite exercises reach 6226 and 8763 — past the 4000 the contract has allowed since #3279. Those courses predate the limit; they read back fine but cannot be edited or re-imported, because the limit is enforced on write and never revalidates stored rows. The same wall is ahead of the multi-sprite course series now in development.

12000 clears the longest course today with roughly 40% of headroom, while still bounding what a prompt can grow into. It stays well inside the copilot message ceiling (`copilotMessageContentMaxLength = 40000`).

Two places move together: the `Course.prompt` schema in `docs/openapi.yaml` (both the create and update request bodies `$ref` it, so this is the only edit needed) and `coursePromptMaxLength` in the API client, which `CourseEditModal` uses for its validation message — the message interpolates the constant, so it reports the new bound without further change.

Requires goplus/builder-backend#329, which relaxes the server-side check. **That one should merge first**: relaxing only the client would let the editor accept a prompt the server still rejects with an opaque `40001`.

## Test plan

- `npx vitest run src/components/course src/apis` — 7 files, 59 tests, all passing.
- ESLint and Prettier clean on both changed files.
- `docs/openapi.yaml` parses, and `Course.properties.prompt.maxLength` reads 12000.