### PR TITLE
docs: formalize Tutorial events and remaining contract semantics

### DIFF
--- a/docs/develop/tutorial-v2/base.ts
+++ b/docs/develop/tutorial-v2/base.ts
@@ -30,6 +30,8 @@ export type ProjectSerialized = {
 };
 
 export type RuntimeOutput = {
+  /** Monotonically increasing output id within a run. */
+  id: number;
   kind: "log" | "error";
   message: string;
 };

--- a/docs/develop/tutorial-v2/base.ts
+++ b/docs/develop/tutorial-v2/base.ts
@@ -30,8 +30,6 @@ export type ProjectSerialized = {
 };
 
 export type RuntimeOutput = {
-  /** Monotonically increasing output id within a run. */
-  id: number;
   kind: "log" | "error";
   message: string;
 };

--- a/docs/develop/tutorial-v2/example-tutorial-course/main_course.gox
+++ b/docs/develop/tutorial-v2/example-tutorial-course/main_course.gox
@@ -1,12 +1,12 @@
 onStart => {
-	editor.codeEditor.filterAPIs ["stepTo"]
+	editor.codeEditor.filterAPIs ["xgo:github.com/goplus/spx/v3?Sprite.stepTo"]
 	showPrelude "Move Lita to Mushroom. Click Mushroom's name to insert it into your code."
 	showVideo "step-to"
 }
 
 editor.runtime.onLog log => {
 	if log == "reached-target" {
-		code := editor.codeEditor.getCode()
+		code := editor.codeEditor.getCode("Lita.spx")
 		feedback := copilot.generateText "Give one short sentence of feedback about this solution:\n" + code
 		completeWith feedback
 	}

--- a/docs/develop/tutorial-v2/example-tutorial-course/main_course.gox
+++ b/docs/develop/tutorial-v2/example-tutorial-course/main_course.gox
@@ -1,13 +1,13 @@
 onStart => {
-	editor.codeEditor.filterAPIs ["xgo:github.com/goplus/spx/v3?Sprite.stepTo"]
+	Editor.CodeEditor.filterAPIs ["xgo:github.com/goplus/spx/v3?Sprite.stepTo"]
 	showPrelude "Move Lita to Mushroom. Click Mushroom's name to insert it into your code."
 	showVideo "step-to"
 }
 
-editor.runtime.onLog log => {
+Editor.Runtime.onLog log => {
 	if log == "reached-target" {
-		code := editor.codeEditor.getCode("Lita.spx")
-		feedback := copilot.generateText "Give one short sentence of feedback about this solution:\n" + code
+		code := Editor.CodeEditor.getCode("Lita.spx")
+		feedback := Copilot.generateText "Give one short sentence of feedback about this solution:\n" + code
 		completeWith feedback
 	}
 }

--- a/docs/develop/tutorial-v2/example-tutorial-course/main_course.gox
+++ b/docs/develop/tutorial-v2/example-tutorial-course/main_course.gox
@@ -6,7 +6,7 @@ onStart => {
 
 Editor.Runtime.onLog log => {
 	if log == "reached-target" {
-		code := Editor.CodeEditor.getCode("Lita.spx")
+		code := Editor.Project.getCode("Lita.spx")
 		feedback := Copilot.generateText "Give one short sentence of feedback about this solution:\n" + code
 		completeWith feedback
 	}

--- a/docs/develop/tutorial-v2/example-tutorial-course/main_course.gox
+++ b/docs/develop/tutorial-v2/example-tutorial-course/main_course.gox
@@ -6,7 +6,7 @@ onStart => {
 
 Editor.Runtime.onLog log => {
 	if log == "reached-target" {
-		code := Editor.Project.getCode("Lita.spx")
+		code := Editor.Project.getCode("Lita")
 		feedback := Copilot.generateText "Give one short sentence of feedback about this solution:\n" + code
 		completeWith feedback
 	}

--- a/docs/develop/tutorial-v2/index.md
+++ b/docs/develop/tutorial-v2/index.md
@@ -27,7 +27,7 @@ Tutorial owns the active Course lifecycle. Its public boundary starts and stops 
 
 For a Playground Course, Course playground interprets the opaque Course content using the Tutorial-project contract, creates a model `SpxProject` without cloud-project identity, builds an `EditorState` from `inEditorRoute` and composes the SPX Project Editor UI. Once that surrounding UI composition is ready, it starts Tutorial with the loaded Course. Tutorial starts a Copilot Topic, combines its own presentation and completion capabilities with the available editor and Copilot capabilities, creates the Tutorial `XGoFramework`, passes that framework through `XGoExecutorOptions` and runs the conventional root `main_course.gox`. Stopping or completing the Course tears these runtime resources down together.
 
-Tutorial is also the event dispatcher for the running Tutorial program (see `TutorialEvent`): it forwards runtime start/exit and Copilot round completion, and adapts the Runtime's `didChangeOutput` notification and cumulative outputs into per-entry `editor.runtime.log` events — one event per newly appended `log`-kind entry, in append order.
+Tutorial is also the event dispatcher for the running Tutorial program: it observes editor and Copilot activity and delivers the framework's events, and it interprets how a run ended.
 
 See [Tutorial](./module_Tutorial.ts).
 
@@ -57,9 +57,7 @@ course
 └── spotlight
 ```
 
-The initial interface includes course start/prelude/message/video/completion with optional feedback, runtime start/exit/log, code reading, API filtering, workspace formatting, Ruler control, Copilot round completion, text and structured JSON generation, and spotlight reveal. For structured generation, Course code passes a non-nil struct pointer; the framework derives its JSON Schema, invokes the frontend capability and decodes the result back into that value. `editor.project` reads the session project model: Course code can read a specific code file's current content or list the project's code files, regardless of what the Code Editor UI shows.
-
-Calling `complete` or `completeWith` ends the Course program from within: after the current callback returns, the framework leaves its event loop and the program exits with reason `completed`. Remaining statements in that callback still run, but queued events are no longer processed, presentation calls after a completion are ignored by the host, and repeated completion calls are idempotent. Executor exit reasons map to Course outcomes accordingly: `completed` following a completion capability call is normal completion, while `completed` without one means the Course program fell through without completing and is treated as a Course-program defect; `stopped` means the Course was ended from outside, such as the learner leaving; `error` means the Course program failed.
+The interface covers Course presentation and completion, observation of the learner's runtime and Copilot activity, reading and constraining the learner's code, Editor tools such as the Ruler and the spotlight, and text or structured generation. Course code drives the Course flow with it and ends the Course from within; the framework owns that program lifecycle, while the surrounding session belongs to Tutorial.
 
 See [Tutorial Class Framework](./module_TutorialFramework.ts), its [Go contract](./tutorial-class-framework.go) and an [example Tutorial Course project](./example-tutorial-course/).
 

--- a/docs/develop/tutorial-v2/index.md
+++ b/docs/develop/tutorial-v2/index.md
@@ -27,6 +27,8 @@ Tutorial owns the active Course lifecycle. Its public boundary starts and stops 
 
 For a Playground Course, Course playground interprets the opaque Course content using the Tutorial-project contract, creates a model `SpxProject` without cloud-project identity, builds an `EditorState` from `inEditorRoute` and composes the SPX Project Editor UI. Once that surrounding UI composition is ready, it starts Tutorial with the loaded Course. Tutorial starts a Copilot Topic, combines its own presentation and completion capabilities with the available editor and Copilot capabilities, creates the Tutorial `XGoFramework`, passes that framework through `XGoExecutorOptions` and runs the conventional root `main_course.gox`. Stopping or completing the Course tears these runtime resources down together.
 
+Tutorial is also the event dispatcher for the running Tutorial program (see `TutorialEvent`): it forwards runtime start/exit and Copilot round completion, and adapts the Runtime's `didChangeOutput` notification and cumulative outputs into per-entry `editor.runtime.log` events — one event per newly appended `log`-kind entry, in append order.
+
 See [Tutorial](./module_Tutorial.ts).
 
 ### XGo Executor
@@ -55,7 +57,9 @@ course
 └── spotlight
 ```
 
-The initial interface includes course start/prelude/message/video/completion with optional feedback, runtime start/exit/log, code reading, API filtering, workspace formatting, Ruler control, Copilot round completion, text and structured JSON generation, and spotlight reveal. For structured generation, Course code passes a non-nil struct pointer; the framework derives its JSON Schema, invokes the frontend capability and decodes the result back into that value. `editor.project` is reserved until concrete project capabilities are required.
+The initial interface includes course start/prelude/message/video/completion with optional feedback, runtime start/exit/log, code reading, API filtering, workspace formatting, Ruler control, Copilot round completion, text and structured JSON generation, and spotlight reveal. For structured generation, Course code passes a non-nil struct pointer; the framework derives its JSON Schema, invokes the frontend capability and decodes the result back into that value. `editor.project` reads the session project model: Course code can read a specific code file's current content or list the project's code files, regardless of what the Code Editor UI shows.
+
+Calling `complete` or `completeWith` ends the Course program from within: after the current callback returns, the framework leaves its event loop and the program exits with reason `completed`. Remaining statements in that callback still run, but queued events are no longer processed, presentation calls after a completion are ignored by the host, and repeated completion calls are idempotent. Executor exit reasons map to Course outcomes accordingly: `completed` following a completion capability call is normal completion, while `completed` without one means the Course program fell through without completing and is treated as a Course-program defect; `stopped` means the Course was ended from outside, such as the learner leaving; `error` means the Course program failed.
 
 See [Tutorial Class Framework](./module_TutorialFramework.ts), its [Go contract](./tutorial-class-framework.go) and an [example Tutorial Course project](./example-tutorial-course/).
 

--- a/docs/develop/tutorial-v2/index.md
+++ b/docs/develop/tutorial-v2/index.md
@@ -46,15 +46,15 @@ The Tutorial Class Framework defines both the Tutorial-project format and the Co
 Its Course-author-facing Go contract is included in this design:
 
 ```text
-course
+Course
 ├── CourseAbilities
-├── editor
-│   ├── project
-│   ├── runtime
-│   ├── codeEditor
-│   └── ruler
-├── copilot
-└── spotlight
+├── Editor
+│   ├── Project
+│   ├── Runtime
+│   ├── CodeEditor
+│   └── Ruler
+├── Copilot
+└── Spotlight
 ```
 
 The interface covers Course presentation and completion, observation of the learner's runtime and Copilot activity, reading and constraining the learner's code, Editor tools such as the Ruler and the spotlight, and text or structured generation. Course code drives the Course flow with it and ends the Course from within; the framework owns that program lifecycle, while the surrounding session belongs to Tutorial.

--- a/docs/develop/tutorial-v2/module_Tutorial.ts
+++ b/docs/develop/tutorial-v2/module_Tutorial.ts
@@ -1,6 +1,16 @@
 import type { Course, CourseSeries } from "./module_CourseApis";
 
-/** Owns Course lifecycle; kind-specific behavior remains internal. */
+/**
+ * Owns Course lifecycle; kind-specific behavior remains internal.
+ *
+ * For a Playground Course, Tutorial interprets how the run ended from the
+ * executor's exit reason together with whether the Course program requested
+ * completion: `completed` after a completion request is a normal finish;
+ * `completed` without one means the Course program fell through and is
+ * reported as a Course-program defect; `stopped` means the Course was ended
+ * from outside, such as the learner leaving; `error` means the Course program
+ * failed.
+ */
 export interface Tutorial {
   readonly currentCourse: Course | null;
   readonly currentSeries: CourseSeries | null;

--- a/docs/develop/tutorial-v2/module_TutorialFramework.ts
+++ b/docs/develop/tutorial-v2/module_TutorialFramework.ts
@@ -102,12 +102,13 @@ export interface TutorialFrameworkHost {
   /** Formats the current code workspace. Resolves after formatting completes. */
   editor_codeEditor_formatWorkspace(): Promise<void>;
   /**
-   * Returns the given sprite's current code, including the learner's unsaved
-   * edits. `sprite` is a sprite name (e.g. `"Lita"`), matching how the
+   * Returns the given sprite's code as it currently stands in the session
+   * project. `sprite` is a sprite name (e.g. `"Lita"`), matching how the
    * project models its contents; addressing a sprite the project does not
-   * contain fails the capability call. Reading whichever code the learner
-   * happens to be editing is deliberately not offered yet: it depends on how
-   * the Code Editor exposes its attached UIs and their active documents.
+   * contain fails the capability call. This reads the project rather than a
+   * Code Editor UI buffer, and reading whichever code the learner happens to
+   * be editing is deliberately not offered yet: it depends on how the Code
+   * Editor exposes its attached UIs and their active documents.
    */
   editor_project_getCode(sprite: string): string;
   /**

--- a/docs/develop/tutorial-v2/module_TutorialFramework.ts
+++ b/docs/develop/tutorial-v2/module_TutorialFramework.ts
@@ -40,9 +40,13 @@ export type TutorialEvent =
   /**
    * One newly appended runtime log entry. Fired exactly once per new entry,
    * in append order, for `log`-kind outputs only: error output is not part
-   * of the judging channel. The Tutorial module adapts the Runtime's
+   * of this channel. The Tutorial module adapts the Runtime's
    * `didChangeOutput` notification and cumulative `outputs` array into these
-   * per-entry events.
+   * per-entry events. The adaptation diffs by the per-entry monotonic `id` —
+   * `outputs` is a bounded ring buffer whose array indices shift once it is
+   * full — and a single `didChangeOutput` notification may carry several
+   * appended entries, which are fanned out in order with the `log`-kind
+   * filter applied per entry.
    */
   | { name: "editor.runtime.log"; payload: { log: string } }
   /** A Copilot conversation round finished. */
@@ -89,7 +93,10 @@ export interface TutorialFrameworkHost {
    * and repeated completion calls are idempotent (the first one wins).
    */
   course_complete(): Promise<void>;
-  /** Completes the Course and displays feedback. Same semantics as `course_complete`. */
+  /**
+   * Same completion/idempotency semantics as `course_complete`, but displays
+   * the given feedback.
+   */
   course_completeWith(message: string): Promise<void>;
   /** Limits APIs offered by Code Editor assistance. */
   editor_codeEditor_filterAPIs(apis: string[]): void;
@@ -105,7 +112,9 @@ export interface TutorialFrameworkHost {
    * Returns the current content of the given code file in the session project
    * model, regardless of what the Code Editor UI shows. `file` is a path
    * relative to the project root (e.g. `"Lita.spx"`); addressing a file that
-   * does not exist fails the capability call.
+   * does not exist fails the capability call. Resolution is confined to the
+   * files `editor_project_listCodeFiles` enumerates: path traversal (`../`)
+   * and absolute paths are rejected.
    */
   editor_project_getCode(file: string): string;
   /**

--- a/docs/develop/tutorial-v2/module_TutorialFramework.ts
+++ b/docs/develop/tutorial-v2/module_TutorialFramework.ts
@@ -105,17 +105,11 @@ export interface TutorialFrameworkHost {
    * Returns the current content of the given code file, including the
    * learner's unsaved edits. `file` is a path relative to the project root
    * (e.g. `"Lita.spx"`); addressing a file the project does not contain fails
-   * the capability call.
+   * the capability call. Reading whichever file the learner happens to be
+   * editing is deliberately not offered yet: it depends on how the Code
+   * Editor exposes its attached UIs and their active documents.
    */
-  editor_codeEditor_getCode(file: string): string;
-  /**
-   * Returns the paths of the code files the learner currently has open, for
-   * composing with `editor_codeEditor_getCode`. One Code Editor may have
-   * several UIs attached, each with at most one active document, so this is a
-   * list; an empty list means nothing is open, which keeps that state
-   * distinct from an open file that happens to be empty.
-   */
-  editor_codeEditor_getActiveDocuments(): string[];
+  editor_project_getCode(file: string): string;
   /**
    * Lists the code files of the session project, e.g. `"main.spx"` and the
    * sprite code files; assets are not included. A Course whose goal is for

--- a/docs/develop/tutorial-v2/module_TutorialFramework.ts
+++ b/docs/develop/tutorial-v2/module_TutorialFramework.ts
@@ -25,6 +25,32 @@ export type TutorialProjectIndex = {
  */
 export type TutorialProjectFiles = FileCollection;
 
+/**
+ * Events dispatched into the running Tutorial program through
+ * `XGoExecutor.dispatchEvent`. The Tutorial module is the dispatcher. The
+ * framework registers a handler for every event name below, whether or not
+ * the Course code subscribed to it. Event names mirror the author-facing API
+ * tree.
+ */
+export type TutorialEvent =
+  /** The learner's project runtime started. */
+  | { name: "editor.runtime.start"; payload: null }
+  /** The learner's project runtime exited with the given code. */
+  | { name: "editor.runtime.exit"; payload: { code: number } }
+  /**
+   * One newly appended runtime log entry. Fired exactly once per new entry,
+   * in append order, for `log`-kind outputs only: error output is not part
+   * of the judging channel. The Tutorial module adapts the Runtime's
+   * `didChangeOutput` notification and cumulative `outputs` array into these
+   * per-entry events.
+   */
+  | { name: "editor.runtime.log"; payload: { log: string } }
+  /** A Copilot conversation round finished. */
+  | {
+      name: "copilot.roundFinish";
+      payload: { userMessage: string; resultMessages: string[] };
+    };
+
 /** Controls how the spotlight presents a UI target. */
 export type SpotlightOptions = {
   /**
@@ -56,16 +82,37 @@ export interface TutorialFrameworkHost {
    * watching or closes it; presentation never advances automatically.
    */
   course_showVideo(videoName: string): Promise<void>;
-  /** Completes the Course without feedback. */
+  /**
+   * Completes the Course without feedback. Resolves as soon as the completion
+   * is accepted; it does not wait for the completion dialog. After a
+   * completion the host treats further presentation capabilities as no-ops,
+   * and repeated completion calls are idempotent (the first one wins).
+   */
   course_complete(): Promise<void>;
-  /** Completes the Course and displays feedback. */
+  /** Completes the Course and displays feedback. Same semantics as `course_complete`. */
   course_completeWith(message: string): Promise<void>;
   /** Limits APIs offered by Code Editor assistance. */
   editor_codeEditor_filterAPIs(apis: string[]): void;
-  /** Formats the current code workspace. */
+  /** Formats the current code workspace. Resolves after formatting completes. */
   editor_codeEditor_formatWorkspace(): Promise<void>;
-  /** Returns the learner's current code. */
+  /**
+   * Returns the code text of the currently attached Code Editor UI, or an
+   * empty string when none is attached. For reading a specific file of the
+   * session project regardless of the UI state, use `editor_project_getCode`.
+   */
   editor_codeEditor_getCode(): string;
+  /**
+   * Returns the current content of the given code file in the session project
+   * model, regardless of what the Code Editor UI shows. `file` is a path
+   * relative to the project root (e.g. `"Lita.spx"`); addressing a file that
+   * does not exist fails the capability call.
+   */
+  editor_project_getCode(file: string): string;
+  /**
+   * Lists the code files of the session project model, e.g. `"main.spx"` and
+   * the sprite code files. Assets are not included.
+   */
+  editor_project_listCodeFiles(): string[];
   /** Displays the Ruler overlay. */
   editor_ruler_show(): void;
   /** Hides the Ruler overlay. */
@@ -76,9 +123,12 @@ export interface TutorialFrameworkHost {
   copilot_generateJSON(message: string, schema: JSONSchema): Promise<unknown>;
   /**
    * Focuses the existing Spotlight on a UI target and shows a short tip
-   * beside it. Spotlight presentation never blocks the Course flow.
+   * beside it. Resolves once the spotlight is shown; it does not wait for the
+   * spotlight to be dismissed, so it never blocks the Course flow.
    * `target` is a stable UI-target ID owned and published by the SPX Project
-   * Editor; session-local Radar node IDs are not valid targets.
+   * Editor (append-only; initially `runButton`, `stopButton`, `rerunButton`,
+   * `formatButton`, `codeEditor`, `stage`, `apiReference` and `copilotEntry`);
+   * session-local Radar node IDs are not valid targets.
    * `options` is always fully specified here: the author-facing `reveal`
    * defaults are materialized by `createTutorialFramework` before this host
    * method is invoked.

--- a/docs/develop/tutorial-v2/module_TutorialFramework.ts
+++ b/docs/develop/tutorial-v2/module_TutorialFramework.ts
@@ -109,12 +109,13 @@ export interface TutorialFrameworkHost {
    */
   editor_codeEditor_getCode(file: string): string;
   /**
-   * Returns the path of the code file the learner is currently editing, for
-   * composing with `editor_codeEditor_getCode`. Fails the capability call
-   * when no Code Editor UI is attached, so "nothing is open" is never
-   * confused with "the open file is empty".
+   * Returns the paths of the code files the learner currently has open, for
+   * composing with `editor_codeEditor_getCode`. One Code Editor may have
+   * several UIs attached, each with at most one active document, so this is a
+   * list; an empty list means nothing is open, which keeps that state
+   * distinct from an open file that happens to be empty.
    */
-  editor_codeEditor_getCurrentActiveDocument(): string;
+  editor_codeEditor_getActiveDocuments(): string[];
   /**
    * Lists the code files of the session project, e.g. `"main.spx"` and the
    * sprite code files; assets are not included. A Course whose goal is for

--- a/docs/develop/tutorial-v2/module_TutorialFramework.ts
+++ b/docs/develop/tutorial-v2/module_TutorialFramework.ts
@@ -98,7 +98,13 @@ export interface TutorialFrameworkHost {
    * the given feedback.
    */
   course_completeWith(message: string): Promise<void>;
-  /** Limits APIs offered by Code Editor assistance. */
+  /**
+   * Limits APIs offered by Code Editor assistance. Each entry is an API
+   * identifier: the author shorthand `name` / `name#overloadId` resolved in
+   * the Course project's API context, or a full definition-identifier string
+   * (`xgo:<package>?<name>#<overloadId>`). An identifier without
+   * `#overloadId` addresses all overloads of the name.
+   */
   editor_codeEditor_filterAPIs(apis: string[]): void;
   /** Formats the current code workspace. Resolves after formatting completes. */
   editor_codeEditor_formatWorkspace(): Promise<void>;
@@ -135,9 +141,22 @@ export interface TutorialFrameworkHost {
    * beside it. Resolves once the spotlight is shown; it does not wait for the
    * spotlight to be dismissed, so it never blocks the Course flow.
    * `target` is a stable UI-target ID owned and published by the SPX Project
-   * Editor (append-only; initially `runButton`, `stopButton`, `rerunButton`,
-   * `formatButton`, `codeEditor`, `stage`, `apiReference` and `copilotEntry`);
-   * session-local Radar node IDs are not valid targets.
+   * Editor (append-only); session-local Radar node IDs are not valid targets.
+   * IDs are either static (initially `runButton`, `stopButton`, `rerunButton`,
+   * `formatButton`, `codeEditor`, `stage`, `apiReference` and `copilotEntry`)
+   * or parameterized: `apiReference.<apiId>` addresses entries of the API
+   * Reference panel, where `<apiId>` uses the same API identifiers as
+   * `editor_codeEditor_filterAPIs`. An `<apiId>` without `#<overloadId>`
+   * addresses all overloads of the name, highlighted together as one group.
+   *
+   * An unknown ID — neither a published static ID nor a well-formed
+   * parameterized ID (a name outside the API vocabulary, or an overload that
+   * does not exist) — fails the capability call, surfacing the authoring
+   * mistake during Preview. A known ID whose elements cannot currently be
+   * resolved (the API is filtered out, or the element is not mounted yet) is
+   * not an error: the host retries briefly, then resolves without showing
+   * anything and logs a warning.
+   *
    * `options` is always fully specified here: the author-facing `reveal`
    * defaults are materialized by `createTutorialFramework` before this host
    * method is invoked.

--- a/docs/develop/tutorial-v2/module_TutorialFramework.ts
+++ b/docs/develop/tutorial-v2/module_TutorialFramework.ts
@@ -102,21 +102,20 @@ export interface TutorialFrameworkHost {
   /** Formats the current code workspace. Resolves after formatting completes. */
   editor_codeEditor_formatWorkspace(): Promise<void>;
   /**
-   * Returns the current content of the given code file, including the
-   * learner's unsaved edits. `file` is a path relative to the project root
-   * (e.g. `"Lita.spx"`); addressing a file the project does not contain fails
-   * the capability call. Reading whichever file the learner happens to be
-   * editing is deliberately not offered yet: it depends on how the Code
-   * Editor exposes its attached UIs and their active documents.
+   * Returns the given sprite's current code, including the learner's unsaved
+   * edits. `sprite` is a sprite name (e.g. `"Lita"`), matching how the
+   * project models its contents; addressing a sprite the project does not
+   * contain fails the capability call. Reading whichever code the learner
+   * happens to be editing is deliberately not offered yet: it depends on how
+   * the Code Editor exposes its attached UIs and their active documents.
    */
-  editor_project_getCode(file: string): string;
+  editor_project_getCode(sprite: string): string;
   /**
-   * Lists the code files of the session project, e.g. `"main.spx"` and the
-   * sprite code files; assets are not included. A Course whose goal is for
+   * Lists the session project's sprites by name. A Course whose goal is for
    * the learner to create a sprite cannot know the name they will choose, so
-   * it discovers the resulting file here.
+   * it discovers it here.
    */
-  editor_project_listCodeFiles(): string[];
+  editor_project_listSprites(): string[];
   /** Displays the Ruler overlay. */
   editor_ruler_show(): void;
   /** Hides the Ruler overlay. */

--- a/docs/develop/tutorial-v2/module_TutorialFramework.ts
+++ b/docs/develop/tutorial-v2/module_TutorialFramework.ts
@@ -40,13 +40,7 @@ export type TutorialEvent =
   /**
    * One newly appended runtime log entry. Fired exactly once per new entry,
    * in append order, for `log`-kind outputs only: error output is not part
-   * of this channel. The Tutorial module adapts the Runtime's
-   * `didChangeOutput` notification and cumulative `outputs` array into these
-   * per-entry events. The adaptation diffs by the per-entry monotonic `id` —
-   * `outputs` is a bounded ring buffer whose array indices shift once it is
-   * full — and a single `didChangeOutput` notification may carry several
-   * appended entries, which are fanned out in order with the `log`-kind
-   * filter applied per entry.
+   * of this channel.
    */
   | { name: "editor.runtime.log"; payload: { log: string } }
   /** A Copilot conversation round finished. */
@@ -99,33 +93,33 @@ export interface TutorialFrameworkHost {
    */
   course_completeWith(message: string): Promise<void>;
   /**
-   * Limits APIs offered by Code Editor assistance. Each entry is an API
-   * identifier: the author shorthand `name` / `name#overloadId` resolved in
-   * the Course project's API context, or a full definition-identifier string
-   * (`xgo:<package>?<name>#<overloadId>`). An identifier without
-   * `#overloadId` addresses all overloads of the name.
+   * Limits APIs offered by Code Editor assistance. Each entry is a definition
+   * identifier string (`xgo:<package>?<name>#<overloadId>`), the same
+   * identifiers the Code Editor uses elsewhere; omitting `#<overloadId>`
+   * addresses every overload of the name.
    */
   editor_codeEditor_filterAPIs(apis: string[]): void;
   /** Formats the current code workspace. Resolves after formatting completes. */
   editor_codeEditor_formatWorkspace(): Promise<void>;
   /**
-   * Returns the code text of the currently attached Code Editor UI, or an
-   * empty string when none is attached. For reading a specific file of the
-   * session project regardless of the UI state, use `editor_project_getCode`.
+   * Returns the current content of the given code file, including the
+   * learner's unsaved edits. `file` is a path relative to the project root
+   * (e.g. `"Lita.spx"`); addressing a file the project does not contain fails
+   * the capability call.
    */
-  editor_codeEditor_getCode(): string;
+  editor_codeEditor_getCode(file: string): string;
   /**
-   * Returns the current content of the given code file in the session project
-   * model, regardless of what the Code Editor UI shows. `file` is a path
-   * relative to the project root (e.g. `"Lita.spx"`); addressing a file that
-   * does not exist fails the capability call. Resolution is confined to the
-   * files `editor_project_listCodeFiles` enumerates: path traversal (`../`)
-   * and absolute paths are rejected.
+   * Returns the path of the code file the learner is currently editing, for
+   * composing with `editor_codeEditor_getCode`. Fails the capability call
+   * when no Code Editor UI is attached, so "nothing is open" is never
+   * confused with "the open file is empty".
    */
-  editor_project_getCode(file: string): string;
+  editor_codeEditor_getCurrentActiveDocument(): string;
   /**
-   * Lists the code files of the session project model, e.g. `"main.spx"` and
-   * the sprite code files. Assets are not included.
+   * Lists the code files of the session project, e.g. `"main.spx"` and the
+   * sprite code files; assets are not included. A Course whose goal is for
+   * the learner to create a sprite cannot know the name they will choose, so
+   * it discovers the resulting file here.
    */
   editor_project_listCodeFiles(): string[];
   /** Displays the Ruler overlay. */
@@ -140,22 +134,16 @@ export interface TutorialFrameworkHost {
    * Focuses the existing Spotlight on a UI target and shows a short tip
    * beside it. Resolves once the spotlight is shown; it does not wait for the
    * spotlight to be dismissed, so it never blocks the Course flow.
-   * `target` is a stable UI-target ID owned and published by the SPX Project
-   * Editor (append-only); session-local Radar node IDs are not valid targets.
-   * IDs are either static (initially `runButton`, `stopButton`, `rerunButton`,
-   * `formatButton`, `codeEditor`, `stage`, `apiReference` and `copilotEntry`)
-   * or parameterized: `apiReference.<apiId>` addresses entries of the API
-   * Reference panel, where `<apiId>` uses the same API identifiers as
-   * `editor_codeEditor_filterAPIs`. An `<apiId>` without `#<overloadId>`
-   * addresses all overloads of the name, highlighted together as one group.
+   * `target` is a Radar selector addressing the UI elements to reveal; see
+   * the Radar module design for its syntax. Session-local Radar node IDs are
+   * not valid targets. A selector matching several elements reveals them
+   * together as one group.
    *
-   * An unknown ID — neither a published static ID nor a well-formed
-   * parameterized ID (a name outside the API vocabulary, or an overload that
-   * does not exist) — fails the capability call, surfacing the authoring
-   * mistake during Preview. A known ID whose elements cannot currently be
-   * resolved (the API is filtered out, or the element is not mounted yet) is
-   * not an error: the host retries briefly, then resolves without showing
-   * anything and logs a warning.
+   * A malformed selector fails the capability call, surfacing the authoring
+   * mistake during Preview. A well-formed selector that currently matches
+   * nothing — the target is filtered out, or not mounted yet — is not an
+   * error: the host retries briefly, then resolves without showing anything
+   * and logs a warning.
    *
    * `options` is always fully specified here: the author-facing `reveal`
    * defaults are materialized by `createTutorialFramework` before this host

--- a/docs/develop/tutorial-v2/tutorial-class-framework.go
+++ b/docs/develop/tutorial-v2/tutorial-class-framework.go
@@ -41,12 +41,13 @@ type Editor struct {
 }
 
 type Project interface {
-	// getCode returns the given sprite's current code, including the learner's
-	// unsaved edits. sprite is a sprite name (e.g. "Lita"), matching how the
+	// getCode returns the given sprite's code as it currently stands in the
+	// session project. sprite is a sprite name (e.g. "Lita"), matching how the
 	// project models its contents; addressing a sprite the project does not
-	// contain fails the Course program. Reading whichever code the learner
-	// happens to be editing is deliberately not offered yet: it depends on how
-	// the Code Editor exposes its attached UIs and their active documents.
+	// contain fails the Course program. This reads the project rather than a
+	// Code Editor UI buffer, and reading whichever code the learner happens to
+	// be editing is deliberately not offered yet: it depends on how the Code
+	// Editor exposes its attached UIs and their active documents.
 	getCode(sprite string) string
 	// listSprites lists the session project's sprites by name. A Course whose
 	// goal is for the learner to create a sprite cannot know the name they

--- a/docs/develop/tutorial-v2/tutorial-class-framework.go
+++ b/docs/develop/tutorial-v2/tutorial-class-framework.go
@@ -41,18 +41,17 @@ type Editor struct {
 }
 
 type Project interface {
-	// getCode returns the current content of the given code file, including
-	// the learner's unsaved edits. file is a path relative to the project root
-	// (e.g. "Lita.spx"); addressing a file the project does not contain fails
-	// the Course program. Reading whichever file the learner happens to be
-	// editing is deliberately not offered yet: it depends on how the Code
-	// Editor exposes its attached UIs and their active documents.
-	getCode(file string) string
-	// listCodeFiles lists the code files of the session project, e.g.
-	// "main.spx" and the sprite code files; assets are not included. A Course
-	// whose goal is for the learner to create a sprite cannot know the name
-	// they will choose, so it discovers the resulting file here.
-	listCodeFiles() []string
+	// getCode returns the given sprite's current code, including the learner's
+	// unsaved edits. sprite is a sprite name (e.g. "Lita"), matching how the
+	// project models its contents; addressing a sprite the project does not
+	// contain fails the Course program. Reading whichever code the learner
+	// happens to be editing is deliberately not offered yet: it depends on how
+	// the Code Editor exposes its attached UIs and their active documents.
+	getCode(sprite string) string
+	// listSprites lists the session project's sprites by name. A Course whose
+	// goal is for the learner to create a sprite cannot know the name they
+	// will choose, so it discovers it here.
+	listSprites() []string
 }
 
 type Runtime interface {

--- a/docs/develop/tutorial-v2/tutorial-class-framework.go
+++ b/docs/develop/tutorial-v2/tutorial-class-framework.go
@@ -111,7 +111,9 @@ type Spotlight interface {
 	// reveal returns once the spotlight is shown; it does not wait for the
 	// spotlight to be dismissed, so it never blocks the Course flow.
 	// target is a stable UI-target ID owned and published by the SPX Project
-	// Editor; session-local Radar node IDs are not valid targets.
+	// Editor (append-only; initially runButton, stopButton, rerunButton,
+	// formatButton, codeEditor, stage, apiReference and copilotEntry);
+	// session-local Radar node IDs are not valid targets.
 	reveal(target, tip string)
 	// revealWith is reveal with explicit presentation options.
 	revealWith(target, tip string, options SpotlightOptions)

--- a/docs/develop/tutorial-v2/tutorial-class-framework.go
+++ b/docs/develop/tutorial-v2/tutorial-class-framework.go
@@ -41,6 +41,13 @@ type Editor struct {
 }
 
 type Project interface {
+	// getCode returns the current content of the given code file, including
+	// the learner's unsaved edits. file is a path relative to the project root
+	// (e.g. "Lita.spx"); addressing a file the project does not contain fails
+	// the Course program. Reading whichever file the learner happens to be
+	// editing is deliberately not offered yet: it depends on how the Code
+	// Editor exposes its attached UIs and their active documents.
+	getCode(file string) string
 	// listCodeFiles lists the code files of the session project, e.g.
 	// "main.spx" and the sprite code files; assets are not included. A Course
 	// whose goal is for the learner to create a sprite cannot know the name
@@ -66,17 +73,6 @@ type CodeEditor interface {
 	filterAPIs(apis []string)
 	// formatWorkspace formats the current code workspace.
 	formatWorkspace()
-	// getCode returns the current content of the given code file, including
-	// the learner's unsaved edits. file is a path relative to the project root
-	// (e.g. "Lita.spx"); addressing a file the project does not contain fails
-	// the Course program.
-	getCode(file string) string
-	// getActiveDocuments returns the paths of the code files the learner
-	// currently has open, for composing with getCode. One Code Editor may have
-	// several UIs attached, each with at most one active document, so this is
-	// a list; an empty list means nothing is open, which keeps that state
-	// distinct from an open file that happens to be empty.
-	getActiveDocuments() []string
 }
 
 type Ruler interface {

--- a/docs/develop/tutorial-v2/tutorial-class-framework.go
+++ b/docs/develop/tutorial-v2/tutorial-class-framework.go
@@ -62,7 +62,11 @@ type Runtime interface {
 }
 
 type CodeEditor interface {
-	// filterAPIs limits the APIs available in the Code Editor.
+	// filterAPIs limits the APIs available in the Code Editor. Each entry is
+	// an API identifier: the author shorthand "name" / "name#overloadId"
+	// resolved in the Course project's API context, or a full definition
+	// identifier ("xgo:<package>?<name>#<overloadId>"). An identifier without
+	// "#overloadId" addresses all overloads of the name.
 	filterAPIs(apis []string)
 	// formatWorkspace formats the current code workspace.
 	formatWorkspace()
@@ -111,9 +115,17 @@ type Spotlight interface {
 	// reveal returns once the spotlight is shown; it does not wait for the
 	// spotlight to be dismissed, so it never blocks the Course flow.
 	// target is a stable UI-target ID owned and published by the SPX Project
-	// Editor (append-only; initially runButton, stopButton, rerunButton,
-	// formatButton, codeEditor, stage, apiReference and copilotEntry);
-	// session-local Radar node IDs are not valid targets.
+	// Editor (append-only). IDs are either static (initially runButton,
+	// stopButton, rerunButton, formatButton, codeEditor, stage, apiReference
+	// and copilotEntry) or parameterized: "apiReference.<apiId>" addresses
+	// entries of the API Reference panel, where <apiId> uses the same API
+	// identifiers as editor.codeEditor.filterAPIs; an <apiId> without
+	// "#overloadId" highlights all overloads of the name together as one
+	// group. Session-local Radar node IDs are not valid targets.
+	// An unknown ID fails the Course program, so typos surface during
+	// Preview. A known ID whose elements cannot currently be resolved (for
+	// example an API filtered out by filterAPIs) is not an error: the host
+	// retries briefly, then skips the highlight and logs a warning.
 	reveal(target, tip string)
 	// revealWith is reveal with explicit presentation options.
 	revealWith(target, tip string, options SpotlightOptions)

--- a/docs/develop/tutorial-v2/tutorial-class-framework.go
+++ b/docs/develop/tutorial-v2/tutorial-class-framework.go
@@ -41,13 +41,10 @@ type Editor struct {
 }
 
 type Project interface {
-	// getCode returns the current content of the given code file in the session
-	// project model, regardless of what the Code Editor UI shows. file is a path
-	// relative to the project root (e.g. "Lita.spx"); addressing a file that
-	// does not exist fails the Course program.
-	getCode(file string) string
-	// listCodeFiles lists the code files of the session project model, e.g.
-	// "main.spx" and the sprite code files. Assets are not included.
+	// listCodeFiles lists the code files of the session project, e.g.
+	// "main.spx" and the sprite code files; assets are not included. A Course
+	// whose goal is for the learner to create a sprite cannot know the name
+	// they will choose, so it discovers the resulting file here.
 	listCodeFiles() []string
 }
 
@@ -62,18 +59,23 @@ type Runtime interface {
 }
 
 type CodeEditor interface {
-	// filterAPIs limits the APIs available in the Code Editor. Each entry is
-	// an API identifier: the author shorthand "name" / "name#overloadId"
-	// resolved in the Course project's API context, or a full definition
-	// identifier ("xgo:<package>?<name>#<overloadId>"). An identifier without
-	// "#overloadId" addresses all overloads of the name.
+	// filterAPIs limits the APIs available in the Code Editor. Each entry is a
+	// definition identifier ("xgo:<package>?<name>#<overloadId>"), the same
+	// identifiers the Code Editor uses elsewhere; omitting "#<overloadId>"
+	// addresses every overload of the name.
 	filterAPIs(apis []string)
 	// formatWorkspace formats the current code workspace.
 	formatWorkspace()
-	// getCode returns the code text of the currently attached Code Editor UI,
-	// or an empty string when none is attached. For reading a specific file of
-	// the session project regardless of the UI state, use editor.project.getCode.
-	getCode() string
+	// getCode returns the current content of the given code file, including
+	// the learner's unsaved edits. file is a path relative to the project root
+	// (e.g. "Lita.spx"); addressing a file the project does not contain fails
+	// the Course program.
+	getCode(file string) string
+	// getCurrentActiveDocument returns the path of the code file the learner
+	// is currently editing, for composing with getCode. It fails the Course
+	// program when no Code Editor UI is attached, so "nothing is open" is
+	// never confused with "the open file is empty".
+	getCurrentActiveDocument() string
 }
 
 type Ruler interface {
@@ -114,18 +116,13 @@ type Spotlight interface {
 	// auto-conceal (the spotlight stays until the learner clicks anywhere).
 	// reveal returns once the spotlight is shown; it does not wait for the
 	// spotlight to be dismissed, so it never blocks the Course flow.
-	// target is a stable UI-target ID owned and published by the SPX Project
-	// Editor (append-only). IDs are either static (initially runButton,
-	// stopButton, rerunButton, formatButton, codeEditor, stage, apiReference
-	// and copilotEntry) or parameterized: "apiReference.<apiId>" addresses
-	// entries of the API Reference panel, where <apiId> uses the same API
-	// identifiers as editor.codeEditor.filterAPIs; an <apiId> without
-	// "#overloadId" highlights all overloads of the name together as one
-	// group. Session-local Radar node IDs are not valid targets.
-	// An unknown ID fails the Course program, so typos surface during
-	// Preview. A known ID whose elements cannot currently be resolved (for
-	// example an API filtered out by filterAPIs) is not an error: the host
-	// retries briefly, then skips the highlight and logs a warning.
+	// target is a Radar selector addressing the UI elements to reveal; see the
+	// Radar module design for its syntax. A selector matching several elements
+	// reveals them together as one group.
+	// A malformed selector fails the Course program, so mistakes surface
+	// during Preview. A well-formed selector that currently matches nothing
+	// (for example an API filtered out by filterAPIs) is not an error: the
+	// host retries briefly, then skips the highlight and logs a warning.
 	reveal(target, tip string)
 	// revealWith is reveal with explicit presentation options.
 	revealWith(target, tip string, options SpotlightOptions)

--- a/docs/develop/tutorial-v2/tutorial-class-framework.go
+++ b/docs/develop/tutorial-v2/tutorial-class-framework.go
@@ -2,9 +2,9 @@ package tutorial
 
 type Course struct {
 	CourseAbilities
-	editor    Editor
-	copilot   Copilot
-	spotlight Spotlight
+	Editor    Editor
+	Copilot   Copilot
+	Spotlight Spotlight
 }
 
 type CourseAbilities interface {
@@ -34,10 +34,10 @@ type CourseAbilities interface {
 }
 
 type Editor struct {
-	project    Project
-	runtime    Runtime
-	codeEditor CodeEditor
-	ruler      Ruler
+	Project    Project
+	Runtime    Runtime
+	CodeEditor CodeEditor
+	Ruler      Ruler
 }
 
 type Project interface {
@@ -71,11 +71,12 @@ type CodeEditor interface {
 	// (e.g. "Lita.spx"); addressing a file the project does not contain fails
 	// the Course program.
 	getCode(file string) string
-	// getCurrentActiveDocument returns the path of the code file the learner
-	// is currently editing, for composing with getCode. It fails the Course
-	// program when no Code Editor UI is attached, so "nothing is open" is
-	// never confused with "the open file is empty".
-	getCurrentActiveDocument() string
+	// getActiveDocuments returns the paths of the code files the learner
+	// currently has open, for composing with getCode. One Code Editor may have
+	// several UIs attached, each with at most one active document, so this is
+	// a list; an empty list means nothing is open, which keeps that state
+	// distinct from an open file that happens to be empty.
+	getActiveDocuments() []string
 }
 
 type Ruler interface {

--- a/docs/develop/tutorial-v2/tutorial-class-framework.go
+++ b/docs/develop/tutorial-v2/tutorial-class-framework.go
@@ -23,9 +23,13 @@ type CourseAbilities interface {
 	// name and returns after the learner finishes watching or closes it.
 	// Presentation never advances automatically.
 	showVideo(videoName string)
-	// complete marks the course as completed.
+	// complete marks the course as completed and ends the Course program: after
+	// the current callback returns, no further events are processed and the
+	// program exits. Remaining statements in the same callback still run, but
+	// presentation calls after a completion are ignored by the host. Calling
+	// complete or completeWith again has no effect.
 	complete()
-	// completeWith marks the course as completed and displays the given feedback.
+	// completeWith is complete with the given feedback displayed to the learner.
 	completeWith(message string)
 }
 
@@ -36,14 +40,24 @@ type Editor struct {
 	ruler      Ruler
 }
 
-type Project struct{}
+type Project interface {
+	// getCode returns the current content of the given code file in the session
+	// project model, regardless of what the Code Editor UI shows. file is a path
+	// relative to the project root (e.g. "Lita.spx"); addressing a file that
+	// does not exist fails the Course program.
+	getCode(file string) string
+	// listCodeFiles lists the code files of the session project model, e.g.
+	// "main.spx" and the sprite code files. Assets are not included.
+	listCodeFiles() []string
+}
 
 type Runtime interface {
 	// onStart registers a callback that is called when the project runtime starts.
 	onStart(callback func())
 	// onExit registers a callback that is called when the project runtime exits.
 	onExit(callback func(code int))
-	// onLog registers a callback that is called when the project runtime emits a log.
+	// onLog registers a callback that is called once for every newly appended
+	// runtime log, in append order. Error output is not part of this channel.
 	onLog(callback func(log string))
 }
 
@@ -52,7 +66,9 @@ type CodeEditor interface {
 	filterAPIs(apis []string)
 	// formatWorkspace formats the current code workspace.
 	formatWorkspace()
-	// getCode returns the learner's current code.
+	// getCode returns the code text of the currently attached Code Editor UI,
+	// or an empty string when none is attached. For reading a specific file of
+	// the session project regardless of the UI state, use editor.project.getCode.
 	getCode() string
 }
 
@@ -92,7 +108,8 @@ type Spotlight interface {
 	// reveal focuses the spotlight on the given UI target and shows the given
 	// tip beside it, with Course-guidance defaults: mask enabled and no
 	// auto-conceal (the spotlight stays until the learner clicks anywhere).
-	// Spotlight presentation never blocks the Course flow.
+	// reveal returns once the spotlight is shown; it does not wait for the
+	// spotlight to be dismissed, so it never blocks the Course flow.
 	// target is a stable UI-target ID owned and published by the SPX Project
 	// Editor; session-local Radar node IDs are not valid targets.
 	reveal(target, tip string)


### PR DESCRIPTION
## Summary

- **Event contract** (`TutorialEvent` in `module_TutorialFramework.ts`): formalizes the JS→XGo events seeded by #3424's validation slice — `editor.runtime.start` (null), `editor.runtime.exit` (`{code}`), `editor.runtime.log` (`{log}`) and `copilot.roundFinish` (`{userMessage, resultMessages}`). Names mirror the author-facing API tree. `editor.runtime.log` fires exactly once per newly appended `log`-kind entry, in append order; error output is not part of the judging channel. Tutorial is the dispatcher and adapts the Runtime's `didChangeOutput` + cumulative `outputs` into these per-entry events; the framework registers a handler for every event name regardless of Course subscriptions.
- **Completion semantics**: `complete` / `completeWith` end the Course program from within — after the current callback returns, the framework leaves its event loop and the program exits with reason `completed`. Remaining statements in that callback still run; presentation calls after a completion are ignored by the host; repeated completions are idempotent. `index.md` documents the exit-reason mapping: `completed` with a prior completion capability call = normal completion, `completed` without one = the Course program fell through (a Course-program defect), `stopped` = ended from outside, `error` = Course-program failure.
- **`editor.project` activated**: the reserved slot now reads the session project model — `getCode(file)` returns a specific code file's current content regardless of the Code Editor UI state (a Course contains its project, so authors know its files; enables cross-file judging), and `listCodeFiles()` lists the code files (assets excluded). Mirrored as `editor_project_getCode` / `editor_project_listCodeFiles` host capabilities; addressing a nonexistent file fails the capability call so typos surface during Preview. `editor_codeEditor_getCode` is now documented with its attached-UI semantics (empty string when none is attached).
- **Resolve timing annotations** for Promise-returning host capabilities, following the capability semantics discussed in #3424 (synchronous return vs promise-resolve; no fire-and-forget): completion resolves on acceptance (not the dialog), `formatWorkspace` on completion, `spotlight_reveal` once shown (not dismissed).
- **Initial spotlight target IDs**: `runButton`, `stopButton`, `rerunButton`, `formatButton`, `codeEditor`, `stage`, `apiReference`, `copilotEntry` — owned and extended (append-only) by the SPX Project Editor; session-local Radar node IDs remain invalid targets.

## Notes

- Docs-only change; no runtime code is affected.
- Field casing and the `main_course.gox` naming in these files are deliberately untouched — both are already handled on the #3424 branch and will land with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)