### PR TITLE
fix(spx-gui): timeout pre-run static checks

### DIFF
--- a/spx-gui/src/components/editor/preview/EditorPreview.vue
+++ b/spx-gui/src/components/editor/preview/EditorPreview.vue
@@ -183,7 +183,7 @@ import { useNetwork } from '@/utils/network'
 import { usePublishProject } from '@/components/project'
 
 // Code Editor operations may take a long time for some projects and block project execution.
-const CODE_EDITOR_OPERATION_TIMEOUT = 5_000 // ms
+const CODE_EDITOR_OPERATION_TIMEOUT = 3_000 // ms
 
 const editorCtx = useEditorCtx()
 const codeEditor = useCodeEditor()
@@ -313,7 +313,7 @@ async function checkAndNotifyMonitorError() {
   const monitors = stage.widgets.filter((w) => w.type === 'monitor')
   const spriteNames = new Set(sprites.map((s) => s.name))
   const invalidMonitors = await withTimeout(CODE_EDITOR_OPERATION_TIMEOUT, (signal) =>
-    getInvalidMonitors(monitors, spriteNames, (target, signal) => codeEditor.getProperties(target, signal), signal)
+    getInvalidMonitors(monitors, spriteNames, (target, s) => codeEditor.getProperties(target, s), signal)
   )
   if (invalidMonitors.length === 0) return
   const monitorNames = humanizeListWithLimit(invalidMonitors.map((m) => ({ en: m.name, zh: m.name })))

--- a/spx-gui/src/components/editor/preview/EditorPreview.vue
+++ b/spx-gui/src/components/editor/preview/EditorPreview.vue
@@ -182,7 +182,7 @@ import StageViewer from './stage-viewer/StageViewer.vue'
 import { useNetwork } from '@/utils/network'
 import { usePublishProject } from '@/components/project'
 
-const STATIC_CHECK_TIMEOUT = 5_000 // ms
+const CODE_EDITOR_OPERATION_TIMEOUT = 5_000 // ms
 
 const editorCtx = useEditorCtx()
 const codeEditor = useCodeEditor()
@@ -290,7 +290,7 @@ function handleExit(code: number) {
 }
 
 async function checkAndNotifyCodeError() {
-  const r = await withTimeout(STATIC_CHECK_TIMEOUT, (signal) => codeEditor.diagnosticWorkspace(signal))
+  const r = await withTimeout(CODE_EDITOR_OPERATION_TIMEOUT, (signal) => codeEditor.diagnosticWorkspace(signal))
   const codeFilesWithError: LocaleMessage[] = []
   for (const item of r.items) {
     if (!item.diagnostics.some((d) => d.severity === DiagnosticSeverity.Error)) continue
@@ -311,7 +311,7 @@ async function checkAndNotifyMonitorError() {
   const { sprites, stage } = editorCtx.project
   const monitors = stage.widgets.filter((w) => w.type === 'monitor')
   const spriteNames = new Set(sprites.map((s) => s.name))
-  const invalidMonitors = await withTimeout(STATIC_CHECK_TIMEOUT, (signal) =>
+  const invalidMonitors = await withTimeout(CODE_EDITOR_OPERATION_TIMEOUT, (signal) =>
     getInvalidMonitors(monitors, spriteNames, (target, signal) => codeEditor.getProperties(target, signal), signal)
   )
   if (invalidMonitors.length === 0) return

--- a/spx-gui/src/components/editor/preview/EditorPreview.vue
+++ b/spx-gui/src/components/editor/preview/EditorPreview.vue
@@ -163,6 +163,7 @@ function isSpxPanicLog(obj: SpxLog): obj is SpxPanicLog {
 <script lang="ts" setup>
 import dayjs from 'dayjs'
 import { computed, nextTick, onBeforeUnmount, ref, watch } from 'vue'
+import { getTimeoutSignal } from '@/utils/disposable'
 import { capture, useMessageHandle } from '@/utils/exception'
 import { useI18n, type LocaleMessage } from '@/utils/i18n'
 import { humanizeListWithLimit, untilNotNull } from '@/utils/utils'
@@ -180,6 +181,8 @@ import { RuntimeOutputKind, type RuntimeOutput, type RuntimeOutputDraft } from '
 import StageViewer from './stage-viewer/StageViewer.vue'
 import { useNetwork } from '@/utils/network'
 import { usePublishProject } from '@/components/project'
+
+const STATIC_CHECK_TIMEOUT = 5_000
 
 const editorCtx = useEditorCtx()
 const codeEditor = useCodeEditor()
@@ -286,8 +289,8 @@ function handleExit(code: number) {
   runnerState.value = shouldRestore ? 'running' : 'loading'
 }
 
-async function checkAndNotifyCodeError() {
-  const r = await codeEditor.diagnosticWorkspace()
+async function checkAndNotifyCodeError(signal?: AbortSignal) {
+  const r = await codeEditor.diagnosticWorkspace(signal)
   const codeFilesWithError: LocaleMessage[] = []
   for (const item of r.items) {
     if (!item.diagnostics.some((d) => d.severity === DiagnosticSeverity.Error)) continue
@@ -304,12 +307,15 @@ async function checkAndNotifyCodeError() {
   })
 }
 
-async function checkAndNotifyMonitorError() {
+async function checkAndNotifyMonitorError(signal?: AbortSignal) {
   const { sprites, stage } = editorCtx.project
   const monitors = stage.widgets.filter((w) => w.type === 'monitor')
   const spriteNames = new Set(sprites.map((s) => s.name))
-  const invalidMonitors = await getInvalidMonitors(monitors, spriteNames, (target, signal) =>
-    codeEditor.getProperties(target, signal)
+  const invalidMonitors = await getInvalidMonitors(
+    monitors,
+    spriteNames,
+    (target, signal) => codeEditor.getProperties(target, signal),
+    signal
   )
   if (invalidMonitors.length === 0) return
   const monitorNames = humanizeListWithLimit(invalidMonitors.map((m) => ({ en: m.name, zh: m.name })))
@@ -357,8 +363,15 @@ const handlePublishProject = useMessageHandle(() => publishProject(editorCtx.pro
 
 const handleRun = useMessageHandle(
   async () => {
-    await checkAndNotifyCodeError()
-    await checkAndNotifyMonitorError()
+    const [signal, cancelTimeout] = getTimeoutSignal(STATIC_CHECK_TIMEOUT)
+    try {
+      await checkAndNotifyCodeError(signal)
+      await checkAndNotifyMonitorError(signal)
+    } catch (error) {
+      if (!signal.aborted) throw error
+    } finally {
+      cancelTimeout()
+    }
     await executeRun('run')
   },
   { en: 'Failed to run project', zh: '运行项目失败' }

--- a/spx-gui/src/components/editor/preview/EditorPreview.vue
+++ b/spx-gui/src/components/editor/preview/EditorPreview.vue
@@ -328,6 +328,11 @@ async function checkAndNotifyMonitorError(signal?: AbortSignal) {
   })
 }
 
+async function checkAndNotifyPreRunErrors(signal?: AbortSignal) {
+  await checkAndNotifyCodeError(signal)
+  await checkAndNotifyMonitorError(signal)
+}
+
 async function executeRun(action: 'run' | 'rerun') {
   exitGuard.value = 'idle'
   runnerState.value = 'loading'
@@ -365,13 +370,7 @@ const handleRun = useMessageHandle(
   async () => {
     const [timeoutSignal, cancelTimeout] = getTimeoutSignal(STATIC_CHECK_TIMEOUT)
     try {
-      await Promise.race([
-        (async () => {
-          await checkAndNotifyCodeError(timeoutSignal)
-          await checkAndNotifyMonitorError(timeoutSignal)
-        })(),
-        promiseForSignal(timeoutSignal)
-      ])
+      await Promise.race([checkAndNotifyPreRunErrors(timeoutSignal), promiseForSignal(timeoutSignal)])
     } catch (error) {
       if (timeoutSignal.aborted) capture(error, 'Pre-run static checks timed out')
       else throw error

--- a/spx-gui/src/components/editor/preview/EditorPreview.vue
+++ b/spx-gui/src/components/editor/preview/EditorPreview.vue
@@ -182,7 +182,7 @@ import StageViewer from './stage-viewer/StageViewer.vue'
 import { useNetwork } from '@/utils/network'
 import { usePublishProject } from '@/components/project'
 
-const STATIC_CHECK_TIMEOUT = 5_000
+const STATIC_CHECK_TIMEOUT = 5_000 // ms
 
 const editorCtx = useEditorCtx()
 const codeEditor = useCodeEditor()

--- a/spx-gui/src/components/editor/preview/EditorPreview.vue
+++ b/spx-gui/src/components/editor/preview/EditorPreview.vue
@@ -363,12 +363,13 @@ const handlePublishProject = useMessageHandle(() => publishProject(editorCtx.pro
 
 const handleRun = useMessageHandle(
   async () => {
-    const [signal, cancelTimeout] = getTimeoutSignal(STATIC_CHECK_TIMEOUT)
+    const [timeoutSignal, cancelTimeout] = getTimeoutSignal(STATIC_CHECK_TIMEOUT)
     try {
-      await checkAndNotifyCodeError(signal)
-      await checkAndNotifyMonitorError(signal)
+      await checkAndNotifyCodeError(timeoutSignal)
+      await checkAndNotifyMonitorError(timeoutSignal)
     } catch (error) {
-      if (!signal.aborted) throw error
+      if (timeoutSignal.aborted) capture(error, 'Pre-run static checks timed out')
+      else throw error
     } finally {
       cancelTimeout()
     }

--- a/spx-gui/src/components/editor/preview/EditorPreview.vue
+++ b/spx-gui/src/components/editor/preview/EditorPreview.vue
@@ -369,14 +369,12 @@ const handlePublishProject = useMessageHandle(() => publishProject(editorCtx.pro
 const handleRun = useMessageHandle(
   async () => {
     const [timeoutSignal, cancelTimeout] = getTimeoutSignal(STATIC_CHECK_TIMEOUT)
-    try {
-      await Promise.race([checkAndNotifyPreRunErrors(timeoutSignal), promiseForSignal(timeoutSignal)])
-    } catch (error) {
-      if (timeoutSignal.aborted) capture(error, 'Pre-run static checks timed out')
-      else throw error
-    } finally {
-      cancelTimeout()
-    }
+    await Promise.race([checkAndNotifyPreRunErrors(timeoutSignal), promiseForSignal(timeoutSignal)])
+      .catch((error) => {
+        if (timeoutSignal.aborted) capture(error, 'Pre-run static checks timed out')
+        else throw error
+      })
+      .finally(cancelTimeout)
     await executeRun('run')
   },
   { en: 'Failed to run project', zh: '运行项目失败' }

--- a/spx-gui/src/components/editor/preview/EditorPreview.vue
+++ b/spx-gui/src/components/editor/preview/EditorPreview.vue
@@ -164,7 +164,7 @@ function isSpxPanicLog(obj: SpxLog): obj is SpxPanicLog {
 import dayjs from 'dayjs'
 import { computed, nextTick, onBeforeUnmount, ref, watch } from 'vue'
 import { getTimeoutSignal, promiseForSignal } from '@/utils/disposable'
-import { capture, useMessageHandle } from '@/utils/exception'
+import { Cancelled, capture, useMessageHandle } from '@/utils/exception'
 import { useI18n, type LocaleMessage } from '@/utils/i18n'
 import { humanizeListWithLimit, untilNotNull } from '@/utils/utils'
 import { useSignedInUser } from '@/stores/user'
@@ -289,8 +289,13 @@ function handleExit(code: number) {
   runnerState.value = shouldRestore ? 'running' : 'loading'
 }
 
-async function checkAndNotifyCodeError(signal?: AbortSignal) {
-  const r = await codeEditor.diagnosticWorkspace(signal)
+async function withStaticCheckTimeout<T>(fn: (signal: AbortSignal) => Promise<T>) {
+  const [timeoutSignal, cancelTimeout] = getTimeoutSignal(STATIC_CHECK_TIMEOUT)
+  return Promise.race([fn(timeoutSignal), promiseForSignal(timeoutSignal)]).finally(cancelTimeout)
+}
+
+async function checkAndNotifyCodeError() {
+  const r = await withStaticCheckTimeout((signal) => codeEditor.diagnosticWorkspace(signal))
   const codeFilesWithError: LocaleMessage[] = []
   for (const item of r.items) {
     if (!item.diagnostics.some((d) => d.severity === DiagnosticSeverity.Error)) continue
@@ -307,15 +312,12 @@ async function checkAndNotifyCodeError(signal?: AbortSignal) {
   })
 }
 
-async function checkAndNotifyMonitorError(signal?: AbortSignal) {
+async function checkAndNotifyMonitorError() {
   const { sprites, stage } = editorCtx.project
   const monitors = stage.widgets.filter((w) => w.type === 'monitor')
   const spriteNames = new Set(sprites.map((s) => s.name))
-  const invalidMonitors = await getInvalidMonitors(
-    monitors,
-    spriteNames,
-    (target, signal) => codeEditor.getProperties(target, signal),
-    signal
+  const invalidMonitors = await withStaticCheckTimeout((signal) =>
+    getInvalidMonitors(monitors, spriteNames, (target, signal) => codeEditor.getProperties(target, signal), signal)
   )
   if (invalidMonitors.length === 0) return
   const monitorNames = humanizeListWithLimit(invalidMonitors.map((m) => ({ en: m.name, zh: m.name })))
@@ -328,9 +330,9 @@ async function checkAndNotifyMonitorError(signal?: AbortSignal) {
   })
 }
 
-async function checkAndNotifyPreRunErrors(signal?: AbortSignal) {
-  await checkAndNotifyCodeError(signal)
-  await checkAndNotifyMonitorError(signal)
+async function checkAndNotifyPreRunErrors() {
+  await checkAndNotifyCodeError()
+  await checkAndNotifyMonitorError()
 }
 
 async function executeRun(action: 'run' | 'rerun') {
@@ -368,13 +370,10 @@ const handlePublishProject = useMessageHandle(() => publishProject(editorCtx.pro
 
 const handleRun = useMessageHandle(
   async () => {
-    const [timeoutSignal, cancelTimeout] = getTimeoutSignal(STATIC_CHECK_TIMEOUT)
-    await Promise.race([checkAndNotifyPreRunErrors(timeoutSignal), promiseForSignal(timeoutSignal)])
-      .catch((error) => {
-        if (timeoutSignal.aborted) capture(error, 'Pre-run static checks timed out')
-        else throw error
-      })
-      .finally(cancelTimeout)
+    await checkAndNotifyPreRunErrors().catch((error) => {
+      if (error instanceof Cancelled) throw error
+      capture(error, 'Failed to check project before running')
+    })
     await executeRun('run')
   },
   { en: 'Failed to run project', zh: '运行项目失败' }

--- a/spx-gui/src/components/editor/preview/EditorPreview.vue
+++ b/spx-gui/src/components/editor/preview/EditorPreview.vue
@@ -182,6 +182,7 @@ import StageViewer from './stage-viewer/StageViewer.vue'
 import { useNetwork } from '@/utils/network'
 import { usePublishProject } from '@/components/project'
 
+// Code Editor operations may take a long time for some projects and block project execution.
 const CODE_EDITOR_OPERATION_TIMEOUT = 5_000 // ms
 
 const editorCtx = useEditorCtx()
@@ -367,7 +368,6 @@ const handleRun = useMessageHandle(
   async () => {
     await checkAndNotifyPreRunErrors().catch((error) => {
       if (error instanceof Cancelled) throw error
-      // Do not let a slow or unavailable language server block project execution.
       capture(error, 'Failed to check project before running')
     })
     await executeRun('run')

--- a/spx-gui/src/components/editor/preview/EditorPreview.vue
+++ b/spx-gui/src/components/editor/preview/EditorPreview.vue
@@ -163,7 +163,7 @@ function isSpxPanicLog(obj: SpxLog): obj is SpxPanicLog {
 <script lang="ts" setup>
 import dayjs from 'dayjs'
 import { computed, nextTick, onBeforeUnmount, ref, watch } from 'vue'
-import { getTimeoutSignal, promiseForSignal } from '@/utils/disposable'
+import { withTimeout } from '@/utils/disposable'
 import { Cancelled, capture, useMessageHandle } from '@/utils/exception'
 import { useI18n, type LocaleMessage } from '@/utils/i18n'
 import { humanizeListWithLimit, untilNotNull } from '@/utils/utils'
@@ -289,13 +289,8 @@ function handleExit(code: number) {
   runnerState.value = shouldRestore ? 'running' : 'loading'
 }
 
-async function withStaticCheckTimeout<T>(fn: (signal: AbortSignal) => Promise<T>) {
-  const [timeoutSignal, cancelTimeout] = getTimeoutSignal(STATIC_CHECK_TIMEOUT)
-  return Promise.race([fn(timeoutSignal), promiseForSignal(timeoutSignal)]).finally(cancelTimeout)
-}
-
 async function checkAndNotifyCodeError() {
-  const r = await withStaticCheckTimeout((signal) => codeEditor.diagnosticWorkspace(signal))
+  const r = await withTimeout(STATIC_CHECK_TIMEOUT, (signal) => codeEditor.diagnosticWorkspace(signal))
   const codeFilesWithError: LocaleMessage[] = []
   for (const item of r.items) {
     if (!item.diagnostics.some((d) => d.severity === DiagnosticSeverity.Error)) continue
@@ -316,7 +311,7 @@ async function checkAndNotifyMonitorError() {
   const { sprites, stage } = editorCtx.project
   const monitors = stage.widgets.filter((w) => w.type === 'monitor')
   const spriteNames = new Set(sprites.map((s) => s.name))
-  const invalidMonitors = await withStaticCheckTimeout((signal) =>
+  const invalidMonitors = await withTimeout(STATIC_CHECK_TIMEOUT, (signal) =>
     getInvalidMonitors(monitors, spriteNames, (target, signal) => codeEditor.getProperties(target, signal), signal)
   )
   if (invalidMonitors.length === 0) return
@@ -372,6 +367,7 @@ const handleRun = useMessageHandle(
   async () => {
     await checkAndNotifyPreRunErrors().catch((error) => {
       if (error instanceof Cancelled) throw error
+      // Do not let a slow or unavailable language server block project execution.
       capture(error, 'Failed to check project before running')
     })
     await executeRun('run')

--- a/spx-gui/src/components/editor/preview/EditorPreview.vue
+++ b/spx-gui/src/components/editor/preview/EditorPreview.vue
@@ -163,7 +163,7 @@ function isSpxPanicLog(obj: SpxLog): obj is SpxPanicLog {
 <script lang="ts" setup>
 import dayjs from 'dayjs'
 import { computed, nextTick, onBeforeUnmount, ref, watch } from 'vue'
-import { getTimeoutSignal } from '@/utils/disposable'
+import { getTimeoutSignal, promiseForSignal } from '@/utils/disposable'
 import { capture, useMessageHandle } from '@/utils/exception'
 import { useI18n, type LocaleMessage } from '@/utils/i18n'
 import { humanizeListWithLimit, untilNotNull } from '@/utils/utils'
@@ -365,8 +365,13 @@ const handleRun = useMessageHandle(
   async () => {
     const [timeoutSignal, cancelTimeout] = getTimeoutSignal(STATIC_CHECK_TIMEOUT)
     try {
-      await checkAndNotifyCodeError(timeoutSignal)
-      await checkAndNotifyMonitorError(timeoutSignal)
+      await Promise.race([
+        (async () => {
+          await checkAndNotifyCodeError(timeoutSignal)
+          await checkAndNotifyMonitorError(timeoutSignal)
+        })(),
+        promiseForSignal(timeoutSignal)
+      ])
     } catch (error) {
       if (timeoutSignal.aborted) capture(error, 'Pre-run static checks timed out')
       else throw error

--- a/spx-gui/src/components/editor/preview/EditorPreview.vue
+++ b/spx-gui/src/components/editor/preview/EditorPreview.vue
@@ -366,6 +366,7 @@ const handlePublishProject = useMessageHandle(() => publishProject(editorCtx.pro
 
 const handleRun = useMessageHandle(
   async () => {
+    // Cancellation means the user declined to run; other check failures should not block project execution.
     await checkAndNotifyPreRunErrors().catch((error) => {
       if (error instanceof Cancelled) throw error
       capture(error, 'Failed to check project before running')

--- a/spx-gui/src/components/editor/preview/EditorPreview.vue
+++ b/spx-gui/src/components/editor/preview/EditorPreview.vue
@@ -366,8 +366,8 @@ const handlePublishProject = useMessageHandle(() => publishProject(editorCtx.pro
 
 const handleRun = useMessageHandle(
   async () => {
-    // Cancellation means the user declined to run; other check failures should not block project execution.
     await checkAndNotifyPreRunErrors().catch((error) => {
+      // Cancellation means the user declined to run; other check failures should not block project execution.
       if (error instanceof Cancelled) throw error
       capture(error, 'Failed to check project before running')
     })

--- a/spx-gui/src/components/editor/spx-code-editor/common.ts
+++ b/spx-gui/src/components/editor/spx-code-editor/common.ts
@@ -302,6 +302,7 @@ export async function getInvalidMonitors(
         ownPropertyNames = new Set(ownProperties.map((p) => p.name))
         propertyNamesMap.set(monitor.target, ownPropertyNames)
       } catch (e) {
+        signal?.throwIfAborted()
         capture(e, `Failed to load properties for target: "${monitor.target}"`)
         continue
       }

--- a/spx-gui/src/components/editor/spx-code-editor/common.ts
+++ b/spx-gui/src/components/editor/spx-code-editor/common.ts
@@ -302,6 +302,7 @@ export async function getInvalidMonitors(
         ownPropertyNames = new Set(ownProperties.map((p) => p.name))
         propertyNamesMap.set(monitor.target, ownPropertyNames)
       } catch (e) {
+        // Propagate cancellation instead of treating it as a property-loading failure.
         signal?.throwIfAborted()
         capture(e, `Failed to load properties for target: "${monitor.target}"`)
         continue

--- a/spx-gui/src/models/spx/project.ts
+++ b/spx-gui/src/models/spx/project.ts
@@ -7,7 +7,7 @@ import { computed, reactive, watch, type ComputedRef, toValue, effectScope } fro
 
 import { join } from '@/utils/path'
 import { debounce } from 'lodash'
-import { Disposable, getCleanupSignal, mergeSignals, withTimeout } from '@/utils/disposable'
+import { Disposable, getCleanupSignal, withTimeout } from '@/utils/disposable'
 import Mutex from '@/utils/mutex'
 import { Cancelled, capture } from '@/utils/exception'
 import { getSpxProjectKnowledge } from '@/utils/spx'
@@ -343,9 +343,7 @@ export class SpxProject extends Disposable implements IProject {
       const reactiveThis = reactive(this) as this
       const screenshotTaker = reactiveThis.screenshotTaker
       if (screenshotTaker == null) return
-      reactiveThis.thumbnail = await withTimeout(screenshotTimeout, (timeoutSignal) =>
-        screenshotTaker('thumbnail', mergeSignals(timeoutSignal, signal))
-      )
+      reactiveThis.thumbnail = await withTimeout(screenshotTimeout, (s) => screenshotTaker('thumbnail', s), signal)
     } catch (e) {
       capture(e, 'failed to update thumbnail')
     }

--- a/spx-gui/src/models/spx/project.ts
+++ b/spx-gui/src/models/spx/project.ts
@@ -7,7 +7,7 @@ import { computed, reactive, watch, type ComputedRef, toValue, effectScope } fro
 
 import { join } from '@/utils/path'
 import { debounce } from 'lodash'
-import { Disposable, getCleanupSignal, getTimeoutSignal, mergeSignals, promiseForSignal } from '@/utils/disposable'
+import { Disposable, getCleanupSignal, mergeSignals, withTimeout } from '@/utils/disposable'
 import Mutex from '@/utils/mutex'
 import { Cancelled, capture } from '@/utils/exception'
 import { getSpxProjectKnowledge } from '@/utils/spx'
@@ -341,12 +341,11 @@ export class SpxProject extends Disposable implements IProject {
   private updateThumbnail = debounce(async (signal?: AbortSignal) => {
     try {
       const reactiveThis = reactive(this) as this
-      if (reactiveThis.screenshotTaker == null) return
-      const [timeoutSignal, cancelTimeout] = getTimeoutSignal(screenshotTimeout)
-      reactiveThis.thumbnail = await Promise.race([
-        reactiveThis.screenshotTaker('thumbnail', mergeSignals(timeoutSignal, signal)),
-        promiseForSignal(timeoutSignal)
-      ]).finally(cancelTimeout)
+      const screenshotTaker = reactiveThis.screenshotTaker
+      if (screenshotTaker == null) return
+      reactiveThis.thumbnail = await withTimeout(screenshotTimeout, (timeoutSignal) =>
+        screenshotTaker('thumbnail', mergeSignals(timeoutSignal, signal))
+      )
     } catch (e) {
       capture(e, 'failed to update thumbnail')
     }

--- a/spx-gui/src/utils/disposable.ts
+++ b/spx-gui/src/utils/disposable.ts
@@ -85,7 +85,10 @@ export function promiseForSignal(signal: AbortSignal): Promise<never> {
   })
 }
 
-/** Run a promise factory with a timeout signal and reject when the timeout expires. */
+/**
+ * Run a promise factory with a signal that aborts with `TimeoutException` when the timeout expires.
+ * The returned promise rejects with the same exception on timeout.
+ */
 export function withTimeout<T>(timeout: number, fn: (signal: AbortSignal) => Promise<T>) {
   const [timeoutSignal, cancelTimeout] = getTimeoutSignal(timeout)
   return Promise.race([fn(timeoutSignal), promiseForSignal(timeoutSignal)]).finally(cancelTimeout)

--- a/spx-gui/src/utils/disposable.ts
+++ b/spx-gui/src/utils/disposable.ts
@@ -84,3 +84,9 @@ export function promiseForSignal(signal: AbortSignal): Promise<never> {
     signal.addEventListener('abort', () => reject(signal.reason), { once: true })
   })
 }
+
+/** Run a promise factory with a timeout signal and reject when the timeout expires. */
+export function withTimeout<T>(timeout: number, fn: (signal: AbortSignal) => Promise<T>) {
+  const [timeoutSignal, cancelTimeout] = getTimeoutSignal(timeout)
+  return Promise.race([fn(timeoutSignal), promiseForSignal(timeoutSignal)]).finally(cancelTimeout)
+}

--- a/spx-gui/src/utils/disposable.ts
+++ b/spx-gui/src/utils/disposable.ts
@@ -86,10 +86,10 @@ export function promiseForSignal(signal: AbortSignal): Promise<never> {
 }
 
 /**
- * Run a promise factory with a signal that aborts with `TimeoutException` when the timeout expires.
+ * Run a promise factory with a signal that aborts when the timeout or an optional external signal expires.
  * The returned promise rejects with the same exception on timeout.
  */
-export function withTimeout<T>(timeout: number, fn: (signal: AbortSignal) => Promise<T>) {
+export function withTimeout<T>(timeout: number, fn: (signal: AbortSignal) => Promise<T>, signal?: AbortSignal) {
   const [timeoutSignal, cancelTimeout] = getTimeoutSignal(timeout)
-  return Promise.race([fn(timeoutSignal), promiseForSignal(timeoutSignal)]).finally(cancelTimeout)
+  return Promise.race([fn(mergeSignals(timeoutSignal, signal)), promiseForSignal(timeoutSignal)]).finally(cancelTimeout)
 }

--- a/spx-gui/src/utils/disposable.ts
+++ b/spx-gui/src/utils/disposable.ts
@@ -87,9 +87,10 @@ export function promiseForSignal(signal: AbortSignal): Promise<never> {
 
 /**
  * Run a promise factory with a signal that aborts when the timeout or an optional external signal expires.
- * The returned promise rejects with the same exception on timeout.
+ * The returned promise rejects with `TimeoutException` on timeout or the external signal's reason on cancellation.
  */
 export function withTimeout<T>(timeout: number, fn: (signal: AbortSignal) => Promise<T>, signal?: AbortSignal) {
   const [timeoutSignal, cancelTimeout] = getTimeoutSignal(timeout)
-  return Promise.race([fn(mergeSignals(timeoutSignal, signal)), promiseForSignal(timeoutSignal)]).finally(cancelTimeout)
+  const mergedSignal = mergeSignals(timeoutSignal, signal)
+  return Promise.race([fn(mergedSignal), promiseForSignal(mergedSignal)]).finally(cancelTimeout)
 }

--- a/spx-gui/src/utils/exception/index.ts
+++ b/spx-gui/src/utils/exception/index.ts
@@ -72,7 +72,7 @@ export function useMessageHandle<Args extends any[], T>(
 export function capture(err: unknown, ctx?: unknown) {
   if (err instanceof Cancelled) return
   if (process.env.NODE_ENV !== 'test') {
-    captureException(err, { extra: { ctx } })
+    captureException(err, { extra: { ctx: String(ctx) } })
     console.warn(ctx, err)
   }
 }

--- a/spx-gui/src/utils/exception/index.ts
+++ b/spx-gui/src/utils/exception/index.ts
@@ -72,7 +72,7 @@ export function useMessageHandle<Args extends any[], T>(
 export function capture(err: unknown, ctx?: unknown) {
   if (err instanceof Cancelled) return
   if (process.env.NODE_ENV !== 'test') {
-    captureException(err)
+    captureException(err, { extra: { ctx } })
     console.warn(ctx, err)
   }
 }


### PR DESCRIPTION
Closes #3409

## Summary

- bound each Code Editor operation used by pre-run checks to 5 seconds
- cancel timed-out LS requests without blocking project execution
- preserve error/monitor confirmation dialogs and their existing cancellation behavior
- include `capture` contexts in Sentry events
- reuse the timeout helper for thumbnail updates

## Validation

- `pnpm --dir spx-gui exec prettier --check src/components/editor/preview/EditorPreview.vue src/models/spx/project.ts src/utils/disposable.ts`
- `pnpm --dir spx-gui run lint`
- `pnpm --dir spx-gui run type-check`
- `pnpm --dir spx-gui test src/models/spx/project.test.ts`
