### PR TITLE
feat(tutorial): add project domain models

### DIFF
--- a/spx-gui/src/apis/course.ts
+++ b/spx-gui/src/apis/course.ts
@@ -1,4 +1,4 @@
-import { client, type ByPage, type PaginationParams } from './common'
+import { client, type ByPage, type FileCollection, type PaginationParams } from './common'
 
 export const courseTitleMaxLength = 200
 /**
@@ -60,4 +60,15 @@ export function listCourses(params?: ListCoursesParams, signal?: AbortSignal) {
 
 export function listSignedInUserCourses(params?: ListCoursesParams, signal?: AbortSignal) {
   return client.get('/user/courses', params, { signal }) as Promise<ByPage<Course>>
+}
+
+export type CourseKind = 'guided' | 'playground'
+
+export type PlaygroundCourseData = {
+  id: string
+  owner: string
+  kind: 'playground'
+  title: string
+  thumbnail: string
+  content: FileCollection
 }

--- a/spx-gui/src/models/common/file.ts
+++ b/spx-gui/src/models/common/file.ts
@@ -262,7 +262,7 @@ export function listAllFiles(
   return fileList
 }
 
-export function extractFiles(files: Files, dirname: string) {
+export function unprefixFiles(files: Files, dirname: string) {
   const prefix = dirname + '/'
   const extracted: Files = {}
   for (const [path, file] of Object.entries(files)) {
@@ -277,11 +277,4 @@ export function prefixFiles(files: Files, dirname: string) {
     prefixed[`${dirname}/${path}`] = file
   }
   return prefixed
-}
-
-export function removeFiles(files: Files, dirname: string) {
-  const prefix = dirname + '/'
-  for (const path of Object.keys(files)) {
-    if (path.startsWith(prefix)) delete files[path]
-  }
 }

--- a/spx-gui/src/models/common/file.ts
+++ b/spx-gui/src/models/common/file.ts
@@ -261,3 +261,27 @@ export function listAllFiles(
   }
   return fileList
 }
+
+export function extractFiles(files: Files, dirname: string) {
+  const prefix = dirname + '/'
+  const extracted: Files = {}
+  for (const [path, file] of Object.entries(files)) {
+    if (path.startsWith(prefix)) extracted[path.slice(prefix.length)] = file
+  }
+  return extracted
+}
+
+export function prefixFiles(files: Files, dirname: string) {
+  const prefixed: Files = {}
+  for (const [path, file] of Object.entries(files)) {
+    prefixed[`${dirname}/${path}`] = file
+  }
+  return prefixed
+}
+
+export function removeFiles(files: Files, dirname: string) {
+  const prefix = dirname + '/'
+  for (const path of Object.keys(files)) {
+    if (path.startsWith(prefix)) delete files[path]
+  }
+}

--- a/spx-gui/src/models/common/file.ts
+++ b/spx-gui/src/models/common/file.ts
@@ -262,6 +262,7 @@ export function listAllFiles(
   return fileList
 }
 
+/** Return files under dirname with that prefix removed from their paths. */
 export function unprefixFiles(files: Files, dirname: string) {
   const prefix = dirname + '/'
   const extracted: Files = {}
@@ -271,6 +272,7 @@ export function unprefixFiles(files: Files, dirname: string) {
   return extracted
 }
 
+/** Add dirname to every file path. This is the inverse of unprefixFiles. */
 export function prefixFiles(files: Files, dirname: string) {
   const prefixed: Files = {}
   for (const [path, file] of Object.entries(files)) {

--- a/spx-gui/src/models/common/name.test.ts
+++ b/spx-gui/src/models/common/name.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from 'vitest'
+
+import { getValidName } from './name'
+
+describe('getValidName', () => {
+  it('increments numeric suffixes while preserving their width', () => {
+    expect(getValidName('video02', (name) => name === 'video03')).toBe('video03')
+  })
+})

--- a/spx-gui/src/models/common/name.ts
+++ b/spx-gui/src/models/common/name.ts
@@ -15,6 +15,7 @@ function formatNumericSuffix(base: string, num: number, numWidth: number) {
   return base + suffix
 }
 
+/** Return initialName or its first available numeric-suffix variant. */
 export function getValidName(initialName: string, isValid: (name: string) => boolean) {
   if (initialName === '') throw new Error('name must not be blank')
   if (isValid(initialName)) return initialName

--- a/spx-gui/src/models/common/name.ts
+++ b/spx-gui/src/models/common/name.ts
@@ -1,0 +1,32 @@
+const numericSuffixRE = /^(.*?)(\d+)$/
+
+function splitNumericSuffix(name: string) {
+  const match = name.match(numericSuffixRE)
+  if (match == null) return null
+  return {
+    base: match[1],
+    num: parseInt(match[2], 10),
+    numWidth: match[2].length
+  }
+}
+
+function formatNumericSuffix(base: string, num: number, numWidth: number) {
+  const suffix = numWidth > 1 ? String(num).padStart(numWidth, '0') : String(num)
+  return base + suffix
+}
+
+export function getValidName(initialName: string, isValid: (name: string) => boolean) {
+  if (initialName === '') throw new Error('name must not be blank')
+  if (isValid(initialName)) return initialName
+
+  const splitted = splitNumericSuffix(initialName)
+  const base = splitted == null ? initialName : splitted.base
+  const initialNum = splitted == null ? 1 : splitted.num
+  const numWidth = splitted == null ? 1 : splitted.numWidth
+
+  for (let i = initialNum + 1; ; i++) {
+    const name = formatNumericSuffix(base, i, numWidth)
+    if (isValid(name)) return name
+    if (i - initialNum > 10000) throw new Error(`unexpected infinite loop with base ${initialName}`)
+  }
+}

--- a/spx-gui/src/models/common/name.ts
+++ b/spx-gui/src/models/common/name.ts
@@ -15,7 +15,7 @@ function formatNumericSuffix(base: string, num: number, numWidth: number) {
   return base + suffix
 }
 
-/** Return initialName or its first available numeric-suffix variant. */
+/** Return initialName or the next higher numeric-suffix variant accepted by isValid. */
 export function getValidName(initialName: string, isValid: (name: string) => boolean) {
   if (initialName === '') throw new Error('name must not be blank')
   if (isValid(initialName)) return initialName

--- a/spx-gui/src/models/spx/common/asset-name.ts
+++ b/spx-gui/src/models/spx/common/asset-name.ts
@@ -1,5 +1,6 @@
 import type { LocaleMessage } from '@/utils/i18n'
 import { assetDisplayNameMaxLength } from '@/apis/asset'
+import { getValidName } from '@/models/common/name'
 import { getStringLengthInCodePoints, lowFirst, unicodeSafeSlice, upFirst } from '@/utils/utils'
 import { getXGoIdentifierNameTip, normalizeXGoIdentifierAssetName, validateXGoIdentifierName } from '@/utils/xgo'
 import {
@@ -168,42 +169,6 @@ export function normalizeAssetName(src: string, cas: 'camel' | 'pascal') {
   // 50 should be enough, it will be hard to read with too long name
   // TODO: should we move the truncation to outer layer?
   return unicodeSafeSlice(result, 0, 50)
-}
-
-const numericSuffixRE = /^(.*?)(\d+)$/
-
-function splitNumericSuffix(name: string) {
-  const match = name.match(numericSuffixRE)
-  if (match == null) return null
-  return {
-    base: match[1],
-    num: parseInt(match[2], 10),
-    numWidth: match[2].length
-  }
-}
-
-function formatNumericSuffix(base: string, num: number, numWidth: number) {
-  const suffix = numWidth > 1 ? String(num).padStart(numWidth, '0') : String(num)
-  return base + suffix
-}
-
-function getValidName(initialName: string, isValid: (name: string) => boolean) {
-  if (initialName === '') throw new Error('name must not be blank')
-  if (isValid(initialName)) return initialName
-
-  // Try to add/increment numeric suffix to find a valid name
-  const splitted = splitNumericSuffix(initialName)
-  const base = splitted == null ? initialName : splitted.base
-  const initialNum = splitted == null ? 1 : splitted.num
-  const numWidth = splitted == null ? 1 : splitted.numWidth
-
-  for (let i = initialNum + 1; ; i++) {
-    const name = formatNumericSuffix(base, i, numWidth)
-    if (isValid(name)) return name
-    if (i - initialNum > 10000) {
-      throw new Error(`unexpected infinite loop with base ${initialName}`)
-    }
-  }
 }
 
 export function getSpriteName(parent: SpriteLikeParent | null, base: string) {

--- a/spx-gui/src/models/tutorial/common.ts
+++ b/spx-gui/src/models/tutorial/common.ts
@@ -1,0 +1,6 @@
+export class TutorialProjectLoadError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'TutorialProjectLoadError'
+  }
+}

--- a/spx-gui/src/models/tutorial/common.ts
+++ b/spx-gui/src/models/tutorial/common.ts
@@ -1,6 +1,0 @@
-export class TutorialProjectLoadError extends Error {
-  constructor(message: string) {
-    super(message)
-    this.name = 'TutorialProjectLoadError'
-  }
-}

--- a/spx-gui/src/models/tutorial/course.ts
+++ b/spx-gui/src/models/tutorial/course.ts
@@ -1,0 +1,28 @@
+import { reactive } from 'vue'
+
+import { fromText, toText, type Files } from '@/models/common/file'
+
+export const mainCourseFilePath = 'main.gox'
+
+export class Course {
+  code: string
+
+  constructor(code = '') {
+    this.code = code
+    return reactive(this) as this
+  }
+
+  setCode(code: string) {
+    this.code = code
+  }
+
+  async loadFiles(files: Files) {
+    const file = files[mainCourseFilePath]
+    if (file == null) throw new Error(`file ${mainCourseFilePath} not found`)
+    this.code = await toText(file)
+  }
+
+  export(): Files {
+    return { [mainCourseFilePath]: fromText(mainCourseFilePath, this.code) }
+  }
+}

--- a/spx-gui/src/models/tutorial/course.ts
+++ b/spx-gui/src/models/tutorial/course.ts
@@ -2,7 +2,7 @@ import { reactive } from 'vue'
 
 import { fromText, toText, type Files } from '@/models/common/file'
 
-export const mainCourseFilePath = 'main.gox'
+export const mainCourseFilePath = 'main_course.gox'
 
 export class Course {
   code: string

--- a/spx-gui/src/models/tutorial/project.test.ts
+++ b/spx-gui/src/models/tutorial/project.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest'
 import type { TutorialProjectMetadata } from './project'
 import { fromConfig, fromText, toConfig, toText, type Files } from '@/models/common/file'
 import { Sprite } from '@/models/spx/sprite'
+import { mainCourseFilePath } from './course'
 import { TutorialProject } from './project'
 import { Video } from './video'
 
@@ -23,7 +24,7 @@ function makeFiles(): Files {
       inEditorRoute: '/simple/sprites/Lita',
       copilotContext: 'Help the learner.'
     }),
-    'main.gox': fromText('main.gox', 'onStart => {}'),
+    [mainCourseFilePath]: fromText(mainCourseFilePath, 'onStart => {}'),
     'project/assets/index.json': fromConfig('index.json', {}),
     'assets/videos/step-to/index.json': fromConfig('index.json', { path: 'step-to.mp4', builder_id: 'video-id' }),
     'assets/videos/step-to/step-to.mp4': fromText('step-to.mp4', 'video')
@@ -53,7 +54,7 @@ describe('TutorialProject', () => {
     tutorial.project.addSprite(new Sprite('Lita'))
 
     const files = tutorial.exportFiles()
-    expect(await toText(files['main.gox']!)).toBe('onStart => { showVideo "step-to" }')
+    expect(await toText(files[mainCourseFilePath]!)).toBe('onStart => { showVideo "step-to" }')
     expect(await toConfig(files['project/assets/index.json']!)).toBeDefined()
 
     const reloaded = new TutorialProject()
@@ -76,7 +77,7 @@ describe('TutorialProject', () => {
 
     const serialized = tutorial.export()
     expect(serialized.metadata.title).toBe('Updated title')
-    expect(await toText(serialized.files['main.gox']!)).toBe('onStart => {}')
+    expect(await toText(serialized.files[mainCourseFilePath]!)).toBe('onStart => {}')
   })
 
   it('adds and removes videos using the resource ID', async () => {

--- a/spx-gui/src/models/tutorial/project.test.ts
+++ b/spx-gui/src/models/tutorial/project.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest'
+
+import { fromConfig, fromText, toText, type Files } from '@/models/common/file'
+import { Sprite } from '@/models/spx/sprite'
+import { TutorialProjectLoadError } from './common'
+import { TutorialProject } from './project'
+import { TutorialVideo } from './video'
+
+function makeFiles(): Files {
+  return {
+    'index.json': fromConfig('index.json', {
+      project: { type: 'spx', root: 'project' },
+      inEditorRoute: '/simple/sprites/Lita',
+      copilotContext: 'Help the learner.'
+    }),
+    'main.gox': fromText('main.gox', 'onStart => {}'),
+    'project/assets/index.json': fromConfig('index.json', {}),
+    'assets/videos/step-to/index.json': fromConfig('index.json', { path: 'step-to.mp4' }),
+    'assets/videos/step-to/step-to.mp4': fromText('step-to.mp4', 'video')
+  }
+}
+
+describe('TutorialProject', () => {
+  it('loads its program, embedded SPX project and named videos', async () => {
+    const tutorial = await TutorialProject.fromFiles(makeFiles())
+
+    expect(await toText(tutorial.program)).toBe('onStart => {}')
+    expect(await toText(tutorial.getVideo('step-to')!.file)).toBe('video')
+    expect(tutorial.videos.map((video) => video.name)).toEqual(['step-to'])
+    expect(tutorial.getVideo('missing')).toBeNull()
+    expect((await tutorial.createSpxProject()).owner).toBeUndefined()
+  })
+
+  it('reports incomplete or malformed Tutorial projects at load time', async () => {
+    const files = makeFiles()
+    delete files['main.gox']
+    await expect(TutorialProject.fromFiles(files)).rejects.toThrow(TutorialProjectLoadError)
+
+    const invalidVideoFiles = makeFiles()
+    invalidVideoFiles['assets/videos/step-to/index.json'] = fromConfig('index.json', { path: '../step-to.mp4' })
+    await expect(TutorialProject.fromFiles(invalidVideoFiles)).rejects.toThrow(TutorialProjectLoadError)
+  })
+
+  it('creates isolated projects and serializes edited project state', async () => {
+    const tutorial = await TutorialProject.fromFiles(makeFiles())
+    const authorProject = await tutorial.createSpxProject()
+    authorProject.addSprite(new Sprite('Lita'))
+
+    const previewProject = await tutorial.createSpxProject()
+    expect(previewProject.sprites).toHaveLength(0)
+
+    const serialized = await tutorial.exportFiles(authorProject)
+    const roundTripped = await TutorialProject.fromFiles(serialized)
+    expect((await roundTripped.createSpxProject()).sprites.map((sprite) => sprite.name)).toEqual(['Lita'])
+
+    const clone = await tutorial.clone()
+    expect(await toText(clone.program)).toBe('onStart => {}')
+  })
+
+  it('owns videos for editor operations and preserves their IDs when serializing', async () => {
+    const tutorial = await TutorialProject.fromFiles(makeFiles())
+    const video = tutorial.getVideo('step-to')!
+    expect(video.project).toBe(tutorial)
+
+    video.setName('step-to-2')
+    expect(tutorial.getVideo('step-to')).toBeNull()
+    expect(tutorial.getVideo('step-to-2')).toBe(video)
+
+    const added = new TutorialVideo('another', 'another.mp4', fromText('another.mp4', 'another'))
+    tutorial.addVideo(added)
+    expect(added.project).toBe(tutorial)
+    tutorial.removeVideo(added.id)
+    expect(added.project).toBeNull()
+
+    const serialized = await tutorial.exportFiles()
+    const reloaded = await TutorialProject.fromFiles(serialized)
+    expect(reloaded.getVideo('step-to-2')!.id).toBe(video.id)
+  })
+})

--- a/spx-gui/src/models/tutorial/project.test.ts
+++ b/spx-gui/src/models/tutorial/project.test.ts
@@ -1,10 +1,20 @@
 import { describe, expect, it } from 'vitest'
 
-import { fromConfig, fromText, toText, type Files } from '@/models/common/file'
+import type { TutorialProjectMetadata } from './project'
+import { fromConfig, fromText, toConfig, toText, type Files } from '@/models/common/file'
 import { Sprite } from '@/models/spx/sprite'
-import { TutorialProjectLoadError } from './common'
 import { TutorialProject } from './project'
-import { TutorialVideo } from './video'
+import { Video } from './video'
+
+function makeMetadata(): TutorialProjectMetadata {
+  return {
+    id: 'course-id',
+    owner: 'teacher',
+    kind: 'playground',
+    title: 'Move Lita',
+    thumbnail: 'https://example.com/thumbnail.png'
+  }
+}
 
 function makeFiles(): Files {
   return {
@@ -15,65 +25,49 @@ function makeFiles(): Files {
     }),
     'main.gox': fromText('main.gox', 'onStart => {}'),
     'project/assets/index.json': fromConfig('index.json', {}),
-    'assets/videos/step-to/index.json': fromConfig('index.json', { path: 'step-to.mp4' }),
+    'assets/videos/step-to/index.json': fromConfig('index.json', { path: 'step-to.mp4', builder_id: 'video-id' }),
     'assets/videos/step-to/step-to.mp4': fromText('step-to.mp4', 'video')
   }
 }
 
+async function loadProject() {
+  const project = new TutorialProject(makeMetadata())
+  await project.loadFiles(makeFiles())
+  return project
+}
+
 describe('TutorialProject', () => {
-  it('loads its program, embedded SPX project and named videos', async () => {
-    const tutorial = await TutorialProject.fromFiles(makeFiles())
+  it('loads course metadata, code, project and videos', async () => {
+    const tutorial = await loadProject()
 
-    expect(await toText(tutorial.program)).toBe('onStart => {}')
-    expect(await toText(tutorial.getVideo('step-to')!.file)).toBe('video')
+    expect(tutorial.id).toBe('course-id')
+    expect(tutorial.project.owner).toBeUndefined()
+    expect(tutorial.courseCode).toBe('onStart => {}')
     expect(tutorial.videos.map((video) => video.name)).toEqual(['step-to'])
-    expect(tutorial.getVideo('missing')).toBeNull()
-    expect((await tutorial.createSpxProject()).owner).toBeUndefined()
+    expect(tutorial.videos[0]._project).toBe(tutorial)
   })
 
-  it('reports incomplete or malformed Tutorial projects at load time', async () => {
-    const files = makeFiles()
-    delete files['main.gox']
-    await expect(TutorialProject.fromFiles(files)).rejects.toThrow(TutorialProjectLoadError)
+  it('writes course code and owned SPX project state', async () => {
+    const tutorial = await loadProject()
+    tutorial.setCourseCode('onStart => { showVideo "step-to" }')
+    tutorial.project.addSprite(new Sprite('Lita'))
 
-    const invalidVideoFiles = makeFiles()
-    invalidVideoFiles['assets/videos/step-to/index.json'] = fromConfig('index.json', { path: '../step-to.mp4' })
-    await expect(TutorialProject.fromFiles(invalidVideoFiles)).rejects.toThrow(TutorialProjectLoadError)
+    const files = tutorial.exportFiles()
+    expect(await toText(files['main.gox']!)).toBe('onStart => { showVideo "step-to" }')
+    expect(await toConfig(files['project/assets/index.json']!)).toBeDefined()
+
+    const reloaded = new TutorialProject(makeMetadata())
+    await reloaded.loadFiles(files)
+    expect(reloaded.project.sprites.map((sprite) => sprite.name)).toEqual(['Lita'])
   })
 
-  it('creates isolated projects and serializes edited project state', async () => {
-    const tutorial = await TutorialProject.fromFiles(makeFiles())
-    const authorProject = await tutorial.createSpxProject()
-    authorProject.addSprite(new Sprite('Lita'))
+  it('adds and removes videos using the resource ID', async () => {
+    const tutorial = await loadProject()
+    const video = new Video('another', fromText('another.mp4', 'another'))
+    tutorial.addVideo(video)
+    expect(video._project).toBe(tutorial)
 
-    const previewProject = await tutorial.createSpxProject()
-    expect(previewProject.sprites).toHaveLength(0)
-
-    const serialized = await tutorial.exportFiles(authorProject)
-    const roundTripped = await TutorialProject.fromFiles(serialized)
-    expect((await roundTripped.createSpxProject()).sprites.map((sprite) => sprite.name)).toEqual(['Lita'])
-
-    const clone = await tutorial.clone()
-    expect(await toText(clone.program)).toBe('onStart => {}')
-  })
-
-  it('owns videos for editor operations and preserves their IDs when serializing', async () => {
-    const tutorial = await TutorialProject.fromFiles(makeFiles())
-    const video = tutorial.getVideo('step-to')!
-    expect(video.project).toBe(tutorial)
-
-    video.setName('step-to-2')
-    expect(tutorial.getVideo('step-to')).toBeNull()
-    expect(tutorial.getVideo('step-to-2')).toBe(video)
-
-    const added = new TutorialVideo('another', 'another.mp4', fromText('another.mp4', 'another'))
-    tutorial.addVideo(added)
-    expect(added.project).toBe(tutorial)
-    tutorial.removeVideo(added.id)
-    expect(added.project).toBeNull()
-
-    const serialized = await tutorial.exportFiles()
-    const reloaded = await TutorialProject.fromFiles(serialized)
-    expect(reloaded.getVideo('step-to-2')!.id).toBe(video.id)
+    tutorial.removeVideo(video.id)
+    expect(video._project).toBeNull()
   })
 })

--- a/spx-gui/src/models/tutorial/project.test.ts
+++ b/spx-gui/src/models/tutorial/project.test.ts
@@ -31,8 +31,8 @@ function makeFiles(): Files {
 }
 
 async function loadProject() {
-  const project = new TutorialProject(makeMetadata())
-  await project.loadFiles(makeFiles())
+  const project = new TutorialProject()
+  await project.load({ metadata: makeMetadata(), files: makeFiles() })
   return project
 }
 
@@ -42,21 +42,21 @@ describe('TutorialProject', () => {
 
     expect(tutorial.id).toBe('course-id')
     expect(tutorial.project.owner).toBeUndefined()
-    expect(tutorial.courseCode).toBe('onStart => {}')
+    expect(tutorial.mainCourse.code).toBe('onStart => {}')
     expect(tutorial.videos.map((video) => video.name)).toEqual(['step-to'])
     expect(tutorial.videos[0]._project).toBe(tutorial)
   })
 
   it('writes course code and owned SPX project state', async () => {
     const tutorial = await loadProject()
-    tutorial.setCourseCode('onStart => { showVideo "step-to" }')
+    tutorial.mainCourse.setCode('onStart => { showVideo "step-to" }')
     tutorial.project.addSprite(new Sprite('Lita'))
 
     const files = tutorial.exportFiles()
     expect(await toText(files['main.gox']!)).toBe('onStart => { showVideo "step-to" }')
     expect(await toConfig(files['project/assets/index.json']!)).toBeDefined()
 
-    const reloaded = new TutorialProject(makeMetadata())
+    const reloaded = new TutorialProject()
     await reloaded.loadFiles(files)
     expect(reloaded.project.sprites.map((sprite) => sprite.name)).toEqual(['Lita'])
   })
@@ -87,5 +87,14 @@ describe('TutorialProject', () => {
 
     tutorial.removeVideo(video.id)
     expect(video._project).toBeNull()
+  })
+
+  it('gives an added video a non-conflicting name', async () => {
+    const tutorial = await loadProject()
+    const video = new Video('step-to', fromText('step-to.mp4', 'another'))
+
+    tutorial.addVideo(video)
+
+    expect(video.name).toBe('step-to2')
   })
 })

--- a/spx-gui/src/models/tutorial/project.test.ts
+++ b/spx-gui/src/models/tutorial/project.test.ts
@@ -61,6 +61,24 @@ describe('TutorialProject', () => {
     expect(reloaded.project.sprites.map((sprite) => sprite.name)).toEqual(['Lita'])
   })
 
+  it('keeps the embedded SPX project while reloading files', async () => {
+    const tutorial = await loadProject()
+    const project = tutorial.project
+
+    await tutorial.loadFiles(makeFiles())
+
+    expect(tutorial.project).toBe(project)
+  })
+
+  it('loads and exports metadata with files', async () => {
+    const tutorial = await loadProject()
+    tutorial.setMetadata({ title: 'Updated title' })
+
+    const serialized = tutorial.export()
+    expect(serialized.metadata.title).toBe('Updated title')
+    expect(await toText(serialized.files['main.gox']!)).toBe('onStart => {}')
+  })
+
   it('adds and removes videos using the resource ID', async () => {
     const tutorial = await loadProject()
     const video = new Video('another', fromText('another.mp4', 'another'))

--- a/spx-gui/src/models/tutorial/project.ts
+++ b/spx-gui/src/models/tutorial/project.ts
@@ -7,7 +7,7 @@ import { fromConfig, prefixFiles, toConfig, unprefixFiles, type Files } from '@/
 import { SpxProject } from '@/models/spx/project'
 
 import { Course } from './course'
-import { Video } from './video'
+import { ensureValidVideoName, Video } from './video'
 
 const indexFilePath = 'index.json'
 
@@ -118,21 +118,5 @@ export class TutorialProject {
       },
       files: this.exportFiles()
     }
-  }
-}
-
-function validateVideoName(name: string, project: TutorialProject) {
-  if (name === '') return 'must not be blank'
-  if (name.includes('/')) return 'must not contain /'
-  if (project.videos.some((video) => video.name === name)) return 'already exists'
-}
-
-function ensureValidVideoName(name: string, project: TutorialProject) {
-  const error = validateVideoName(name, project)
-  if (error == null) return name
-  if (error !== 'already exists') throw new Error(`invalid video name ${name}: ${error}`)
-  for (let i = 2; ; i++) {
-    const candidate = `${name}${i}`
-    if (validateVideoName(candidate, project) == null) return candidate
   }
 }

--- a/spx-gui/src/models/tutorial/project.ts
+++ b/spx-gui/src/models/tutorial/project.ts
@@ -2,22 +2,14 @@ import { reactive } from 'vue'
 
 import type { PlaygroundCourseData } from '@/apis/course'
 import { getFiles } from '@/models/common/cloud'
-import {
-  extractFiles,
-  fromConfig,
-  fromText,
-  prefixFiles,
-  removeFiles,
-  toConfig,
-  toText,
-  type Files
-} from '@/models/common/file'
+import { assign } from '@/models/common'
+import { fromConfig, prefixFiles, toConfig, unprefixFiles, type Files } from '@/models/common/file'
 import { SpxProject } from '@/models/spx/project'
 
-import { Video, videoAssetPath } from './video'
+import { Course } from './course'
+import { Video } from './video'
 
 const indexFilePath = 'index.json'
-const courseCodeFilePath = 'main.gox'
 
 export type TutorialProjectIndex = {
   project: {
@@ -36,37 +28,34 @@ export type TutorialProjectSerialized = {
 }
 
 export { Video } from './video'
+export { Course } from './course'
 
 export class TutorialProject {
-  id: string
-  owner: string
+  id = ''
+  owner = ''
   kind = 'playground' as const
-  title: string
-  thumbnail: string
+  title = ''
+  thumbnail = ''
 
   index: TutorialProjectIndex | null = null
   project: SpxProject
-  courseCode = ''
+  mainCourse: Course
   videos: Video[] = []
-  private files: Files = {}
 
-  constructor(metadata: TutorialProjectMetadata) {
-    this.id = metadata.id
-    this.owner = metadata.owner
-    this.title = metadata.title
-    this.thumbnail = metadata.thumbnail
+  constructor() {
     this.project = new SpxProject()
+    this.mainCourse = new Course()
     return reactive(this) as this
   }
 
   static async load(course: PlaygroundCourseData) {
-    const project = new TutorialProject(course)
+    const project = new TutorialProject()
     await project.load({ metadata: course, files: getFiles(course.content) })
     return project
   }
 
   setMetadata(metadata: Partial<TutorialProjectMetadata>) {
-    Object.assign(this, metadata)
+    assign<TutorialProject>(this, metadata)
   }
 
   async load({ metadata, files }: TutorialProjectSerialized) {
@@ -78,32 +67,24 @@ export class TutorialProject {
     const indexFile = files[indexFilePath]
     if (indexFile == null) throw new Error(`file ${indexFilePath} not found`)
     const index = (await toConfig(indexFile)) as TutorialProjectIndex
-    const courseCodeFile = files[courseCodeFilePath]
-    if (courseCodeFile == null) throw new Error(`file ${courseCodeFilePath} not found`)
-
-    await this.project.loadFiles(extractFiles(files, index.project.root))
+    await this.project.loadFiles(unprefixFiles(files, index.project.root))
+    await this.mainCourse.loadFiles(files)
     const videos = await Video.loadAll(files)
 
     this.index = index
-    this.courseCode = await toText(courseCodeFile)
     this.videos.splice(0).forEach((video) => video.setProject(null))
     videos.forEach((video) => this.addVideo(video))
-    this.files = files
   }
 
-  setCourseCode(code: string) {
-    this.courseCode = code
+  private prepareAddVideo(video: Video) {
+    const name = ensureValidVideoName(video.name, this)
+    video.setName(name)
+    video.setProject(this)
   }
 
   addVideo(video: Video) {
-    video.setProject(this)
-    try {
-      video.setName(video.name)
-      this.videos.push(video)
-    } catch (error) {
-      video.setProject(null)
-      throw error
-    }
+    this.prepareAddVideo(video)
+    this.videos.push(video)
   }
 
   removeVideo(id: string) {
@@ -115,14 +96,12 @@ export class TutorialProject {
 
   exportFiles() {
     if (this.index == null) throw new Error('Tutorial project has not been loaded')
-    const files = { ...this.files }
-    removeFiles(files, this.index.project.root)
-    removeFiles(files, videoAssetPath)
+    const files: Files = {}
     files[indexFilePath] = fromConfig(indexFilePath, this.index)
-    files[courseCodeFilePath] = fromText(courseCodeFilePath, this.courseCode)
     Object.assign(
       files,
       prefixFiles(this.project.exportFiles(), this.index.project.root),
+      this.mainCourse.export(),
       ...this.videos.map((video) => video.export())
     )
     return files
@@ -139,5 +118,21 @@ export class TutorialProject {
       },
       files: this.exportFiles()
     }
+  }
+}
+
+function validateVideoName(name: string, project: TutorialProject) {
+  if (name === '') return 'must not be blank'
+  if (name.includes('/')) return 'must not contain /'
+  if (project.videos.some((video) => video.name === name)) return 'already exists'
+}
+
+function ensureValidVideoName(name: string, project: TutorialProject) {
+  const error = validateVideoName(name, project)
+  if (error == null) return name
+  if (error !== 'already exists') throw new Error(`invalid video name ${name}: ${error}`)
+  for (let i = 2; ; i++) {
+    const candidate = `${name}${i}`
+    if (validateVideoName(candidate, project) == null) return candidate
   }
 }

--- a/spx-gui/src/models/tutorial/project.ts
+++ b/spx-gui/src/models/tutorial/project.ts
@@ -9,14 +9,17 @@ import { SpxProject } from '@/models/spx/project'
 import { Course } from './course'
 import { ensureValidVideoName, Video } from './video'
 
-const indexFilePath = 'index.json'
+const configFilePath = 'index.json'
 
-export type TutorialProjectIndex = {
+export type TutorialProjectConfig = {
+  /** The embedded learner project. */
   project: {
     type: 'spx'
     root: string
   }
+  /** The route initially displayed in the editor. */
   inEditorRoute: string
+  /** Copilot instructions supplied by the course author. */
   copilotContext: string
 }
 
@@ -37,9 +40,13 @@ export class TutorialProject {
   title = ''
   thumbnail = ''
 
-  index: TutorialProjectIndex | null = null
+  /** Tutorial-project configuration. */
+  config: TutorialProjectConfig | null = null
+  /** The embedded learner project. */
   project: SpxProject
+  /** The course author's main program. */
   mainCourse: Course
+  /** Course-local video resources. */
   videos: Video[] = []
 
   constructor() {
@@ -64,14 +71,14 @@ export class TutorialProject {
   }
 
   async loadFiles(files: Files) {
-    const indexFile = files[indexFilePath]
-    if (indexFile == null) throw new Error(`file ${indexFilePath} not found`)
-    const index = (await toConfig(indexFile)) as TutorialProjectIndex
-    await this.project.loadFiles(unprefixFiles(files, index.project.root))
+    const configFile = files[configFilePath]
+    if (configFile == null) throw new Error(`file ${configFilePath} not found`)
+    const config = (await toConfig(configFile)) as TutorialProjectConfig
+    await this.project.loadFiles(unprefixFiles(files, config.project.root))
     await this.mainCourse.loadFiles(files)
     const videos = await Video.loadAll(files)
 
-    this.index = index
+    this.config = config
     this.videos.splice(0).forEach((video) => video.setProject(null))
     videos.forEach((video) => this.addVideo(video))
   }
@@ -95,12 +102,12 @@ export class TutorialProject {
   }
 
   exportFiles() {
-    if (this.index == null) throw new Error('Tutorial project has not been loaded')
+    if (this.config == null) throw new Error('Tutorial project has not been loaded')
     const files: Files = {}
-    files[indexFilePath] = fromConfig(indexFilePath, this.index)
+    files[configFilePath] = fromConfig(configFilePath, this.config)
     Object.assign(
       files,
-      prefixFiles(this.project.exportFiles(), this.index.project.root),
+      prefixFiles(this.project.exportFiles(), this.config.project.root),
       this.mainCourse.export(),
       ...this.videos.map((video) => video.export())
     )

--- a/spx-gui/src/models/tutorial/project.ts
+++ b/spx-gui/src/models/tutorial/project.ts
@@ -1,15 +1,23 @@
 import { reactive } from 'vue'
 
-import type { FileCollection } from '@/apis/common'
+import type { PlaygroundCourseData } from '@/apis/course'
 import { getFiles } from '@/models/common/cloud'
-import { File, toConfig, type Files } from '@/models/common/file'
+import {
+  extractFiles,
+  fromConfig,
+  fromText,
+  prefixFiles,
+  removeFiles,
+  toConfig,
+  toText,
+  type Files
+} from '@/models/common/file'
 import { SpxProject } from '@/models/spx/project'
 
-import { TutorialProjectLoadError } from './common'
-import { TutorialVideo, tutorialVideoAssetPath } from './video'
+import { Video, videoAssetPath } from './video'
 
 const indexFilePath = 'index.json'
-const programFilePath = 'main.gox'
+const courseCodeFilePath = 'main.gox'
 
 export type TutorialProjectIndex = {
   project: {
@@ -20,45 +28,63 @@ export type TutorialProjectIndex = {
   copilotContext: string
 }
 
-export { TutorialProjectLoadError } from './common'
-export { TutorialVideo } from './video'
+export type TutorialProjectMetadata = Omit<PlaygroundCourseData, 'content'>
+
+export { Video } from './video'
 
 export class TutorialProject {
-  private constructor(
-    readonly index: TutorialProjectIndex,
-    readonly program: File,
-    readonly videos: TutorialVideo[],
-    private readonly files: Files
-  ) {
+  id: string
+  owner: string
+  kind = 'playground' as const
+  title: string
+  thumbnail: string
+
+  index: TutorialProjectIndex | null = null
+  project: SpxProject
+  courseCode = ''
+  videos: Video[] = []
+  private files: Files = {}
+
+  constructor(metadata: TutorialProjectMetadata) {
+    this.id = metadata.id
+    this.owner = metadata.owner
+    this.title = metadata.title
+    this.thumbnail = metadata.thumbnail
+    this.project = new SpxProject()
     return reactive(this) as this
   }
 
-  static async fromFileCollection(fileCollection: FileCollection) {
-    return this.fromFiles(getFiles(fileCollection))
-  }
-
-  static async fromFiles(files: Files): Promise<TutorialProject> {
-    const clonedFiles = await cloneFiles(files)
-    const index = await loadIndex(clonedFiles)
-    const program = requireFile(clonedFiles, programFilePath)
-    const projectFiles = extractDirectory(clonedFiles, index.project.root)
-    requireFile(projectFiles, 'assets/index.json')
-    const videos = await TutorialVideo.loadAll(clonedFiles)
-    const project = new TutorialProject(index, program, videos, clonedFiles)
-    videos.forEach((video) => video.setProject(project))
+  static async load(course: PlaygroundCourseData) {
+    const project = new TutorialProject(course)
+    await project.loadFiles(getFiles(course.content))
     return project
   }
 
-  getVideo(name: string) {
-    return this.videos.find((video) => video.name === name) ?? null
+  async loadFiles(files: Files) {
+    const indexFile = files[indexFilePath]
+    if (indexFile == null) throw new Error(`file ${indexFilePath} not found`)
+    const index = (await toConfig(indexFile)) as TutorialProjectIndex
+    const courseCodeFile = files[courseCodeFilePath]
+    if (courseCodeFile == null) throw new Error(`file ${courseCodeFilePath} not found`)
+
+    const project = new SpxProject()
+    await project.loadFiles(extractFiles(files, index.project.root))
+    const videos = await Video.loadAll(files)
+
+    this.index = index
+    this.project = project
+    this.courseCode = await toText(courseCodeFile)
+    this.videos.splice(0).forEach((video) => video.setProject(null))
+    videos.forEach((video) => this.addVideo(video))
+    this.files = files
   }
 
-  getVideoById(id: string) {
-    return this.videos.find((video) => video.id === id) ?? null
+  setCourseCode(code: string) {
+    this.courseCode = code
   }
 
-  addVideo(video: TutorialVideo) {
-    if (this.getVideo(video.name) != null) throw new Error(`video ${video.name} already exists`)
+  addVideo(video: Video) {
+    if (this.videos.some((item) => item.name === video.name)) throw new Error(`video ${video.name} already exists`)
     video.setProject(this)
     this.videos.push(video)
   }
@@ -70,101 +96,18 @@ export class TutorialProject {
     video.setProject(null)
   }
 
-  async createSpxProject() {
-    const project = new SpxProject()
-    await project.loadFiles(await cloneFiles(extractDirectory(this.files, this.index.project.root)))
-    return project
-  }
-
-  async clone() {
-    return TutorialProject.fromFiles(await this.exportFiles())
-  }
-
-  async exportFiles(project: SpxProject | null = null) {
-    const files = await cloneFiles(this.files)
-    for (const path of Object.keys(files)) {
-      if (path.startsWith(`${tutorialVideoAssetPath}/`)) delete files[path]
-    }
-    Object.assign(files, ...this.videos.map((video) => video.clone(true).export()))
-    if (project == null) return files
-    Object.assign(files, prefixFiles(await cloneFiles(project.exportFiles()), this.index.project.root))
+  exportFiles() {
+    if (this.index == null) throw new Error('Tutorial project has not been loaded')
+    const files = { ...this.files }
+    removeFiles(files, this.index.project.root)
+    removeFiles(files, videoAssetPath)
+    files[indexFilePath] = fromConfig(indexFilePath, this.index)
+    files[courseCodeFilePath] = fromText(courseCodeFilePath, this.courseCode)
+    Object.assign(
+      files,
+      prefixFiles(this.project.exportFiles(), this.index.project.root),
+      ...this.videos.map((video) => video.export())
+    )
     return files
   }
-}
-
-async function loadIndex(files: Files): Promise<TutorialProjectIndex> {
-  const rawIndex = await parseConfig(requireFile(files, indexFilePath), indexFilePath)
-  const project = asRecord(rawIndex.project, 'index.json project')
-  if (project.type !== 'spx') throw new TutorialProjectLoadError('index.json project type must be "spx"')
-  if (!isRelativeDirectory(project.root))
-    throw new TutorialProjectLoadError('index.json project root must be a relative directory')
-  if (typeof rawIndex.inEditorRoute !== 'string')
-    throw new TutorialProjectLoadError('index.json inEditorRoute must be a string')
-  if (typeof rawIndex.copilotContext !== 'string')
-    throw new TutorialProjectLoadError('index.json copilotContext must be a string')
-  return {
-    project: { type: 'spx', root: project.root },
-    inEditorRoute: rawIndex.inEditorRoute,
-    copilotContext: rawIndex.copilotContext
-  }
-}
-
-function requireFile(files: Files, path: string) {
-  const file = files[path]
-  if (file == null) throw new TutorialProjectLoadError(`missing required file: ${path}`)
-  return file
-}
-
-async function parseConfig(file: File, path: string) {
-  try {
-    return asRecord(await toConfig(file), path)
-  } catch (error) {
-    throw new TutorialProjectLoadError(
-      `invalid JSON in ${path}: ${error instanceof Error ? error.message : String(error)}`
-    )
-  }
-}
-
-function asRecord(value: unknown, name: string): Record<string, unknown> {
-  if (value == null || typeof value !== 'object' || Array.isArray(value)) {
-    throw new TutorialProjectLoadError(`${name} must be a JSON object`)
-  }
-  return value as Record<string, unknown>
-}
-
-function isRelativeDirectory(value: unknown): value is string {
-  return (
-    typeof value === 'string' &&
-    value.split('/').every((segment) => segment !== '' && segment !== '.' && segment !== '..')
-  )
-}
-
-function extractDirectory(files: Files, directory: string) {
-  const prefix = `${directory}/`
-  const extracted: Files = {}
-  for (const [path, file] of Object.entries(files)) {
-    if (path.startsWith(prefix)) extracted[path.slice(prefix.length)] = file
-  }
-  return extracted
-}
-
-function prefixFiles(files: Files, directory: string) {
-  const prefixed: Files = {}
-  for (const [path, file] of Object.entries(files)) {
-    prefixed[`${directory}/${path}`] = file
-  }
-  return prefixed
-}
-
-async function cloneFiles(files: Files) {
-  const cloned: Files = {}
-  for (const [path, file] of Object.entries(files)) {
-    if (file == null) continue
-    cloned[path] = new File(file.name, (signal) => file.arrayBuffer(signal), {
-      type: file.type,
-      lastModified: file.lastModified,
-      meta: { ...file.meta }
-    })
-  }
-  return cloned
 }

--- a/spx-gui/src/models/tutorial/project.ts
+++ b/spx-gui/src/models/tutorial/project.ts
@@ -1,0 +1,170 @@
+import { reactive } from 'vue'
+
+import type { FileCollection } from '@/apis/common'
+import { getFiles } from '@/models/common/cloud'
+import { File, toConfig, type Files } from '@/models/common/file'
+import { SpxProject } from '@/models/spx/project'
+
+import { TutorialProjectLoadError } from './common'
+import { TutorialVideo, tutorialVideoAssetPath } from './video'
+
+const indexFilePath = 'index.json'
+const programFilePath = 'main.gox'
+
+export type TutorialProjectIndex = {
+  project: {
+    type: 'spx'
+    root: string
+  }
+  inEditorRoute: string
+  copilotContext: string
+}
+
+export { TutorialProjectLoadError } from './common'
+export { TutorialVideo } from './video'
+
+export class TutorialProject {
+  private constructor(
+    readonly index: TutorialProjectIndex,
+    readonly program: File,
+    readonly videos: TutorialVideo[],
+    private readonly files: Files
+  ) {
+    return reactive(this) as this
+  }
+
+  static async fromFileCollection(fileCollection: FileCollection) {
+    return this.fromFiles(getFiles(fileCollection))
+  }
+
+  static async fromFiles(files: Files): Promise<TutorialProject> {
+    const clonedFiles = await cloneFiles(files)
+    const index = await loadIndex(clonedFiles)
+    const program = requireFile(clonedFiles, programFilePath)
+    const projectFiles = extractDirectory(clonedFiles, index.project.root)
+    requireFile(projectFiles, 'assets/index.json')
+    const videos = await TutorialVideo.loadAll(clonedFiles)
+    const project = new TutorialProject(index, program, videos, clonedFiles)
+    videos.forEach((video) => video.setProject(project))
+    return project
+  }
+
+  getVideo(name: string) {
+    return this.videos.find((video) => video.name === name) ?? null
+  }
+
+  getVideoById(id: string) {
+    return this.videos.find((video) => video.id === id) ?? null
+  }
+
+  addVideo(video: TutorialVideo) {
+    if (this.getVideo(video.name) != null) throw new Error(`video ${video.name} already exists`)
+    video.setProject(this)
+    this.videos.push(video)
+  }
+
+  removeVideo(id: string) {
+    const index = this.videos.findIndex((video) => video.id === id)
+    if (index < 0) throw new Error(`video ${id} not found`)
+    const [video] = this.videos.splice(index, 1)
+    video.setProject(null)
+  }
+
+  async createSpxProject() {
+    const project = new SpxProject()
+    await project.loadFiles(await cloneFiles(extractDirectory(this.files, this.index.project.root)))
+    return project
+  }
+
+  async clone() {
+    return TutorialProject.fromFiles(await this.exportFiles())
+  }
+
+  async exportFiles(project: SpxProject | null = null) {
+    const files = await cloneFiles(this.files)
+    for (const path of Object.keys(files)) {
+      if (path.startsWith(`${tutorialVideoAssetPath}/`)) delete files[path]
+    }
+    Object.assign(files, ...this.videos.map((video) => video.clone(true).export()))
+    if (project == null) return files
+    Object.assign(files, prefixFiles(await cloneFiles(project.exportFiles()), this.index.project.root))
+    return files
+  }
+}
+
+async function loadIndex(files: Files): Promise<TutorialProjectIndex> {
+  const rawIndex = await parseConfig(requireFile(files, indexFilePath), indexFilePath)
+  const project = asRecord(rawIndex.project, 'index.json project')
+  if (project.type !== 'spx') throw new TutorialProjectLoadError('index.json project type must be "spx"')
+  if (!isRelativeDirectory(project.root))
+    throw new TutorialProjectLoadError('index.json project root must be a relative directory')
+  if (typeof rawIndex.inEditorRoute !== 'string')
+    throw new TutorialProjectLoadError('index.json inEditorRoute must be a string')
+  if (typeof rawIndex.copilotContext !== 'string')
+    throw new TutorialProjectLoadError('index.json copilotContext must be a string')
+  return {
+    project: { type: 'spx', root: project.root },
+    inEditorRoute: rawIndex.inEditorRoute,
+    copilotContext: rawIndex.copilotContext
+  }
+}
+
+function requireFile(files: Files, path: string) {
+  const file = files[path]
+  if (file == null) throw new TutorialProjectLoadError(`missing required file: ${path}`)
+  return file
+}
+
+async function parseConfig(file: File, path: string) {
+  try {
+    return asRecord(await toConfig(file), path)
+  } catch (error) {
+    throw new TutorialProjectLoadError(
+      `invalid JSON in ${path}: ${error instanceof Error ? error.message : String(error)}`
+    )
+  }
+}
+
+function asRecord(value: unknown, name: string): Record<string, unknown> {
+  if (value == null || typeof value !== 'object' || Array.isArray(value)) {
+    throw new TutorialProjectLoadError(`${name} must be a JSON object`)
+  }
+  return value as Record<string, unknown>
+}
+
+function isRelativeDirectory(value: unknown): value is string {
+  return (
+    typeof value === 'string' &&
+    value.split('/').every((segment) => segment !== '' && segment !== '.' && segment !== '..')
+  )
+}
+
+function extractDirectory(files: Files, directory: string) {
+  const prefix = `${directory}/`
+  const extracted: Files = {}
+  for (const [path, file] of Object.entries(files)) {
+    if (path.startsWith(prefix)) extracted[path.slice(prefix.length)] = file
+  }
+  return extracted
+}
+
+function prefixFiles(files: Files, directory: string) {
+  const prefixed: Files = {}
+  for (const [path, file] of Object.entries(files)) {
+    prefixed[`${directory}/${path}`] = file
+  }
+  return prefixed
+}
+
+async function cloneFiles(files: Files) {
+  const cloned: Files = {}
+  for (const [path, file] of Object.entries(files)) {
+    if (file == null) continue
+    cloned[path] = new File(file.name, (signal) => file.arrayBuffer(signal), {
+      type: file.type,
+      lastModified: file.lastModified,
+      meta: { ...file.meta }
+    })
+  }
+  return cloned
+}

--- a/spx-gui/src/models/tutorial/project.ts
+++ b/spx-gui/src/models/tutorial/project.ts
@@ -30,6 +30,11 @@ export type TutorialProjectIndex = {
 
 export type TutorialProjectMetadata = Omit<PlaygroundCourseData, 'content'>
 
+export type TutorialProjectSerialized = {
+  metadata: TutorialProjectMetadata
+  files: Files
+}
+
 export { Video } from './video'
 
 export class TutorialProject {
@@ -56,8 +61,17 @@ export class TutorialProject {
 
   static async load(course: PlaygroundCourseData) {
     const project = new TutorialProject(course)
-    await project.loadFiles(getFiles(course.content))
+    await project.load({ metadata: course, files: getFiles(course.content) })
     return project
+  }
+
+  setMetadata(metadata: Partial<TutorialProjectMetadata>) {
+    Object.assign(this, metadata)
+  }
+
+  async load({ metadata, files }: TutorialProjectSerialized) {
+    this.setMetadata(metadata)
+    await this.loadFiles(files)
   }
 
   async loadFiles(files: Files) {
@@ -67,12 +81,10 @@ export class TutorialProject {
     const courseCodeFile = files[courseCodeFilePath]
     if (courseCodeFile == null) throw new Error(`file ${courseCodeFilePath} not found`)
 
-    const project = new SpxProject()
-    await project.loadFiles(extractFiles(files, index.project.root))
+    await this.project.loadFiles(extractFiles(files, index.project.root))
     const videos = await Video.loadAll(files)
 
     this.index = index
-    this.project = project
     this.courseCode = await toText(courseCodeFile)
     this.videos.splice(0).forEach((video) => video.setProject(null))
     videos.forEach((video) => this.addVideo(video))
@@ -84,9 +96,14 @@ export class TutorialProject {
   }
 
   addVideo(video: Video) {
-    if (this.videos.some((item) => item.name === video.name)) throw new Error(`video ${video.name} already exists`)
     video.setProject(this)
-    this.videos.push(video)
+    try {
+      video.setName(video.name)
+      this.videos.push(video)
+    } catch (error) {
+      video.setProject(null)
+      throw error
+    }
   }
 
   removeVideo(id: string) {
@@ -109,5 +126,18 @@ export class TutorialProject {
       ...this.videos.map((video) => video.export())
     )
     return files
+  }
+
+  export(): TutorialProjectSerialized {
+    return {
+      metadata: {
+        id: this.id,
+        owner: this.owner,
+        kind: this.kind,
+        title: this.title,
+        thumbnail: this.thumbnail
+      },
+      files: this.exportFiles()
+    }
   }
 }

--- a/spx-gui/src/models/tutorial/video.test.ts
+++ b/spx-gui/src/models/tutorial/video.test.ts
@@ -33,4 +33,10 @@ describe('Video', () => {
 
     expect((await Video.loadAll(files)).map((video) => video.name)).toEqual(['step-to', 'another'])
   })
+
+  it('rejects names that cannot identify a video directory', () => {
+    const video = new Video('step-to', fromText('step-to.mp4', 'video'))
+
+    expect(() => video.setName('assets/step-to')).toThrow('must not contain /')
+  })
 })

--- a/spx-gui/src/models/tutorial/video.test.ts
+++ b/spx-gui/src/models/tutorial/video.test.ts
@@ -1,54 +1,36 @@
 import { describe, expect, it } from 'vitest'
 
 import { fromConfig, fromText, toConfig, toText, type Files } from '@/models/common/file'
-import { TutorialProjectLoadError } from './common'
-import { TutorialVideo } from './video'
+import { Video } from './video'
 
 function makeFiles(): Files {
   return {
-    'assets/videos/step-to/index.json': fromConfig('index.json', { path: 'media/step-to.mp4' }),
-    'assets/videos/step-to/media/step-to.mp4': fromText('step-to.mp4', 'video')
+    'assets/videos/step-to/index.json': fromConfig('index.json', { path: 'step-to.mp4', builder_id: 'video-id' }),
+    'assets/videos/step-to/step-to.mp4': fromText('step-to.mp4', 'video')
   }
 }
 
-describe('TutorialVideo', () => {
+describe('Video', () => {
   it('loads and exports a named video resource', async () => {
-    const video = await TutorialVideo.load('step-to', makeFiles())
+    const video = await Video.load('step-to', makeFiles())
+    if (video == null) throw new Error('video expected')
 
-    expect(video.path).toBe('media/step-to.mp4')
+    expect(video.id).toBe('video-id')
     expect(await toText(video.file)).toBe('video')
 
     const exported = video.export()
     expect(await toConfig(exported['assets/videos/step-to/index.json']!)).toEqual({
-      path: 'media/step-to.mp4',
-      builder_id: video.id
+      path: 'step-to.mp4',
+      builder_id: 'video-id'
     })
-    expect(await toText(exported['assets/videos/step-to/media/step-to.mp4']!)).toBe('video')
+    expect(await toText(exported['assets/videos/step-to/step-to.mp4']!)).toBe('video')
   })
 
-  it('loads every declared video and rejects incomplete resources', async () => {
+  it('loads every declared video', async () => {
     const files = makeFiles()
     files['assets/videos/another/index.json'] = fromConfig('index.json', { path: 'another.mp4' })
     files['assets/videos/another/another.mp4'] = fromText('another.mp4', 'another video')
 
-    expect((await TutorialVideo.loadAll(files)).map((video) => video.name)).toEqual(['step-to', 'another'])
-
-    const incomplete = makeFiles()
-    incomplete['assets/videos/step-to/index.json'] = fromConfig('index.json', { path: '../step-to.mp4' })
-    await expect(TutorialVideo.load('step-to', incomplete)).rejects.toThrow(TutorialProjectLoadError)
-  })
-
-  it('clones resource state without changing its serialized contract', async () => {
-    const video = await TutorialVideo.load('step-to', makeFiles())
-    const clone = video.clone()
-
-    expect(clone).not.toBe(video)
-    expect(clone.file).not.toBe(video.file)
-    expect(clone.id).not.toBe(video.id)
-    expect(await toConfig(clone.export()['assets/videos/step-to/index.json']!)).toEqual({
-      path: 'media/step-to.mp4',
-      builder_id: clone.id
-    })
-    expect(await toText(clone.export()['assets/videos/step-to/media/step-to.mp4']!)).toBe('video')
+    expect((await Video.loadAll(files)).map((video) => video.name)).toEqual(['step-to', 'another'])
   })
 })

--- a/spx-gui/src/models/tutorial/video.test.ts
+++ b/spx-gui/src/models/tutorial/video.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+
+import { fromConfig, fromText, toConfig, toText, type Files } from '@/models/common/file'
+import { TutorialProjectLoadError } from './common'
+import { TutorialVideo } from './video'
+
+function makeFiles(): Files {
+  return {
+    'assets/videos/step-to/index.json': fromConfig('index.json', { path: 'media/step-to.mp4' }),
+    'assets/videos/step-to/media/step-to.mp4': fromText('step-to.mp4', 'video')
+  }
+}
+
+describe('TutorialVideo', () => {
+  it('loads and exports a named video resource', async () => {
+    const video = await TutorialVideo.load('step-to', makeFiles())
+
+    expect(video.path).toBe('media/step-to.mp4')
+    expect(await toText(video.file)).toBe('video')
+
+    const exported = video.export()
+    expect(await toConfig(exported['assets/videos/step-to/index.json']!)).toEqual({
+      path: 'media/step-to.mp4',
+      builder_id: video.id
+    })
+    expect(await toText(exported['assets/videos/step-to/media/step-to.mp4']!)).toBe('video')
+  })
+
+  it('loads every declared video and rejects incomplete resources', async () => {
+    const files = makeFiles()
+    files['assets/videos/another/index.json'] = fromConfig('index.json', { path: 'another.mp4' })
+    files['assets/videos/another/another.mp4'] = fromText('another.mp4', 'another video')
+
+    expect((await TutorialVideo.loadAll(files)).map((video) => video.name)).toEqual(['step-to', 'another'])
+
+    const incomplete = makeFiles()
+    incomplete['assets/videos/step-to/index.json'] = fromConfig('index.json', { path: '../step-to.mp4' })
+    await expect(TutorialVideo.load('step-to', incomplete)).rejects.toThrow(TutorialProjectLoadError)
+  })
+
+  it('clones resource state without changing its serialized contract', async () => {
+    const video = await TutorialVideo.load('step-to', makeFiles())
+    const clone = video.clone()
+
+    expect(clone).not.toBe(video)
+    expect(clone.file).not.toBe(video.file)
+    expect(clone.id).not.toBe(video.id)
+    expect(await toConfig(clone.export()['assets/videos/step-to/index.json']!)).toEqual({
+      path: 'media/step-to.mp4',
+      builder_id: clone.id
+    })
+    expect(await toText(clone.export()['assets/videos/step-to/media/step-to.mp4']!)).toBe('video')
+  })
+})

--- a/spx-gui/src/models/tutorial/video.test.ts
+++ b/spx-gui/src/models/tutorial/video.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import { fromConfig, fromText, toConfig, toText, type Files } from '@/models/common/file'
-import { Video } from './video'
+import { validateVideoName, Video } from './video'
 
 function makeFiles(): Files {
   return {
@@ -37,6 +37,10 @@ describe('Video', () => {
   it('rejects names that cannot identify a video directory', () => {
     const video = new Video('step-to', fromText('step-to.mp4', 'video'))
 
-    expect(() => video.setName('assets/step-to')).toThrow('must not contain /')
+    expect(() => video.setName('assets/step-to')).toThrow('The name must not contain /')
+  })
+
+  it('limits names to 100 code points', () => {
+    expect(validateVideoName('a'.repeat(101), null)?.en).toContain('maximum is 100 characters')
   })
 })

--- a/spx-gui/src/models/tutorial/video.ts
+++ b/spx-gui/src/models/tutorial/video.ts
@@ -22,14 +22,6 @@ export type VideoExportLoadOptions = {
   includeId?: boolean
 }
 
-export interface VideoLike {
-  name: string
-}
-
-export interface VideoLikeProject {
-  videos: VideoLike[]
-}
-
 export class Video {
   id: string
 
@@ -88,13 +80,13 @@ export class Video {
   }
 }
 
-export function validateVideoName(name: string, project: VideoLikeProject | null) {
+export function validateVideoName(name: string, project: TutorialProject | null) {
   if (name === '') return 'must not be blank'
   if (name.includes('/')) return 'must not contain /'
   if (project?.videos.some((video) => video.name === name)) return 'already exists'
 }
 
-export function ensureValidVideoName(name: string, project: VideoLikeProject | null) {
+export function ensureValidVideoName(name: string, project: TutorialProject | null) {
   const error = validateVideoName(name, project)
   if (error == null) return name
   if (error !== 'already exists') throw new Error(`invalid video name ${name}: ${error}`)

--- a/spx-gui/src/models/tutorial/video.ts
+++ b/spx-gui/src/models/tutorial/video.ts
@@ -32,7 +32,7 @@ export class Video {
 
   name: string
   setName(name: string) {
-    const error = validateVideoName(name, this, this._project)
+    const error = validateVideoName(name, this._project)
     if (error != null) throw new Error(`invalid video name ${name}: ${error}`)
     this.name = name
   }
@@ -80,8 +80,8 @@ export class Video {
   }
 }
 
-function validateVideoName(name: string, video: Video, project: TutorialProject | null) {
+function validateVideoName(name: string, project: TutorialProject | null) {
   if (name === '') return 'must not be blank'
   if (name.includes('/')) return 'must not contain /'
-  if (project?.videos.some((item) => item !== video && item.name === name)) return 'already exists'
+  if (project?.videos.some((video) => video.name === name)) return 'already exists'
 }

--- a/spx-gui/src/models/tutorial/video.ts
+++ b/spx-gui/src/models/tutorial/video.ts
@@ -1,0 +1,122 @@
+import { nanoid } from 'nanoid'
+import { reactive } from 'vue'
+
+import { join } from '@/utils/path'
+import { File, fromConfig, listDirs, toConfig, type Files } from '@/models/common/file'
+
+import { TutorialProjectLoadError } from './common'
+import type { TutorialProject } from './project'
+
+export type RawTutorialVideoConfig = {
+  path: string
+  builder_id?: string
+}
+
+export const tutorialVideoAssetPath = 'assets/videos'
+const videoConfigFileName = 'index.json'
+
+export class TutorialVideo {
+  id: string
+  project: TutorialProject | null = null
+  name: string
+  path: string
+  file: File
+
+  constructor(name: string, path: string, file: File, id?: string) {
+    this.id = id ?? nanoid()
+    this.name = name
+    this.path = path
+    this.file = file
+    return reactive(this) as this
+  }
+
+  setProject(project: TutorialProject | null) {
+    this.project = project
+  }
+
+  setName(name: string) {
+    if (!isPathSegment(name)) throw new Error(`invalid video name: ${name}`)
+    if (this.project?.videos.some((video) => video !== this && video.name === name)) {
+      throw new Error(`video ${name} already exists`)
+    }
+    this.name = name
+  }
+
+  setFile(file: File) {
+    this.file = file
+  }
+
+  static async load(name: string, files: Files) {
+    if (!isPathSegment(name)) throw new TutorialProjectLoadError(`invalid video name: ${name}`)
+    const directory = join(tutorialVideoAssetPath, name)
+    const configFile = files[join(directory, videoConfigFileName)]
+    if (configFile == null) throw new TutorialProjectLoadError(`missing video configuration: ${name}`)
+
+    const config = await loadConfig(configFile, name)
+    if (!isRelativePath(config.path)) {
+      throw new TutorialProjectLoadError(`video ${name} path must be a relative file path`)
+    }
+    const file = files[join(directory, config.path)]
+    if (file == null) throw new TutorialProjectLoadError(`missing video file: ${name}/${config.path}`)
+    return new TutorialVideo(name, config.path, file, config.builder_id)
+  }
+
+  static async loadAll(files: Files) {
+    return Promise.all(listDirs(files, tutorialVideoAssetPath).map((name) => TutorialVideo.load(name, files)))
+  }
+
+  clone(preserveId = false) {
+    const file = this.file
+    return new TutorialVideo(
+      this.name,
+      this.path,
+      new File(file.name, (signal) => file.arrayBuffer(signal), {
+        type: file.type,
+        lastModified: file.lastModified,
+        meta: { ...file.meta }
+      }),
+      preserveId ? this.id : undefined
+    )
+  }
+
+  export(): Files {
+    const directory = join(tutorialVideoAssetPath, this.name)
+    return {
+      [join(directory, videoConfigFileName)]: fromConfig(videoConfigFileName, {
+        path: this.path,
+        builder_id: this.id
+      }),
+      [join(directory, this.path)]: this.file
+    }
+  }
+}
+
+async function loadConfig(file: File, name: string): Promise<RawTutorialVideoConfig> {
+  let config: unknown
+  try {
+    config = await toConfig(file)
+  } catch (error) {
+    throw new TutorialProjectLoadError(
+      `invalid video configuration for ${name}: ${error instanceof Error ? error.message : String(error)}`
+    )
+  }
+  if (config == null || typeof config !== 'object' || Array.isArray(config)) {
+    throw new TutorialProjectLoadError(`invalid video configuration for ${name}`)
+  }
+  if (!('path' in config) || !isRelativePath(config.path)) {
+    throw new TutorialProjectLoadError(`invalid video configuration for ${name}`)
+  }
+  const id = 'builder_id' in config ? config.builder_id : undefined
+  if (id != null && typeof id !== 'string') {
+    throw new TutorialProjectLoadError(`invalid video configuration for ${name}`)
+  }
+  return { path: config.path, builder_id: typeof id === 'string' ? id : undefined }
+}
+
+function isPathSegment(value: string) {
+  return value !== '' && value !== '.' && value !== '..' && !value.includes('/')
+}
+
+function isRelativePath(value: unknown): value is string {
+  return typeof value === 'string' && value.split('/').every(isPathSegment)
+}

--- a/spx-gui/src/models/tutorial/video.ts
+++ b/spx-gui/src/models/tutorial/video.ts
@@ -32,9 +32,8 @@ export class Video {
 
   name: string
   setName(name: string) {
-    if (this._project?.videos.some((video) => video !== this && video.name === name)) {
-      throw new Error(`video ${name} already exists`)
-    }
+    const error = validateVideoName(name, this, this._project)
+    if (error != null) throw new Error(`invalid video name ${name}: ${error}`)
     this.name = name
   }
 
@@ -79,4 +78,10 @@ export class Video {
       [join(assetPath, filename)]: this.file
     }
   }
+}
+
+function validateVideoName(name: string, video: Video, project: TutorialProject | null) {
+  if (name === '') return 'must not be blank'
+  if (name.includes('/')) return 'must not contain /'
+  if (project?.videos.some((item) => item !== video && item.name === name)) return 'already exists'
 }

--- a/spx-gui/src/models/tutorial/video.ts
+++ b/spx-gui/src/models/tutorial/video.ts
@@ -2,6 +2,8 @@ import { nanoid } from 'nanoid'
 import { reactive } from 'vue'
 
 import { extname, join, resolve } from '@/utils/path'
+import type { LocaleMessage } from '@/utils/i18n'
+import { getStringLengthInCodePoints } from '@/utils/utils'
 import { File, fromConfig, listDirs, toConfig, type Files } from '@/models/common/file'
 
 import type { TutorialProject } from './project'
@@ -17,6 +19,7 @@ export type RawVideoConfig = Omit<VideoInits, 'id'> & {
 
 export const videoAssetPath = 'assets/videos'
 const videoConfigFileName = 'index.json'
+const videoNameMaxLength = 100
 
 export type VideoExportLoadOptions = {
   includeId?: boolean
@@ -33,7 +36,7 @@ export class Video {
   name: string
   setName(name: string) {
     const error = validateVideoName(name, this._project)
-    if (error != null) throw new Error(`invalid video name ${name}: ${error}`)
+    if (error != null) throw new Error(`invalid video name ${name}: ${error.en}`)
     this.name = name
   }
 
@@ -80,18 +83,36 @@ export class Video {
   }
 }
 
-export function validateVideoName(name: string, project: TutorialProject | null) {
-  if (name === '') return 'must not be blank'
-  if (name.includes('/')) return 'must not contain /'
-  if (project?.videos.some((video) => video.name === name)) return 'already exists'
+export function validateVideoName(name: string, project: TutorialProject | null): LocaleMessage | null {
+  if (name === '') return { en: 'The name must not be blank', zh: '名字不可为空' }
+  if (getStringLengthInCodePoints(name) > videoNameMaxLength) {
+    return {
+      en: `The name is too long (maximum is ${videoNameMaxLength} characters)`,
+      zh: `名字长度超出限制（最多 ${videoNameMaxLength} 个字符）`
+    }
+  }
+  if (name.includes('/')) return { en: 'The name must not contain /', zh: '名字不可包含 /' }
+  if (project?.videos.some((video) => video.name === name)) {
+    return { en: `Video with name ${name} already exists`, zh: '存在同名的视频' }
+  }
+  return null
 }
 
 export function ensureValidVideoName(name: string, project: TutorialProject | null) {
-  const error = validateVideoName(name, project)
-  if (error == null) return name
-  if (error !== 'already exists') throw new Error(`invalid video name ${name}: ${error}`)
-  for (let i = 2; ; i++) {
-    const candidate = `${name}${i}`
-    if (validateVideoName(candidate, project) == null) return candidate
+  if (validateVideoName(name, project) == null) return name
+  return getVideoName(project, name)
+}
+
+export function getVideoName(project: TutorialProject | null, base: string) {
+  if (validateVideoName(base, null) != null) throw new Error(`invalid video name ${base}`)
+  const match = base.match(/^(.*?)(\d+)$/)
+  const nameBase = match?.[1] ?? base
+  const initialNumber = match == null ? 1 : parseInt(match[2], 10)
+  const numberWidth = match?.[2].length ?? 1
+  for (let i = initialNumber + 1; ; i++) {
+    const suffix = numberWidth > 1 ? String(i).padStart(numberWidth, '0') : String(i)
+    const name = nameBase + suffix
+    if (validateVideoName(name, project) == null) return name
+    if (i - initialNumber > 10000) throw new Error(`unexpected infinite loop with base ${base}`)
   }
 }

--- a/spx-gui/src/models/tutorial/video.ts
+++ b/spx-gui/src/models/tutorial/video.ts
@@ -5,6 +5,7 @@ import { extname, join, resolve } from '@/utils/path'
 import type { LocaleMessage } from '@/utils/i18n'
 import { getStringLengthInCodePoints } from '@/utils/utils'
 import { File, fromConfig, listDirs, toConfig, type Files } from '@/models/common/file'
+import { getValidName } from '@/models/common/name'
 
 import type { TutorialProject } from './project'
 
@@ -105,14 +106,5 @@ export function ensureValidVideoName(name: string, project: TutorialProject | nu
 
 export function getVideoName(project: TutorialProject | null, base: string) {
   if (validateVideoName(base, null) != null) throw new Error(`invalid video name ${base}`)
-  const match = base.match(/^(.*?)(\d+)$/)
-  const nameBase = match?.[1] ?? base
-  const initialNumber = match == null ? 1 : parseInt(match[2], 10)
-  const numberWidth = match?.[2].length ?? 1
-  for (let i = initialNumber + 1; ; i++) {
-    const suffix = numberWidth > 1 ? String(i).padStart(numberWidth, '0') : String(i)
-    const name = nameBase + suffix
-    if (validateVideoName(name, project) == null) return name
-    if (i - initialNumber > 10000) throw new Error(`unexpected infinite loop with base ${base}`)
-  }
+  return getValidName(base, (name) => validateVideoName(name, project) == null)
 }

--- a/spx-gui/src/models/tutorial/video.ts
+++ b/spx-gui/src/models/tutorial/video.ts
@@ -1,122 +1,82 @@
 import { nanoid } from 'nanoid'
 import { reactive } from 'vue'
 
-import { join } from '@/utils/path'
+import { extname, join, resolve } from '@/utils/path'
 import { File, fromConfig, listDirs, toConfig, type Files } from '@/models/common/file'
 
-import { TutorialProjectLoadError } from './common'
 import type { TutorialProject } from './project'
 
-export type RawTutorialVideoConfig = {
-  path: string
-  builder_id?: string
+export type VideoInits = {
+  id?: string
 }
 
-export const tutorialVideoAssetPath = 'assets/videos'
+export type RawVideoConfig = Omit<VideoInits, 'id'> & {
+  builder_id?: string
+  path?: string
+}
+
+export const videoAssetPath = 'assets/videos'
 const videoConfigFileName = 'index.json'
 
-export class TutorialVideo {
+export type VideoExportLoadOptions = {
+  includeId?: boolean
+}
+
+export class Video {
   id: string
-  project: TutorialProject | null = null
-  name: string
-  path: string
-  file: File
 
-  constructor(name: string, path: string, file: File, id?: string) {
-    this.id = id ?? nanoid()
-    this.name = name
-    this.path = path
-    this.file = file
-    return reactive(this) as this
-  }
-
+  _project: TutorialProject | null = null
   setProject(project: TutorialProject | null) {
-    this.project = project
+    this._project = project
   }
 
+  name: string
   setName(name: string) {
-    if (!isPathSegment(name)) throw new Error(`invalid video name: ${name}`)
-    if (this.project?.videos.some((video) => video !== this && video.name === name)) {
+    if (this._project?.videos.some((video) => video !== this && video.name === name)) {
       throw new Error(`video ${name} already exists`)
     }
     this.name = name
   }
 
+  file: File
   setFile(file: File) {
     this.file = file
   }
 
-  static async load(name: string, files: Files) {
-    if (!isPathSegment(name)) throw new TutorialProjectLoadError(`invalid video name: ${name}`)
-    const directory = join(tutorialVideoAssetPath, name)
-    const configFile = files[join(directory, videoConfigFileName)]
-    if (configFile == null) throw new TutorialProjectLoadError(`missing video configuration: ${name}`)
-
-    const config = await loadConfig(configFile, name)
-    if (!isRelativePath(config.path)) {
-      throw new TutorialProjectLoadError(`video ${name} path must be a relative file path`)
-    }
-    const file = files[join(directory, config.path)]
-    if (file == null) throw new TutorialProjectLoadError(`missing video file: ${name}/${config.path}`)
-    return new TutorialVideo(name, config.path, file, config.builder_id)
+  constructor(name: string, file: File, inits?: VideoInits) {
+    this.id = inits?.id ?? nanoid()
+    this.name = name
+    this.file = file
+    return reactive(this) as this
   }
 
-  static async loadAll(files: Files) {
-    return Promise.all(listDirs(files, tutorialVideoAssetPath).map((name) => TutorialVideo.load(name, files)))
+  static async load(name: string, files: Files, { includeId = true }: VideoExportLoadOptions = {}) {
+    const pathPrefix = join(videoAssetPath, name)
+    const configFile = files[join(pathPrefix, videoConfigFileName)]
+    if (configFile == null) return null
+    const { builder_id: id, path } = (await toConfig(configFile)) as RawVideoConfig
+    if (path == null) throw new Error(`path expected for video ${name}`)
+    const file = files[resolve(pathPrefix, path)]
+    if (file == null) throw new Error(`file ${path} for video ${name} not found`)
+    return new Video(name, file, { id: includeId ? id : undefined })
   }
 
-  clone(preserveId = false) {
-    const file = this.file
-    return new TutorialVideo(
-      this.name,
-      this.path,
-      new File(file.name, (signal) => file.arrayBuffer(signal), {
-        type: file.type,
-        lastModified: file.lastModified,
-        meta: { ...file.meta }
-      }),
-      preserveId ? this.id : undefined
+  static async loadAll(files: Files, options?: VideoExportLoadOptions) {
+    const names = listDirs(files, videoAssetPath)
+    const videos = (await Promise.all(names.map((name) => Video.load(name, files, options)))).filter(
+      (video) => video != null
     )
+    return videos as Video[]
   }
 
-  export(): Files {
-    const directory = join(tutorialVideoAssetPath, this.name)
+  export({ includeId = true }: VideoExportLoadOptions = {}): Files {
+    const filename = this.name + extname(this.file.name)
+    const config: RawVideoConfig = { path: filename }
+    if (includeId) config.builder_id = this.id
+    const assetPath = join(videoAssetPath, this.name)
     return {
-      [join(directory, videoConfigFileName)]: fromConfig(videoConfigFileName, {
-        path: this.path,
-        builder_id: this.id
-      }),
-      [join(directory, this.path)]: this.file
+      [join(assetPath, videoConfigFileName)]: fromConfig(videoConfigFileName, config),
+      [join(assetPath, filename)]: this.file
     }
   }
-}
-
-async function loadConfig(file: File, name: string): Promise<RawTutorialVideoConfig> {
-  let config: unknown
-  try {
-    config = await toConfig(file)
-  } catch (error) {
-    throw new TutorialProjectLoadError(
-      `invalid video configuration for ${name}: ${error instanceof Error ? error.message : String(error)}`
-    )
-  }
-  if (config == null || typeof config !== 'object' || Array.isArray(config)) {
-    throw new TutorialProjectLoadError(`invalid video configuration for ${name}`)
-  }
-  if (!('path' in config) || !isRelativePath(config.path)) {
-    throw new TutorialProjectLoadError(`invalid video configuration for ${name}`)
-  }
-  const id = 'builder_id' in config ? config.builder_id : undefined
-  if (id != null && typeof id !== 'string') {
-    throw new TutorialProjectLoadError(`invalid video configuration for ${name}`)
-  }
-  return { path: config.path, builder_id: typeof id === 'string' ? id : undefined }
-}
-
-function isPathSegment(value: string) {
-  return value !== '' && value !== '.' && value !== '..' && !value.includes('/')
-}
-
-function isRelativePath(value: unknown): value is string {
-  return typeof value === 'string' && value.split('/').every(isPathSegment)
 }

--- a/spx-gui/src/models/tutorial/video.ts
+++ b/spx-gui/src/models/tutorial/video.ts
@@ -22,6 +22,14 @@ export type VideoExportLoadOptions = {
   includeId?: boolean
 }
 
+export interface VideoLike {
+  name: string
+}
+
+export interface VideoLikeProject {
+  videos: VideoLike[]
+}
+
 export class Video {
   id: string
 
@@ -80,8 +88,18 @@ export class Video {
   }
 }
 
-function validateVideoName(name: string, project: TutorialProject | null) {
+export function validateVideoName(name: string, project: VideoLikeProject | null) {
   if (name === '') return 'must not be blank'
   if (name.includes('/')) return 'must not contain /'
   if (project?.videos.some((video) => video.name === name)) return 'already exists'
+}
+
+export function ensureValidVideoName(name: string, project: VideoLikeProject | null) {
+  const error = validateVideoName(name, project)
+  if (error == null) return name
+  if (error !== 'already exists') throw new Error(`invalid video name ${name}: ${error}`)
+  for (let i = 2; ; i++) {
+    const candidate = `${name}${i}`
+    if (validateVideoName(candidate, project) == null) return candidate
+  }
 }


### PR DESCRIPTION
## Summary

- Add `TutorialProject`, `Course`, and `Video` domain models for Playground Course `FileCollection` content.
- Model the Tutorial-project config, `main_course.gox`, embedded in-memory `SpxProject`, and course-local named videos with persistent `builder_id` using the `assets/videos/<name>/index.json` contract from #3437.
- Add the Playground Course API type and reuse a common numeric-suffix name generator across SPX assets and Tutorial videos.

## Validation

- Prettier checks for changed model files
- Focused Vitest: 23 tests passed (`models/common`, `models/spx/common/asset-name`, and `models/tutorial`)
- ESLint for changed model files
- `vue-tsc --noEmit -p tsconfig.app.json`

Closes #3435
