### PR TITLE
docs(api): describe course kinds and opaque content in openapi.yaml

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -2837,6 +2837,9 @@ paths:
       description: |
         Create a new course owned by the authenticated user.
 
+        The request either provides `kind` and `content`, or uses the transitional legacy flat shape (`entrypoint` and
+        `prompt` without `kind` and `content`, treated as a guided course) accepted until the API contract release.
+
         Permission requirements:
 
         - Only users with the `courseAdmin` role can create courses.
@@ -2849,13 +2852,15 @@ paths:
               required:
                 - title
                 - thumbnail
-                - entrypoint
-                - prompt
               properties:
+                kind:
+                  $ref: "#/components/schemas/Course/properties/kind"
                 title:
                   $ref: "#/components/schemas/Course/properties/title"
                 thumbnail:
                   $ref: "#/components/schemas/Course/properties/thumbnail"
+                content:
+                  $ref: "#/components/schemas/Course/properties/content"
                 entrypoint:
                   $ref: "#/components/schemas/Course/properties/entrypoint"
                 prompt:
@@ -2882,6 +2887,67 @@ paths:
           $ref: "#/components/responses/Unauthorized"
         "403":
           $ref: "#/components/responses/Forbidden"
+
+  /user/courses/playground/copilot-context:
+    post:
+      operationId: generatePlaygroundCourseCopilotContext
+      tags:
+        - Courses
+      summary: Generate a playground course copilot context
+      description: |
+        Generate an editable Copilot context draft from the author's current, possibly unsaved, playground course
+        content.
+
+        Permission requirements:
+
+        - Only users with the `courseAdmin` role can generate course copilot contexts.
+
+        Quota and rate limits:
+
+        - Each generation consumes 1 quota from the authenticated user's `copilotMessage` allowance; the quota is
+          refunded when generation fails.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - title
+                - content
+              properties:
+                title:
+                  $ref: "#/components/schemas/Course/properties/title"
+                thumbnail:
+                  $ref: "#/components/schemas/Course/properties/thumbnail"
+                content:
+                  description: Current, possibly unsaved, playground course content mapping file paths to universal URLs.
+                  type: object
+                  minProperties: 1
+                  additionalProperties:
+                    type: string
+                    format: uri-reference
+      responses:
+        "200":
+          description: Successfully generated the copilot context.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - copilotContext
+                properties:
+                  copilotContext:
+                    description: Generated copilot context, editable by the author before saving.
+                    type: string
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
 
   /courses/{courseID}:
     get:
@@ -2919,6 +2985,9 @@ paths:
       description: |
         Update the details of a specific course.
 
+        The course kind is immutable: a `kind` field is accepted only when it matches the course's current kind, and the
+        transitional legacy fields (`entrypoint`, `prompt`) apply only to guided courses when `content` is absent.
+
         Permission requirements:
 
         - Only users with the `courseAdmin` role can update courses.
@@ -2937,10 +3006,14 @@ paths:
               type: object
               minProperties: 1
               properties:
+                kind:
+                  $ref: "#/components/schemas/Course/properties/kind"
                 title:
                   $ref: "#/components/schemas/Course/properties/title"
                 thumbnail:
                   $ref: "#/components/schemas/Course/properties/thumbnail"
+                content:
+                  $ref: "#/components/schemas/Course/properties/content"
                 entrypoint:
                   $ref: "#/components/schemas/Course/properties/entrypoint"
                 prompt:
@@ -3060,6 +3133,11 @@ paths:
         - {}
         - bearerAuth: []
       parameters:
+        - name: kind
+          description: Filter course series by kind.
+          in: query
+          schema:
+            $ref: "#/components/schemas/CourseSeries/properties/kind"
         - name: orderBy
           description: Field by which to order the results.
           in: query
@@ -3103,6 +3181,11 @@ paths:
       summary: List course series owned by the authenticated user
       description: Retrieve a list of course series owned by the authenticated user.
       parameters:
+        - name: kind
+          description: Filter course series by kind.
+          in: query
+          schema:
+            $ref: "#/components/schemas/CourseSeries/properties/kind"
         - name: orderBy
           description: Field by which to order the results.
           in: query
@@ -3147,6 +3230,8 @@ paths:
       description: |
         Create a new course series owned by the authenticated user.
 
+        Omitting `kind` means a guided series (transitional legacy shape, accepted until the API contract release).
+
         Permission requirements:
 
         - Only users with the `courseAdmin` role can create course series.
@@ -3162,6 +3247,8 @@ paths:
                 - courseIDs
                 - order
               properties:
+                kind:
+                  $ref: "#/components/schemas/CourseSeries/properties/kind"
                 title:
                   $ref: "#/components/schemas/CourseSeries/properties/title"
                 thumbnail:
@@ -3251,6 +3338,8 @@ paths:
               type: object
               minProperties: 1
               properties:
+                kind:
+                  $ref: "#/components/schemas/CourseSeries/properties/kind"
                 title:
                   $ref: "#/components/schemas/CourseSeries/properties/title"
                 thumbnail:
@@ -3321,6 +3410,11 @@ paths:
           required: true
           schema:
             $ref: "#/components/schemas/User/properties/username"
+        - name: kind
+          description: Filter course series by kind.
+          in: query
+          schema:
+            $ref: "#/components/schemas/CourseSeries/properties/kind"
         - name: orderBy
           description: Field by which to order the results.
           in: query
@@ -7562,8 +7656,10 @@ components:
         - createdAt
         - updatedAt
         - owner
+        - kind
         - title
         - thumbnail
+        - content
         - entrypoint
         - prompt
       properties:
@@ -7576,6 +7672,14 @@ components:
         owner:
           description: Username of the course's owner.
           $ref: "#/components/schemas/User/properties/username"
+        kind:
+          description: Kind of the course, deciding how the course is driven and what its content holds. Immutable after creation.
+          type: string
+          enum:
+            - guided
+            - playground
+          examples:
+            - guided
         title:
           description: Title of the course.
           type: string
@@ -7590,15 +7694,30 @@ components:
           minLength: 1
           examples:
             - kodo://xbuilder-usercontent-test/files/FvYyHLNrtx8qFHSwnLjEe57UA2fF-2824936
+        content:
+          description: |
+            Kind-specific course content. For a `guided` course it holds the guided course data (`entrypoint` and `prompt`);
+            for a `playground` course it is a file collection mapping file paths to universal URLs. The API validates only
+            the top-level shape (and, for `playground`, that every value is a universal URL); internals follow the Tutorial
+            content-format contract and stay opaque to the API and storage.
+          type: object
+          examples:
+            - entrypoint: /editor/john/loop
+              prompt: Learn the basics of XGo programming language
         entrypoint:
-          description: Starting entrypoint of the course.
+          description: |
+            Starting entrypoint of the course. Transitional top-level copy of the guided course content, kept so pre-kind
+            clients keep working; empty for playground courses. Removed by the API contract release.
+          deprecated: true
           type: string
           format: uri-reference
-          minLength: 1
           examples:
             - /editor/john/loop
         prompt:
-          description: Prompt text for the course (used for copilot assistance).
+          description: |
+            Prompt text for the course (used for copilot assistance). Transitional top-level copy of the guided course
+            content; empty for playground courses. Removed by the API contract release.
+          deprecated: true
           type: string
           maxLength: 12000
           examples:
@@ -7612,6 +7731,7 @@ components:
         - createdAt
         - updatedAt
         - owner
+        - kind
         - title
         - thumbnail
         - description
@@ -7627,6 +7747,16 @@ components:
         owner:
           description: Username of the course series' owner.
           $ref: "#/components/schemas/User/properties/username"
+        kind:
+          description: |
+            Kind of the courses in this series; a course series holds courses of exactly one kind. Changing it requires
+            every course in the series to have the new kind.
+          type: string
+          enum:
+            - guided
+            - playground
+          examples:
+            - guided
         title:
           description: Title of the course series.
           type: string

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -2838,7 +2838,7 @@ paths:
         Create a new course owned by the authenticated user.
 
         The request either provides `kind` and `content`, or uses the transitional legacy flat shape (`entrypoint` and
-        `prompt` without `kind` and `content`, treated as a guided course) accepted until the API contract release.
+        `prompt` without `kind` and `content`, treated as a guided course) accepted until the API contract release (goplus/builder-backend#352).
 
         Permission requirements:
 
@@ -3233,7 +3233,7 @@ paths:
       description: |
         Create a new course series owned by the authenticated user.
 
-        Omitting `kind` means a guided series (transitional legacy shape, accepted until the API contract release).
+        Omitting `kind` means a guided series (transitional legacy shape, accepted until the API contract release (goplus/builder-backend#352)).
 
         Permission requirements:
 
@@ -7707,10 +7707,13 @@ components:
           examples:
             - entrypoint: /editor/john/loop
               prompt: Learn the basics of XGo programming language
+            - main_course.gox: kodo://xbuilder-usercontent-test/files/FvYyHLNrtx8qFHSwnLjEe57UA2fF-2824936
+              project/Lita.spx: kodo://xbuilder-usercontent-test/files/FoSC8ngQn_jzAIPBqCp9VZLBVkSq-52661
+              assets/videos/step-to/index.json: data:application/json,%7B%22path%22%3A%22step-to.mp4%22%7D
         entrypoint:
           description: |
             Starting entrypoint of the course. Transitional top-level copy of the guided course content, kept so pre-kind
-            clients keep working; empty for playground courses. Removed by the API contract release.
+            clients keep working; empty for playground courses. Removed by the API contract release (goplus/builder-backend#352).
           deprecated: true
           type: string
           format: uri-reference
@@ -7719,7 +7722,7 @@ components:
         prompt:
           description: |
             Prompt text for the course (used for copilot assistance). Transitional top-level copy of the guided course
-            content; empty for playground courses. Removed by the API contract release.
+            content; empty for playground courses. Removed by the API contract release (goplus/builder-backend#352).
           deprecated: true
           type: string
           maxLength: 12000

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -2837,9 +2837,8 @@ paths:
       description: |
         Create a new course owned by the authenticated user.
 
-        The request either provides `kind` and `content`, or uses the transitional legacy flat shape (`entrypoint` and
-        `prompt` without `content`, with `kind` omitted or `guided`, treated as a guided course) accepted until the API contract
-        release (goplus/builder-backend#352). When both are present, `content` wins.
+        `content` must match `kind`: `GuidedCourseContent` for a `guided` course, `PlaygroundCourseContent` for a
+        `playground` course.
 
         Permission requirements:
 
@@ -2851,8 +2850,10 @@ paths:
             schema:
               type: object
               required:
+                - kind
                 - title
                 - thumbnail
+                - content
               properties:
                 kind:
                   $ref: "#/components/schemas/Course/properties/kind"
@@ -2862,10 +2863,6 @@ paths:
                   $ref: "#/components/schemas/Course/properties/thumbnail"
                 content:
                   $ref: "#/components/schemas/Course/properties/content"
-                entrypoint:
-                  $ref: "#/components/schemas/Course/properties/entrypoint"
-                prompt:
-                  $ref: "#/components/schemas/Course/properties/prompt"
       responses:
         "201":
           description: Successfully created the course.
@@ -2989,8 +2986,8 @@ paths:
       description: |
         Update the details of a specific course.
 
-        The course kind is immutable: a `kind` field is accepted only when it matches the course's current kind, and the
-        transitional legacy fields (`entrypoint`, `prompt`) apply only to guided courses when `content` is absent.
+        The course kind is immutable: a `kind` field is accepted only when it matches the course's current kind. `content`
+        is validated against the course's kind and replaced as a whole, never merged.
 
         Permission requirements:
 
@@ -3018,10 +3015,6 @@ paths:
                   $ref: "#/components/schemas/Course/properties/thumbnail"
                 content:
                   $ref: "#/components/schemas/Course/properties/content"
-                entrypoint:
-                  $ref: "#/components/schemas/Course/properties/entrypoint"
-                prompt:
-                  $ref: "#/components/schemas/Course/properties/prompt"
       responses:
         "200":
           description: Successfully updated the course.
@@ -3234,8 +3227,6 @@ paths:
       description: |
         Create a new course series owned by the authenticated user.
 
-        Omitting `kind` means a guided series (transitional legacy shape, accepted until the API contract release (goplus/builder-backend#352)).
-
         Permission requirements:
 
         - Only users with the `courseAdmin` role can create course series.
@@ -3246,6 +3237,7 @@ paths:
             schema:
               type: object
               required:
+                - kind
                 - title
                 - thumbnail
                 - courseIDs
@@ -7664,8 +7656,6 @@ components:
         - title
         - thumbnail
         - content
-        - entrypoint
-        - prompt
       properties:
         id:
           $ref: "#/components/schemas/Model/properties/id"
@@ -7700,35 +7690,47 @@ components:
             - kodo://xbuilder-usercontent-test/files/FvYyHLNrtx8qFHSwnLjEe57UA2fF-2824936
         content:
           description: |
-            Kind-specific course content. For a `guided` course it holds the guided course data (`entrypoint` and `prompt`);
-            for a `playground` course it is a file collection mapping file paths to universal URLs. The API validates only
-            the top-level shape (and, for `playground`, that every value is a universal URL); internals follow the Tutorial
-            content-format contract and stay opaque to the API and storage.
-          type: object
-          examples:
-            - entrypoint: /editor/john/loop
-              prompt: Learn the basics of XGo programming language
-            - main_course.gox: kodo://xbuilder-usercontent-test/files/FvYyHLNrtx8qFHSwnLjEe57UA2fF-2824936
-              project/Lita.spx: kodo://xbuilder-usercontent-test/files/FoSC8ngQn_jzAIPBqCp9VZLBVkSq-52661
-              assets/videos/step-to/index.json: data:application/json,%7B%22path%22%3A%22step-to.mp4%22%7D
+            Kind-specific course content, selected by `kind`: `GuidedCourseContent` for a `guided` course,
+            `PlaygroundCourseContent` for a `playground` course. The API validates only the top-level shape; internals
+            follow the Tutorial content-format contract and stay opaque to the API and storage.
+          oneOf:
+            - $ref: "#/components/schemas/GuidedCourseContent"
+            - $ref: "#/components/schemas/PlaygroundCourseContent"
+
+    GuidedCourseContent:
+      description: Content of a `guided` course, driven by Copilot.
+      type: object
+      required:
+        - entrypoint
+        - prompt
+      properties:
         entrypoint:
-          description: |
-            Starting entrypoint of the course. Transitional top-level copy of the guided course content, kept so pre-kind
-            clients keep working; empty for playground courses. Removed by the API contract release (goplus/builder-backend#352).
-          deprecated: true
+          description: Starting entrypoint of the course.
           type: string
           format: uri-reference
+          minLength: 1
           examples:
             - /editor/john/loop
         prompt:
-          description: |
-            Prompt text for the course (used for copilot assistance). Transitional top-level copy of the guided course
-            content; empty for playground courses. Removed by the API contract release (goplus/builder-backend#352).
-          deprecated: true
+          description: Prompt text for the course (used for copilot assistance).
           type: string
           maxLength: 12000
           examples:
             - Learn the basics of XGo programming language
+
+    PlaygroundCourseContent:
+      description: |
+        Content of a `playground` course, driven by course code: a file collection mapping file paths to universal URLs.
+        The referenced files form the Tutorial project; its layout is owned by the Tutorial Class Framework contract. An
+        empty collection is valid, so a course can be created before its files are uploaded.
+      type: object
+      additionalProperties:
+        type: string
+        format: uri-reference
+      examples:
+        - main_course.gox: kodo://xbuilder-usercontent-test/files/FvYyHLNrtx8qFHSwnLjEe57UA2fF-2824936
+          project/Lita.spx: kodo://xbuilder-usercontent-test/files/FoSC8ngQn_jzAIPBqCp9VZLBVkSq-52661
+          assets/videos/step-to/index.json: data:application/json,%7B%22path%22%3A%22step-to.mp4%22%7D
 
     CourseSeries:
       description: Collection of related courses.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -2838,7 +2838,8 @@ paths:
         Create a new course owned by the authenticated user.
 
         The request either provides `kind` and `content`, or uses the transitional legacy flat shape (`entrypoint` and
-        `prompt` without `kind` and `content`, treated as a guided course) accepted until the API contract release (goplus/builder-backend#352).
+        `prompt` without `content`, with `kind` omitted or `guided`, treated as a guided course) accepted until the API contract
+        release (goplus/builder-backend#352). When both are present, `content` wins.
 
         Permission requirements:
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -2914,6 +2914,7 @@ paths:
               type: object
               required:
                 - title
+                - thumbnail
                 - content
               properties:
                 title:

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -2854,6 +2854,27 @@ paths:
                 - title
                 - thumbnail
                 - content
+              allOf:
+                - if:
+                    required:
+                      - kind
+                    properties:
+                      kind:
+                        const: guided
+                  then:
+                    properties:
+                      content:
+                        $ref: "#/components/schemas/GuidedCourseContent"
+                - if:
+                    required:
+                      - kind
+                    properties:
+                      kind:
+                        const: playground
+                  then:
+                    properties:
+                      content:
+                        $ref: "#/components/schemas/PlaygroundCourseContent"
               properties:
                 kind:
                   $ref: "#/components/schemas/Course/properties/kind"
@@ -2987,7 +3008,8 @@ paths:
         Update the details of a specific course.
 
         The course kind is immutable: a `kind` field is accepted only when it matches the course's current kind. `content`
-        is validated against the course's kind and replaced as a whole, never merged.
+        is validated against the course's kind (`GuidedCourseContent` or `PlaygroundCourseContent`) and replaced as a
+        whole, never merged.
 
         Permission requirements:
 
@@ -3006,6 +3028,27 @@ paths:
             schema:
               type: object
               minProperties: 1
+              allOf:
+                - if:
+                    required:
+                      - kind
+                    properties:
+                      kind:
+                        const: guided
+                  then:
+                    properties:
+                      content:
+                        $ref: "#/components/schemas/GuidedCourseContent"
+                - if:
+                    required:
+                      - kind
+                    properties:
+                      kind:
+                        const: playground
+                  then:
+                    properties:
+                      content:
+                        $ref: "#/components/schemas/PlaygroundCourseContent"
               properties:
                 kind:
                   $ref: "#/components/schemas/Course/properties/kind"
@@ -7656,6 +7699,27 @@ components:
         - title
         - thumbnail
         - content
+      allOf:
+        - if:
+            required:
+              - kind
+            properties:
+              kind:
+                const: guided
+          then:
+            properties:
+              content:
+                $ref: "#/components/schemas/GuidedCourseContent"
+        - if:
+            required:
+              - kind
+            properties:
+              kind:
+                const: playground
+          then:
+            properties:
+              content:
+                $ref: "#/components/schemas/PlaygroundCourseContent"
       properties:
         id:
           $ref: "#/components/schemas/Model/properties/id"
@@ -7693,9 +7757,7 @@ components:
             Kind-specific course content, selected by `kind`: `GuidedCourseContent` for a `guided` course,
             `PlaygroundCourseContent` for a `playground` course. The API validates only the top-level shape; internals
             follow the Tutorial content-format contract and stay opaque to the API and storage.
-          oneOf:
-            - $ref: "#/components/schemas/GuidedCourseContent"
-            - $ref: "#/components/schemas/PlaygroundCourseContent"
+          type: object
 
     GuidedCourseContent:
       description: Content of a `guided` course, driven by Copilot.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -2904,8 +2904,10 @@ paths:
 
         Quota and rate limits:
 
-        - Each generation consumes 1 quota from the authenticated user's `copilotMessage` allowance; the quota is
-          refunded when generation fails.
+        - Each generation consumes 1 quota from the authenticated user's `copilotMessage` allowance. The quota is
+          refunded when generation fails on the server side; it is not refunded when the client cancels the request.
+        - Per-user short-window rate limits also apply. Hitting them returns 429 with `Retry-After`; reaching the
+          long-window quota limit returns 403 with `Retry-After`.
       requestBody:
         required: true
         content:
@@ -2946,9 +2948,9 @@ paths:
         "401":
           $ref: "#/components/responses/Unauthorized"
         "403":
-          $ref: "#/components/responses/Forbidden"
+          $ref: "#/components/responses/ForbiddenOrQuotaExceeded"
         "429":
-          $ref: "#/components/responses/TooManyRequests"
+          $ref: "#/components/responses/RateLimitExceeded"
 
   /courses/{courseID}:
     get:


### PR DESCRIPTION
Syncs `docs/openapi.yaml` (the backend API spec source of truth) with the Tutorial v2 course storage and API changes. Part of #3422. Backend: goplus/builder-backend#350 / goplus/builder-backend#353 / goplus/builder-backend#354 (expand release) and goplus/builder-backend#352 (contract release).

The spec documents the **final contract** as specified by `docs/develop/tutorial-v2/module_CourseApis.ts`, not the transitional shapes of the rollout: the document has no machine consumers (the frontend client is hand-written, nothing generates from it), so there is no reason to publish an intermediate spec. Until goplus/builder-backend#352 is deployed, the Release 1 backend serves a **superset** of this spec — it still returns top-level `entrypoint` / `prompt` on guided courses, still accepts the flat `{entrypoint, prompt}` create/update payload, and defaults an omitted series `kind` to `guided`. A client written against this spec works on both releases; nothing new needs the superset.

- `Course` gains `kind` (immutable, `guided | playground`) and kind-specific `content`. `content` is selected by `kind` through `allOf` / `if` / `then` branches (the `AIGCEnrich…` settings precedent) into `GuidedCourseContent` (`entrypoint`, `prompt`) or `PlaygroundCourseContent` (a file collection mapping paths to universal URLs; may be empty so a course can be created before its files are uploaded). Not `oneOf`: a guided content document is itself a string→string map and would satisfy both alternatives.
- Course create requires `kind` + `content`; update replaces `content` as a whole after validating it against the course's kind and documents kind immutability.
- `CourseSeries` gains `kind` (required on create); the three series list endpoints gain a `kind` query filter; the series kind is immutable on update, and both create and update state the member-kind consistency rule.
- New `POST /user/courses/playground/copilot-context` endpoint (courseAdmin gate, `copilotMessage` quota, refunded on failure).

## API surface changes (as documented in this spec)

No new routes besides the copilot-context endpoint — a Playground Course is a `kind` of the existing course resource, so support lands as payload changes on the existing endpoints.

| Endpoint | Change |
| --- | --- |
| `POST /user/courses` | Request is `{kind, title, thumbnail, content}`; `kind: guided` with `GuidedCourseContent`, `kind: playground` with `PlaygroundCourseContent`. Response gains `kind` / `content`. |
| `PATCH /courses/{courseID}` | Request accepts `content` (validated against the course's kind, replaced as a whole); `kind` may be echoed but is immutable. |
| `GET /courses/{courseID}`, `GET /courses`, `GET /user/courses`, `GET /users/{username}/courses` | `Course` schema gains `kind` and `content`; the pre-kind top-level `entrypoint` / `prompt` are gone from the spec (the Release 1 backend still returns them, see above). |
| `GET /courses`, `GET /user/courses`, `GET /users/{username}/courses` | New optional `kind` query parameter (goplus/builder-backend#353). |
| `DELETE /courses/{courseID}` | Unchanged. |
| `POST /user/course-series`, `PATCH /course-series/{courseSeriesID}` | `kind` required on create and immutable afterwards (`PATCH` accepts only an echoed, unchanged `kind`); both state that every course in `courseIDs` must have the series' kind. |
| `GET /course-series`, `GET /user/course-series`, `GET /users/{username}/course-series` | New `kind` query parameter; `CourseSeries` schema gains `kind`. |
| `GET /course-series/{courseSeriesID}`, `DELETE /course-series/{courseSeriesID}` | Response carries `kind`; otherwise unchanged. |
| **`POST /user/courses/playground/copilot-context`** | **New.** `{title, thumbnail, content}` → `{copilotContext}`; `courseAdmin` gate; `copilotMessage` quota with `ForbiddenOrQuotaExceeded` / `RateLimitExceeded` responses (40301/42901 + `Retry-After`); server-side failures refund, client cancellation does not. |

Beyond the spec, this PR amends one line of the design contract: `docs/develop/tutorial-v2/module_CourseApis.ts` gains `kind?: CourseKind` on `ListCoursesParams`, mirroring `ListCourseSeriesParams`, so the contract and the spec agree on the course list filter. It is its own commit. The frontend client type and the two call sites that adopt the filter live in #3494, with the rest of the course management UI work.

The documented 400s and response shapes were verified against the Release 2 backend binary in the goplus/builder-backend#352 rehearsal (see its description).



