### PR TITLE
fix(auth): preserve state on transient refresh failures

### DIFF
--- a/spx-gui/src/stores/user/signed-in.test.ts
+++ b/spx-gui/src/stores/user/signed-in.test.ts
@@ -1,21 +1,21 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { OAuthException } from '@/apis/common/exception'
+import { accountOAuthApisForXBuilder } from '@/apis/account/oauth'
+import { OAuthErrorCode } from '@/utils/oauth'
+import { ensureAccessToken, initUserState } from './signed-in'
 
 const userStateStorageKey = 'builder-user'
+const originalNavigatorLocks = Object.getOwnPropertyDescriptor(navigator, 'locks')
 
 describe('ensureAccessToken', () => {
-  let ensureAccessToken: typeof import('./signed-in').ensureAccessToken
-  let initUserState: typeof import('./signed-in').initUserState
-  let accountOAuthApisForXBuilder: typeof import('@/apis/account/oauth').accountOAuthApisForXBuilder
-
-  beforeEach(async () => {
-    vi.resetModules()
+  beforeEach(() => {
     localStorage.clear()
-    ;({ ensureAccessToken, initUserState } = await import('./signed-in'))
-    ;({ accountOAuthApisForXBuilder } = await import('@/apis/account/oauth'))
   })
 
   afterEach(() => {
     vi.restoreAllMocks()
+    if (originalNavigatorLocks != null) Object.defineProperty(navigator, 'locks', originalNavigatorLocks)
+    else Reflect.deleteProperty(navigator, 'locks')
   })
 
   it('uses credentials refreshed by another page while waiting for the refresh lock', async () => {
@@ -77,6 +77,107 @@ describe('ensureAccessToken', () => {
 
     await expect(ensureAccessToken()).resolves.toBe('access-token')
     expect(request).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    ['a network error', () => new TypeError('Failed to fetch')],
+    ['a timeout', () => new DOMException('The operation timed out', 'TimeoutError')],
+    [
+      'a server error',
+      () =>
+        new OAuthException('server_error', 'server error', null, {
+          req: new Request('https://example.com/account/oauth/token')
+        })
+    ],
+    [
+      'an invalid client error',
+      () =>
+        new OAuthException(OAuthErrorCode.InvalidClient, 'invalid client authentication', null, {
+          req: new Request('https://example.com/account/oauth/token')
+        })
+    ],
+    [
+      'an invalid request error',
+      () =>
+        new OAuthException(OAuthErrorCode.InvalidRequest, 'invalid request', null, {
+          req: new Request('https://example.com/account/oauth/token')
+        })
+    ],
+    [
+      'an invalid scope error',
+      () =>
+        new OAuthException(OAuthErrorCode.InvalidScope, 'invalid scope', null, {
+          req: new Request('https://example.com/account/oauth/token')
+        })
+    ],
+    [
+      'an unsupported grant type error',
+      () =>
+        new OAuthException(OAuthErrorCode.UnsupportedGrantType, 'unsupported grant_type', null, {
+          req: new Request('https://example.com/account/oauth/token')
+        })
+    ],
+    [
+      'an unauthorized client error',
+      () =>
+        new OAuthException(OAuthErrorCode.UnauthorizedClient, 'unauthorized client', null, {
+          req: new Request('https://example.com/account/oauth/token')
+        })
+    ]
+  ])('keeps cached state and propagates %s during refresh', async (_name, createError) => {
+    const error = createError()
+    const storedState = {
+      accessToken: 'expired-access-token',
+      accessTokenExpiresAt: Date.now(),
+      refreshToken: 'refresh-token',
+      username: 'alice'
+    }
+    localStorage.setItem(userStateStorageKey, JSON.stringify(storedState))
+    Object.defineProperty(navigator, 'locks', {
+      configurable: true,
+      value: {
+        request: vi.fn(async (_name: string, callback: () => Promise<void>) => callback())
+      }
+    })
+    vi.spyOn(accountOAuthApisForXBuilder, 'refreshToken').mockRejectedValue(error)
+
+    initUserState('client-id')
+
+    await expect(ensureAccessToken()).rejects.toBe(error)
+    expect(JSON.parse(localStorage.getItem(userStateStorageKey)!)).toEqual(storedState)
+  })
+
+  it('clears cached state when refresh token is invalid', async () => {
+    localStorage.setItem(
+      userStateStorageKey,
+      JSON.stringify({
+        accessToken: 'expired-access-token',
+        accessTokenExpiresAt: Date.now(),
+        refreshToken: 'refresh-token',
+        username: 'alice'
+      })
+    )
+    Object.defineProperty(navigator, 'locks', {
+      configurable: true,
+      value: {
+        request: vi.fn(async (_name: string, callback: () => Promise<void>) => callback())
+      }
+    })
+    vi.spyOn(accountOAuthApisForXBuilder, 'refreshToken').mockRejectedValue(
+      new OAuthException(OAuthErrorCode.InvalidGrant, 'invalid grant', null, {
+        req: new Request('https://example.com/account/oauth/token')
+      })
+    )
+
+    initUserState('client-id')
+
+    await expect(ensureAccessToken()).resolves.toBe(null)
+    expect(JSON.parse(localStorage.getItem(userStateStorageKey)!)).toEqual({
+      accessToken: null,
+      accessTokenExpiresAt: null,
+      refreshToken: null,
+      username: null
+    })
   })
 
   it('clears cached state when the shared state is removed', async () => {

--- a/spx-gui/src/stores/user/signed-in.test.ts
+++ b/spx-gui/src/stores/user/signed-in.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { OAuthException } from '@/apis/common/exception'
 import { accountOAuthApisForXBuilder } from '@/apis/account/oauth'
+import * as userApis from '@/apis/user'
 import { OAuthErrorCode } from '@/utils/oauth'
 import { ensureAccessToken, initUserState } from './signed-in'
 
@@ -77,6 +78,42 @@ describe('ensureAccessToken', () => {
 
     await expect(ensureAccessToken()).resolves.toBe('access-token')
     expect(request).not.toHaveBeenCalled()
+  })
+
+  it('keeps the cached username without fetching it after refresh', async () => {
+    localStorage.setItem(
+      userStateStorageKey,
+      JSON.stringify({
+        accessToken: 'expired-access-token',
+        accessTokenExpiresAt: Date.now(),
+        refreshToken: 'refresh-token',
+        username: 'alice'
+      })
+    )
+    Object.defineProperty(navigator, 'locks', {
+      configurable: true,
+      value: {
+        request: vi.fn(async (_name: string, callback: () => Promise<void>) => callback())
+      }
+    })
+    vi.spyOn(accountOAuthApisForXBuilder, 'refreshToken').mockResolvedValue({
+      access_token: 'new-access-token',
+      expires_in: 3600,
+      refresh_token: 'new-refresh-token',
+      token_type: 'Bearer'
+    })
+    const getSignedInUser = vi.spyOn(userApis, 'getSignedInUser')
+
+    initUserState('client-id')
+
+    await expect(ensureAccessToken()).resolves.toBe('new-access-token')
+    expect(getSignedInUser).not.toHaveBeenCalled()
+    expect(JSON.parse(localStorage.getItem(userStateStorageKey)!)).toEqual({
+      accessToken: 'new-access-token',
+      accessTokenExpiresAt: Date.now() + 60 * 60 * 1000,
+      refreshToken: 'new-refresh-token',
+      username: 'alice'
+    })
   })
 
   it.each([

--- a/spx-gui/src/stores/user/signed-in.ts
+++ b/spx-gui/src/stores/user/signed-in.ts
@@ -69,6 +69,9 @@ async function getSignedInUsernameByAccessToken(accessToken: string) {
   return user.username
 }
 
+/**
+ * Persists OAuth tokens, retrieving the username only when one was not already available.
+ */
 async function handleTokenResponse(resp: OAuthTokenResponse, username: string | null = null) {
   username ??= await getSignedInUsernameByAccessToken(resp.access_token)
   setUserState({
@@ -139,6 +142,7 @@ export async function ensureAccessToken(): Promise<string | null> {
     const refreshTokenBeforeRefresh = userState.refreshToken
     try {
       const token = await ensureOAuthFlow().refreshToken(refreshTokenBeforeRefresh)
+      // Reuse the cached username so a failing GET /user cannot prevent persisting rotated tokens.
       await handleTokenResponse(token, userState.username)
     } catch (e) {
       capture(e, 'Failed to refresh access token')

--- a/spx-gui/src/stores/user/signed-in.ts
+++ b/spx-gui/src/stores/user/signed-in.ts
@@ -69,8 +69,8 @@ async function getSignedInUsernameByAccessToken(accessToken: string) {
   return user.username
 }
 
-async function handleTokenResponse(resp: OAuthTokenResponse) {
-  const username = await getSignedInUsernameByAccessToken(resp.access_token)
+async function handleTokenResponse(resp: OAuthTokenResponse, username: string | null = null) {
+  username ??= await getSignedInUsernameByAccessToken(resp.access_token)
   setUserState({
     accessToken: resp.access_token,
     accessTokenExpiresAt: resp.expires_in != null ? Date.now() + resp.expires_in * 1000 : null,
@@ -139,7 +139,7 @@ export async function ensureAccessToken(): Promise<string | null> {
     const refreshTokenBeforeRefresh = userState.refreshToken
     try {
       const token = await ensureOAuthFlow().refreshToken(refreshTokenBeforeRefresh)
-      await handleTokenResponse(token)
+      await handleTokenResponse(token, userState.username)
     } catch (e) {
       capture(e, 'Failed to refresh access token')
       if (e instanceof OAuthException && e.error === OAuthErrorCode.InvalidGrant) {

--- a/spx-gui/src/stores/user/signed-in.ts
+++ b/spx-gui/src/stores/user/signed-in.ts
@@ -1,8 +1,9 @@
 import { reactive, computed } from 'vue'
 import { composeQuery, useQuery, useQueryCache, useQueryWithCache } from '@/utils/query'
 import { capture, useAction } from '@/utils/exception'
-import { OAuthFlow, type OAuthTokenResponse } from '@/utils/oauth'
+import { OAuthErrorCode, OAuthFlow, type OAuthTokenResponse } from '@/utils/oauth'
 import { normalizeLang, useI18n } from '@/utils/i18n'
+import { OAuthException } from '@/apis/common/exception'
 import * as userApis from '@/apis/user'
 import { accountOAuthApisForXBuilder as oauthApis } from '@/apis/account/oauth'
 import { getUserQueryKey } from './query-keys'
@@ -117,6 +118,12 @@ export async function signOut() {
   ).catch((e) => capture(e, 'Failed to revoke tokens during sign out'))
 }
 
+/**
+ * Returns a valid access token, or null when the user is not signed in.
+ *
+ * Clears state and resolves null when the refresh token is invalid; preserves state and rejects
+ * for other refresh failures.
+ */
 export async function ensureAccessToken(): Promise<string | null> {
   if (isAccessTokenValid()) return userState.accessToken
 
@@ -135,7 +142,11 @@ export async function ensureAccessToken(): Promise<string | null> {
       await handleTokenResponse(token)
     } catch (e) {
       capture(e, 'Failed to refresh access token')
-      clearUserState()
+      if (e instanceof OAuthException && e.error === OAuthErrorCode.InvalidGrant) {
+        clearUserState()
+        return
+      }
+      throw e
     }
   })
   return userState.accessToken

--- a/spx-gui/src/utils/oauth/index.ts
+++ b/spx-gui/src/utils/oauth/index.ts
@@ -125,6 +125,15 @@ export type OAuthRefreshTokenParams = {
   refresh_token: string
 }
 
+export enum OAuthErrorCode {
+  InvalidRequest = 'invalid_request',
+  InvalidClient = 'invalid_client',
+  InvalidGrant = 'invalid_grant',
+  UnauthorizedClient = 'unauthorized_client',
+  InvalidScope = 'invalid_scope',
+  UnsupportedGrantType = 'unsupported_grant_type'
+}
+
 export type OAuthTokenResponse = {
   /** Access token returned by the token endpoint. */
   access_token: string


### PR DESCRIPTION
Closes #3453

## Summary

- preserve the cached login state when token refresh fails due to a transport timeout, network error, or OAuth `server_error`
- clear the cached state only when Account returns the definitive `invalid_grant` refresh-token failure
- add focused coverage for both branches

## Dependency

- Requires [goplus/builder-backend#347](https://github.com/goplus/builder-backend/pull/347) to return `invalid_grant` for invalid or reused refresh tokens. Deploy the backend change before relying on the frontend to clear this state.
