### PR TITLE
fix(spx-gui): disable automatic query refetching

### DIFF
--- a/spx-gui/src/setup/index.ts
+++ b/spx-gui/src/setup/index.ts
@@ -52,7 +52,6 @@ export function configureApp(app: VueApp, router: Router | undefined, config: Ap
     queryClientConfig: {
       defaultOptions: {
         queries: {
-          refetchOnMount: false,
           refetchOnReconnect: false,
           refetchOnWindowFocus: false
         }

--- a/spx-gui/src/setup/index.ts
+++ b/spx-gui/src/setup/index.ts
@@ -48,7 +48,17 @@ export function configureApp(app: VueApp, router: Router | undefined, config: Ap
   app.use(VueKonva as any, {
     customNodes: { CustomTransformer }
   })
-  app.use(VueQueryPlugin)
+  app.use(VueQueryPlugin, {
+    queryClientConfig: {
+      defaultOptions: {
+        queries: {
+          refetchOnMount: false,
+          refetchOnReconnect: false,
+          refetchOnWindowFocus: false
+        }
+      }
+    }
+  })
   app.use(createRadar())
   app.use(createSpotlight())
   app.use(createAppState())

--- a/spx-gui/src/stores/user/signed-in.test.ts
+++ b/spx-gui/src/stores/user/signed-in.test.ts
@@ -81,6 +81,8 @@ describe('ensureAccessToken', () => {
   })
 
   it('keeps the cached username without fetching it after refresh', async () => {
+    const now = Date.now()
+    vi.spyOn(Date, 'now').mockReturnValue(now)
     localStorage.setItem(
       userStateStorageKey,
       JSON.stringify({
@@ -110,7 +112,7 @@ describe('ensureAccessToken', () => {
     expect(getSignedInUser).not.toHaveBeenCalled()
     expect(JSON.parse(localStorage.getItem(userStateStorageKey)!)).toEqual({
       accessToken: 'new-access-token',
-      accessTokenExpiresAt: Date.now() + 60 * 60 * 1000,
+      accessTokenExpiresAt: now + 60 * 60 * 1000,
       refreshToken: 'new-refresh-token',
       username: 'alice'
     })


### PR DESCRIPTION
## Summary

- disable automatic Vue Query refetching globally
- preserve explicit query refetching and cache invalidation

Closes #3462
