### PR TITLE
feat(spx-gui): support WebP image assets

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -8175,7 +8175,7 @@ components:
                 - frameUrls
               properties:
                 frameUrls:
-                  description: Universal URLs of the extracted WebP frame images (e.g. kodo://bucket/key).
+                  description: Universal URLs of the extracted frame images (e.g. kodo://bucket/key).
                   type: array
                   items:
                     type: string
@@ -8186,7 +8186,7 @@ components:
                 - imageUrls
               properties:
                 imageUrls:
-                  description: Universal URLs of the generated WebP backdrop images (e.g. kodo://bucket/key).
+                  description: Universal URLs of the generated backdrop images (e.g. kodo://bucket/key).
                   type: array
                   items:
                     type: string

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -8175,7 +8175,7 @@ components:
                 - frameUrls
               properties:
                 frameUrls:
-                  description: Universal URLs of the extracted frame images (e.g. kodo://bucket/key).
+                  description: Universal URLs of the extracted WebP frame images (e.g. kodo://bucket/key).
                   type: array
                   items:
                     type: string
@@ -8186,7 +8186,7 @@ components:
                 - imageUrls
               properties:
                 imageUrls:
-                  description: Universal URLs of the generated backdrop images (e.g. kodo://bucket/key).
+                  description: Universal URLs of the generated WebP backdrop images (e.g. kodo://bucket/key).
                   type: array
                   items:
                     type: string

--- a/spx-gui/src/models/spx/gen/aigc-mock.ts
+++ b/spx-gui/src/models/spx/gen/aigc-mock.ts
@@ -461,14 +461,14 @@ export class MockAigcApis {
         const interval = p.interval ?? 200
         const count = Math.max(1, Math.floor(p.duration / interval))
         return {
-          frameUrls: this.range(count).map((i) => this.url(`frame-${i + 1}.png`))
+          frameUrls: this.range(count).map((i) => this.url(`frame-${i + 1}.webp`))
         } as TaskResult<T>
       }
       case TaskType.GenerateBackdrop: {
         const p = params as TaskParams<TaskType.GenerateBackdrop>
         const name = this.sanitize(p.settings.name)
         return {
-          imageUrls: this.range(p.n).map((i) => this.url(`backdrop-${name}-${i + 1}.png`))
+          imageUrls: this.range(p.n).map((i) => this.url(`backdrop-${name}-${i + 1}.webp`))
         } as TaskResult<T>
       }
       default:

--- a/spx-gui/src/utils/spx/index.test.ts
+++ b/spx-gui/src/utils/spx/index.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import { File } from '@/models/common/file'
-import { adaptAudio, getSpxProjectKnowledge } from './index'
+import { adaptAudio, adaptImg, getSpxProjectKnowledge } from './index'
 
 function makeImaAdpcmWav() {
   const output = new ArrayBuffer(54)
@@ -56,5 +56,13 @@ describe('adaptAudio', () => {
     const file = new File('sound.wav', async () => content)
 
     await expect(adaptAudio(file)).resolves.toBe(file)
+  })
+})
+
+describe('adaptImg', () => {
+  it('keeps WebP files unchanged', async () => {
+    const file = new File('frame.webp', async () => new ArrayBuffer(0))
+
+    await expect(adaptImg(file)).resolves.toBe(file)
   })
 })

--- a/spx-gui/src/utils/spx/index.ts
+++ b/spx-gui/src/utils/spx/index.ts
@@ -51,11 +51,10 @@ export async function adaptAudio(file: File): Promise<File> {
 }
 
 /**
- * Image file formats supported by spx. See details in
- * - https://github.com/goplus/spx/blob/7f46dc7879e2320a9889f1396b9e592efb6d888d/spbase.go#L25-L26
- * - https://github.com/goplus/spx/blob/7f46dc7879e2320a9889f1396b9e592efb6d888d/internal/svgr/svg.go#L22
+ * Image file formats preserved by Builder for SPX.
+ * See https://github.com/goplus/spx/blob/4953f393febca4bede367e54392320c80ae18f77/docs/en/dev/image_assets.md for WebP support.
  */
-const supportedImgExts = ['jpg', 'jpeg', 'png', 'svg']
+const supportedImgExts = ['jpg', 'jpeg', 'png', 'svg', 'webp']
 
 /** Adapt image file to fit spx. Unsupported image files will be converted to jpeg. */
 export async function adaptImg(file: File): Promise<File> {


### PR DESCRIPTION
## Background

The AIGC backend now returns generated backdrops and animation frames as WebP objects. `adaptImg` did not include WebP in its SPX-supported extension list, so importing those files through the Editor could convert them to JPEG. That conversion would lose the intended end-to-end format and could discard transparency from animation frames.

## Summary

- treat WebP as an SPX-supported image format so `adaptImg` preserves the original file
- add a regression test that verifies a WebP file is returned unchanged
- update AIGC mocks to return WebP filenames for generated backdrops and animation frames
- document the WebP result format for generated backdrops and extracted frames

Refs #3464

## Validation

- `pnpm exec vitest --run src/utils/spx/index.test.ts` (5 tests)
- `pnpm exec eslint src/utils/spx/index.ts src/utils/spx/index.test.ts src/models/spx/gen/aigc-mock.ts`
- `pnpm exec prettier --check src/utils/spx/index.ts src/utils/spx/index.test.ts src/models/spx/gen/aigc-mock.ts ../docs/openapi.yaml`
- `pnpm run type-check`
- manual end-to-end validation with the local frontend and backend: generated a WebP backdrop and a 50-frame animation; previewed and ran them with SPX 3.2.3; exported the project and verified the generated backdrop and animation frames remained real WebP files