### PR TITLE
fix(spx-gui): highlight `in` as a keyword

### DIFF
--- a/spx-gui/src/utils/xgo/gop-tm-language.json
+++ b/spx-gui/src/utils/xgo/gop-tm-language.json
@@ -470,7 +470,7 @@
 			"patterns": [
 				{
 					"comment": "Flow control keywords",
-					"match": "\\b(break|case|continue|default|defer|else|fallthrough|for|go|if|range|return|select|switch)\\b",
+					"match": "\\b(break|case|continue|default|defer|else|fallthrough|for|go|if|in|range|return|select|switch)\\b",
 					"name": "keyword.control.gop"
 				},
 				{


### PR DESCRIPTION
## Summary

- recognize `in` as a flow-control keyword in the XGo TextMate grammar
- make `for value in values {}` highlight `in` consistently with `for` and `else`

## Validation

- tokenized `for v in [] {}` with the production Shiki grammar and confirmed both `for` and `in` use the keyword color
- `pnpm exec prettier --check src/utils/xgo/gop-tm-language.json`
- `pnpm run type-check`

## Upstream grammar

The copied source grammar is updated directly in [nighca/better-gop-syntax@65d6f78](https://github.com/nighca/better-gop-syntax/commit/65d6f78).

Closes #3458
