### PR TITLE
feat(spx-gui): normalize animation frame extraction timing

### DIFF
--- a/spx-gui/src/components/asset/gen/animation/AnimationVideoPreview.vue
+++ b/spx-gui/src/components/asset/gen/animation/AnimationVideoPreview.vue
@@ -200,7 +200,7 @@ watch(
     // to persist the cut range across animation / costume selections. TODO: Improve this later
     if (newDuration > 0 && cutEndRef.value === 0) {
       cutStartRef.value = 0
-      cutEndRef.value = newDuration
+      cutEndRef.value = snapDown(newDuration)
       notifyFramesConfigChanged()
     }
   },
@@ -335,16 +335,19 @@ function adjustStartTime(newTime: number, withSnap = false) {
 
 function adjustEndTime(newTime: number, videoDuration: number, withSnap = false) {
   const time = withSnap ? snap(newTime) : newTime
-  return clamp(time, cutStartRef.value + minDuration, videoDuration)
+  const maxTime = withSnap ? snapDown(videoDuration) : videoDuration
+  return clamp(time, cutStartRef.value + minDuration, maxTime)
 }
 
-/** Precision for snapping in ms */
-const precision = 100
 /** Minimum allowed segment duration in ms */
-const minDuration = precision
+const minDuration = frameInterval
 
 function snap(timeInMs: number) {
-  return Math.round(timeInMs / precision) * precision
+  return Math.round(timeInMs / frameInterval) * frameInterval
+}
+
+function snapDown(timeInMs: number) {
+  return Math.floor(timeInMs / frameInterval) * frameInterval
 }
 
 function clamp(timeInMs: number, min: number, max: number) {

--- a/spx-gui/src/components/asset/gen/animation/AnimationVideoPreview.vue
+++ b/spx-gui/src/components/asset/gen/animation/AnimationVideoPreview.vue
@@ -1,8 +1,4 @@
 <script lang="ts">
-/** Precision for video time values in ms */
-const precision = 100
-const frameInterval = 200
-
 type PlayRange = {
   /** Timepoint in ms to start playing */
   start: number
@@ -77,9 +73,7 @@ function useVideoPlayer(videoRef: Ref<HTMLVideoElement | null>, rangeRef: WatchS
     (video, _, onCleanup) => {
       if (video == null) return
       const handleLoadedMetadata = () => {
-        duration.value = Number.isFinite(video.duration)
-          ? Math.floor(Math.round(video.duration * 1000) / precision) * precision
-          : 0
+        duration.value = Number.isFinite(video.duration) ? Math.round(video.duration * 1000) : 0
       }
       video.addEventListener('loadedmetadata', handleLoadedMetadata)
       const handleSeeked = () => flushPendingSeek(video)
@@ -164,6 +158,9 @@ const videoRef = ref<HTMLVideoElement | null>(null)
 const cutStartRef = ref(0)
 /** Timepoint in ms to cut end */
 const cutEndRef = ref(0)
+
+/** Interval in ms between extracted animation frames */
+const frameInterval = 200
 
 function notifyFramesConfigChanged() {
   emit('update:framesConfig', {
@@ -341,6 +338,8 @@ function adjustEndTime(newTime: number, videoDuration: number, withSnap = false)
   return clamp(time, cutStartRef.value + minDuration, videoDuration)
 }
 
+/** Precision for snapping in ms */
+const precision = 100
 /** Minimum allowed segment duration in ms */
 const minDuration = precision
 

--- a/spx-gui/src/components/asset/gen/animation/AnimationVideoPreview.vue
+++ b/spx-gui/src/components/asset/gen/animation/AnimationVideoPreview.vue
@@ -1,4 +1,8 @@
 <script lang="ts">
+/** Precision for video time values in ms */
+const precision = 100
+const frameInterval = 200
+
 type PlayRange = {
   /** Timepoint in ms to start playing */
   start: number
@@ -73,7 +77,9 @@ function useVideoPlayer(videoRef: Ref<HTMLVideoElement | null>, rangeRef: WatchS
     (video, _, onCleanup) => {
       if (video == null) return
       const handleLoadedMetadata = () => {
-        duration.value = Number.isFinite(video.duration) ? Math.round(video.duration * 1000) : 0
+        duration.value = Number.isFinite(video.duration)
+          ? Math.floor(Math.round(video.duration * 1000) / precision) * precision
+          : 0
       }
       video.addEventListener('loadedmetadata', handleLoadedMetadata)
       const handleSeeked = () => flushPendingSeek(video)
@@ -160,13 +166,10 @@ const cutStartRef = ref(0)
 const cutEndRef = ref(0)
 
 function notifyFramesConfigChanged() {
-  const duration = cutEndRef.value - cutStartRef.value
-  // TODO: We may improve the interval calculation logic later
-  const interval = duration >= 2000 ? 300 : 100
   emit('update:framesConfig', {
     startTime: cutStartRef.value,
     duration: cutEndRef.value - cutStartRef.value,
-    interval
+    interval: frameInterval
   })
 }
 
@@ -338,8 +341,6 @@ function adjustEndTime(newTime: number, videoDuration: number, withSnap = false)
   return clamp(time, cutStartRef.value + minDuration, videoDuration)
 }
 
-/** Precision for snapping in ms */
-const precision = 100
 /** Minimum allowed segment duration in ms */
 const minDuration = precision
 

--- a/spx-gui/src/models/spx/gen/animation-gen.test.ts
+++ b/spx-gui/src/models/spx/gen/animation-gen.test.ts
@@ -75,6 +75,8 @@ describe('AnimationGen', () => {
     expect(gen.finishState.status).toBe('finished')
     expect(gen.finishState.result).not.toBeNull()
     expect(animation.name).toBe('enriched-animation')
+    expect(animation.costumes).toHaveLength(5)
+    expect(animation.duration).toBe(1)
   })
 
   it('should validate animation name correctly', async () => {
@@ -481,5 +483,6 @@ describe('AnimationGen', () => {
     expect(loadedGen.finishState.status).toBe('finished')
     expect(loadedGen.finishState.result?.name).toBe(gen.finishState.result?.name)
     expect(loadedGen.finishState.result?.costumes.length).toBe(gen.finishState.result?.costumes.length)
+    expect(loadedGen.finishState.result?.duration).toBe(1)
   })
 })

--- a/spx-gui/src/models/spx/gen/animation-gen.test.ts
+++ b/spx-gui/src/models/spx/gen/animation-gen.test.ts
@@ -61,12 +61,12 @@ describe('AnimationGen', () => {
     // 6. Configure frames extraction
     gen.setFramesConfig({
       startTime: 0,
-      duration: 1000,
+      duration: 1100,
       interval: 200
     })
     expect(gen.framesConfig).toEqual({
       startTime: 0,
-      duration: 1000,
+      duration: 1100,
       interval: 200
     })
 
@@ -76,7 +76,7 @@ describe('AnimationGen', () => {
     expect(gen.finishState.result).not.toBeNull()
     expect(animation.name).toBe('enriched-animation')
     expect(animation.costumes).toHaveLength(5)
-    expect(animation.duration).toBe(1)
+    expect(animation.duration).toBe(1.1)
   })
 
   it('should validate animation name correctly', async () => {

--- a/spx-gui/src/models/spx/gen/animation-gen.ts
+++ b/spx-gui/src/models/spx/gen/animation-gen.ts
@@ -31,7 +31,10 @@ import {
 } from './common'
 import type { SpriteGen } from './sprite-gen'
 
-export type FramesConfig = Omit<TaskParamsExtractVideoFrames, 'videoUrl'>
+export type FramesConfig = Omit<TaskParamsExtractVideoFrames, 'videoUrl' | 'interval'> & {
+  /** Interval between frames in milliseconds. */
+  interval: number
+}
 
 export type AnimationGenInits = {
   id?: string
@@ -216,7 +219,7 @@ export class AnimationGen extends Disposable {
   get result() {
     return this.finishPhase.state.result
   }
-  private async createAnimationFromFrames(frameUrls: string[]) {
+  private async createAnimationFromFrames(frameUrls: string[], frameIntervalInMs: number) {
     const frameImgs = frameUrls.map((url) => createFileWithUniversalUrl(url))
     const costumes = await Promise.all(
       frameImgs.map(async (img, i) => {
@@ -226,7 +229,10 @@ export class AnimationGen extends Disposable {
         return costume
       })
     )
-    return Animation.create(this.settings.name, costumes)
+    return Animation.create(this.settings.name, costumes, {
+      // Preserve the frame sampling cadence in the generated animation.
+      duration: (costumes.length * frameIntervalInMs) / 1000
+    })
   }
   async finish() {
     const { video, framesConfig } = this
@@ -238,15 +244,16 @@ export class AnimationGen extends Disposable {
       this.extractFramesTask = new Task(TaskType.ExtractVideoFrames)
       await this.extractFramesTask.start({ videoUrl, ...framesConfig })
       const { frameUrls } = await this.extractFramesTask.untilCompleted(reporter)
-      return this.createAnimationFromFrames(frameUrls)
+      return this.createAnimationFromFrames(frameUrls, framesConfig.interval)
     })
   }
   restoreExtractFramesTask() {
     const task = this.extractFramesTask
-    if (task?.data == null || isTerminalTaskStatus(task.data.status)) return
+    const framesConfig = this.framesConfig
+    if (task?.data == null || isTerminalTaskStatus(task.data.status) || framesConfig == null) return
     this.finishPhase.run(async (reporter) => {
       const { frameUrls } = await task.untilCompleted(reporter)
-      return this.createAnimationFromFrames(frameUrls)
+      return this.createAnimationFromFrames(frameUrls, framesConfig.interval)
     })
   }
 

--- a/spx-gui/src/models/spx/gen/animation-gen.ts
+++ b/spx-gui/src/models/spx/gen/animation-gen.ts
@@ -31,10 +31,7 @@ import {
 } from './common'
 import type { SpriteGen } from './sprite-gen'
 
-export type FramesConfig = Omit<TaskParamsExtractVideoFrames, 'videoUrl' | 'interval'> & {
-  /** Interval between frames in milliseconds. */
-  interval: number
-}
+export type FramesConfig = Omit<TaskParamsExtractVideoFrames, 'videoUrl'>
 
 export type AnimationGenInits = {
   id?: string
@@ -219,7 +216,7 @@ export class AnimationGen extends Disposable {
   get result() {
     return this.finishPhase.state.result
   }
-  private async createAnimationFromFrames(frameUrls: string[], frameIntervalInMs: number) {
+  private async createAnimationFromFrames(frameUrls: string[], durationInMs: number) {
     const frameImgs = frameUrls.map((url) => createFileWithUniversalUrl(url))
     const costumes = await Promise.all(
       frameImgs.map(async (img, i) => {
@@ -230,8 +227,7 @@ export class AnimationGen extends Disposable {
       })
     )
     return Animation.create(this.settings.name, costumes, {
-      // Preserve the frame sampling cadence in the generated animation.
-      duration: (costumes.length * frameIntervalInMs) / 1000
+      duration: durationInMs / 1000
     })
   }
   async finish() {
@@ -244,7 +240,7 @@ export class AnimationGen extends Disposable {
       this.extractFramesTask = new Task(TaskType.ExtractVideoFrames)
       await this.extractFramesTask.start({ videoUrl, ...framesConfig })
       const { frameUrls } = await this.extractFramesTask.untilCompleted(reporter)
-      return this.createAnimationFromFrames(frameUrls, framesConfig.interval)
+      return this.createAnimationFromFrames(frameUrls, framesConfig.duration)
     })
   }
   restoreExtractFramesTask() {
@@ -253,7 +249,7 @@ export class AnimationGen extends Disposable {
     if (task?.data == null || isTerminalTaskStatus(task.data.status) || framesConfig == null) return
     this.finishPhase.run(async (reporter) => {
       const { frameUrls } = await task.untilCompleted(reporter)
-      return this.createAnimationFromFrames(frameUrls, framesConfig.interval)
+      return this.createAnimationFromFrames(frameUrls, framesConfig.duration)
     })
   }
 


### PR DESCRIPTION
Use a fixed 200 ms frame interval instead of switching between 100 ms and 300 ms based on clip length. This keeps extraction parameters deterministic and produces about 25 frames from a five-second clip.

The video cut range snaps to the same 200 ms cadence, including the initial full range and the maximum selectable end time. This keeps the selected duration aligned with the extraction interval; backend normalization remains the final validation boundary.

Generated animations use the selected clip duration as their initial duration. Builder therefore derives playback FPS from the returned frame count and clip duration instead of replaying generated frames at the default 10 FPS. The extraction interval remains optional in FramesConfig, matching the API definition.

## Validation

- pnpm run lint
- pnpm run type-check
- pnpm run test -- --run (80 files, 741 tests)
- git diff --check