### PR TITLE
feat: support IMA ADPCM WAV sounds

### DIFF
--- a/spx-gui/src/components/editor/stage/sound/SoundDetail.vue
+++ b/spx-gui/src/components/editor/stage/sound/SoundDetail.vue
@@ -35,22 +35,33 @@
       />
       <VolumeSlider class="mx-6 flex-[0_1_438px]" :value="gain" @update:value="handleGainUpdate" />
       <div class="flex-[1_1_0]" />
-      <div v-if="editing" class="flex-none flex items-center gap-2">
+      <div v-if="isDeveloperMode || editing" class="flex-none flex items-center gap-2">
         <UIButton
-          v-radar="{ name: 'Cancel button', desc: 'Click to cancel sound editing' }"
+          v-if="isDeveloperMode"
+          v-radar="{ name: 'Adapt audio button', desc: 'Click to adapt the current sound file' }"
           type="neutral"
-          @click="handleResetEdit"
+          :loading="handleAdaptAudio.isLoading.value"
+          @click="handleAdaptAudio.fn"
         >
-          {{ $t({ en: 'Cancel', zh: '取消' }) }}
+          {{ $t({ en: 'Adapt audio', zh: '适配音频' }) }}
         </UIButton>
-        <UIButton
-          v-radar="{ name: 'Save button', desc: 'Click to save sound edits' }"
-          type="green"
-          :loading="handleSave.isLoading.value"
-          @click="handleSave.fn"
-        >
-          {{ $t({ en: 'Save', zh: '保存' }) }}
-        </UIButton>
+        <template v-if="editing">
+          <UIButton
+            v-radar="{ name: 'Cancel button', desc: 'Click to cancel sound editing' }"
+            type="neutral"
+            @click="handleResetEdit"
+          >
+            {{ $t({ en: 'Cancel', zh: '取消' }) }}
+          </UIButton>
+          <UIButton
+            v-radar="{ name: 'Save button', desc: 'Click to save sound edits' }"
+            type="green"
+            :loading="handleSave.isLoading.value"
+            @click="handleSave.fn"
+          >
+            {{ $t({ en: 'Save', zh: '保存' }) }}
+          </UIButton>
+        </template>
       </div>
     </div>
   </div>
@@ -58,10 +69,12 @@
 
 <script setup lang="ts">
 import { ref, computed, watch } from 'vue'
+import { isDeveloperMode } from '@/utils/developer-mode'
 import { useFileUrl } from '@/utils/file'
 import { stripExt } from '@/utils/path'
 import { useMessageHandle } from '@/utils/exception'
 import { formatDuration, useAudioDuration } from '@/utils/audio'
+import { adaptAudio } from '@/utils/spx'
 import { fromBlob } from '@/models/common/file'
 import type { Sound } from '@/models/spx/sound'
 import { UIIcon, UIButton } from '@/components/ui'
@@ -134,6 +147,23 @@ const handleGainUpdate = (v: number) => {
   gain.value = v
   waveformPlayerRef.value?.play()
 }
+
+const handleAdaptAudio = useMessageHandle(
+  async () => {
+    const sound = props.sound
+    const sourceFile = sound.file
+    const newFile = await adaptAudio(sourceFile)
+    if (newFile === sourceFile) return
+
+    const sname = sound.name
+    const action = { name: { en: `Adapt sound ${sname}`, zh: `适配声音 ${sname}` } }
+    await editorCtx.state.history.doAction(action, () => sound.setFile(newFile))
+  },
+  {
+    en: 'Failed to adapt audio',
+    zh: '适配音频失败'
+  }
+)
 
 const handleSave = useMessageHandle(
   async () => {

--- a/spx-gui/src/utils/spx/index.test.ts
+++ b/spx-gui/src/utils/spx/index.test.ts
@@ -35,12 +35,12 @@ describe('getSpxProjectKnowledge', () => {
 
 describe('adaptAudio', () => {
   it('keeps MP3 files unchanged', async () => {
-    const file = new File('sound.mp3', async () => new ArrayBuffer(0), { type: '' })
+    const file = new File('sound.mp3', async () => new ArrayBuffer(0))
     await expect(adaptAudio(file)).resolves.toBe(file)
   })
 
   it('converts IMA ADPCM WAV files to PCM WAV files', async () => {
-    const file = new File('sound.wav', async () => makeImaAdpcmWav(), { type: 'audio/x-wav' })
+    const file = new File('sound.wav', async () => makeImaAdpcmWav())
     const adapted = await adaptAudio(file)
     const content = await adapted.arrayBuffer()
 

--- a/spx-gui/src/utils/spx/index.test.ts
+++ b/spx-gui/src/utils/spx/index.test.ts
@@ -1,6 +1,28 @@
 import { describe, expect, it } from 'vitest'
 
-import { getSpxProjectKnowledge } from './index'
+import { File } from '@/models/common/file'
+import { adaptAudio, getSpxProjectKnowledge } from './index'
+
+function makeImaAdpcmWav() {
+  const output = new ArrayBuffer(54)
+  const bytes = new Uint8Array(output)
+  const view = new DataView(output)
+  bytes.set(new TextEncoder().encode('RIFF'), 0)
+  view.setUint32(4, 46, true)
+  bytes.set(new TextEncoder().encode('WAVEfmt '), 8)
+  view.setUint32(16, 20, true)
+  view.setUint16(20, 0x11, true)
+  view.setUint16(22, 1, true)
+  view.setUint32(24, 22050, true)
+  view.setUint16(32, 5, true)
+  view.setUint16(34, 4, true)
+  view.setUint16(36, 2, true)
+  view.setUint16(38, 3, true)
+  bytes.set(new TextEncoder().encode('data'), 40)
+  view.setUint32(44, 5, true)
+  bytes.set([0, 0, 0, 0, 0x21], 48)
+  return output
+}
 
 describe('getSpxProjectKnowledge', () => {
   it('builds SPX project knowledge from fixed documents', () => {
@@ -8,5 +30,31 @@ describe('getSpxProjectKnowledge', () => {
 
     expect(knowledge).toContain('# About spx')
     expect(knowledge).toContain('# spx APIs')
+  })
+})
+
+describe('adaptAudio', () => {
+  it('keeps MP3 files unchanged', async () => {
+    const file = new File('sound.mp3', async () => new ArrayBuffer(0), { type: '' })
+    await expect(adaptAudio(file)).resolves.toBe(file)
+  })
+
+  it('converts IMA ADPCM WAV files to PCM WAV files', async () => {
+    const file = new File('sound.wav', async () => makeImaAdpcmWav(), { type: 'audio/x-wav' })
+    const adapted = await adaptAudio(file)
+    const content = await adapted.arrayBuffer()
+
+    expect(adapted).not.toBe(file)
+    expect(adapted.name).toBe('sound.wav')
+    expect(adapted.type).toBe('audio/wav')
+    expect(new DataView(content).getUint16(20, true)).toBe(1)
+  })
+
+  it('keeps PCM WAV files unchanged', async () => {
+    const content = makeImaAdpcmWav()
+    new DataView(content).setUint16(20, 1, true)
+    const file = new File('sound.wav', async () => content)
+
+    await expect(adaptAudio(file)).resolves.toBe(file)
   })
 })

--- a/spx-gui/src/utils/spx/index.ts
+++ b/spx-gui/src/utils/spx/index.ts
@@ -35,7 +35,7 @@ export const packageSpx = 'github.com/goplus/spx/v3'
  * Currently spx supports `mp3` and `wav` only, and it seems that wav-encoding is simpler than mp3-encoding.
  * So we convert unsupported audio files to wav before added to project.
  *
- * SPX supports PCM WAV only, so IMA ADPCM WAV files are converted to PCM.
+ * SPX does not support IMA ADPCM WAV, so those files are converted to PCM.
  */
 export async function adaptAudio(file: File): Promise<File> {
   if (file.type === getMimeFromExt('mp3')) return file

--- a/spx-gui/src/utils/spx/index.ts
+++ b/spx-gui/src/utils/spx/index.ts
@@ -12,7 +12,7 @@ import { stripExt } from '../path'
 import { toWav } from '../audio'
 import { toJpeg } from '../img'
 import type { LocaleMessage } from '../i18n'
-import { normalizeWav } from '../wav'
+import { convertImaAdpcmWavToPcm, isImaAdpcmWav } from '../wav'
 import {
   builderRGB2CSSColorString,
   builderRGBA2CSSColorString,
@@ -41,9 +41,9 @@ export async function adaptAudio(file: File): Promise<File> {
   if (file.type === getMimeFromExt('mp3')) return file
   if (file.type === getMimeFromExt('wav')) {
     const source = await file.arrayBuffer()
-    const normalized = normalizeWav(source)
-    if (normalized === source) return file
-    return new File(file.name, async () => normalized)
+    if (!isImaAdpcmWav(source)) return file
+    const pcm = convertImaAdpcmWavToPcm(source)
+    return new File(file.name, async () => pcm)
   }
   const wavAb = await toWav(await file.arrayBuffer())
   const wavFileName = stripExt(file.name) + '.wav'

--- a/spx-gui/src/utils/spx/index.ts
+++ b/spx-gui/src/utils/spx/index.ts
@@ -8,7 +8,7 @@ import { mapKeys } from 'lodash'
 import { File, fromBlob, toNativeFile } from '@/models/common/file'
 import { getMimeFromExt } from '../file'
 import { parseMarkdownWithFrontmatter } from '../frontmatter'
-import { extname, stripExt } from '../path'
+import { stripExt } from '../path'
 import { toWav } from '../audio'
 import { toJpeg } from '../img'
 import type { LocaleMessage } from '../i18n'
@@ -38,9 +38,8 @@ export const packageSpx = 'github.com/goplus/spx/v3'
  * SPX supports PCM WAV only, so IMA ADPCM WAV files are converted to PCM.
  */
 export async function adaptAudio(file: File): Promise<File> {
-  const extension = extname(file.name).toLowerCase()
-  if (file.type === getMimeFromExt('mp3') || extension === '.mp3') return file
-  if (file.type === getMimeFromExt('wav') || extension === '.wav') {
+  if (file.type === getMimeFromExt('mp3')) return file
+  if (file.type === getMimeFromExt('wav')) {
     const source = await file.arrayBuffer()
     const normalized = normalizeWav(source)
     if (normalized === source) return file

--- a/spx-gui/src/utils/spx/index.ts
+++ b/spx-gui/src/utils/spx/index.ts
@@ -8,10 +8,11 @@ import { mapKeys } from 'lodash'
 import { File, fromBlob, toNativeFile } from '@/models/common/file'
 import { getMimeFromExt } from '../file'
 import { parseMarkdownWithFrontmatter } from '../frontmatter'
-import { stripExt } from '../path'
+import { extname, stripExt } from '../path'
 import { toWav } from '../audio'
 import { toJpeg } from '../img'
 import type { LocaleMessage } from '../i18n'
+import { normalizeWav } from '../wav'
 import {
   builderRGB2CSSColorString,
   builderRGBA2CSSColorString,
@@ -29,24 +30,21 @@ import spxProjectSkillMainDoc from './skills/spx-project/SKILL.md?raw'
 export const packageSpx = 'github.com/goplus/spx/v3'
 
 /**
- * Audio file formats supported by spx.
- * See details in https://github.com/goplus/spx/blob/7f46dc7879e2320a9889f1396b9e592efb6d888d/audio.go
- */
-const supportedAudioExts = ['mp3', 'wav']
-
-/**
  * Adapt audio file to fit spx.
  *
  * Currently spx supports `mp3` and `wav` only, and it seems that wav-encoding is simpler than mp3-encoding.
  * So we convert unsupported audio files to wav before added to project.
  *
- * NOTE: wav with codec `adpcm` is supported by spx, while not natively supported by chrome (& maybe more other browsers).
- * So it is allowed to add a sound of wav file with codec `adpcm` to project, and it works in the game.
- * But it does not work as expected with audio element (`SoundPlayer`) & wavesurfer.
+ * SPX supports PCM WAV only, so IMA ADPCM WAV files are converted to PCM.
  */
 export async function adaptAudio(file: File): Promise<File> {
-  for (const ext of supportedAudioExts) {
-    if (file.type === getMimeFromExt(ext)) return file
+  const extension = extname(file.name).toLowerCase()
+  if (file.type === getMimeFromExt('mp3') || extension === '.mp3') return file
+  if (file.type === getMimeFromExt('wav') || extension === '.wav') {
+    const source = await file.arrayBuffer()
+    const normalized = normalizeWav(source)
+    if (normalized === source) return file
+    return new File(file.name, async () => normalized)
   }
   const wavAb = await toWav(await file.arrayBuffer())
   const wavFileName = stripExt(file.name) + '.wav'

--- a/spx-gui/src/utils/wav.test.ts
+++ b/spx-gui/src/utils/wav.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { normalizeWav } from './wav'
+import { convertImaAdpcmWavToPcm, isImaAdpcmWav } from './wav'
 
 function appendChunk(wav: number[], type: string, content: number[]) {
   const size = content.length
@@ -59,9 +59,17 @@ function makePcmWav() {
   return output
 }
 
-describe('normalizeWav', () => {
+describe('isImaAdpcmWav', () => {
+  it('identifies IMA ADPCM WAV files', () => {
+    expect(isImaAdpcmWav(makeImaAdpcmWav())).toBe(true)
+    expect(isImaAdpcmWav(makePcmWav())).toBe(false)
+    expect(isImaAdpcmWav(new ArrayBuffer(0))).toBe(false)
+  })
+})
+
+describe('convertImaAdpcmWavToPcm', () => {
   it('converts IMA ADPCM WAV to 16-bit PCM WAV', () => {
-    const normalized = normalizeWav(makeImaAdpcmWav())
+    const normalized = convertImaAdpcmWavToPcm(makeImaAdpcmWav())
     const view = new DataView(normalized)
 
     expect(view.getUint16(20, true)).toBe(1)
@@ -72,31 +80,28 @@ describe('normalizeWav', () => {
   })
 
   it('uses fact sample count to trim decoded samples', () => {
-    const normalized = normalizeWav(makeImaAdpcmWav({ factSampleCount: 1 }))
+    const normalized = convertImaAdpcmWavToPcm(makeImaAdpcmWav({ factSampleCount: 1 }))
     expect(normalized.byteLength).toBe(46)
   })
 
   it('derives a missing samples-per-block value', () => {
-    const normalized = normalizeWav(makeImaAdpcmWav({ samplesPerBlock: 0 }))
+    const normalized = convertImaAdpcmWavToPcm(makeImaAdpcmWav({ samplesPerBlock: 0 }))
     expect(new DataView(normalized).getUint32(40, true)).toBe(6)
   })
 
   it('decodes multichannel and partial blocks', () => {
     const data = [0, 0, 0, 0, 10, 0, 0, 0, 0x11, 0x11, 0x11, 0x11, 0x22]
-    const normalized = normalizeWav(makeImaAdpcmWav({ channels: 2, blockAlign: data.length, samplesPerBlock: 9, data }))
+    const normalized = convertImaAdpcmWavToPcm(
+      makeImaAdpcmWav({ channels: 2, blockAlign: data.length, samplesPerBlock: 9, data })
+    )
     const view = new DataView(normalized)
 
     expect(view.getUint16(22, true)).toBe(2)
     expect(view.getUint32(40, true)).toBe(12)
   })
 
-  it('returns PCM WAV unchanged', () => {
-    const pcm = makePcmWav()
-    expect(normalizeWav(pcm)).toBe(pcm)
-  })
-
   it('rejects invalid IMA ADPCM metadata', () => {
     const invalid = makeImaAdpcmWav({ data: [0, 0, 89, 0], blockAlign: 4, samplesPerBlock: 1 })
-    expect(() => normalizeWav(invalid)).toThrow('invalid IMA ADPCM step index 89')
+    expect(() => convertImaAdpcmWavToPcm(invalid)).toThrow('invalid IMA ADPCM step index 89')
   })
 })

--- a/spx-gui/src/utils/wav.test.ts
+++ b/spx-gui/src/utils/wav.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest'
+
+import { normalizeWav } from './wav'
+
+function appendChunk(wav: number[], type: string, content: number[]) {
+  const size = content.length
+  wav.push(...new TextEncoder().encode(type), size, 0, 0, 0, ...content)
+  if (size % 2 !== 0) wav.push(0)
+}
+
+function makeImaAdpcmWav({
+  channels = 1,
+  blockAlign = 5,
+  samplesPerBlock = 3,
+  data = [0, 0, 0, 0, 0x21],
+  factSampleCount = 0
+}: {
+  channels?: number
+  blockAlign?: number
+  samplesPerBlock?: number
+  data?: number[]
+  factSampleCount?: number
+} = {}) {
+  const wav = [...new TextEncoder().encode('RIFF'), 0, 0, 0, 0, ...new TextEncoder().encode('WAVE')]
+  const format = new ArrayBuffer(20)
+  const formatView = new DataView(format)
+  formatView.setUint16(0, 0x11, true)
+  formatView.setUint16(2, channels, true)
+  formatView.setUint32(4, 22050, true)
+  formatView.setUint16(12, blockAlign, true)
+  formatView.setUint16(14, 4, true)
+  formatView.setUint16(16, 2, true)
+  formatView.setUint16(18, samplesPerBlock, true)
+  appendChunk(wav, 'fmt ', Array.from(new Uint8Array(format)))
+  if (factSampleCount > 0) appendChunk(wav, 'fact', [factSampleCount, 0, 0, 0])
+  appendChunk(wav, 'data', data)
+  const output = Uint8Array.from(wav)
+  new DataView(output.buffer).setUint32(4, output.length - 8, true)
+  return output.buffer
+}
+
+function makePcmWav() {
+  const output = new ArrayBuffer(46)
+  const bytes = new Uint8Array(output)
+  const view = new DataView(output)
+  bytes.set(new TextEncoder().encode('RIFF'), 0)
+  view.setUint32(4, 38, true)
+  bytes.set(new TextEncoder().encode('WAVEfmt '), 8)
+  view.setUint32(16, 16, true)
+  view.setUint16(20, 1, true)
+  view.setUint16(22, 1, true)
+  view.setUint32(24, 22050, true)
+  view.setUint32(28, 44100, true)
+  view.setUint16(32, 2, true)
+  view.setUint16(34, 16, true)
+  bytes.set(new TextEncoder().encode('data'), 36)
+  view.setUint32(40, 2, true)
+  view.setInt16(44, 123, true)
+  return output
+}
+
+describe('normalizeWav', () => {
+  it('converts IMA ADPCM WAV to 16-bit PCM WAV', () => {
+    const normalized = normalizeWav(makeImaAdpcmWav())
+    const view = new DataView(normalized)
+
+    expect(view.getUint16(20, true)).toBe(1)
+    expect(view.getUint16(22, true)).toBe(1)
+    expect(view.getUint32(24, true)).toBe(22050)
+    expect(view.getUint16(34, true)).toBe(16)
+    expect([view.getInt16(44, true), view.getInt16(46, true), view.getInt16(48, true)]).toEqual([0, 1, 4])
+  })
+
+  it('uses fact sample count to trim decoded samples', () => {
+    const normalized = normalizeWav(makeImaAdpcmWav({ factSampleCount: 1 }))
+    expect(normalized.byteLength).toBe(46)
+  })
+
+  it('derives a missing samples-per-block value', () => {
+    const normalized = normalizeWav(makeImaAdpcmWav({ samplesPerBlock: 0 }))
+    expect(new DataView(normalized).getUint32(40, true)).toBe(6)
+  })
+
+  it('decodes multichannel and partial blocks', () => {
+    const data = [0, 0, 0, 0, 10, 0, 0, 0, 0x11, 0x11, 0x11, 0x11, 0x22]
+    const normalized = normalizeWav(makeImaAdpcmWav({ channels: 2, blockAlign: data.length, samplesPerBlock: 9, data }))
+    const view = new DataView(normalized)
+
+    expect(view.getUint16(22, true)).toBe(2)
+    expect(view.getUint32(40, true)).toBe(12)
+  })
+
+  it('returns PCM WAV unchanged', () => {
+    const pcm = makePcmWav()
+    expect(normalizeWav(pcm)).toBe(pcm)
+  })
+
+  it('rejects invalid IMA ADPCM metadata', () => {
+    const invalid = makeImaAdpcmWav({ data: [0, 0, 89, 0], blockAlign: 4, samplesPerBlock: 1 })
+    expect(() => normalizeWav(invalid)).toThrow('invalid IMA ADPCM step index 89')
+  })
+})

--- a/spx-gui/src/utils/wav.test.ts
+++ b/spx-gui/src/utils/wav.test.ts
@@ -104,4 +104,9 @@ describe('convertImaAdpcmWavToPcm', () => {
     const invalid = makeImaAdpcmWav({ data: [0, 0, 89, 0], blockAlign: 4, samplesPerBlock: 1 })
     expect(() => convertImaAdpcmWavToPcm(invalid)).toThrow('invalid IMA ADPCM step index 89')
   })
+
+  it('rejects IMA ADPCM with more than two channels', () => {
+    const invalid = makeImaAdpcmWav({ channels: 3, data: new Array(12).fill(0), blockAlign: 12, samplesPerBlock: 1 })
+    expect(() => convertImaAdpcmWavToPcm(invalid)).toThrow('invalid IMA ADPCM WAV metadata')
+  })
 })

--- a/spx-gui/src/utils/wav.ts
+++ b/spx-gui/src/utils/wav.ts
@@ -1,5 +1,6 @@
 const waveFormatPcm = 1
 const waveFormatImaAdpcm = 0x11
+const maxImaAdpcmChannels = 2
 
 type ImaAdpcmFormat = {
   channels: number
@@ -163,6 +164,7 @@ export function convertImaAdpcmWavToPcm(source: ArrayBuffer) {
   if (
     format == null ||
     format.channels === 0 ||
+    format.channels > maxImaAdpcmChannels ||
     format.blockAlign < format.channels * 4 ||
     format.sampleRate === 0 ||
     encodedData == null ||
@@ -170,11 +172,12 @@ export function convertImaAdpcmWavToPcm(source: ArrayBuffer) {
   ) {
     throw new Error('invalid IMA ADPCM WAV metadata')
   }
-  if (format.samplesPerBlock === 0) {
-    format.samplesPerBlock = 1 + Math.floor(((format.blockAlign - format.channels * 4) * 2) / format.channels)
-  }
+  const samplesPerBlock =
+    format.samplesPerBlock === 0
+      ? 1 + Math.floor(((format.blockAlign - format.channels * 4) * 2) / format.channels)
+      : format.samplesPerBlock
 
-  let samples = decodeImaAdpcm(encodedData, format)
+  let samples = decodeImaAdpcm(encodedData, { ...format, samplesPerBlock })
   const expectedSampleCount = factSampleCount * format.channels
   if (expectedSampleCount > 0 && samples.length > expectedSampleCount) {
     samples = samples.slice(0, expectedSampleCount)

--- a/spx-gui/src/utils/wav.ts
+++ b/spx-gui/src/utils/wav.ts
@@ -1,0 +1,164 @@
+const waveFormatPcm = 1
+const waveFormatImaAdpcm = 0x11
+
+type ImaAdpcmFormat = {
+  channels: number
+  sampleRate: number
+  blockAlign: number
+  samplesPerBlock: number
+}
+
+type ImaState = {
+  predictor: number
+  index: number
+}
+
+const imaIndexTable = [-1, -1, -1, -1, 2, 4, 6, 8, -1, -1, -1, -1, 2, 4, 6, 8]
+const imaStepTable = [
+  7, 8, 9, 10, 11, 12, 13, 14, 16, 17, 19, 21, 23, 25, 28, 31, 34, 37, 41, 45, 50, 55, 60, 66, 73, 80, 88, 97, 107, 118,
+  130, 143, 157, 173, 190, 209, 230, 253, 279, 307, 337, 371, 408, 449, 494, 544, 598, 658, 724, 796, 876, 963, 1060,
+  1166, 1282, 1411, 1552, 1707, 1878, 2066, 2272, 2499, 2749, 3024, 3327, 3660, 4026, 4428, 4871, 5358, 5894, 6484,
+  7132, 7845, 8630, 9493, 10442, 11487, 12635, 13899, 15289, 16818, 18500, 20350, 22385, 24623, 27086, 29794, 32767
+]
+
+function readString(data: Uint8Array, offset: number, length: number) {
+  return String.fromCharCode(...data.subarray(offset, offset + length))
+}
+
+function decodeImaNibbles(data: Uint8Array, state: ImaState, samples: number[]) {
+  for (const byte of data) {
+    for (const code of [byte & 0x0f, byte >> 4]) {
+      const step = imaStepTable[state.index]
+      let difference = step >> 3
+      if ((code & 1) !== 0) difference += step >> 2
+      if ((code & 2) !== 0) difference += step >> 1
+      if ((code & 4) !== 0) difference += step
+      state.predictor += (code & 8) !== 0 ? -difference : difference
+      state.predictor = Math.max(-32768, Math.min(32767, state.predictor))
+      state.index = Math.max(0, Math.min(88, state.index + imaIndexTable[code]))
+      samples.push(state.predictor)
+    }
+  }
+}
+
+function decodeImaAdpcm(data: Uint8Array, format: ImaAdpcmFormat) {
+  const output: number[] = []
+  for (let offset = 0; offset < data.length; offset += format.blockAlign) {
+    const block = data.subarray(offset, Math.min(offset + format.blockAlign, data.length))
+    if (block.length < format.channels * 4) throw new Error('truncated IMA ADPCM block')
+
+    const view = new DataView(block.buffer, block.byteOffset, block.byteLength)
+    const states: ImaState[] = []
+    const channelSamples: number[][] = []
+    for (let channel = 0; channel < format.channels; channel++) {
+      const position = channel * 4
+      const index = view.getUint8(position + 2)
+      if (index > 88) throw new Error(`invalid IMA ADPCM step index ${index}`)
+      const state = { predictor: view.getInt16(position, true), index }
+      states.push(state)
+      channelSamples.push([state.predictor])
+    }
+
+    let payload = block.subarray(format.channels * 4)
+    if (format.channels === 1) {
+      decodeImaNibbles(payload, states[0], channelSamples[0])
+    } else {
+      while (payload.length > 0) {
+        for (let channel = 0; channel < format.channels && payload.length > 0; channel++) {
+          const size = Math.min(4, payload.length)
+          decodeImaNibbles(payload.subarray(0, size), states[channel], channelSamples[channel])
+          payload = payload.subarray(size)
+        }
+      }
+    }
+
+    const sampleCount = Math.min(format.samplesPerBlock, ...channelSamples.map((samples) => samples.length))
+    for (let index = 0; index < sampleCount; index++) {
+      for (let channel = 0; channel < format.channels; channel++) {
+        output.push(channelSamples[channel][index])
+      }
+    }
+  }
+  return output
+}
+
+function makePcmWav(samples: number[], channels: number, sampleRate: number) {
+  const dataSize = samples.length * 2
+  const output = new ArrayBuffer(44 + dataSize)
+  const bytes = new Uint8Array(output)
+  const view = new DataView(output)
+  bytes.set(new TextEncoder().encode('RIFF'), 0)
+  view.setUint32(4, 36 + dataSize, true)
+  bytes.set(new TextEncoder().encode('WAVEfmt '), 8)
+  view.setUint32(16, 16, true)
+  view.setUint16(20, waveFormatPcm, true)
+  view.setUint16(22, channels, true)
+  view.setUint32(24, sampleRate, true)
+  view.setUint32(28, sampleRate * channels * 2, true)
+  view.setUint16(32, channels * 2, true)
+  view.setUint16(34, 16, true)
+  bytes.set(new TextEncoder().encode('data'), 36)
+  view.setUint32(40, dataSize, true)
+  for (let index = 0; index < samples.length; index++) {
+    view.setInt16(44 + index * 2, samples[index], true)
+  }
+  return output
+}
+
+/** Convert an IMA ADPCM WAV to a 16-bit PCM WAV. Other WAV encodings are returned unchanged. */
+export function normalizeWav(source: ArrayBuffer) {
+  const data = new Uint8Array(source)
+  if (data.length < 12 || readString(data, 0, 4) !== 'RIFF' || readString(data, 8, 4) !== 'WAVE') {
+    return source
+  }
+
+  const view = new DataView(source)
+  let format: ImaAdpcmFormat | null = null
+  let encoding = 0
+  let encodedData: Uint8Array | null = null
+  let factSampleCount = 0
+  for (let offset = 12; offset + 8 <= data.length; ) {
+    const chunkSize = view.getUint32(offset + 4, true)
+    const start = offset + 8
+    const end = start + chunkSize
+    if (end < start || end > data.length) throw new Error(`invalid WAV chunk at offset ${offset}`)
+
+    const chunkType = readString(data, offset, 4)
+    if (chunkType === 'fmt ') {
+      if (chunkSize < 16) throw new Error('invalid WAV fmt chunk')
+      encoding = view.getUint16(start, true)
+      const channels = view.getUint16(start + 2, true)
+      const sampleRate = view.getUint32(start + 4, true)
+      const blockAlign = view.getUint16(start + 12, true)
+      const samplesPerBlock = chunkSize >= 20 ? view.getUint16(start + 18, true) : 0
+      format = { channels, sampleRate, blockAlign, samplesPerBlock }
+    } else if (chunkType === 'fact' && chunkSize >= 4) {
+      factSampleCount = view.getUint32(start, true)
+    } else if (chunkType === 'data') {
+      encodedData = data.subarray(start, end)
+    }
+    offset = end + (chunkSize % 2)
+  }
+
+  if (encoding !== waveFormatImaAdpcm) return source
+  if (
+    format == null ||
+    format.channels === 0 ||
+    format.blockAlign < format.channels * 4 ||
+    format.sampleRate === 0 ||
+    encodedData == null ||
+    encodedData.length === 0
+  ) {
+    throw new Error('invalid IMA ADPCM WAV metadata')
+  }
+  if (format.samplesPerBlock === 0) {
+    format.samplesPerBlock = 1 + Math.floor(((format.blockAlign - format.channels * 4) * 2) / format.channels)
+  }
+
+  let samples = decodeImaAdpcm(encodedData, format)
+  const expectedSampleCount = factSampleCount * format.channels
+  if (expectedSampleCount > 0 && samples.length > expectedSampleCount) {
+    samples = samples.slice(0, expectedSampleCount)
+  }
+  return makePcmWav(samples, format.channels, format.sampleRate)
+}

--- a/spx-gui/src/utils/wav.ts
+++ b/spx-gui/src/utils/wav.ts
@@ -13,6 +13,13 @@ type ImaState = {
   index: number
 }
 
+type ParsedWav = {
+  encoding: number
+  format: ImaAdpcmFormat | null
+  encodedData: Uint8Array | null
+  factSampleCount: number
+}
+
 const imaIndexTable = [-1, -1, -1, -1, 2, 4, 6, 8, -1, -1, -1, -1, 2, 4, 6, 8]
 const imaStepTable = [
   7, 8, 9, 10, 11, 12, 13, 14, 16, 17, 19, 21, 23, 25, 28, 31, 34, 37, 41, 45, 50, 55, 60, 66, 73, 80, 88, 97, 107, 118,
@@ -107,11 +114,10 @@ function makePcmWav(samples: Int16Array, channels: number, sampleRate: number) {
   return output
 }
 
-/** Convert an IMA ADPCM WAV to a 16-bit PCM WAV. Other WAV encodings are returned unchanged. */
-export function normalizeWav(source: ArrayBuffer) {
+function parseWav(source: ArrayBuffer): ParsedWav | null {
   const data = new Uint8Array(source)
   if (data.length < 12 || readString(data, 0, 4) !== 'RIFF' || readString(data, 8, 4) !== 'WAVE') {
-    return source
+    return null
   }
 
   const view = new DataView(source)
@@ -142,7 +148,18 @@ export function normalizeWav(source: ArrayBuffer) {
     offset = end + (chunkSize % 2)
   }
 
-  if (encoding !== waveFormatImaAdpcm) return source
+  return { encoding, format, encodedData, factSampleCount }
+}
+
+export function isImaAdpcmWav(source: ArrayBuffer) {
+  return parseWav(source)?.encoding === waveFormatImaAdpcm
+}
+
+/** Convert an IMA ADPCM WAV to a 16-bit PCM WAV. */
+export function convertImaAdpcmWavToPcm(source: ArrayBuffer) {
+  const wav = parseWav(source)
+  if (wav == null || wav.encoding !== waveFormatImaAdpcm) throw new Error('IMA ADPCM WAV expected')
+  const { format, encodedData, factSampleCount } = wav
   if (
     format == null ||
     format.channels === 0 ||

--- a/spx-gui/src/utils/wav.ts
+++ b/spx-gui/src/utils/wav.ts
@@ -42,7 +42,9 @@ function decodeImaNibbles(data: Uint8Array, state: ImaState, samples: number[]) 
 }
 
 function decodeImaAdpcm(data: Uint8Array, format: ImaAdpcmFormat) {
-  const output: number[] = []
+  const blockCount = Math.ceil(data.length / format.blockAlign)
+  const output = new Int16Array(data.length * 2 + blockCount * format.channels)
+  let outputLength = 0
   for (let offset = 0; offset < data.length; offset += format.blockAlign) {
     const block = data.subarray(offset, Math.min(offset + format.blockAlign, data.length))
     if (block.length < format.channels * 4) throw new Error('truncated IMA ADPCM block')
@@ -75,14 +77,14 @@ function decodeImaAdpcm(data: Uint8Array, format: ImaAdpcmFormat) {
     const sampleCount = Math.min(format.samplesPerBlock, ...channelSamples.map((samples) => samples.length))
     for (let index = 0; index < sampleCount; index++) {
       for (let channel = 0; channel < format.channels; channel++) {
-        output.push(channelSamples[channel][index])
+        output[outputLength++] = channelSamples[channel][index]
       }
     }
   }
-  return output
+  return output.subarray(0, outputLength)
 }
 
-function makePcmWav(samples: number[], channels: number, sampleRate: number) {
+function makePcmWav(samples: Int16Array, channels: number, sampleRate: number) {
   const dataSize = samples.length * 2
   const output = new ArrayBuffer(44 + dataSize)
   const bytes = new Uint8Array(output)


### PR DESCRIPTION
## Summary

- Convert IMA ADPCM WAV files to 16-bit PCM WAV when client-side audio is added to a project, so both SPX and Editor waveform/playback can consume the sound.
- Add a Developer Mode **Adapt audio** action on Sound Detail to convert an existing sound and save it through editor history.

Closes #3443

## Testing

- `pnpm exec vitest --run src/utils/wav.test.ts src/utils/spx/index.test.ts`
- `pnpm type-check`
- `pnpm exec eslint src/utils/wav.ts src/utils/wav.test.ts src/utils/spx/index.ts src/components/editor/stage/sound/SoundDetail.vue`
- `pnpm exec prettier --check src/utils/wav.ts src/utils/wav.test.ts src/utils/spx/index.ts src/components/editor/stage/sound/SoundDetail.vue`
- Browser verification with an FFmpeg-generated IMA ADPCM WAV: PCM conversion, waveform rendering, and playback.
