### PR TITLE
fix(spx-gui): encode asset filenames safely

### DIFF
--- a/spx-gui/package.json
+++ b/spx-gui/package.json
@@ -20,7 +20,6 @@
   },
   "dependencies": {
     "@floating-ui/dom": "^1.7.6",
-    "@jridgewell/resolve-uri": "^3.1.2",
     "@lottiefiles/dotlottie-vue": "^0.5.8",
     "@lottiefiles/dotlottie-web": "0.41.0",
     "@nighca/fflate": "^0.8.3",

--- a/spx-gui/pnpm-lock.yaml
+++ b/spx-gui/pnpm-lock.yaml
@@ -11,9 +11,6 @@ importers:
       '@floating-ui/dom':
         specifier: ^1.7.6
         version: 1.7.6
-      '@jridgewell/resolve-uri':
-        specifier: ^3.1.2
-        version: 3.1.2
       '@lottiefiles/dotlottie-vue':
         specifier: ^0.5.8
         version: 0.5.8(vue@3.5.25(typescript@5.9.3))

--- a/spx-gui/src/models/common/cloud.ts
+++ b/spx-gui/src/models/common/cloud.ts
@@ -21,7 +21,13 @@ import type { Metadata, PartialMetadata, ProjectSerialized } from '../project'
 import { File, toText, type Files, isText } from './file'
 import { hashFileCollection } from './hash'
 import { createAIDescriptionFiles, extractAIDescription } from './'
-import { getUniversalUrlScheme, stringifyDataUrl, stringifyKodoUrl, UniversalUrlScheme } from '@/utils/universal-url'
+import {
+  getUniversalUrlFilename,
+  getUniversalUrlScheme,
+  stringifyDataUrl,
+  stringifyKodoUrl,
+  UniversalUrlScheme
+} from '@/utils/universal-url'
 
 export type PreferPublishedContent = boolean | ((project: ProjectData) => boolean | Promise<boolean>)
 
@@ -196,7 +202,7 @@ function getUniversalUrl(file: File): UniversalUrl | null {
   return file.meta.universalUrl ?? null
 }
 
-export function createFileWithUniversalUrl(url: UniversalUrl, name = filename(url)) {
+export function createFileWithUniversalUrl(url: UniversalUrl, name = getUniversalUrlFilename(url)) {
   const file = new File(name, async (signal) => {
     const webUrl = await cloudHelpers.universalUrlToWebUrl(url)
     signal?.throwIfAborted()
@@ -206,7 +212,7 @@ export function createFileWithUniversalUrl(url: UniversalUrl, name = filename(ur
   return file
 }
 
-export function createFileWithWebUrl(url: WebUrl, name = filename(url)) {
+export function createFileWithWebUrl(url: WebUrl, name = getUniversalUrlFilename(url)) {
   return new File(name, async (signal) => fetchFile(url, signal))
 }
 

--- a/spx-gui/src/models/spx/backdrop.test.ts
+++ b/spx-gui/src/models/spx/backdrop.test.ts
@@ -142,6 +142,14 @@ describe('Backdrop', () => {
     expect(rawSize).toEqual({ width: 512, height: 288 })
   })
 
+  it('should export a slash-containing name with a safe path', () => {
+    const backdrop = new Backdrop('a/b', fromText('backdrop.svg', '<svg />'))
+    const [config, files] = backdrop.export()
+
+    expect(config).toMatchObject({ name: 'a/b', path: 'backdrop-a%2Fb.svg' })
+    expect(Object.keys(files)).toEqual(['assets/backdrop-a%2Fb.svg'])
+  })
+
   it('should get size divided by bitmap resolution', async () => {
     const file = new File('stage.png', async () => new ArrayBuffer(0), {
       type: 'image/png',

--- a/spx-gui/src/models/spx/backdrop.test.ts
+++ b/spx-gui/src/models/spx/backdrop.test.ts
@@ -146,8 +146,8 @@ describe('Backdrop', () => {
     const backdrop = new Backdrop('a/b', fromText('backdrop.svg', '<svg />'))
     const [config, files] = backdrop.export()
 
-    expect(config).toMatchObject({ name: 'a/b', path: 'backdrop-a%2Fb.svg' })
-    expect(Object.keys(files)).toEqual(['assets/backdrop-a%2Fb.svg'])
+    expect(config).toMatchObject({ name: 'a/b', path: 'a%2Fb.svg' })
+    expect(Object.keys(files)).toEqual(['assets/a%2Fb.svg'])
   })
 
   it('should get size divided by bitmap resolution', async () => {

--- a/spx-gui/src/models/spx/backdrop.ts
+++ b/spx-gui/src/models/spx/backdrop.ts
@@ -4,7 +4,7 @@ import { isSvgMimeType } from '@/utils/file'
 import { extname, resolve } from '@/utils/path'
 import { adaptImg } from '@/utils/spx'
 import { getImageSize, type File, type Files } from '../common/file'
-import { getBackdropName, validateBackdropName } from './common/asset-name'
+import { getAssetFilename, getBackdropName, validateBackdropName } from './common/asset-name'
 import type { AssetMetadata } from './common/asset'
 import type { Pivot } from './costume'
 import type { Stage } from './stage'
@@ -198,7 +198,7 @@ export class Backdrop {
     includeAssetMetadata = true,
     assetPath = backdropAssetPath
   }: BackdropExportLoadOptions = {}): [RawBackdropConfig, Files] {
-    const filename = this.name + extname(this.img.name)
+    const filename = getAssetFilename('backdrop', this.name, extname(this.img.name))
     const config: RawBackdropConfig = {
       x: this.pivot.x * this.bitmapResolution,
       y: this.pivot.y * this.bitmapResolution,

--- a/spx-gui/src/models/spx/backdrop.ts
+++ b/spx-gui/src/models/spx/backdrop.ts
@@ -198,7 +198,7 @@ export class Backdrop {
     includeAssetMetadata = true,
     assetPath = backdropAssetPath
   }: BackdropExportLoadOptions = {}): [RawBackdropConfig, Files] {
-    const filename = getAssetFilename('backdrop', this.name, extname(this.img.name))
+    const filename = getAssetFilename(this.name, extname(this.img.name))
     const config: RawBackdropConfig = {
       x: this.pivot.x * this.bitmapResolution,
       y: this.pivot.y * this.bitmapResolution,

--- a/spx-gui/src/models/spx/backdrop.ts
+++ b/spx-gui/src/models/spx/backdrop.ts
@@ -1,7 +1,7 @@
 import { reactive } from 'vue'
 import { nanoid } from 'nanoid'
 import { isSvgMimeType } from '@/utils/file'
-import { encodePathSegment, extname, resolve } from '@/utils/path'
+import { encodeFilename, extname, resolve } from '@/utils/path'
 import { adaptImg } from '@/utils/spx'
 import { getImageSize, type File, type Files } from '../common/file'
 import { getBackdropName, validateBackdropName } from './common/asset-name'
@@ -198,7 +198,7 @@ export class Backdrop {
     includeAssetMetadata = true,
     assetPath = backdropAssetPath
   }: BackdropExportLoadOptions = {}): [RawBackdropConfig, Files] {
-    const filename = encodePathSegment(this.name) + extname(this.img.name)
+    const filename = encodeFilename(this.name + extname(this.img.name))
     const config: RawBackdropConfig = {
       x: this.pivot.x * this.bitmapResolution,
       y: this.pivot.y * this.bitmapResolution,

--- a/spx-gui/src/models/spx/backdrop.ts
+++ b/spx-gui/src/models/spx/backdrop.ts
@@ -1,10 +1,10 @@
 import { reactive } from 'vue'
 import { nanoid } from 'nanoid'
 import { isSvgMimeType } from '@/utils/file'
-import { extname, resolve } from '@/utils/path'
+import { encodePathSegment, extname, resolve } from '@/utils/path'
 import { adaptImg } from '@/utils/spx'
 import { getImageSize, type File, type Files } from '../common/file'
-import { getAssetFilename, getBackdropName, validateBackdropName } from './common/asset-name'
+import { getBackdropName, validateBackdropName } from './common/asset-name'
 import type { AssetMetadata } from './common/asset'
 import type { Pivot } from './costume'
 import type { Stage } from './stage'
@@ -198,7 +198,7 @@ export class Backdrop {
     includeAssetMetadata = true,
     assetPath = backdropAssetPath
   }: BackdropExportLoadOptions = {}): [RawBackdropConfig, Files] {
-    const filename = getAssetFilename(this.name, extname(this.img.name))
+    const filename = encodePathSegment(this.name) + extname(this.img.name)
     const config: RawBackdropConfig = {
       x: this.pivot.x * this.bitmapResolution,
       y: this.pivot.y * this.bitmapResolution,

--- a/spx-gui/src/models/spx/common/asset-name.test.ts
+++ b/spx-gui/src/models/spx/common/asset-name.test.ts
@@ -96,7 +96,7 @@ describe('getSoundName', () => {
 
 describe('validateSoundName', () => {
   it('rejects names that cannot be sound resource directories', () => {
-    expect(validateSoundName('a/b', null)).toMatchObject({ en: 'The path segment must not contain /' })
+    expect(validateSoundName('a/b', null)).toMatchObject({ en: 'Must not contain /' })
     expect(validateSoundName('CON', null)).toBeUndefined()
     expect(validateSoundName('sound', null)).toBeUndefined()
   })
@@ -104,7 +104,7 @@ describe('validateSoundName', () => {
 
 describe('validateFontName', () => {
   it('shares the path segment requirement with sound names', () => {
-    expect(validateFontName('a/b')).toMatchObject({ en: 'The path segment must not contain /' })
+    expect(validateFontName('a/b')).toMatchObject({ en: 'Must not contain /' })
     expect(validateFontName('default')).toMatchObject({ en: 'font family default is reserved' })
     expect(validateFontName('font')).toBeUndefined()
   })

--- a/spx-gui/src/models/spx/common/asset-name.test.ts
+++ b/spx-gui/src/models/spx/common/asset-name.test.ts
@@ -96,7 +96,7 @@ describe('getSoundName', () => {
 
 describe('validateSoundName', () => {
   it('rejects names that cannot be sound resource directories', () => {
-    expect(validateSoundName('a/b', null)).toMatchObject({ en: '`/` is not allowed' })
+    expect(validateSoundName('a/b', null)).toMatchObject({ en: 'The value must not contain /' })
     expect(validateSoundName('CON', null)).toBeUndefined()
     expect(validateSoundName('sound', null)).toBeUndefined()
   })
@@ -104,7 +104,7 @@ describe('validateSoundName', () => {
 
 describe('validateFontName', () => {
   it('shares the path segment requirement with sound names', () => {
-    expect(validateFontName('a/b')).toMatchObject({ en: '`/` is not allowed' })
+    expect(validateFontName('a/b')).toMatchObject({ en: 'The value must not contain /' })
     expect(validateFontName('default')).toMatchObject({ en: 'font family default is reserved' })
     expect(validateFontName('font')).toBeUndefined()
   })

--- a/spx-gui/src/models/spx/common/asset-name.test.ts
+++ b/spx-gui/src/models/spx/common/asset-name.test.ts
@@ -96,7 +96,7 @@ describe('getSoundName', () => {
 
 describe('validateSoundName', () => {
   it('rejects names that cannot be sound resource directories', () => {
-    expect(validateSoundName('a/b', null)).toMatchObject({ en: 'Must not contain /' })
+    expect(validateSoundName('a/b', null)).toMatchObject({ en: '`/` is not allowed' })
     expect(validateSoundName('CON', null)).toBeUndefined()
     expect(validateSoundName('sound', null)).toBeUndefined()
   })
@@ -104,7 +104,7 @@ describe('validateSoundName', () => {
 
 describe('validateFontName', () => {
   it('shares the path segment requirement with sound names', () => {
-    expect(validateFontName('a/b')).toMatchObject({ en: 'Must not contain /' })
+    expect(validateFontName('a/b')).toMatchObject({ en: '`/` is not allowed' })
     expect(validateFontName('default')).toMatchObject({ en: 'font family default is reserved' })
     expect(validateFontName('font')).toBeUndefined()
   })

--- a/spx-gui/src/models/spx/common/asset-name.test.ts
+++ b/spx-gui/src/models/spx/common/asset-name.test.ts
@@ -1,5 +1,4 @@
 import { describe, it, expect } from 'vitest'
-import { isSafePathSegment } from '@/utils/path'
 import {
   getAssetFilename,
   getSoundName,
@@ -107,18 +106,6 @@ describe('validateSoundName', () => {
     expect(validateSoundName('a/b', null)).toMatchObject({ en: 'The name must be a safe path segment' })
     expect(validateSoundName('CON', null)).toBeUndefined()
     expect(validateSoundName('sound', null)).toBeUndefined()
-  })
-})
-
-describe('isSafePathSegment', () => {
-  it.each(['', '.', '..', 'a/b', 'a\0b'])('rejects %j', (value) => {
-    expect(isSafePathSegment(value)).toBe(false)
-  })
-
-  it('accepts ordinary names', () => {
-    expect(isSafePathSegment('中文 😀')).toBe(true)
-    expect(isSafePathSegment('CON')).toBe(true)
-    expect(isSafePathSegment('a\\b')).toBe(true)
   })
 })
 

--- a/spx-gui/src/models/spx/common/asset-name.test.ts
+++ b/spx-gui/src/models/spx/common/asset-name.test.ts
@@ -118,9 +118,9 @@ describe('validateFontName', () => {
 })
 
 describe('getAssetFilename', () => {
-  it('preserves the resource prefix and extension', () => {
-    expect(getAssetFilename('costume', '=/', '.svg')).toBe('costume-%3D%2F.svg')
-    expect(getAssetFilename('backdrop', '中文 😀', '.png')).toBe('backdrop-%E4%B8%AD%E6%96%87%20%F0%9F%98%80.png')
+  it('preserves the encoded name and extension', () => {
+    expect(getAssetFilename('=/', '.svg')).toBe('%3D%2F.svg')
+    expect(getAssetFilename('中文 😀', '.png')).toBe('%E4%B8%AD%E6%96%87%20%F0%9F%98%80.png')
   })
 })
 

--- a/spx-gui/src/models/spx/common/asset-name.test.ts
+++ b/spx-gui/src/models/spx/common/asset-name.test.ts
@@ -96,7 +96,7 @@ describe('getSoundName', () => {
 
 describe('validateSoundName', () => {
   it('rejects names that cannot be sound resource directories', () => {
-    expect(validateSoundName('a/b', null)).toMatchObject({ en: 'The name must not contain /' })
+    expect(validateSoundName('a/b', null)).toMatchObject({ en: 'The path segment must not contain /' })
     expect(validateSoundName('CON', null)).toBeUndefined()
     expect(validateSoundName('sound', null)).toBeUndefined()
   })
@@ -104,7 +104,7 @@ describe('validateSoundName', () => {
 
 describe('validateFontName', () => {
   it('shares the path segment requirement with sound names', () => {
-    expect(validateFontName('a/b')).toMatchObject({ en: 'The name must not contain /' })
+    expect(validateFontName('a/b')).toMatchObject({ en: 'The path segment must not contain /' })
     expect(validateFontName('default')).toMatchObject({ en: 'font family default is reserved' })
     expect(validateFontName('font')).toBeUndefined()
   })

--- a/spx-gui/src/models/spx/common/asset-name.test.ts
+++ b/spx-gui/src/models/spx/common/asset-name.test.ts
@@ -1,12 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import {
-  getAssetFilename,
-  getSoundName,
-  getSpriteName,
-  normalizeAssetName,
-  validateFontName,
-  validateSoundName
-} from './asset-name'
+import { getSoundName, getSpriteName, normalizeAssetName, validateFontName, validateSoundName } from './asset-name'
 import { SpxProject } from '../project'
 import { Sprite } from '../sprite'
 import { Sound } from '../sound'
@@ -114,13 +107,6 @@ describe('validateFontName', () => {
     expect(validateFontName('a/b')).toMatchObject({ en: 'font family name must be a safe path segment' })
     expect(validateFontName('default')).toMatchObject({ en: 'font family default is reserved' })
     expect(validateFontName('font')).toBeUndefined()
-  })
-})
-
-describe('getAssetFilename', () => {
-  it('preserves the encoded name and extension', () => {
-    expect(getAssetFilename('=/', '.svg')).toBe('%3D%2F.svg')
-    expect(getAssetFilename('中文 😀', '.png')).toBe('%E4%B8%AD%E6%96%87%20%F0%9F%98%80.png')
   })
 })
 

--- a/spx-gui/src/models/spx/common/asset-name.test.ts
+++ b/spx-gui/src/models/spx/common/asset-name.test.ts
@@ -1,5 +1,13 @@
 import { describe, it, expect } from 'vitest'
-import { getSoundName, getSpriteName, normalizeAssetName } from './asset-name'
+import { isSafePathSegment } from '@/utils/path'
+import {
+  getAssetFilename,
+  getSoundName,
+  getSpriteName,
+  normalizeAssetName,
+  validateFontName,
+  validateSoundName
+} from './asset-name'
 import { SpxProject } from '../project'
 import { Sprite } from '../sprite'
 import { Sound } from '../sound'
@@ -91,6 +99,41 @@ describe('getSoundName', () => {
     expect(getSoundName(project, '')).toBe('sound1')
     project.addSound(new Sound('sound1', mockFile()))
     expect(getSoundName(project, '')).toBe('sound2')
+  })
+})
+
+describe('validateSoundName', () => {
+  it('rejects names that cannot be sound resource directories', () => {
+    expect(validateSoundName('a/b', null)).toMatchObject({ en: 'The name must be a safe path segment' })
+    expect(validateSoundName('CON', null)).toBeUndefined()
+    expect(validateSoundName('sound', null)).toBeUndefined()
+  })
+})
+
+describe('isSafePathSegment', () => {
+  it.each(['', '.', '..', 'a/b', 'a\0b'])('rejects %j', (value) => {
+    expect(isSafePathSegment(value)).toBe(false)
+  })
+
+  it('accepts ordinary names', () => {
+    expect(isSafePathSegment('中文 😀')).toBe(true)
+    expect(isSafePathSegment('CON')).toBe(true)
+    expect(isSafePathSegment('a\\b')).toBe(true)
+  })
+})
+
+describe('validateFontName', () => {
+  it('shares the path segment requirement with sound names', () => {
+    expect(validateFontName('a/b')).toMatchObject({ en: 'font family name must be a safe path segment' })
+    expect(validateFontName('default')).toMatchObject({ en: 'font family default is reserved' })
+    expect(validateFontName('font')).toBeUndefined()
+  })
+})
+
+describe('getAssetFilename', () => {
+  it('preserves the resource prefix and extension', () => {
+    expect(getAssetFilename('costume', '=/', '.svg')).toBe('costume-%3D%2F.svg')
+    expect(getAssetFilename('backdrop', '中文 😀', '.png')).toBe('backdrop-%E4%B8%AD%E6%96%87%20%F0%9F%98%80.png')
   })
 })
 

--- a/spx-gui/src/models/spx/common/asset-name.test.ts
+++ b/spx-gui/src/models/spx/common/asset-name.test.ts
@@ -96,7 +96,7 @@ describe('getSoundName', () => {
 
 describe('validateSoundName', () => {
   it('rejects names that cannot be sound resource directories', () => {
-    expect(validateSoundName('a/b', null)).toMatchObject({ en: 'The name must be a safe path segment' })
+    expect(validateSoundName('a/b', null)).toMatchObject({ en: 'The name must not contain /' })
     expect(validateSoundName('CON', null)).toBeUndefined()
     expect(validateSoundName('sound', null)).toBeUndefined()
   })
@@ -104,7 +104,7 @@ describe('validateSoundName', () => {
 
 describe('validateFontName', () => {
   it('shares the path segment requirement with sound names', () => {
-    expect(validateFontName('a/b')).toMatchObject({ en: 'font family name must be a safe path segment' })
+    expect(validateFontName('a/b')).toMatchObject({ en: 'The name must not contain /' })
     expect(validateFontName('default')).toMatchObject({ en: 'font family default is reserved' })
     expect(validateFontName('font')).toBeUndefined()
   })

--- a/spx-gui/src/models/spx/common/asset-name.ts
+++ b/spx-gui/src/models/spx/common/asset-name.ts
@@ -1,4 +1,5 @@
 import type { LocaleMessage } from '@/utils/i18n'
+import { isSafePathSegment } from '@/utils/path'
 import { assetDisplayNameMaxLength } from '@/apis/asset'
 import { getStringLengthInCodePoints, lowFirst, unicodeSafeSlice, upFirst } from '@/utils/utils'
 import { getXGoIdentifierNameTip, normalizeXGoIdentifierAssetName, validateXGoIdentifierName } from '@/utils/xgo'
@@ -20,6 +21,17 @@ function validateAssetName(name: string) {
       en: `The name is too long (maximum is ${assetNameMaxLength} characters)`,
       zh: `名字长度超出限制（最多 ${assetNameMaxLength} 个字符）`
     }
+}
+
+export function getAssetFilename(
+  /** ASCII resource type, without path separators. */
+  prefix: string,
+  /** Logical asset name; it will be encoded with `encodeURIComponent`. */
+  name: string,
+  /** Filename extension, including the leading dot, or an empty string. */
+  ext: string
+) {
+  return `${prefix}-${encodeURIComponent(name)}${ext}`
 }
 
 function getAssetNameTip(asset: LocaleMessage) {
@@ -123,8 +135,16 @@ export interface SoundLikeParent {
 export function validateSoundName(name: string, parent: SoundLikeParent | null) {
   const err = validateAssetName(name)
   if (err != null) return err
+  if (!isSafePathSegment(name)) return { en: 'The name must be a safe path segment', zh: '名称必须是安全的单一路径段' }
   if (parent != null && parent.sounds.find((s) => s.name === name))
     return { en: `Sound with name ${name} already exists`, zh: '存在同名的声音' }
+}
+
+export function validateFontName(name: string) {
+  const err = validateAssetName(name)
+  if (err != null) return err
+  if (name === 'default') return { en: 'font family default is reserved', zh: '字体名称 default 已被保留' }
+  if (!isSafePathSegment(name)) return { en: 'font family name must be a safe path segment', zh: '字体名称必须是安全的单一路径段' }
 }
 
 export const backdropNameTip = getAssetNameTip(resourceBackdropName)

--- a/spx-gui/src/models/spx/common/asset-name.ts
+++ b/spx-gui/src/models/spx/common/asset-name.ts
@@ -1,5 +1,5 @@
 import type { LocaleMessage } from '@/utils/i18n'
-import { isSafePathSegment } from '@/utils/path'
+import { encodePathSegment, isSafePathSegment } from '@/utils/path'
 import { assetDisplayNameMaxLength } from '@/apis/asset'
 import { getStringLengthInCodePoints, lowFirst, unicodeSafeSlice, upFirst } from '@/utils/utils'
 import { getXGoIdentifierNameTip, normalizeXGoIdentifierAssetName, validateXGoIdentifierName } from '@/utils/xgo'
@@ -24,14 +24,12 @@ function validateAssetName(name: string) {
 }
 
 export function getAssetFilename(
-  /** ASCII resource type, without path separators. */
-  prefix: string,
-  /** Logical asset name; it will be encoded with `encodeURIComponent`. */
+  /** Logical asset name; it will be encoded as a POSIX-style path segment. */
   name: string,
   /** Filename extension, including the leading dot, or an empty string. */
   ext: string
 ) {
-  return `${prefix}-${encodeURIComponent(name)}${ext}`
+  return `${encodePathSegment(name)}${ext}`
 }
 
 function getAssetNameTip(asset: LocaleMessage) {

--- a/spx-gui/src/models/spx/common/asset-name.ts
+++ b/spx-gui/src/models/spx/common/asset-name.ts
@@ -144,7 +144,8 @@ export function validateFontName(name: string) {
   const err = validateAssetName(name)
   if (err != null) return err
   if (name === 'default') return { en: 'font family default is reserved', zh: '字体名称 default 已被保留' }
-  if (!isSafePathSegment(name)) return { en: 'font family name must be a safe path segment', zh: '字体名称必须是安全的单一路径段' }
+  if (!isSafePathSegment(name))
+    return { en: 'font family name must be a safe path segment', zh: '字体名称必须是安全的单一路径段' }
 }
 
 export const backdropNameTip = getAssetNameTip(resourceBackdropName)

--- a/spx-gui/src/models/spx/common/asset-name.ts
+++ b/spx-gui/src/models/spx/common/asset-name.ts
@@ -1,5 +1,5 @@
 import type { LocaleMessage } from '@/utils/i18n'
-import { isSafePathSegment } from '@/utils/path'
+import { validatePathSegment } from '@/utils/path'
 import { assetDisplayNameMaxLength } from '@/apis/asset'
 import { getStringLengthInCodePoints, lowFirst, unicodeSafeSlice, upFirst } from '@/utils/utils'
 import { getXGoIdentifierNameTip, normalizeXGoIdentifierAssetName, validateXGoIdentifierName } from '@/utils/xgo'
@@ -124,7 +124,8 @@ export interface SoundLikeParent {
 export function validateSoundName(name: string, parent: SoundLikeParent | null) {
   const err = validateAssetName(name)
   if (err != null) return err
-  if (!isSafePathSegment(name)) return { en: 'The name must be a safe path segment', zh: '名称必须是安全的单一路径段' }
+  const pathErr = validatePathSegment(name)
+  if (pathErr != null) return pathErr
   if (parent != null && parent.sounds.find((s) => s.name === name))
     return { en: `Sound with name ${name} already exists`, zh: '存在同名的声音' }
 }
@@ -133,8 +134,8 @@ export function validateFontName(name: string) {
   const err = validateAssetName(name)
   if (err != null) return err
   if (name === 'default') return { en: 'font family default is reserved', zh: '字体名称 default 已被保留' }
-  if (!isSafePathSegment(name))
-    return { en: 'font family name must be a safe path segment', zh: '字体名称必须是安全的单一路径段' }
+  const pathErr = validatePathSegment(name)
+  if (pathErr != null) return pathErr
 }
 
 export const backdropNameTip = getAssetNameTip(resourceBackdropName)

--- a/spx-gui/src/models/spx/common/asset-name.ts
+++ b/spx-gui/src/models/spx/common/asset-name.ts
@@ -1,5 +1,5 @@
 import type { LocaleMessage } from '@/utils/i18n'
-import { encodePathSegment, isSafePathSegment } from '@/utils/path'
+import { isSafePathSegment } from '@/utils/path'
 import { assetDisplayNameMaxLength } from '@/apis/asset'
 import { getStringLengthInCodePoints, lowFirst, unicodeSafeSlice, upFirst } from '@/utils/utils'
 import { getXGoIdentifierNameTip, normalizeXGoIdentifierAssetName, validateXGoIdentifierName } from '@/utils/xgo'
@@ -21,15 +21,6 @@ function validateAssetName(name: string) {
       en: `The name is too long (maximum is ${assetNameMaxLength} characters)`,
       zh: `名字长度超出限制（最多 ${assetNameMaxLength} 个字符）`
     }
-}
-
-export function getAssetFilename(
-  /** Logical asset name; it will be encoded as a POSIX-style path segment. */
-  name: string,
-  /** Filename extension, including the leading dot, or an empty string. */
-  ext: string
-) {
-  return `${encodePathSegment(name)}${ext}`
 }
 
 function getAssetNameTip(asset: LocaleMessage) {

--- a/spx-gui/src/models/spx/costume.test.ts
+++ b/spx-gui/src/models/spx/costume.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { resolve as resolvePath } from '@/utils/path'
+import { getFiles } from '../common/cloud'
 import { File, fromText, type Files } from '../common/file'
 import { Animation } from './animation'
 import { Costume } from './costume'
@@ -84,5 +85,20 @@ describe('Costume', () => {
 
     expect(config.imageWidth).toEqual(320)
     expect(config.imageHeight).toEqual(240)
+  })
+
+  it('should preserve slash-containing names after loading from cloud files', () => {
+    const costume = new Costume('=/', fromText('source.svg', '<svg />'))
+    const [config, files] = costume.export({ basePath: 'assets/sprites/Sprite' })
+    const fileCollection = Object.fromEntries(Object.keys(files).map((path) => [path, 'data:,']))
+    const loaded = Costume.load(config, getFiles(fileCollection), {
+      basePath: 'assets/sprites/Sprite',
+      includeId: true
+    })
+    const [reExportedConfig, reExportedFiles] = loaded.export({ basePath: 'assets/sprites/Sprite' })
+
+    expect(config.path).toBe('costume-%3D%2F.svg')
+    expect(reExportedConfig.path).toBe(config.path)
+    expect(Object.keys(reExportedFiles)).toEqual(Object.keys(files))
   })
 })

--- a/spx-gui/src/models/spx/costume.test.ts
+++ b/spx-gui/src/models/spx/costume.test.ts
@@ -97,7 +97,7 @@ describe('Costume', () => {
     })
     const [reExportedConfig, reExportedFiles] = loaded.export({ basePath: 'assets/sprites/Sprite' })
 
-    expect(config.path).toBe('%3D%2F.svg')
+    expect(config.path).toBe('=%2F.svg')
     expect(reExportedConfig.path).toBe(config.path)
     expect(Object.keys(reExportedFiles)).toEqual(Object.keys(files))
   })

--- a/spx-gui/src/models/spx/costume.test.ts
+++ b/spx-gui/src/models/spx/costume.test.ts
@@ -97,7 +97,7 @@ describe('Costume', () => {
     })
     const [reExportedConfig, reExportedFiles] = loaded.export({ basePath: 'assets/sprites/Sprite' })
 
-    expect(config.path).toBe('costume-%3D%2F.svg')
+    expect(config.path).toBe('%3D%2F.svg')
     expect(reExportedConfig.path).toBe(config.path)
     expect(Object.keys(reExportedFiles)).toEqual(Object.keys(files))
   })

--- a/spx-gui/src/models/spx/costume.ts
+++ b/spx-gui/src/models/spx/costume.ts
@@ -2,10 +2,10 @@ import { reactive } from 'vue'
 import { nanoid } from 'nanoid'
 
 import { isSvgMimeType } from '@/utils/file'
-import { extname, resolve } from '@/utils/path'
+import { encodePathSegment, extname, resolve } from '@/utils/path'
 import { adaptImg } from '@/utils/spx'
 import { File, type Files, getImageSize } from '../common/file'
-import { getAssetFilename, getCostumeName, validateCostumeName } from './common/asset-name'
+import { getCostumeName, validateCostumeName } from './common/asset-name'
 import type { Sprite } from './sprite'
 import type { Animation } from './animation'
 
@@ -190,7 +190,7 @@ export class Costume {
 
   export({ basePath, includeId = true, namePrefix = '' }: CostumeExportLoadOptions): [RawCostumeConfig, Files] {
     const name = namePrefix + this.name
-    const filename = getAssetFilename(name, extname(this.img.name))
+    const filename = encodePathSegment(name) + extname(this.img.name)
     const config: RawCostumeConfig = {
       x: this.pivot.x * this.bitmapResolution,
       y: this.pivot.y * this.bitmapResolution,

--- a/spx-gui/src/models/spx/costume.ts
+++ b/spx-gui/src/models/spx/costume.ts
@@ -5,7 +5,7 @@ import { isSvgMimeType } from '@/utils/file'
 import { extname, resolve } from '@/utils/path'
 import { adaptImg } from '@/utils/spx'
 import { File, type Files, getImageSize } from '../common/file'
-import { getCostumeName, validateCostumeName } from './common/asset-name'
+import { getAssetFilename, getCostumeName, validateCostumeName } from './common/asset-name'
 import type { Sprite } from './sprite'
 import type { Animation } from './animation'
 
@@ -190,7 +190,7 @@ export class Costume {
 
   export({ basePath, includeId = true, namePrefix = '' }: CostumeExportLoadOptions): [RawCostumeConfig, Files] {
     const name = namePrefix + this.name
-    const filename = name + extname(this.img.name)
+    const filename = getAssetFilename('costume', name, extname(this.img.name))
     const config: RawCostumeConfig = {
       x: this.pivot.x * this.bitmapResolution,
       y: this.pivot.y * this.bitmapResolution,

--- a/spx-gui/src/models/spx/costume.ts
+++ b/spx-gui/src/models/spx/costume.ts
@@ -190,7 +190,7 @@ export class Costume {
 
   export({ basePath, includeId = true, namePrefix = '' }: CostumeExportLoadOptions): [RawCostumeConfig, Files] {
     const name = namePrefix + this.name
-    const filename = getAssetFilename('costume', name, extname(this.img.name))
+    const filename = getAssetFilename(name, extname(this.img.name))
     const config: RawCostumeConfig = {
       x: this.pivot.x * this.bitmapResolution,
       y: this.pivot.y * this.bitmapResolution,

--- a/spx-gui/src/models/spx/costume.ts
+++ b/spx-gui/src/models/spx/costume.ts
@@ -2,7 +2,7 @@ import { reactive } from 'vue'
 import { nanoid } from 'nanoid'
 
 import { isSvgMimeType } from '@/utils/file'
-import { encodePathSegment, extname, resolve } from '@/utils/path'
+import { encodeFilename, extname, resolve } from '@/utils/path'
 import { adaptImg } from '@/utils/spx'
 import { File, type Files, getImageSize } from '../common/file'
 import { getCostumeName, validateCostumeName } from './common/asset-name'
@@ -190,7 +190,7 @@ export class Costume {
 
   export({ basePath, includeId = true, namePrefix = '' }: CostumeExportLoadOptions): [RawCostumeConfig, Files] {
     const name = namePrefix + this.name
-    const filename = encodePathSegment(name) + extname(this.img.name)
+    const filename = encodeFilename(name + extname(this.img.name))
     const config: RawCostumeConfig = {
       x: this.pivot.x * this.bitmapResolution,
       y: this.pivot.y * this.bitmapResolution,

--- a/spx-gui/src/models/spx/font.test.ts
+++ b/spx-gui/src/models/spx/font.test.ts
@@ -5,7 +5,7 @@ import { FontFamily } from './font'
 
 describe('FontFamily', () => {
   it('rejects empty family names', () => {
-    expect(() => new FontFamily('', fromText('font.otf', 'font'))).toThrow('font family name must not be empty')
+    expect(() => new FontFamily('', fromText('font.otf', 'font'))).toThrow('The name must not be blank')
   })
 
   it('loads and exports a project font', async () => {
@@ -18,8 +18,12 @@ describe('FontFamily', () => {
     expect(fontFamily.name).toBe('basic-chinese')
     expect(fontFamily.file.name).toBe('font.otf')
     expect(await toConfig(fontFamily.export()['assets/fonts/basic-chinese/index.json']!)).toEqual({
-      faces: [{ path: 'font.otf' }]
+      faces: [{ path: 'font-basic-chinese.otf' }]
     })
+  })
+
+  it('rejects unsafe family names', () => {
+    expect(() => new FontFamily('a/b', fromText('font.ttf', 'font'))).toThrow('safe path segment')
   })
 
   it('rejects the reserved default family', async () => {

--- a/spx-gui/src/models/spx/font.test.ts
+++ b/spx-gui/src/models/spx/font.test.ts
@@ -23,7 +23,7 @@ describe('FontFamily', () => {
   })
 
   it('rejects unsafe family names', () => {
-    expect(() => new FontFamily('a/b', fromText('font.ttf', 'font'))).toThrow('must not contain /')
+    expect(() => new FontFamily('a/b', fromText('font.ttf', 'font'))).toThrow('Must not contain /')
   })
 
   it('rejects the reserved default family', async () => {

--- a/spx-gui/src/models/spx/font.test.ts
+++ b/spx-gui/src/models/spx/font.test.ts
@@ -23,7 +23,7 @@ describe('FontFamily', () => {
   })
 
   it('rejects unsafe family names', () => {
-    expect(() => new FontFamily('a/b', fromText('font.ttf', 'font'))).toThrow('safe path segment')
+    expect(() => new FontFamily('a/b', fromText('font.ttf', 'font'))).toThrow('must not contain /')
   })
 
   it('rejects the reserved default family', async () => {

--- a/spx-gui/src/models/spx/font.test.ts
+++ b/spx-gui/src/models/spx/font.test.ts
@@ -23,7 +23,7 @@ describe('FontFamily', () => {
   })
 
   it('rejects unsafe family names', () => {
-    expect(() => new FontFamily('a/b', fromText('font.ttf', 'font'))).toThrow('Must not contain /')
+    expect(() => new FontFamily('a/b', fromText('font.ttf', 'font'))).toThrow('`/` is not allowed')
   })
 
   it('rejects the reserved default family', async () => {

--- a/spx-gui/src/models/spx/font.test.ts
+++ b/spx-gui/src/models/spx/font.test.ts
@@ -18,7 +18,7 @@ describe('FontFamily', () => {
     expect(fontFamily.name).toBe('basic-chinese')
     expect(fontFamily.file.name).toBe('font.otf')
     expect(await toConfig(fontFamily.export()['assets/fonts/basic-chinese/index.json']!)).toEqual({
-      faces: [{ path: 'font-basic-chinese.otf' }]
+      faces: [{ path: 'basic-chinese.otf' }]
     })
   })
 

--- a/spx-gui/src/models/spx/font.test.ts
+++ b/spx-gui/src/models/spx/font.test.ts
@@ -23,7 +23,7 @@ describe('FontFamily', () => {
   })
 
   it('rejects unsafe family names', () => {
-    expect(() => new FontFamily('a/b', fromText('font.ttf', 'font'))).toThrow('`/` is not allowed')
+    expect(() => new FontFamily('a/b', fromText('font.ttf', 'font'))).toThrow('The value must not contain /')
   })
 
   it('rejects the reserved default family', async () => {

--- a/spx-gui/src/models/spx/font.test.ts
+++ b/spx-gui/src/models/spx/font.test.ts
@@ -18,7 +18,7 @@ describe('FontFamily', () => {
     expect(fontFamily.name).toBe('basic-chinese')
     expect(fontFamily.file.name).toBe('font.otf')
     expect(await toConfig(fontFamily.export()['assets/fonts/basic-chinese/index.json']!)).toEqual({
-      faces: [{ path: 'basic-chinese.otf' }]
+      faces: [{ path: 'font.otf' }]
     })
   })
 

--- a/spx-gui/src/models/spx/font.ts
+++ b/spx-gui/src/models/spx/font.ts
@@ -1,6 +1,6 @@
 import { reactive } from 'vue'
 
-import { encodePathSegment, extname, join } from '@/utils/path'
+import { encodeFilename, extname, join } from '@/utils/path'
 import { createFileWithWebUrl } from '../common/cloud'
 import { File, fromConfig, listDirs, toConfig, type Files } from '../common/file'
 import { validateFontName } from './common/asset-name'
@@ -46,7 +46,7 @@ export class FontFamily {
 
   export(): Files {
     const prefix = join(fontAssetPath, this.name)
-    const filename = encodePathSegment(this.name) + extname(this.file.name)
+    const filename = encodeFilename(this.name + extname(this.file.name))
     const config: RawFontConfig = { faces: [{ path: filename }] }
     return {
       [join(prefix, fontConfigFileName)]: fromConfig(fontConfigFileName, config),

--- a/spx-gui/src/models/spx/font.ts
+++ b/spx-gui/src/models/spx/font.ts
@@ -1,6 +1,6 @@
 import { reactive } from 'vue'
 
-import { encodeFilename, extname, join } from '@/utils/path'
+import { extname, join } from '@/utils/path'
 import { createFileWithWebUrl } from '../common/cloud'
 import { File, fromConfig, listDirs, toConfig, type Files } from '../common/file'
 import { validateFontName } from './common/asset-name'
@@ -46,7 +46,7 @@ export class FontFamily {
 
   export(): Files {
     const prefix = join(fontAssetPath, this.name)
-    const filename = encodeFilename(this.name + extname(this.file.name))
+    const filename = `font${extname(this.file.name)}`
     const config: RawFontConfig = { faces: [{ path: filename }] }
     return {
       [join(prefix, fontConfigFileName)]: fromConfig(fontConfigFileName, config),

--- a/spx-gui/src/models/spx/font.ts
+++ b/spx-gui/src/models/spx/font.ts
@@ -46,7 +46,7 @@ export class FontFamily {
 
   export(): Files {
     const prefix = join(fontAssetPath, this.name)
-    const filename = getAssetFilename('font', this.name, extname(this.file.name))
+    const filename = getAssetFilename(this.name, extname(this.file.name))
     const config: RawFontConfig = { faces: [{ path: filename }] }
     return {
       [join(prefix, fontConfigFileName)]: fromConfig(fontConfigFileName, config),

--- a/spx-gui/src/models/spx/font.ts
+++ b/spx-gui/src/models/spx/font.ts
@@ -1,9 +1,9 @@
 import { reactive } from 'vue'
 
-import { extname, join } from '@/utils/path'
+import { encodePathSegment, extname, join } from '@/utils/path'
 import { createFileWithWebUrl } from '../common/cloud'
 import { File, fromConfig, listDirs, toConfig, type Files } from '../common/file'
-import { getAssetFilename, validateFontName } from './common/asset-name'
+import { validateFontName } from './common/asset-name'
 
 export const fontAssetPath = 'assets/fonts'
 const fontConfigFileName = 'index.json'
@@ -46,7 +46,7 @@ export class FontFamily {
 
   export(): Files {
     const prefix = join(fontAssetPath, this.name)
-    const filename = getAssetFilename(this.name, extname(this.file.name))
+    const filename = encodePathSegment(this.name) + extname(this.file.name)
     const config: RawFontConfig = { faces: [{ path: filename }] }
     return {
       [join(prefix, fontConfigFileName)]: fromConfig(fontConfigFileName, config),

--- a/spx-gui/src/models/spx/font.ts
+++ b/spx-gui/src/models/spx/font.ts
@@ -1,8 +1,9 @@
 import { reactive } from 'vue'
 
-import { join } from '@/utils/path'
+import { extname, join } from '@/utils/path'
 import { createFileWithWebUrl } from '../common/cloud'
 import { File, fromConfig, listDirs, toConfig, type Files } from '../common/file'
+import { getAssetFilename, validateFontName } from './common/asset-name'
 
 export const fontAssetPath = 'assets/fonts'
 const fontConfigFileName = 'index.json'
@@ -11,24 +12,21 @@ type RawFontConfig = {
   faces?: { path?: string }[]
 }
 
-function validateFontFamilyName(name: string) {
-  if (name === '') throw new Error('font family name must not be empty')
-  if (name === 'default') throw new Error('font family default is reserved')
-}
-
 export class FontFamily {
   name: string
   file: File
 
   constructor(name: string, file: File) {
-    validateFontFamilyName(name)
+    const err = validateFontName(name)
+    if (err != null) throw new Error(`invalid font family name ${name}: ${err.en}`)
     this.name = name
     this.file = file
     return reactive(this) as this
   }
 
   static async load(name: string, files: Files) {
-    validateFontFamilyName(name)
+    const err = validateFontName(name)
+    if (err != null) throw new Error(`invalid font family name ${name}: ${err.en}`)
     const prefix = join(fontAssetPath, name)
     const configFile = files[join(prefix, fontConfigFileName)]
     if (configFile == null) throw new Error(`font configuration not found for ${name}`)
@@ -48,10 +46,11 @@ export class FontFamily {
 
   export(): Files {
     const prefix = join(fontAssetPath, this.name)
-    const config: RawFontConfig = { faces: [{ path: this.file.name }] }
+    const filename = getAssetFilename('font', this.name, extname(this.file.name))
+    const config: RawFontConfig = { faces: [{ path: filename }] }
     return {
       [join(prefix, fontConfigFileName)]: fromConfig(fontConfigFileName, config),
-      [join(prefix, this.file.name)]: this.file
+      [join(prefix, filename)]: this.file
     }
   }
 }

--- a/spx-gui/src/models/spx/gen/animation-gen.test.ts
+++ b/spx-gui/src/models/spx/gen/animation-gen.test.ts
@@ -20,6 +20,18 @@ describe('AnimationGen', () => {
     aigcMock.reset()
   })
 
+  it('encodes an animation name when using it as a directory', () => {
+    const project = makeSpxProject()
+    const sprite = Sprite.create('TestSprite', '')
+    const gen = new AnimationGen(i18n, sprite, project, {
+      settings: { name: 'a/b' },
+      video: mockFile('video.mp4')
+    })
+
+    const [, files] = gen.export('gen/assets/sprites/TestSprite')
+    expect(Object.keys(files)).toContain('gen/assets/sprites/TestSprite/animations/a%2Fb/video.mp4')
+  })
+
   it('should work well', async () => {
     const project = makeSpxProject()
     const sprite = Sprite.create('TestSprite', '')

--- a/spx-gui/src/models/spx/gen/animation-gen.ts
+++ b/spx-gui/src/models/spx/gen/animation-gen.ts
@@ -1,7 +1,7 @@
 import { nanoid } from 'nanoid'
 import { reactive } from 'vue'
 import type { Prettify } from '@/utils/types'
-import { extname } from '@/utils/path'
+import { encodePathSegment, extname } from '@/utils/path'
 import { Disposable } from '@/utils/disposable'
 import type { I18n } from '@/utils/i18n'
 import { AnimationLoopMode, ArtStyle, Perspective } from '@/apis/common'
@@ -64,7 +64,7 @@ export type RawAnimationGenConfig = Prettify<
 >
 
 function assetsPathFor(basePath: string, name: string) {
-  return `${basePath}/animations/${name}`
+  return `${basePath}/animations/${encodePathSegment(name)}`
 }
 
 export class AnimationGen extends Disposable {

--- a/spx-gui/src/models/spx/gen/backdrop-gen.test.ts
+++ b/spx-gui/src/models/spx/gen/backdrop-gen.test.ts
@@ -509,4 +509,16 @@ describe('BackdropGen', () => {
     expect(loadedMountain.enrichState.status).toBe('finished')
     expect(loadedMountain.imagesGenState.status).toBe('initial')
   })
+
+  it('encodes a backdrop name when using it as a directory', async () => {
+    const project = makeSpxProject()
+    const gen = new BackdropGen(i18n, project, { settings: { name: 'a/b' } })
+    const files = sndFiles(gen.export())
+
+    expect(Object.keys(files)).toContain('assets/backdrop-gens/a%2Fb/index.json')
+    expect(Object.keys(files)).not.toContain('assets/backdrop-gens/a/b/index.json')
+
+    const [loaded] = await BackdropGen.loadAll(i18n, project, files)
+    expect(loaded?.name).toBe('a/b')
+  })
 })

--- a/spx-gui/src/models/spx/gen/backdrop-gen.ts
+++ b/spx-gui/src/models/spx/gen/backdrop-gen.ts
@@ -3,7 +3,7 @@ import { reactive } from 'vue'
 import { Disposable } from '@/utils/disposable'
 import type { Prettify } from '@/utils/types'
 import type { I18n } from '@/utils/i18n'
-import { extname } from '@/utils/path'
+import { encodePathSegment, extname } from '@/utils/path'
 import { ArtStyle, BackdropCategory, Perspective } from '@/apis/common'
 import {
   adoptAsset,
@@ -46,7 +46,7 @@ export const backdropGenAssetPath = 'assets/backdrop-gens'
 const backdropGenConfigFileName = 'index.json'
 
 function assetsPathFor(name: string) {
-  return `gen/assets/backdrops/${name}`
+  return `gen/assets/backdrops/${encodePathSegment(name)}`
 }
 
 export class BackdropGen extends Disposable {
@@ -227,7 +227,7 @@ export class BackdropGen extends Disposable {
       config.resultConfig = resultConfig
       Object.assign(files, resultFiles)
     }
-    files[`${backdropGenAssetPath}/${this.name}/${backdropGenConfigFileName}`] = fromConfig(
+    files[`${backdropGenAssetPath}/${encodePathSegment(this.name)}/${backdropGenConfigFileName}`] = fromConfig(
       backdropGenConfigFileName,
       config
     )

--- a/spx-gui/src/models/spx/gen/costume-gen.test.ts
+++ b/spx-gui/src/models/spx/gen/costume-gen.test.ts
@@ -32,6 +32,26 @@ describe('CostumeGen', () => {
     expect(Object.keys(files)).toContain('gen/assets/sprites/TestSprite/costumes/a%2Fb/image.png')
   })
 
+  it('does not repeatedly encode a costume name across export/load cycles', () => {
+    const project = makeSpxProject()
+    const sprite = Sprite.create('TestSprite', '')
+    const basePath = 'gen/assets/sprites/TestSprite'
+    let gen = new CostumeGen(i18n, sprite, project, {
+      settings: { name: 'a/b' },
+      image: mockFile('image.png')
+    })
+
+    for (let i = 0; i < 3; i++) {
+      const [rawConfig, rawFiles] = gen.export(basePath)
+      const files = sndFiles(rawFiles)
+      expect(Object.keys(files)).toContain(`${basePath}/costumes/a%2Fb/image.png`)
+      expect(Object.keys(files)).not.toContain(`${basePath}/costumes/a%252Fb/image.png`)
+
+      gen = CostumeGen.load(i18n, sprite, project, sndConfig(rawConfig), files, basePath)
+      expect(gen.name).toBe('a/b')
+    }
+  })
+
   it('should work well', async () => {
     const project = makeSpxProject()
     const sprite = Sprite.create('TestSprite', '')

--- a/spx-gui/src/models/spx/gen/costume-gen.test.ts
+++ b/spx-gui/src/models/spx/gen/costume-gen.test.ts
@@ -4,7 +4,7 @@ import { ArtStyle, Perspective } from '@/apis/common'
 import { setupAigcMock } from './aigc-mock' // Put me before importing `@/apis/aigc` to ensure the mock is set up correctly
 import { Facing, TaskStatus, TaskType } from '@/apis/aigc'
 import * as fileHelpers from '@/models/common/file'
-import { sndConfig, sndFiles } from '@/models/common/test'
+import { mockFile, sndConfig, sndFiles } from '@/models/common/test'
 import { makeSpxProject } from '../common/test'
 import { Sprite } from '../sprite'
 import { createI18n } from '@/utils/i18n'
@@ -18,6 +18,18 @@ vi.spyOn(fileHelpers, 'getImageSize').mockReturnValue(Promise.resolve({ width: 1
 describe('CostumeGen', () => {
   beforeEach(() => {
     aigcMock.reset()
+  })
+
+  it('encodes a costume name when using it as a directory', () => {
+    const project = makeSpxProject()
+    const sprite = Sprite.create('TestSprite', '')
+    const gen = new CostumeGen(i18n, sprite, project, {
+      settings: { name: 'a/b' },
+      image: mockFile('image.png')
+    })
+
+    const [, files] = gen.export('gen/assets/sprites/TestSprite')
+    expect(Object.keys(files)).toContain('gen/assets/sprites/TestSprite/costumes/a%2Fb/image.png')
   })
 
   it('should work well', async () => {

--- a/spx-gui/src/models/spx/gen/costume-gen.ts
+++ b/spx-gui/src/models/spx/gen/costume-gen.ts
@@ -1,7 +1,7 @@
 import { nanoid } from 'nanoid'
 import { reactive } from 'vue'
 import type { Prettify } from '@/utils/types'
-import { extname } from '@/utils/path'
+import { encodePathSegment, extname } from '@/utils/path'
 import { Disposable } from '@/utils/disposable'
 import type { I18n } from '@/utils/i18n'
 import { ArtStyle, Perspective } from '@/apis/common'
@@ -52,7 +52,7 @@ export type RawCostumeGenConfig = Prettify<
 >
 
 function assetsPathFor(basePath: string, name: string) {
-  return `${basePath}/costumes/${name}`
+  return `${basePath}/costumes/${encodePathSegment(name)}`
 }
 
 /** `CostumeGen` tracks the generation process of a costume. */

--- a/spx-gui/src/models/spx/gen/sprite-gen.ts
+++ b/spx-gui/src/models/spx/gen/sprite-gen.ts
@@ -1,7 +1,7 @@
 import { nanoid } from 'nanoid'
 import { reactive, watch } from 'vue'
 import type { Prettify } from '@/utils/types'
-import { extname } from '@/utils/path'
+import { encodePathSegment, extname } from '@/utils/path'
 import { Disposable } from '@/utils/disposable'
 import type { I18n, LocaleMessage } from '@/utils/i18n'
 import { getContentBoundingRect } from '@/utils/img'
@@ -47,7 +47,7 @@ export const spriteGenAssetPath = 'assets/sprite-gens'
 const spriteGenConfigFileName = 'index.json'
 
 function assetsPathFor(name: string) {
-  return `gen/assets/sprites/${name}`
+  return `gen/assets/sprites/${encodePathSegment(name)}`
 }
 
 export type SpriteGenInits = {
@@ -587,7 +587,10 @@ export class SpriteGen extends Disposable {
     }
     if (this.imageIndex != null) config.imageIndex = this.imageIndex
     if (this.selectedItem != null) config.selectedItem = this.selectedItem
-    files[`${spriteGenAssetPath}/${this.name}/${spriteGenConfigFileName}`] = fromConfig(spriteGenConfigFileName, config)
+    files[`${spriteGenAssetPath}/${encodePathSegment(this.name)}/${spriteGenConfigFileName}`] = fromConfig(
+      spriteGenConfigFileName,
+      config
+    )
     return files
   }
 }

--- a/spx-gui/src/models/spx/sound.test.ts
+++ b/spx-gui/src/models/spx/sound.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { fromText } from '../common/file'
+import { fromText, toConfig } from '../common/file'
 import { SpxProject } from './project'
 import { Sprite } from './sprite'
 import { Costume } from './costume'
@@ -45,5 +45,19 @@ describe('Sound', () => {
     const sprite = project.sprites[0]
     const animation = sprite.animations[0]
     expect(animation.sound).not.toBe(clone.id)
+  })
+
+  it('uses the logical name as the resource directory and a safe filename', async () => {
+    const sound = new Sound('sound', fromText('sound.mp3', 'sound'))
+    const files = sound.export()
+
+    expect(Object.keys(files).sort()).toEqual([
+      'assets/sounds/sound/index.json',
+      'assets/sounds/sound/sound-sound.mp3'
+    ])
+    expect(await toConfig(files['assets/sounds/sound/index.json']!)).toMatchObject({
+      path: 'sound-sound.mp3'
+    })
+    await expect(Sound.loadAll(files)).resolves.toMatchObject([{ name: 'sound' }])
   })
 })

--- a/spx-gui/src/models/spx/sound.test.ts
+++ b/spx-gui/src/models/spx/sound.test.ts
@@ -51,10 +51,7 @@ describe('Sound', () => {
     const sound = new Sound('sound', fromText('sound.mp3', 'sound'))
     const files = sound.export()
 
-    expect(Object.keys(files).sort()).toEqual([
-      'assets/sounds/sound/index.json',
-      'assets/sounds/sound/sound-sound.mp3'
-    ])
+    expect(Object.keys(files).sort()).toEqual(['assets/sounds/sound/index.json', 'assets/sounds/sound/sound-sound.mp3'])
     expect(await toConfig(files['assets/sounds/sound/index.json']!)).toMatchObject({
       path: 'sound-sound.mp3'
     })

--- a/spx-gui/src/models/spx/sound.test.ts
+++ b/spx-gui/src/models/spx/sound.test.ts
@@ -51,9 +51,9 @@ describe('Sound', () => {
     const sound = new Sound('laser', fromText('sound.mp3', 'sound'))
     const files = sound.export()
 
-    expect(Object.keys(files).sort()).toEqual(['assets/sounds/laser/audio.mp3', 'assets/sounds/laser/index.json'])
+    expect(Object.keys(files).sort()).toEqual(['assets/sounds/laser/index.json', 'assets/sounds/laser/sound.mp3'])
     expect(await toConfig(files['assets/sounds/laser/index.json']!)).toMatchObject({
-      path: 'audio.mp3'
+      path: 'sound.mp3'
     })
     await expect(Sound.loadAll(files)).resolves.toMatchObject([{ name: 'laser' }])
   })

--- a/spx-gui/src/models/spx/sound.test.ts
+++ b/spx-gui/src/models/spx/sound.test.ts
@@ -51,9 +51,9 @@ describe('Sound', () => {
     const sound = new Sound('sound', fromText('sound.mp3', 'sound'))
     const files = sound.export()
 
-    expect(Object.keys(files).sort()).toEqual(['assets/sounds/sound/index.json', 'assets/sounds/sound/sound-sound.mp3'])
+    expect(Object.keys(files).sort()).toEqual(['assets/sounds/sound/index.json', 'assets/sounds/sound/sound.mp3'])
     expect(await toConfig(files['assets/sounds/sound/index.json']!)).toMatchObject({
-      path: 'sound-sound.mp3'
+      path: 'sound.mp3'
     })
     await expect(Sound.loadAll(files)).resolves.toMatchObject([{ name: 'sound' }])
   })

--- a/spx-gui/src/models/spx/sound.test.ts
+++ b/spx-gui/src/models/spx/sound.test.ts
@@ -47,14 +47,14 @@ describe('Sound', () => {
     expect(animation.sound).not.toBe(clone.id)
   })
 
-  it('uses the logical name as the resource directory and a safe filename', async () => {
-    const sound = new Sound('sound', fromText('sound.mp3', 'sound'))
+  it('uses the logical name as the resource directory and a fixed filename', async () => {
+    const sound = new Sound('laser', fromText('sound.mp3', 'sound'))
     const files = sound.export()
 
-    expect(Object.keys(files).sort()).toEqual(['assets/sounds/sound/index.json', 'assets/sounds/sound/sound.mp3'])
-    expect(await toConfig(files['assets/sounds/sound/index.json']!)).toMatchObject({
-      path: 'sound.mp3'
+    expect(Object.keys(files).sort()).toEqual(['assets/sounds/laser/audio.mp3', 'assets/sounds/laser/index.json'])
+    expect(await toConfig(files['assets/sounds/laser/index.json']!)).toMatchObject({
+      path: 'audio.mp3'
     })
-    await expect(Sound.loadAll(files)).resolves.toMatchObject([{ name: 'sound' }])
+    await expect(Sound.loadAll(files)).resolves.toMatchObject([{ name: 'laser' }])
   })
 })

--- a/spx-gui/src/models/spx/sound.ts
+++ b/spx-gui/src/models/spx/sound.ts
@@ -1,5 +1,5 @@
 import { reactive } from 'vue'
-import { encodeFilename, extname, join, resolve } from '@/utils/path'
+import { extname, join, resolve } from '@/utils/path'
 import { adaptAudio } from '@/utils/spx'
 import { Disposable } from '@/utils/disposable'
 import { File, fromConfig, type Files, listDirs, toConfig } from '../common/file'
@@ -146,7 +146,7 @@ export class Sound extends Disposable {
 
   // config is included in files
   export({ includeId = true, includeAssetMetadata = true }: SoundExportLoadOptions = {}): Files {
-    const filename = encodeFilename(this.name + extname(this.file.name))
+    const filename = `audio${extname(this.file.name)}`
     const config: RawSoundConfig = {
       rate: this.rate,
       sampleCount: this.sampleCount,

--- a/spx-gui/src/models/spx/sound.ts
+++ b/spx-gui/src/models/spx/sound.ts
@@ -1,5 +1,5 @@
 import { reactive } from 'vue'
-import { encodePathSegment, extname, join, resolve } from '@/utils/path'
+import { encodeFilename, extname, join, resolve } from '@/utils/path'
 import { adaptAudio } from '@/utils/spx'
 import { Disposable } from '@/utils/disposable'
 import { File, fromConfig, type Files, listDirs, toConfig } from '../common/file'
@@ -146,7 +146,7 @@ export class Sound extends Disposable {
 
   // config is included in files
   export({ includeId = true, includeAssetMetadata = true }: SoundExportLoadOptions = {}): Files {
-    const filename = encodePathSegment(this.name) + extname(this.file.name)
+    const filename = encodeFilename(this.name + extname(this.file.name))
     const config: RawSoundConfig = {
       rate: this.rate,
       sampleCount: this.sampleCount,

--- a/spx-gui/src/models/spx/sound.ts
+++ b/spx-gui/src/models/spx/sound.ts
@@ -146,7 +146,7 @@ export class Sound extends Disposable {
 
   // config is included in files
   export({ includeId = true, includeAssetMetadata = true }: SoundExportLoadOptions = {}): Files {
-    const filename = `audio${extname(this.file.name)}`
+    const filename = `sound${extname(this.file.name)}`
     const config: RawSoundConfig = {
       rate: this.rate,
       sampleCount: this.sampleCount,

--- a/spx-gui/src/models/spx/sound.ts
+++ b/spx-gui/src/models/spx/sound.ts
@@ -3,7 +3,7 @@ import { extname, join, resolve } from '@/utils/path'
 import { adaptAudio } from '@/utils/spx'
 import { Disposable } from '@/utils/disposable'
 import { File, fromConfig, type Files, listDirs, toConfig } from '../common/file'
-import { getSoundName, validateSoundName } from './common/asset-name'
+import { getAssetFilename, getSoundName, validateSoundName } from './common/asset-name'
 import type { AssetMetadata } from './common/asset'
 import type { SpxProject } from './project'
 import { nanoid } from 'nanoid'
@@ -146,7 +146,7 @@ export class Sound extends Disposable {
 
   // config is included in files
   export({ includeId = true, includeAssetMetadata = true }: SoundExportLoadOptions = {}): Files {
-    const filename = this.name + extname(this.file.name)
+    const filename = getAssetFilename('sound', this.name, extname(this.file.name))
     const config: RawSoundConfig = {
       rate: this.rate,
       sampleCount: this.sampleCount,

--- a/spx-gui/src/models/spx/sound.ts
+++ b/spx-gui/src/models/spx/sound.ts
@@ -1,9 +1,9 @@
 import { reactive } from 'vue'
-import { extname, join, resolve } from '@/utils/path'
+import { encodePathSegment, extname, join, resolve } from '@/utils/path'
 import { adaptAudio } from '@/utils/spx'
 import { Disposable } from '@/utils/disposable'
 import { File, fromConfig, type Files, listDirs, toConfig } from '../common/file'
-import { getAssetFilename, getSoundName, validateSoundName } from './common/asset-name'
+import { getSoundName, validateSoundName } from './common/asset-name'
 import type { AssetMetadata } from './common/asset'
 import type { SpxProject } from './project'
 import { nanoid } from 'nanoid'
@@ -146,7 +146,7 @@ export class Sound extends Disposable {
 
   // config is included in files
   export({ includeId = true, includeAssetMetadata = true }: SoundExportLoadOptions = {}): Files {
-    const filename = getAssetFilename(this.name, extname(this.file.name))
+    const filename = encodePathSegment(this.name) + extname(this.file.name)
     const config: RawSoundConfig = {
       rate: this.rate,
       sampleCount: this.sampleCount,

--- a/spx-gui/src/models/spx/sound.ts
+++ b/spx-gui/src/models/spx/sound.ts
@@ -146,7 +146,7 @@ export class Sound extends Disposable {
 
   // config is included in files
   export({ includeId = true, includeAssetMetadata = true }: SoundExportLoadOptions = {}): Files {
-    const filename = getAssetFilename('sound', this.name, extname(this.file.name))
+    const filename = getAssetFilename(this.name, extname(this.file.name))
     const config: RawSoundConfig = {
       rate: this.rate,
       sampleCount: this.sampleCount,

--- a/spx-gui/src/utils/path.test.ts
+++ b/spx-gui/src/utils/path.test.ts
@@ -96,10 +96,10 @@ describe('extname', () => {
 
 describe('validatePathSegment', () => {
   it.each([
-    ['.', 'The path segment cannot be . or ..'],
-    ['..', 'The path segment cannot be . or ..'],
-    ['a/b', 'The path segment must not contain /'],
-    ['a\0b', 'The path segment contains an unsupported character']
+    ['.', 'Cannot be . or ..'],
+    ['..', 'Cannot be . or ..'],
+    ['a/b', 'Must not contain /'],
+    ['a\0b', 'Contains an unsupported character']
   ])('explains why %j is rejected', (value, message) => {
     expect(validatePathSegment(value)).toMatchObject({ en: message })
   })

--- a/spx-gui/src/utils/path.test.ts
+++ b/spx-gui/src/utils/path.test.ts
@@ -107,8 +107,10 @@ describe('isSafePathSegment', () => {
 })
 
 describe('encodePathSegment', () => {
-  it('uses percent encoding and encodes dots', () => {
-    expect(encodePathSegment('=/')).toBe('%3D%2F')
+  it('escapes only path syntax and the escape marker', () => {
+    expect(encodePathSegment('=/')).toBe('=%2F')
+    expect(encodePathSegment('中文 😀')).toBe('中文 😀')
+    expect(encodePathSegment('%2F')).toBe('%252F')
     expect(encodePathSegment('.')).toBe('%2E')
     expect(encodePathSegment('..')).toBe('%2E%2E')
   })

--- a/spx-gui/src/utils/path.test.ts
+++ b/spx-gui/src/utils/path.test.ts
@@ -8,15 +8,8 @@ describe('resolve', () => {
     expect(resolve('/foo/bar', 'baz')).toBe('/foo/bar/baz')
     expect(resolve('/foo/bar', 'baz', 'qux')).toBe('/foo/bar/baz/qux')
   })
-  it('should work well with url', () => {
-    expect(resolve('https://test.com/foo', 'bar')).toBe('https://test.com/foo/bar')
-    expect(resolve('https://test.com/foo', 'bar', 'baz')).toBe('https://test.com/foo/bar/baz')
-    expect(resolve('https://test.com/foo/bar', 'baz')).toBe('https://test.com/foo/bar/baz')
-    expect(resolve('https://test.com/foo/bar', 'baz', 'qux')).toBe('https://test.com/foo/bar/baz/qux')
-  })
   it('should work well with no path', () => {
     expect(resolve('foo')).toBe('foo')
-    expect(resolve('https://test.com/foo')).toBe('https://test.com/foo')
   })
   it('should work well with complex path', () => {
     expect(resolve('foo', 'bar/baz')).toBe('foo/bar/baz')
@@ -38,14 +31,9 @@ describe('filename', () => {
     expect(filename('你好/世界.png')).toBe('世界.png')
     expect(filename('src/你好/世界.png')).toBe('世界.png')
   })
-  it('should work well with url', () => {
-    expect(filename('https://test.com/abc.txt')).toBe('abc.txt')
-    expect(filename('https://test.com/foo/%E4%B8%AD%E6%96%87.png')).toBe('%E4%B8%AD%E6%96%87.png')
-  })
   it('should work well with no ext', () => {
     expect(filename('abc')).toBe('abc')
     expect(filename('/foo/.git/a')).toBe('a')
-    expect(filename('https://test.com/project/foo')).toBe('foo')
   })
   it('should work well with complex ext', () => {
     expect(filename('foo/abc.d.ts')).toBe('abc.d.ts')
@@ -55,9 +43,8 @@ describe('filename', () => {
   it('should work well with special characters', () => {
     expect(filename('foo/Artificial Axolotl 😡.svg')).toBe('Artificial Axolotl 😡.svg')
   })
-  it('should work well with url containing search', () => {
-    expect(filename('https://test.com/abc.txt?version=1.2.3')).toBe('abc.txt')
-    expect(filename('https://test.com/foo?bar')).toBe('foo')
+  it('keeps question marks in POSIX paths', () => {
+    expect(filename('foo/image?draft.png')).toBe('image?draft.png')
   })
 })
 
@@ -67,14 +54,9 @@ describe('stripExt', () => {
     expect(stripExt('中文.png')).toBe('中文')
     expect(stripExt('src/你好/世界.png')).toBe('src/你好/世界')
   })
-  it('should work well with url', () => {
-    expect(stripExt('https://test.com/abc.txt')).toBe('https://test.com/abc')
-    expect(stripExt('https://test.com/foo/%E4%B8%AD%E6%96%87.png')).toBe('https://test.com/foo/%E4%B8%AD%E6%96%87')
-  })
   it('should work well with no ext', () => {
     expect(stripExt('abc')).toBe('abc')
     expect(stripExt('/foo/.git/a')).toBe('/foo/.git/a')
-    expect(stripExt('https://test.com/project/foo')).toBe('https://test.com/project/foo')
   })
   it('should work well with complex ext', () => {
     expect(stripExt('abc.d.ts')).toBe('abc.d')
@@ -84,9 +66,8 @@ describe('stripExt', () => {
   it('should work well with special characters', () => {
     expect(stripExt('foo/Artificial Axolotl 😡.svg')).toBe('foo/Artificial Axolotl 😡')
   })
-  it('should work well with url containing search', () => {
-    expect(stripExt('https://test.com/abc.txt?version=1.2.3')).toBe('https://test.com/abc')
-    expect(stripExt('https://test.com/foo?bar')).toBe('https://test.com/foo')
+  it('keeps question marks in POSIX paths', () => {
+    expect(stripExt('foo/image?draft.png')).toBe('foo/image?draft')
   })
 })
 
@@ -96,14 +77,9 @@ describe('extname', () => {
     expect(extname('中文.png')).toBe('.png')
     expect(extname('src/你好/世界.png')).toBe('.png')
   })
-  it('should work well with url', () => {
-    expect(extname('https://test.com/abc.txt')).toBe('.txt')
-    expect(extname('https://test.com/foo/%E4%B8%AD%E6%96%87.png')).toBe('.png')
-  })
   it('should work well with no ext', () => {
     expect(extname('abc')).toBe('')
     expect(extname('/foo/.git/a')).toBe('')
-    expect(extname('https://test.com/project/foo')).toBe('')
   })
   it('should work well with complex ext', () => {
     expect(extname('abc.d.ts')).toBe('.ts')
@@ -113,8 +89,7 @@ describe('extname', () => {
   it('should work well with special characters', () => {
     expect(extname('foo/Artificial Axolotl 😡.svg')).toBe('.svg')
   })
-  it('should work well with url containing search', () => {
-    expect(extname('https://test.com/abc.txt?version=1.2.3')).toBe('.txt')
-    expect(extname('https://test.com/foo?bar')).toBe('')
+  it('keeps question marks in POSIX paths', () => {
+    expect(extname('foo/image?draft.png')).toBe('.png')
   })
 })

--- a/spx-gui/src/utils/path.test.ts
+++ b/spx-gui/src/utils/path.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { encodeFilename, encodePathSegment, resolve, filename, stripExt, extname, isSafePathSegment } from './path'
+import { encodeFilename, encodePathSegment, resolve, filename, stripExt, extname, validatePathSegment } from './path'
 
 describe('resolve', () => {
   it('should work well with path', () => {
@@ -94,15 +94,20 @@ describe('extname', () => {
   })
 })
 
-describe('isSafePathSegment', () => {
-  it.each(['', '.', '..', 'a/b', 'a\0b'])('rejects %j', (value) => {
-    expect(isSafePathSegment(value)).toBe(false)
+describe('validatePathSegment', () => {
+  it.each([
+    ['.', 'The name cannot be . or ..'],
+    ['..', 'The name cannot be . or ..'],
+    ['a/b', 'The name must not contain /'],
+    ['a\0b', 'The name contains an unsupported character']
+  ])('explains why %j is rejected', (value, message) => {
+    expect(validatePathSegment(value)).toMatchObject({ en: message })
   })
 
   it('accepts ordinary names', () => {
-    expect(isSafePathSegment('中文 😀')).toBe(true)
-    expect(isSafePathSegment('CON')).toBe(true)
-    expect(isSafePathSegment('a\\b')).toBe(true)
+    expect(validatePathSegment('中文 😀')).toBeUndefined()
+    expect(validatePathSegment('CON')).toBeUndefined()
+    expect(validatePathSegment('a\\b')).toBeUndefined()
   })
 })
 

--- a/spx-gui/src/utils/path.test.ts
+++ b/spx-gui/src/utils/path.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { resolve, filename, stripExt, extname, isSafePathSegment } from './path'
+import { encodePathSegment, resolve, filename, stripExt, extname, isSafePathSegment } from './path'
 
 describe('resolve', () => {
   it('should work well with path', () => {
@@ -103,5 +103,13 @@ describe('isSafePathSegment', () => {
     expect(isSafePathSegment('中文 😀')).toBe(true)
     expect(isSafePathSegment('CON')).toBe(true)
     expect(isSafePathSegment('a\\b')).toBe(true)
+  })
+})
+
+describe('encodePathSegment', () => {
+  it('uses percent encoding and encodes dots', () => {
+    expect(encodePathSegment('=/')).toBe('%3D%2F')
+    expect(encodePathSegment('.')).toBe('%2E')
+    expect(encodePathSegment('..')).toBe('%2E%2E')
   })
 })

--- a/spx-gui/src/utils/path.test.ts
+++ b/spx-gui/src/utils/path.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { resolve, filename, stripExt, extname } from './path'
+import { resolve, filename, stripExt, extname, isSafePathSegment } from './path'
 
 describe('resolve', () => {
   it('should work well with path', () => {
@@ -91,5 +91,17 @@ describe('extname', () => {
   })
   it('keeps question marks in POSIX paths', () => {
     expect(extname('foo/image?draft.png')).toBe('.png')
+  })
+})
+
+describe('isSafePathSegment', () => {
+  it.each(['', '.', '..', 'a/b', 'a\0b'])('rejects %j', (value) => {
+    expect(isSafePathSegment(value)).toBe(false)
+  })
+
+  it('accepts ordinary names', () => {
+    expect(isSafePathSegment('中文 😀')).toBe(true)
+    expect(isSafePathSegment('CON')).toBe(true)
+    expect(isSafePathSegment('a\\b')).toBe(true)
   })
 })

--- a/spx-gui/src/utils/path.test.ts
+++ b/spx-gui/src/utils/path.test.ts
@@ -96,10 +96,10 @@ describe('extname', () => {
 
 describe('validatePathSegment', () => {
   it.each([
-    ['.', '`.` and `..` are not allowed'],
-    ['..', '`.` and `..` are not allowed'],
-    ['a/b', '`/` is not allowed'],
-    ['a\0b', 'Unsupported characters are not allowed']
+    ['.', 'The value cannot be . or ..'],
+    ['..', 'The value cannot be . or ..'],
+    ['a/b', 'The value must not contain /'],
+    ['a\0b', 'The value contains an unsupported character']
   ])('explains why %j is rejected', (value, message) => {
     expect(validatePathSegment(value)).toMatchObject({ en: message })
   })

--- a/spx-gui/src/utils/path.test.ts
+++ b/spx-gui/src/utils/path.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { encodePathSegment, resolve, filename, stripExt, extname, isSafePathSegment } from './path'
+import { encodeFilename, encodePathSegment, resolve, filename, stripExt, extname, isSafePathSegment } from './path'
 
 describe('resolve', () => {
   it('should work well with path', () => {
@@ -113,5 +113,11 @@ describe('encodePathSegment', () => {
     expect(encodePathSegment('%2F')).toBe('%252F')
     expect(encodePathSegment('.')).toBe('%2E')
     expect(encodePathSegment('..')).toBe('%2E%2E')
+  })
+})
+
+describe('encodeFilename', () => {
+  it('uses path segment encoding after the extension is appended', () => {
+    expect(encodeFilename('=/.svg')).toBe('=%2F.svg')
   })
 })

--- a/spx-gui/src/utils/path.test.ts
+++ b/spx-gui/src/utils/path.test.ts
@@ -96,10 +96,10 @@ describe('extname', () => {
 
 describe('validatePathSegment', () => {
   it.each([
-    ['.', 'Cannot be . or ..'],
-    ['..', 'Cannot be . or ..'],
-    ['a/b', 'Must not contain /'],
-    ['a\0b', 'Contains an unsupported character']
+    ['.', '`.` and `..` are not allowed'],
+    ['..', '`.` and `..` are not allowed'],
+    ['a/b', '`/` is not allowed'],
+    ['a\0b', 'Unsupported characters are not allowed']
   ])('explains why %j is rejected', (value, message) => {
     expect(validatePathSegment(value)).toMatchObject({ en: message })
   })

--- a/spx-gui/src/utils/path.test.ts
+++ b/spx-gui/src/utils/path.test.ts
@@ -96,10 +96,10 @@ describe('extname', () => {
 
 describe('validatePathSegment', () => {
   it.each([
-    ['.', 'The name cannot be . or ..'],
-    ['..', 'The name cannot be . or ..'],
-    ['a/b', 'The name must not contain /'],
-    ['a\0b', 'The name contains an unsupported character']
+    ['.', 'The path segment cannot be . or ..'],
+    ['..', 'The path segment cannot be . or ..'],
+    ['a/b', 'The path segment must not contain /'],
+    ['a\0b', 'The path segment contains an unsupported character']
   ])('explains why %j is rejected', (value, message) => {
     expect(validatePathSegment(value)).toMatchObject({ en: message })
   })

--- a/spx-gui/src/utils/path.ts
+++ b/spx-gui/src/utils/path.ts
@@ -41,9 +41,12 @@ export function extname(path: string) {
   return path.slice(stripExt(path).length)
 }
 
-/** Whether a value can be used directly as one POSIX-style path segment. */
-export function isSafePathSegment(value: string) {
-  return value !== '' && value !== '.' && value !== '..' && !value.includes('/') && !value.includes('\0')
+/** Return a user-facing validation error when a value is not one POSIX-style path segment. */
+export function validatePathSegment(value: string) {
+  if (value === '') return { en: 'The name must not be blank', zh: '名字不可为空' }
+  if (value === '.' || value === '..') return { en: 'The name cannot be . or ..', zh: '名称不可为 . 或 ..' }
+  if (value.includes('/')) return { en: 'The name must not contain /', zh: '名称不可包含 /' }
+  if (value.includes('\0')) return { en: 'The name contains an unsupported character', zh: '名称包含不支持的字符' }
 }
 
 /** Encode a non-empty value as one POSIX-style path segment. */

--- a/spx-gui/src/utils/path.ts
+++ b/spx-gui/src/utils/path.ts
@@ -46,7 +46,9 @@ export function isSafePathSegment(value: string) {
   return value !== '' && value !== '.' && value !== '..' && !value.includes('/') && !value.includes('\0')
 }
 
-/** Encode a value as one POSIX-style path segment. */
+/** Encode a non-empty value as one POSIX-style path segment. */
 export function encodePathSegment(value: string) {
-  return encodeURIComponent(value).replaceAll('.', '%2E')
+  if (value === '.') return '%2E'
+  if (value === '..') return '%2E%2E'
+  return value.replaceAll('%', '%25').replaceAll('/', '%2F').replaceAll('\0', '%00')
 }

--- a/spx-gui/src/utils/path.ts
+++ b/spx-gui/src/utils/path.ts
@@ -43,10 +43,10 @@ export function extname(path: string) {
 
 /** Return a user-facing validation error when a value is not one POSIX-style path segment. */
 export function validatePathSegment(value: string) {
-  if (value === '') return { en: 'Must not be blank', zh: '不可为空' }
-  if (value === '.' || value === '..') return { en: 'Cannot be . or ..', zh: '不可为 . 或 ..' }
-  if (value.includes('/')) return { en: 'Must not contain /', zh: '不可包含 /' }
-  if (value.includes('\0')) return { en: 'Contains an unsupported character', zh: '包含不支持的字符' }
+  if (value === '') return { en: 'Blank content is not allowed', zh: '不可为空' }
+  if (value === '.' || value === '..') return { en: '`.` and `..` are not allowed', zh: '不可为 . 或 ..' }
+  if (value.includes('/')) return { en: '`/` is not allowed', zh: '不可包含 /' }
+  if (value.includes('\0')) return { en: 'Unsupported characters are not allowed', zh: '包含不支持的字符' }
 }
 
 /** Encode a non-empty value as one POSIX-style path segment. */

--- a/spx-gui/src/utils/path.ts
+++ b/spx-gui/src/utils/path.ts
@@ -43,10 +43,10 @@ export function extname(path: string) {
 
 /** Return a user-facing validation error when a value is not one POSIX-style path segment. */
 export function validatePathSegment(value: string) {
-  if (value === '') return { en: 'Blank content is not allowed', zh: '不可为空' }
-  if (value === '.' || value === '..') return { en: '`.` and `..` are not allowed', zh: '不可为 . 或 ..' }
-  if (value.includes('/')) return { en: '`/` is not allowed', zh: '不可包含 /' }
-  if (value.includes('\0')) return { en: 'Unsupported characters are not allowed', zh: '包含不支持的字符' }
+  if (value === '') return { en: 'The value must not be blank', zh: '不可为空' }
+  if (value === '.' || value === '..') return { en: 'The value cannot be . or ..', zh: '不可为 . 或 ..' }
+  if (value.includes('/')) return { en: 'The value must not contain /', zh: '不可包含 /' }
+  if (value.includes('\0')) return { en: 'The value contains an unsupported character', zh: '包含不支持的字符' }
 }
 
 /** Encode a non-empty value as one POSIX-style path segment. */

--- a/spx-gui/src/utils/path.ts
+++ b/spx-gui/src/utils/path.ts
@@ -52,3 +52,8 @@ export function encodePathSegment(value: string) {
   if (value === '..') return '%2E%2E'
   return value.replaceAll('%', '%25').replaceAll('/', '%2F').replaceAll('\0', '%00')
 }
+
+/** Encode a filename as one POSIX-style path segment. */
+export function encodeFilename(filename: string) {
+  return encodePathSegment(filename)
+}

--- a/spx-gui/src/utils/path.ts
+++ b/spx-gui/src/utils/path.ts
@@ -45,3 +45,8 @@ export function extname(path: string) {
 export function isSafePathSegment(value: string) {
   return value !== '' && value !== '.' && value !== '..' && !value.includes('/') && !value.includes('\0')
 }
+
+/** Encode a value as one POSIX-style path segment. */
+export function encodePathSegment(value: string) {
+  return encodeURIComponent(value).replaceAll('.', '%2E')
+}

--- a/spx-gui/src/utils/path.ts
+++ b/spx-gui/src/utils/path.ts
@@ -43,10 +43,11 @@ export function extname(path: string) {
 
 /** Return a user-facing validation error when a value is not one POSIX-style path segment. */
 export function validatePathSegment(value: string) {
-  if (value === '') return { en: 'The name must not be blank', zh: '名字不可为空' }
-  if (value === '.' || value === '..') return { en: 'The name cannot be . or ..', zh: '名称不可为 . 或 ..' }
-  if (value.includes('/')) return { en: 'The name must not contain /', zh: '名称不可包含 /' }
-  if (value.includes('\0')) return { en: 'The name contains an unsupported character', zh: '名称包含不支持的字符' }
+  if (value === '') return { en: 'The path segment must not be blank', zh: '路径段不可为空' }
+  if (value === '.' || value === '..') return { en: 'The path segment cannot be . or ..', zh: '路径段不可为 . 或 ..' }
+  if (value.includes('/')) return { en: 'The path segment must not contain /', zh: '路径段不可包含 /' }
+  if (value.includes('\0'))
+    return { en: 'The path segment contains an unsupported character', zh: '路径段包含不支持的字符' }
 }
 
 /** Encode a non-empty value as one POSIX-style path segment. */

--- a/spx-gui/src/utils/path.ts
+++ b/spx-gui/src/utils/path.ts
@@ -43,11 +43,10 @@ export function extname(path: string) {
 
 /** Return a user-facing validation error when a value is not one POSIX-style path segment. */
 export function validatePathSegment(value: string) {
-  if (value === '') return { en: 'The path segment must not be blank', zh: '路径段不可为空' }
-  if (value === '.' || value === '..') return { en: 'The path segment cannot be . or ..', zh: '路径段不可为 . 或 ..' }
-  if (value.includes('/')) return { en: 'The path segment must not contain /', zh: '路径段不可包含 /' }
-  if (value.includes('\0'))
-    return { en: 'The path segment contains an unsupported character', zh: '路径段包含不支持的字符' }
+  if (value === '') return { en: 'Must not be blank', zh: '不可为空' }
+  if (value === '.' || value === '..') return { en: 'Cannot be . or ..', zh: '不可为 . 或 ..' }
+  if (value.includes('/')) return { en: 'Must not contain /', zh: '不可包含 /' }
+  if (value.includes('\0')) return { en: 'Contains an unsupported character', zh: '包含不支持的字符' }
 }
 
 /** Encode a non-empty value as one POSIX-style path segment. */

--- a/spx-gui/src/utils/path.ts
+++ b/spx-gui/src/utils/path.ts
@@ -1,37 +1,47 @@
-import resolveUri from '@jridgewell/resolve-uri'
+// Utilities for POSIX-style paths.
 
+/** Concatenate path components without normalizing them. */
 export function join(base: string, ...paths: string[]) {
-  // TODO
   return [base, ...paths].join('/')
 }
 
+/** Resolve path components and normalize `.` and `..` segments. */
 export function resolve(base: string, ...paths: string[]) {
-  return resolveUri([base, ...paths].join('/'), undefined)
+  const path = [base, ...paths].join('/')
+  const absolute = path.startsWith('/')
+  const segments: string[] = []
+  for (const segment of path.split('/')) {
+    if (segment === '' || segment === '.') continue
+    if (segment === '..') {
+      if (segments.length > 0 && segments[segments.length - 1] !== '..') segments.pop()
+      else if (!absolute) segments.push(segment)
+      continue
+    }
+    segments.push(segment)
+  }
+  return (absolute ? '/' : '') + segments.join('/')
 }
 
-export function stripSearch(urlOrPath: string) {
-  const searchIdx = urlOrPath.lastIndexOf('?')
-  if (searchIdx >= 0) return urlOrPath.slice(0, searchIdx)
-  return urlOrPath
+/** Return the final path segment. */
+export function filename(path: string) {
+  const slashPos = path.lastIndexOf('/')
+  return slashPos >= 0 ? path.slice(slashPos + 1) : path
 }
 
-export function filename(urlOrPath: string) {
-  urlOrPath = stripSearch(urlOrPath)
-  const slashPos = urlOrPath.lastIndexOf('/')
-  if (slashPos >= 0) urlOrPath = urlOrPath.slice(slashPos + 1)
-  return urlOrPath
+/** Remove the final extension from the final path segment. */
+export function stripExt(path: string) {
+  const slashPos = path.lastIndexOf('/')
+  const dotPos = path.lastIndexOf('.')
+  if (dotPos > slashPos + 1) return path.slice(0, dotPos)
+  return path
 }
 
-export function stripExt(urlOrPath: string) {
-  urlOrPath = stripSearch(urlOrPath)
-  const slashPos = urlOrPath.lastIndexOf('/')
-  const dotPos = urlOrPath.lastIndexOf('.')
-  if (dotPos > slashPos + 1) return urlOrPath.slice(0, dotPos)
-  return urlOrPath
+/** Return the final filename extension, including the dot. e.g. `.txt` */
+export function extname(path: string) {
+  return path.slice(stripExt(path).length)
 }
 
-/** get extname, with dot. e.g. `.txt` */
-export function extname(urlOrPath: string) {
-  urlOrPath = stripSearch(urlOrPath)
-  return urlOrPath.slice(stripExt(urlOrPath).length)
+/** Whether a value can be used directly as one POSIX-style path segment. */
+export function isSafePathSegment(value: string) {
+  return value !== '' && value !== '.' && value !== '..' && !value.includes('/') && !value.includes('\0')
 }

--- a/spx-gui/src/utils/universal-url.test.ts
+++ b/spx-gui/src/utils/universal-url.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest'
 import {
   UniversalUrlScheme,
   getUniversalUrlScheme,
+  getUniversalUrlFilename,
   parseUniversalUrl,
   stringifyDataUrl,
   stringifyKodoUrl,
@@ -40,6 +41,16 @@ describe('getUniversalUrlScheme', () => {
     expect(() => getUniversalUrlScheme('ftp://example.com')).toThrow('unsupported universal url scheme: ftp')
     expect(() => getUniversalUrlScheme('file:///path/to/file')).toThrow('unsupported universal url scheme: file')
     expect(() => getUniversalUrlScheme('custom://something')).toThrow('unsupported universal url scheme: custom')
+  })
+})
+
+describe('getUniversalUrlFilename', () => {
+  it('extracts the POSIX path before reading HTTP URL filenames', () => {
+    expect(getUniversalUrlFilename('https://example.com/path/file.png?version=1')).toBe('file.png')
+  })
+
+  it('gets Kodo object filenames from their keys', () => {
+    expect(getUniversalUrlFilename('kodo://bucket/path/to/file.png')).toBe('file.png')
   })
 })
 

--- a/spx-gui/src/utils/universal-url.test.ts
+++ b/spx-gui/src/utils/universal-url.test.ts
@@ -49,8 +49,8 @@ describe('getUniversalUrlFilename', () => {
     expect(getUniversalUrlFilename('https://example.com/path/file.png?version=1')).toBe('file.png')
   })
 
-  it('gets Kodo object filenames from opaque keys', () => {
-    expect(getUniversalUrlFilename('kodo://bucket/path/to/file.png?version=1')).toBe('file.png?version=1')
+  it('ignores Kodo FOP operations after the object key', () => {
+    expect(getUniversalUrlFilename('kodo://bucket/path/to/file.png?imageView2/0/w/100')).toBe('file.png')
   })
 })
 
@@ -128,9 +128,9 @@ describe('parseUniversalUrl', () => {
       expect(result.key).toBe('deep/nested/path/file-name.jpg')
     })
 
-    it('treats URL-like characters as part of the key', () => {
-      const result = parseUniversalUrl('kodo://bucket/path/file.png?version=1') as KodoUrlParsed
-      expect(result.key).toBe('path/file.png?version=1')
+    it('keeps FOP operations with the Kodo key', () => {
+      const result = parseUniversalUrl('kodo://bucket/path/file.png?imageView2/0/w/100') as KodoUrlParsed
+      expect(result.key).toBe('path/file.png?imageView2/0/w/100')
     })
 
     it('should throw error for invalid kodo url without slash', () => {

--- a/spx-gui/src/utils/universal-url.test.ts
+++ b/spx-gui/src/utils/universal-url.test.ts
@@ -49,8 +49,8 @@ describe('getUniversalUrlFilename', () => {
     expect(getUniversalUrlFilename('https://example.com/path/file.png?version=1')).toBe('file.png')
   })
 
-  it('gets Kodo object filenames from their keys', () => {
-    expect(getUniversalUrlFilename('kodo://bucket/path/to/file.png')).toBe('file.png')
+  it('gets Kodo object filenames from opaque keys', () => {
+    expect(getUniversalUrlFilename('kodo://bucket/path/to/file.png?version=1')).toBe('file.png?version=1')
   })
 })
 
@@ -126,6 +126,11 @@ describe('parseUniversalUrl', () => {
       expect(result.scheme).toBe(UniversalUrlScheme.Kodo)
       expect(result.bucket).toBe('test-bucket')
       expect(result.key).toBe('deep/nested/path/file-name.jpg')
+    })
+
+    it('treats URL-like characters as part of the key', () => {
+      const result = parseUniversalUrl('kodo://bucket/path/file.png?version=1') as KodoUrlParsed
+      expect(result.key).toBe('path/file.png?version=1')
     })
 
     it('should throw error for invalid kodo url without slash', () => {

--- a/spx-gui/src/utils/universal-url.ts
+++ b/spx-gui/src/utils/universal-url.ts
@@ -15,7 +15,7 @@ export const enum UniversalUrlScheme {
   Https = 'https',
   /** For inlineable data, usually plain text or json, e.g. `data:text/plain,hello%20world` */
   Data = 'data',
-  /** For objects stored in Qiniu Kodo, e.g. `kodo://bucket/key`; the key is opaque and may contain `?` */
+  /** For objects stored in Qiniu Kodo, e.g. `kodo://bucket/key?fop` */
   Kodo = 'kodo'
 }
 
@@ -24,7 +24,7 @@ export type DataUrlParsed = { scheme: UniversalUrlScheme.Data; url: string }
 export type KodoUrlParsed = {
   scheme: UniversalUrlScheme.Kodo
   bucket: string
-  /** Opaque object key, which may contain URL-like characters such as `?`. */
+  /** Object key, optionally followed by Qiniu FOP operations after `?`. */
   key: string
 }
 
@@ -71,7 +71,7 @@ export function parseUniversalUrl(urlStr: string): UniversalUrlParsed {
   }
 }
 
-/** Get the filename from an HTTP URL pathname or a Kodo object key. */
+/** Get the filename from an HTTP URL pathname or the object-key part of a Kodo URL. */
 export function getUniversalUrlFilename(urlStr: string) {
   const parsed = parseUniversalUrl(urlStr)
   switch (parsed.scheme) {
@@ -79,7 +79,7 @@ export function getUniversalUrlFilename(urlStr: string) {
     case UniversalUrlScheme.Https:
       return filename(new URL(parsed.url).pathname)
     case UniversalUrlScheme.Kodo:
-      return filename(parsed.key)
+      return filename(parsed.key.split('?', 1)[0])
     case UniversalUrlScheme.Data:
       return ''
   }

--- a/spx-gui/src/utils/universal-url.ts
+++ b/spx-gui/src/utils/universal-url.ts
@@ -5,6 +5,8 @@
  * Check https://github.com/goplus/builder/issues/369#issuecomment-2167100296 for details.
  */
 
+import { filename } from './path'
+
 /** Universal URL schemes */
 export const enum UniversalUrlScheme {
   /** Standard HTTP URLs, for resources stored in third-party services */
@@ -61,6 +63,20 @@ export function parseUniversalUrl(urlStr: string): UniversalUrlParsed {
     }
     default:
       throw new Error(`unsupported universal url scheme: ${scheme} in url: ${urlStr.slice(0, 200)}`)
+  }
+}
+
+/** Get the filename from the POSIX-style path contained in a universal URL. */
+export function getUniversalUrlFilename(urlStr: string) {
+  const parsed = parseUniversalUrl(urlStr)
+  switch (parsed.scheme) {
+    case UniversalUrlScheme.Http:
+    case UniversalUrlScheme.Https:
+      return filename(new URL(parsed.url).pathname)
+    case UniversalUrlScheme.Kodo:
+      return filename(parsed.key)
+    case UniversalUrlScheme.Data:
+      return ''
   }
 }
 

--- a/spx-gui/src/utils/universal-url.ts
+++ b/spx-gui/src/utils/universal-url.ts
@@ -15,13 +15,18 @@ export const enum UniversalUrlScheme {
   Https = 'https',
   /** For inlineable data, usually plain text or json, e.g. `data:text/plain,hello%20world` */
   Data = 'data',
-  /** For objects stored in Qiniu Kodo, e.g. `kodo://bucket/key` */
+  /** For objects stored in Qiniu Kodo, e.g. `kodo://bucket/key`; the key is opaque and may contain `?` */
   Kodo = 'kodo'
 }
 
 export type HttpUrlParsed = { scheme: UniversalUrlScheme.Http | UniversalUrlScheme.Https; url: string }
 export type DataUrlParsed = { scheme: UniversalUrlScheme.Data; url: string }
-export type KodoUrlParsed = { scheme: UniversalUrlScheme.Kodo; bucket: string; key: string }
+export type KodoUrlParsed = {
+  scheme: UniversalUrlScheme.Kodo
+  bucket: string
+  /** Opaque object key, which may contain URL-like characters such as `?`. */
+  key: string
+}
 
 export type UniversalUrlParsed = HttpUrlParsed | DataUrlParsed | KodoUrlParsed
 
@@ -66,7 +71,7 @@ export function parseUniversalUrl(urlStr: string): UniversalUrlParsed {
   }
 }
 
-/** Get the filename from the POSIX-style path contained in a universal URL. */
+/** Get the filename from an HTTP URL pathname or a Kodo object key. */
 export function getUniversalUrlFilename(urlStr: string) {
   const parsed = parseUniversalUrl(urlStr)
   switch (parsed.scheme) {


### PR DESCRIPTION
Closes #3461

## Summary

- Preserve logical asset names in configuration while generating readable, encoded physical filenames for costumes and backdrops.
- Encode logical names used by persisted asset generators as physical directory segments, so names containing path syntax round-trip correctly.
- Keep sound and font directory names compatible with SPX runtime lookup, validate names used as resource directories, and use fixed `sound<ext>` / `font<ext>` filenames within them.
- Split POSIX path helpers from universal URL filename extraction, ignore Kodo FOP suffixes when deriving local filenames, and remove the unused resolve-uri direct dependency.

## Validation

- Focused Vitest suites for paths, universal URLs, cloud files, SPX assets, and asset generators
- `pnpm run type-check`
- `pnpm run lint`

* Related SPX format specification: https://github.com/goplus/spx/issues/1778