### PR TITLE
fix(spx-gui): use 100ms animation frame interval

### DIFF
--- a/spx-gui/src/components/asset/gen/animation/AnimationVideoPreview.vue
+++ b/spx-gui/src/components/asset/gen/animation/AnimationVideoPreview.vue
@@ -160,7 +160,7 @@ const cutStartRef = ref(0)
 const cutEndRef = ref(0)
 
 /** Interval in ms between extracted animation frames */
-const frameInterval = 200
+const frameInterval = 100
 
 function notifyFramesConfigChanged() {
   emit('update:framesConfig', {


### PR DESCRIPTION
## Problem

Animation video frames are currently extracted every 200 ms, producing a 5 FPS animation. The desired output cadence is 10 FPS so generated animations retain more temporal detail and align with Builder's standard animation frame rate.

## Root cause

`AnimationVideoPreview` uses a single `frameInterval` value for frame extraction, crop snapping, and the minimum selectable segment duration. That value was set to 200 ms.

## Fix

Change the shared frame interval from 200 ms to 100 ms. This keeps crop boundaries and extraction timing aligned while producing 10 FPS animations. The backend already accepts 100 ms intervals and uses 100 ms as both its precision and default interval, so no backend change is required.

This intentionally doubles the number of extracted frames compared with the 200 ms setting, with proportional client processing, server processing, storage, and screenshot billing costs.

## Validation

- `pnpm test --run` (81 files, 751 tests)
- `pnpm lint`
- `pnpm type-check`
- `git diff --check`

Follow-up to #3430.
