### PR TITLE
Add in-product notification center

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -7352,7 +7352,7 @@ components:
           type: string
           minLength: 1
           maxLength: 2000
-          pattern: '^/(?!/)[^\\]*$'
+          pattern: '^/(?!/)[^\\\s\u0000-\u001F\u007F-\u009F]*$'
           examples:
             - /feedbacks/123
         readAt:

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1042,10 +1042,17 @@ paths:
       tags:
         - Notifications
       summary: List notifications for the authenticated user
-      description: Retrieve persistent in-product notifications, ordered from newest to oldest.
+      description: |
+        Retrieve persistent in-product notifications, ordered from newest to oldest.
+
+        To load the next page, pass the opaque `nextCursor` returned by the previous response.
       parameters:
-        - $ref: "#/components/parameters/PageIndex"
         - $ref: "#/components/parameters/PageSize"
+        - name: cursor
+          description: Opaque cursor returned as `nextCursor` by the previous page.
+          in: query
+          schema:
+            type: string
       responses:
         "200":
           description: Successful response.
@@ -1054,17 +1061,14 @@ paths:
               schema:
                 type: object
                 required:
-                  - total
-                  - unreadCount
+                  - nextCursor
                   - data
                 properties:
-                  total:
-                    $ref: "#/components/schemas/ByPage/properties/total"
-                  unreadCount:
-                    description: Current number of unread notifications for the authenticated user.
-                    type: integer
-                    format: int64
-                    minimum: 0
+                  nextCursor:
+                    description: Opaque cursor for the next page, or null when there are no older notifications.
+                    type:
+                      - string
+                      - "null"
                   data:
                     type: array
                     items:

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1043,7 +1043,8 @@ paths:
         - Notifications
       summary: List notifications for the authenticated user
       description: |
-        Retrieve persistent in-product notifications, ordered from newest to oldest.
+        Retrieve persistent in-product notifications. Unread notifications are returned before read notifications;
+        each group is ordered from newest to oldest. Both groups share one cursor and pagination sequence.
 
         To load the next page, pass the opaque `nextCursor` returned by the previous response.
       parameters:
@@ -1078,13 +1079,13 @@ paths:
         "401":
           $ref: "#/components/responses/Unauthorized"
 
-  /user/notifications/unread-count:
+  /user/notifications/status:
     get:
-      operationId: getAuthenticatedUserNotificationUnreadCount
+      operationId: getAuthenticatedUserNotificationStatus
       tags:
         - Notifications
-      summary: Get the unread notification count
-      description: Retrieve the current number of unread notifications for the authenticated user.
+      summary: Get the notification status
+      description: Check whether the authenticated user has any unread notifications.
       responses:
         "200":
           description: Successful response.
@@ -1093,13 +1094,11 @@ paths:
               schema:
                 type: object
                 required:
-                  - unreadCount
+                  - hasUnread
                 properties:
-                  unreadCount:
-                    description: Current number of unread notifications for the authenticated user.
-                    type: integer
-                    format: int64
-                    minimum: 0
+                  hasUnread:
+                    description: Whether the authenticated user has at least one unread notification.
+                    type: boolean
         "401":
           $ref: "#/components/responses/Unauthorized"
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1036,6 +1036,110 @@ paths:
         "415":
           $ref: "#/components/responses/UnsupportedMediaType"
 
+  /user/notifications:
+    get:
+      operationId: listAuthenticatedUserNotifications
+      tags:
+        - Notifications
+      summary: List notifications for the authenticated user
+      description: Retrieve persistent in-product notifications, ordered from newest to oldest.
+      parameters:
+        - $ref: "#/components/parameters/PageIndex"
+        - $ref: "#/components/parameters/PageSize"
+      responses:
+        "200":
+          description: Successful response.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - total
+                  - unreadCount
+                  - data
+                properties:
+                  total:
+                    $ref: "#/components/schemas/ByPage/properties/total"
+                  unreadCount:
+                    description: Current number of unread notifications for the authenticated user.
+                    type: integer
+                    format: int64
+                    minimum: 0
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/UserNotification"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+
+  /user/notifications/unread-count:
+    get:
+      operationId: getAuthenticatedUserNotificationUnreadCount
+      tags:
+        - Notifications
+      summary: Get the unread notification count
+      description: Retrieve the current number of unread notifications for the authenticated user.
+      responses:
+        "200":
+          description: Successful response.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - unreadCount
+                properties:
+                  unreadCount:
+                    description: Current number of unread notifications for the authenticated user.
+                    type: integer
+                    format: int64
+                    minimum: 0
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+
+  /user/notifications/{notificationID}:
+    patch:
+      operationId: updateAuthenticatedUserNotification
+      tags:
+        - Notifications
+      summary: Mark a notification as read
+      description: Idempotently mark one notification belonging to the authenticated user as read.
+      parameters:
+        - name: notificationID
+          description: Unique identifier of the notification.
+          in: path
+          required: true
+          schema:
+            $ref: "#/components/schemas/Model/properties/id"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - read
+              properties:
+                read:
+                  description: Must be `true`. Notifications cannot be marked unread.
+                  type: boolean
+                  const: true
+      responses:
+        "200":
+          description: Notification marked as read.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UserNotification"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
   /user/followers:
     get:
       operationId: listAuthenticatedUserFollowers
@@ -7232,6 +7336,47 @@ components:
 
             **This field is only present for the authenticated user's own profile.**
           $ref: "#/components/schemas/UserCapabilities"
+
+    UserNotification:
+      description: Persistent in-product notification delivered to a user.
+      type: object
+      required:
+        - id
+        - createdAt
+        - updatedAt
+        - title
+        - body
+        - readAt
+      properties:
+        id:
+          $ref: "#/components/schemas/Model/properties/id"
+        createdAt:
+          $ref: "#/components/schemas/Model/properties/createdAt"
+        updatedAt:
+          $ref: "#/components/schemas/Model/properties/updatedAt"
+        title:
+          description: User-visible notification title snapshot.
+          type: string
+          minLength: 1
+          maxLength: 200
+        body:
+          description: User-visible notification body snapshot.
+          type: string
+          maxLength: 5000
+        actionPath:
+          description: Optional application-relative destination opened from the notification.
+          type: string
+          minLength: 1
+          maxLength: 2000
+          pattern: "^/(?!/)"
+          examples:
+            - /feedbacks/123
+        readAt:
+          description: Time when the recipient first read the notification, or null when unread.
+          type:
+            - string
+            - "null"
+          format: date-time
 
     AuthenticatedUser:
       description: Authenticated user account information.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -7368,7 +7368,7 @@ components:
           type: string
           minLength: 1
           maxLength: 2000
-          pattern: "^/(?!/)"
+          pattern: '^/(?!/)[^\\]*$'
           examples:
             - /feedbacks/123
         readAt:

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1062,9 +1062,13 @@ paths:
               schema:
                 type: object
                 required:
+                  - hasUnread
                   - nextCursor
                   - data
                 properties:
+                  hasUnread:
+                    description: Whether the authenticated user has at least one unread notification.
+                    type: boolean
                   nextCursor:
                     description: Opaque cursor for the next page, or null when there are no older notifications.
                     type:
@@ -1076,29 +1080,6 @@ paths:
                       $ref: "#/components/schemas/UserNotification"
         "400":
           $ref: "#/components/responses/BadRequest"
-        "401":
-          $ref: "#/components/responses/Unauthorized"
-
-  /user/notifications/status:
-    get:
-      operationId: getAuthenticatedUserNotificationStatus
-      tags:
-        - Notifications
-      summary: Get the notification status
-      description: Check whether the authenticated user has any unread notifications.
-      responses:
-        "200":
-          description: Successful response.
-          content:
-            application/json:
-              schema:
-                type: object
-                required:
-                  - hasUnread
-                properties:
-                  hasUnread:
-                    description: Whether the authenticated user has at least one unread notification.
-                    type: boolean
         "401":
           $ref: "#/components/responses/Unauthorized"
 

--- a/spx-gui/src/apis/notification.test.ts
+++ b/spx-gui/src/apis/notification.test.ts
@@ -1,25 +1,17 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { client } from './common'
-import { getUserNotificationStatus, listUserNotifications, markUserNotificationRead } from './notification'
+import { listUserNotifications, markUserNotificationRead } from './notification'
 
 afterEach(() => vi.restoreAllMocks())
 
 describe('notification APIs', () => {
   it('lists authenticated user notifications with pagination', async () => {
-    const response = { nextCursor: null, data: [] }
+    const response = { hasUnread: false, nextCursor: null, data: [] }
     const get = vi.spyOn(client, 'get').mockResolvedValue(response)
 
     const params = { pageSize: 50, cursor: 'next-page' }
     await expect(listUserNotifications(params)).resolves.toBe(response)
     expect(get).toHaveBeenCalledWith('/user/notifications', params, { signal: undefined })
-  })
-
-  it('gets the notification status', async () => {
-    const response = { hasUnread: true }
-    const get = vi.spyOn(client, 'get').mockResolvedValue(response)
-
-    await expect(getUserNotificationStatus()).resolves.toBe(response)
-    expect(get).toHaveBeenCalledWith('/user/notifications/status', undefined, { signal: undefined })
   })
 
   it('marks a notification as read', async () => {

--- a/spx-gui/src/apis/notification.test.ts
+++ b/spx-gui/src/apis/notification.test.ts
@@ -22,10 +22,10 @@ describe('notification APIs', () => {
   })
 
   it('marks a notification as read', async () => {
-    const notification = { id: 'notification/1', readAt: '2026-08-26T00:00:00Z' }
+    const notification = { id: '11', readAt: '2026-08-26T00:00:00Z' }
     const patch = vi.spyOn(client, 'patch').mockResolvedValue(notification)
 
-    await expect(markUserNotificationRead('notification/1')).resolves.toBe(notification)
-    expect(patch).toHaveBeenCalledWith('/user/notifications/notification%2F1', { read: true })
+    await expect(markUserNotificationRead('11')).resolves.toBe(notification)
+    expect(patch).toHaveBeenCalledWith('/user/notifications/11', { read: true })
   })
 })

--- a/spx-gui/src/apis/notification.test.ts
+++ b/spx-gui/src/apis/notification.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { client } from './common'
-import { getUserNotificationUnreadCount, listUserNotifications, markUserNotificationRead } from './notification'
+import { getUserNotificationStatus, listUserNotifications, markUserNotificationRead } from './notification'
 
 afterEach(() => vi.restoreAllMocks())
 
@@ -14,12 +14,12 @@ describe('notification APIs', () => {
     expect(get).toHaveBeenCalledWith('/user/notifications', params, { signal: undefined })
   })
 
-  it('gets the unread notification count', async () => {
-    const response = { unreadCount: 3 }
+  it('gets the notification status', async () => {
+    const response = { hasUnread: true }
     const get = vi.spyOn(client, 'get').mockResolvedValue(response)
 
-    await expect(getUserNotificationUnreadCount()).resolves.toBe(response)
-    expect(get).toHaveBeenCalledWith('/user/notifications/unread-count', undefined, { signal: undefined })
+    await expect(getUserNotificationStatus()).resolves.toBe(response)
+    expect(get).toHaveBeenCalledWith('/user/notifications/status', undefined, { signal: undefined })
   })
 
   it('marks a notification as read', async () => {

--- a/spx-gui/src/apis/notification.test.ts
+++ b/spx-gui/src/apis/notification.test.ts
@@ -6,11 +6,12 @@ afterEach(() => vi.restoreAllMocks())
 
 describe('notification APIs', () => {
   it('lists authenticated user notifications with pagination', async () => {
-    const response = { total: 0, unreadCount: 0, data: [] }
+    const response = { nextCursor: null, data: [] }
     const get = vi.spyOn(client, 'get').mockResolvedValue(response)
 
-    await expect(listUserNotifications({ pageIndex: 2, pageSize: 50 })).resolves.toBe(response)
-    expect(get).toHaveBeenCalledWith('/user/notifications', { pageIndex: 2, pageSize: 50 })
+    const params = { pageSize: 50, cursor: 'next-page' }
+    await expect(listUserNotifications(params)).resolves.toBe(response)
+    expect(get).toHaveBeenCalledWith('/user/notifications', params, { signal: undefined })
   })
 
   it('gets the unread notification count', async () => {
@@ -18,7 +19,7 @@ describe('notification APIs', () => {
     const get = vi.spyOn(client, 'get').mockResolvedValue(response)
 
     await expect(getUserNotificationUnreadCount()).resolves.toBe(response)
-    expect(get).toHaveBeenCalledWith('/user/notifications/unread-count')
+    expect(get).toHaveBeenCalledWith('/user/notifications/unread-count', undefined, { signal: undefined })
   })
 
   it('marks a notification as read', async () => {
@@ -26,6 +27,6 @@ describe('notification APIs', () => {
     const patch = vi.spyOn(client, 'patch').mockResolvedValue(notification)
 
     await expect(markUserNotificationRead('11')).resolves.toBe(notification)
-    expect(patch).toHaveBeenCalledWith('/user/notifications/11', { read: true })
+    expect(patch).toHaveBeenCalledWith('/user/notifications/11', { read: true }, { signal: undefined })
   })
 })

--- a/spx-gui/src/apis/notification.test.ts
+++ b/spx-gui/src/apis/notification.test.ts
@@ -1,0 +1,31 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { client } from './common'
+import { getUserNotificationUnreadCount, listUserNotifications, markUserNotificationRead } from './notification'
+
+afterEach(() => vi.restoreAllMocks())
+
+describe('notification APIs', () => {
+  it('lists authenticated user notifications with pagination', async () => {
+    const response = { total: 0, unreadCount: 0, data: [] }
+    const get = vi.spyOn(client, 'get').mockResolvedValue(response)
+
+    await expect(listUserNotifications({ pageIndex: 2, pageSize: 50 })).resolves.toBe(response)
+    expect(get).toHaveBeenCalledWith('/user/notifications', { pageIndex: 2, pageSize: 50 })
+  })
+
+  it('gets the unread notification count', async () => {
+    const response = { unreadCount: 3 }
+    const get = vi.spyOn(client, 'get').mockResolvedValue(response)
+
+    await expect(getUserNotificationUnreadCount()).resolves.toBe(response)
+    expect(get).toHaveBeenCalledWith('/user/notifications/unread-count')
+  })
+
+  it('marks a notification as read', async () => {
+    const notification = { id: 'notification/1', readAt: '2026-08-26T00:00:00Z' }
+    const patch = vi.spyOn(client, 'patch').mockResolvedValue(notification)
+
+    await expect(markUserNotificationRead('notification/1')).resolves.toBe(notification)
+    expect(patch).toHaveBeenCalledWith('/user/notifications/notification%2F1', { read: true })
+  })
+})

--- a/spx-gui/src/apis/notification.ts
+++ b/spx-gui/src/apis/notification.ts
@@ -1,4 +1,4 @@
-import { client, type PaginationParams } from './common'
+import { client } from './common'
 
 export type UserNotification = {
   id: string
@@ -11,21 +11,29 @@ export type UserNotification = {
 }
 
 export type UserNotifications = {
-  total: number
-  unreadCount: number
+  nextCursor: string | null
   data: UserNotification[]
 }
 
-export function listUserNotifications(params?: PaginationParams) {
-  return client.get('/user/notifications', params) as Promise<UserNotifications>
+export type ListUserNotificationsParams = {
+  pageSize?: number
+  cursor?: string
 }
 
-export function getUserNotificationUnreadCount() {
-  return client.get('/user/notifications/unread-count') as Promise<Pick<UserNotifications, 'unreadCount'>>
+export function listUserNotifications(params?: ListUserNotificationsParams, signal?: AbortSignal) {
+  return client.get('/user/notifications', params, { signal }) as Promise<UserNotifications>
 }
 
-export function markUserNotificationRead(notificationID: string) {
-  return client.patch(`/user/notifications/${encodeURIComponent(notificationID)}`, {
-    read: true
-  }) as Promise<UserNotification>
+export function getUserNotificationUnreadCount(signal?: AbortSignal) {
+  return client.get('/user/notifications/unread-count', undefined, { signal }) as Promise<{ unreadCount: number }>
+}
+
+export function markUserNotificationRead(notificationID: string, signal?: AbortSignal) {
+  return client.patch(
+    `/user/notifications/${encodeURIComponent(notificationID)}`,
+    {
+      read: true
+    },
+    { signal }
+  ) as Promise<UserNotification>
 }

--- a/spx-gui/src/apis/notification.ts
+++ b/spx-gui/src/apis/notification.ts
@@ -11,6 +11,7 @@ export type UserNotification = {
 }
 
 export type UserNotifications = {
+  hasUnread: boolean
   nextCursor: string | null
   data: UserNotification[]
 }
@@ -22,10 +23,6 @@ export type ListUserNotificationsParams = {
 
 export function listUserNotifications(params?: ListUserNotificationsParams, signal?: AbortSignal) {
   return client.get('/user/notifications', params, { signal }) as Promise<UserNotifications>
-}
-
-export function getUserNotificationStatus(signal?: AbortSignal) {
-  return client.get('/user/notifications/status', undefined, { signal }) as Promise<{ hasUnread: boolean }>
 }
 
 export function markUserNotificationRead(notificationID: string, signal?: AbortSignal) {

--- a/spx-gui/src/apis/notification.ts
+++ b/spx-gui/src/apis/notification.ts
@@ -1,0 +1,31 @@
+import { client, type PaginationParams } from './common'
+
+export type UserNotification = {
+  id: string
+  createdAt: string
+  updatedAt: string
+  title: string
+  body: string
+  actionPath?: string
+  readAt: string | null
+}
+
+export type UserNotifications = {
+  total: number
+  unreadCount: number
+  data: UserNotification[]
+}
+
+export function listUserNotifications(params?: PaginationParams) {
+  return client.get('/user/notifications', params) as Promise<UserNotifications>
+}
+
+export function getUserNotificationUnreadCount() {
+  return client.get('/user/notifications/unread-count') as Promise<Pick<UserNotifications, 'unreadCount'>>
+}
+
+export function markUserNotificationRead(notificationID: string) {
+  return client.patch(`/user/notifications/${encodeURIComponent(notificationID)}`, {
+    read: true
+  }) as Promise<UserNotification>
+}

--- a/spx-gui/src/apis/notification.ts
+++ b/spx-gui/src/apis/notification.ts
@@ -24,8 +24,8 @@ export function listUserNotifications(params?: ListUserNotificationsParams, sign
   return client.get('/user/notifications', params, { signal }) as Promise<UserNotifications>
 }
 
-export function getUserNotificationUnreadCount(signal?: AbortSignal) {
-  return client.get('/user/notifications/unread-count', undefined, { signal }) as Promise<{ unreadCount: number }>
+export function getUserNotificationStatus(signal?: AbortSignal) {
+  return client.get('/user/notifications/status', undefined, { signal }) as Promise<{ hasUnread: boolean }>
 }
 
 export function markUserNotificationRead(notificationID: string, signal?: AbortSignal) {

--- a/spx-gui/src/components/copilot/CopilotUI.vue
+++ b/spx-gui/src/components/copilot/CopilotUI.vue
@@ -646,7 +646,8 @@ onMounted(async () => {
 
 .copilot-panel {
   position: fixed;
-  z-index: 9999;
+  /* Stay above regular popups (1000) without breaking modal dialogs (1100). */
+  z-index: 1050;
   right: 10px;
   bottom: 20px;
   width: 340px;

--- a/spx-gui/src/components/navbar/NavbarNotifications.test.ts
+++ b/spx-gui/src/components/navbar/NavbarNotifications.test.ts
@@ -190,14 +190,55 @@ describe('NavbarNotifications', () => {
 
     const loadMoreButton = wrapper.findAll('button').find((button) => button.text().includes('Load more'))
     await loadMoreButton!.trigger('click')
+    const pageSignal = mocks.list.mock.calls[2][1] as AbortSignal
     const notificationButton = wrapper.findAll('button').find((button) => button.text().includes(notification.title))
     await notificationButton!.trigger('click')
+    expect(pageSignal.aborted).toBe(true)
     await flushPromises()
     expect(wrapper.get('[aria-label="Notifications"]').find('.absolute').exists()).toBe(false)
 
     pendingPage.resolve({ hasUnread: true, nextCursor: null, data: [] })
     await flushPromises()
     expect(wrapper.get('[aria-label="Notifications"]').find('.absolute').exists()).toBe(false)
+  })
+
+  it('does not append a notification again when marking it read moves it behind the cursor', async () => {
+    const earlierNotification = {
+      ...notification,
+      id: '10',
+      createdAt: '2026-08-25T06:02:00Z',
+      title: 'Earlier notification',
+      readAt: '2026-08-26T07:00:00Z'
+    }
+    mocks.useSignedInUser.mockReturnValue(ref({ id: 'user-1' }))
+    mocks.list
+      .mockResolvedValueOnce({ hasUnread: true, nextCursor: 'next-page', data: [{ ...notification }] })
+      .mockResolvedValueOnce({ hasUnread: true, nextCursor: 'next-page', data: [{ ...notification }] })
+      .mockResolvedValueOnce({
+        hasUnread: false,
+        nextCursor: null,
+        data: [{ ...notification, readAt: '2026-08-26T07:01:00Z' }, earlierNotification]
+      })
+    mocks.markRead.mockResolvedValue({ ...notification, readAt: '2026-08-26T07:01:00Z' })
+
+    const wrapper = mountNotifications()
+    await flushPromises()
+    await wrapper.get('[aria-label="Notifications, unread notifications available"]').trigger('click')
+    await flushPromises()
+    await wrapper
+      .findAll('button')
+      .find((button) => button.text().includes(notification.title))!
+      .trigger('click')
+    await flushPromises()
+    await wrapper.get('[aria-label="Back to notifications"]').trigger('click')
+    await wrapper
+      .findAll('button')
+      .find((button) => button.text().includes('Load more'))!
+      .trigger('click')
+    await flushPromises()
+
+    expect(wrapper.findAll('button').filter((button) => button.text().includes(notification.title))).toHaveLength(1)
+    expect(wrapper.text()).toContain(earlierNotification.title)
   })
 
   it('waits for mark-as-read and defers list refresh while the request is pending', async () => {

--- a/spx-gui/src/components/navbar/NavbarNotifications.test.ts
+++ b/spx-gui/src/components/navbar/NavbarNotifications.test.ts
@@ -320,25 +320,18 @@ describe('NavbarNotifications', () => {
     expect(wrapper.text()).toContain('No notifications')
   })
 
-  it('moves a newly read notification behind every unread notification', async () => {
+  it('keeps a notification in place after marking it as read', async () => {
     const olderUnread = {
       ...notification,
       id: '10',
       createdAt: '2026-08-25T06:02:00Z',
       title: 'Older unread notification'
     }
-    const olderRead = {
-      ...notification,
-      id: '9',
-      createdAt: '2026-08-24T06:02:00Z',
-      title: 'Older read notification',
-      readAt: '2026-08-25T07:00:00Z'
-    }
     mocks.useSignedInUser.mockReturnValue(ref({ id: 'user-1' }))
     mocks.list.mockResolvedValue({
       hasUnread: true,
       nextCursor: null,
-      data: [{ ...notification }, olderUnread, olderRead]
+      data: [{ ...notification }, olderUnread]
     })
     mocks.markRead.mockResolvedValue({ ...notification, readAt: '2026-08-26T07:01:00Z' })
 
@@ -353,13 +346,11 @@ describe('NavbarNotifications', () => {
     await flushPromises()
     await wrapper.get('[aria-label="Back to notifications"]').trigger('click')
 
-    const titles = wrapper
-      .findAll('button')
-      .filter((button) => button.find('time').exists())
-      .map((button) => button.text())
-    expect(titles[0]).toContain(olderUnread.title)
-    expect(titles[1]).toContain(notification.title)
-    expect(titles[2]).toContain(olderRead.title)
+    const rows = wrapper.findAll('button').filter((button) => button.find('time').exists())
+    expect(rows[0].text()).toContain(notification.title)
+    expect(rows[0].find('.bg-primary-main').exists()).toBe(false)
+    expect(rows[1].text()).toContain(olderUnread.title)
+    expect(rows[1].find('.bg-primary-main').exists()).toBe(true)
   })
 
   it('marks different notifications as read concurrently', async () => {

--- a/spx-gui/src/components/navbar/NavbarNotifications.test.ts
+++ b/spx-gui/src/components/navbar/NavbarNotifications.test.ts
@@ -100,7 +100,7 @@ describe('NavbarNotifications', () => {
     expect(mocks.list).not.toHaveBeenCalled()
   })
 
-  it('refreshes notifications when opened and when the page becomes visible', async () => {
+  it('refreshes notifications when opened', async () => {
     mocks.useSignedInUser.mockReturnValue(ref({ id: 'user-1' }))
     mocks.list.mockResolvedValue({ hasUnread: true, nextCursor: null, data: [] })
 
@@ -111,11 +111,6 @@ describe('NavbarNotifications', () => {
     await wrapper.get('[aria-label="Notifications, unread notifications available"]').trigger('click')
     await flushPromises()
     expect(mocks.list).toHaveBeenCalledTimes(2)
-
-    Object.defineProperty(document, 'visibilityState', { configurable: true, value: 'visible' })
-    document.dispatchEvent(new Event('visibilitychange'))
-    await flushPromises()
-    expect(mocks.list).toHaveBeenCalledTimes(3)
   })
 
   it('loads pages, marks a notification read, and opens its application route', async () => {
@@ -241,7 +236,7 @@ describe('NavbarNotifications', () => {
     expect(wrapper.text()).toContain(earlierNotification.title)
   })
 
-  it('waits for mark-as-read and defers list refresh while the request is pending', async () => {
+  it('waits for mark-as-read before clearing the unread indicator', async () => {
     mocks.useSignedInUser.mockReturnValue(ref({ id: 'user-1' }))
     mocks.list.mockResolvedValue({ hasUnread: true, nextCursor: null, data: [{ ...notification }] })
     const pendingRead = deferred<typeof notification>()
@@ -257,14 +252,8 @@ describe('NavbarNotifications', () => {
     expect(wrapper.get('[aria-label="Notifications, unread notifications available"]').find('.absolute').exists()).toBe(
       true
     )
-    Object.defineProperty(document, 'visibilityState', { configurable: true, value: 'visible' })
-    document.dispatchEvent(new Event('visibilitychange'))
-    await flushPromises()
-    expect(mocks.list).toHaveBeenCalledTimes(2)
-
     pendingRead.resolve({ ...notification, readAt: '2026-08-26T07:01:00Z' })
     await flushPromises()
-    expect(mocks.list).toHaveBeenCalledTimes(2)
     expect(wrapper.get('[aria-label="Notifications"]').find('.absolute').exists()).toBe(false)
   })
 

--- a/spx-gui/src/components/navbar/NavbarNotifications.test.ts
+++ b/spx-gui/src/components/navbar/NavbarNotifications.test.ts
@@ -176,6 +176,7 @@ describe('NavbarNotifications', () => {
       .mockResolvedValueOnce({ hasUnread: true, nextCursor: 'next-page', data: [{ ...notification }] })
       .mockResolvedValueOnce({ hasUnread: true, nextCursor: 'next-page', data: [{ ...notification }] })
       .mockReturnValueOnce(pendingPage.promise)
+      .mockResolvedValueOnce({ hasUnread: false, nextCursor: null, data: [] })
     mocks.markRead.mockResolvedValue({ ...notification, readAt: '2026-08-26T07:01:00Z' })
 
     const wrapper = mountNotifications()
@@ -255,6 +256,110 @@ describe('NavbarNotifications', () => {
     pendingRead.resolve({ ...notification, readAt: '2026-08-26T07:01:00Z' })
     await flushPromises()
     expect(wrapper.get('[aria-label="Notifications"]').find('.absolute').exists()).toBe(false)
+  })
+
+  it('runs a queued load-more request after marking a notification as read', async () => {
+    mocks.useSignedInUser.mockReturnValue(ref({ id: 'user-1' }))
+    mocks.list
+      .mockResolvedValueOnce({ hasUnread: true, nextCursor: 'next-page', data: [{ ...notification }] })
+      .mockResolvedValueOnce({ hasUnread: true, nextCursor: 'next-page', data: [{ ...notification }] })
+      .mockResolvedValueOnce({
+        hasUnread: false,
+        nextCursor: null,
+        data: [{ ...notification, id: '10', title: 'Earlier notification', readAt: '2026-08-26T07:00:00Z' }]
+      })
+    const pendingRead = deferred<typeof notification>()
+    mocks.markRead.mockReturnValue(pendingRead.promise)
+
+    const wrapper = mountNotifications()
+    await flushPromises()
+    await wrapper.get('[aria-label="Notifications, unread notifications available"]').trigger('click')
+    await flushPromises()
+    await wrapper
+      .findAll('button')
+      .find((button) => button.text().includes(notification.title))!
+      .trigger('click')
+    await wrapper.get('[aria-label="Back to notifications"]').trigger('click')
+    await wrapper
+      .findAll('button')
+      .find((button) => button.text().includes('Load more'))!
+      .trigger('click')
+    expect(mocks.list).toHaveBeenCalledTimes(2)
+
+    pendingRead.resolve({ ...notification, readAt: '2026-08-26T07:01:00Z' })
+    await flushPromises()
+
+    expect(mocks.list).toHaveBeenNthCalledWith(3, { pageSize: 50, cursor: 'next-page' }, expect.any(AbortSignal))
+    expect(wrapper.text()).toContain('Earlier notification')
+  })
+
+  it('runs a queued refresh after marking a notification as read', async () => {
+    mocks.useSignedInUser.mockReturnValue(ref({ id: 'user-1' }))
+    mocks.list
+      .mockResolvedValueOnce({ hasUnread: true, nextCursor: null, data: [{ ...notification }] })
+      .mockResolvedValueOnce({ hasUnread: true, nextCursor: null, data: [{ ...notification }] })
+      .mockResolvedValueOnce({ hasUnread: false, nextCursor: null, data: [] })
+    const pendingRead = deferred<typeof notification>()
+    mocks.markRead.mockReturnValue(pendingRead.promise)
+
+    const wrapper = mountNotifications()
+    await flushPromises()
+    await wrapper.get('[aria-label="Notifications, unread notifications available"]').trigger('click')
+    await flushPromises()
+    await wrapper
+      .findAll('button')
+      .find((button) => button.text().includes(notification.title))!
+      .trigger('click')
+    await wrapper.get('[aria-label="Notifications, unread notifications available"]').trigger('click')
+    expect(mocks.list).toHaveBeenCalledTimes(2)
+
+    pendingRead.resolve({ ...notification, readAt: '2026-08-26T07:01:00Z' })
+    await flushPromises()
+
+    expect(mocks.list).toHaveBeenNthCalledWith(3, { pageSize: 50 }, expect.any(AbortSignal))
+    expect(wrapper.text()).toContain('No notifications')
+  })
+
+  it('moves a newly read notification behind every unread notification', async () => {
+    const olderUnread = {
+      ...notification,
+      id: '10',
+      createdAt: '2026-08-25T06:02:00Z',
+      title: 'Older unread notification'
+    }
+    const olderRead = {
+      ...notification,
+      id: '9',
+      createdAt: '2026-08-24T06:02:00Z',
+      title: 'Older read notification',
+      readAt: '2026-08-25T07:00:00Z'
+    }
+    mocks.useSignedInUser.mockReturnValue(ref({ id: 'user-1' }))
+    mocks.list.mockResolvedValue({
+      hasUnread: true,
+      nextCursor: null,
+      data: [{ ...notification }, olderUnread, olderRead]
+    })
+    mocks.markRead.mockResolvedValue({ ...notification, readAt: '2026-08-26T07:01:00Z' })
+
+    const wrapper = mountNotifications()
+    await flushPromises()
+    await wrapper.get('[aria-label="Notifications, unread notifications available"]').trigger('click')
+    await flushPromises()
+    await wrapper
+      .findAll('button')
+      .find((button) => button.text().includes(notification.title))!
+      .trigger('click')
+    await flushPromises()
+    await wrapper.get('[aria-label="Back to notifications"]').trigger('click')
+
+    const titles = wrapper
+      .findAll('button')
+      .filter((button) => button.find('time').exists())
+      .map((button) => button.text())
+    expect(titles[0]).toContain(olderUnread.title)
+    expect(titles[1]).toContain(notification.title)
+    expect(titles[2]).toContain(olderRead.title)
   })
 
   it('marks different notifications as read concurrently', async () => {

--- a/spx-gui/src/components/navbar/NavbarNotifications.test.ts
+++ b/spx-gui/src/components/navbar/NavbarNotifications.test.ts
@@ -368,12 +368,12 @@ describe('NavbarNotifications', () => {
     expect(wrapper.text()).toContain('Refreshed notification')
   })
 
-  it('does not open an unsafe notification action', async () => {
+  it.each([`/\\example.com`, '/\t/evil.com'])('does not open the unsafe notification action %j', async (actionPath) => {
     mocks.useSignedInUser.mockReturnValue(ref({ id: 'user-1' }))
     mocks.list.mockResolvedValue({
       hasUnread: false,
       nextCursor: null,
-      data: [{ ...notification, actionPath: `/\\example.com`, readAt: '2026-08-26T07:00:00Z' }]
+      data: [{ ...notification, actionPath, readAt: '2026-08-26T07:00:00Z' }]
     })
 
     const wrapper = mountNotifications()

--- a/spx-gui/src/components/navbar/NavbarNotifications.test.ts
+++ b/spx-gui/src/components/navbar/NavbarNotifications.test.ts
@@ -150,6 +150,54 @@ describe('NavbarNotifications', () => {
     expect(mocks.push).toHaveBeenCalledWith(notification.actionPath)
   })
 
+  it('does not overwrite an optimistic unread count with a stale page response', async () => {
+    mocks.useSignedInUser.mockReturnValue(ref({ id: 'user-1' }))
+    mocks.unreadCount.mockResolvedValue({ unreadCount: 2 })
+    const pendingPage = deferred<{ total: number; unreadCount: number; data: (typeof notification)[] }>()
+    mocks.list
+      .mockResolvedValueOnce({ total: 2, unreadCount: 2, data: [{ ...notification }] })
+      .mockReturnValueOnce(pendingPage.promise)
+    mocks.markRead.mockResolvedValue({ ...notification, readAt: '2026-08-26T07:01:00Z' })
+
+    const wrapper = mountNotifications()
+    await flushPromises()
+    await wrapper.get('[aria-label="Notifications, 2 unread"]').trigger('click')
+    await flushPromises()
+
+    const loadMoreButton = wrapper.findAll('button').find((button) => button.text().includes('Load more'))
+    await loadMoreButton!.trigger('click')
+    const notificationButton = wrapper.findAll('button').find((button) => button.text().includes(notification.title))
+    await notificationButton!.trigger('click')
+    await flushPromises()
+    expect(wrapper.get('[aria-label="Notifications, 1 unread"]').text()).toContain('1')
+
+    pendingPage.resolve({ total: 2, unreadCount: 2, data: [] })
+    await flushPromises()
+    expect(wrapper.get('[aria-label="Notifications, 1 unread"]').text()).toContain('1')
+  })
+
+  it('does not open an unsafe notification action', async () => {
+    mocks.useSignedInUser.mockReturnValue(ref({ id: 'user-1' }))
+    mocks.unreadCount.mockResolvedValue({ unreadCount: 0 })
+    mocks.list.mockResolvedValue({
+      total: 1,
+      unreadCount: 0,
+      data: [{ ...notification, actionPath: `/\\example.com`, readAt: '2026-08-26T07:00:00Z' }]
+    })
+
+    const wrapper = mountNotifications()
+    await flushPromises()
+    await wrapper.get('[aria-label="Notifications"]').trigger('click')
+    await flushPromises()
+    const notificationButton = wrapper.findAll('button').find((button) => button.text().includes(notification.title))
+    await notificationButton!.trigger('click')
+    const viewDetailsButton = wrapper.findAll('button').find((button) => button.text().includes('View details'))
+    await viewDetailsButton!.trigger('click')
+    await flushPromises()
+
+    expect(mocks.push).not.toHaveBeenCalled()
+  })
+
   it('does not roll an old failed read request back into a new user session', async () => {
     const user = ref<{ id: string } | null>({ id: 'user-1' })
     const pendingRead = deferred<typeof notification>()

--- a/spx-gui/src/components/navbar/NavbarNotifications.test.ts
+++ b/spx-gui/src/components/navbar/NavbarNotifications.test.ts
@@ -1,0 +1,180 @@
+import { flushPromises, mount } from '@vue/test-utils'
+import { ref } from 'vue'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createI18n } from '@/utils/i18n'
+import NavbarNotifications from './NavbarNotifications.vue'
+
+const mocks = vi.hoisted(() => ({
+  useSignedInUser: vi.fn(),
+  push: vi.fn(),
+  list: vi.fn(),
+  unreadCount: vi.fn(),
+  markRead: vi.fn()
+}))
+
+vi.mock('@/stores/user', () => ({ useSignedInUser: mocks.useSignedInUser }))
+vi.mock('vue-router', () => ({ useRouter: () => ({ push: mocks.push }) }))
+vi.mock('@/apis/notification', () => ({
+  listUserNotifications: mocks.list,
+  getUserNotificationUnreadCount: mocks.unreadCount,
+  markUserNotificationRead: mocks.markRead
+}))
+vi.mock('@/utils/exception', async (importOriginal) => {
+  const original = await importOriginal<typeof import('@/utils/exception')>()
+  return {
+    ...original,
+    useMessageHandle: (fn: (...args: any[]) => unknown) => ({
+      fn: async (...args: any[]) => {
+        try {
+          await fn(...args)
+        } catch {
+          // Production useMessageHandle reports and consumes action failures.
+        }
+      },
+      isLoading: ref(false)
+    })
+  }
+})
+
+const notification = {
+  id: '11',
+  createdAt: '2026-08-26T06:02:00Z',
+  updatedAt: '2026-08-26T06:02:00Z',
+  title: 'Support replied',
+  body: 'Please try again.',
+  actionPath: '/feedbacks/3',
+  readAt: null
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, resolve, reject }
+}
+
+function mountNotifications() {
+  return mount(NavbarNotifications, {
+    global: {
+      plugins: [createI18n({ lang: 'en' })],
+      directives: { radar: () => undefined },
+      stubs: {
+        UIIcon: true,
+        UIButton: {
+          emits: ['click'],
+          template: '<button type="button" @click="$emit(\'click\')"><slot name="icon"/><slot/></button>'
+        },
+        UIModal: {
+          props: ['visible'],
+          emits: ['update:visible'],
+          template: '<div v-if="visible" role="dialog"><slot/></div>'
+        }
+      }
+    }
+  })
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('NavbarNotifications', () => {
+  it('does not fetch or render notifications without a signed-in user', async () => {
+    mocks.useSignedInUser.mockReturnValue(ref(null))
+
+    const wrapper = mountNotifications()
+    await flushPromises()
+
+    expect(wrapper.find('button').exists()).toBe(false)
+    expect(mocks.unreadCount).not.toHaveBeenCalled()
+  })
+
+  it('refreshes the unread count periodically and when the page becomes visible', async () => {
+    vi.useFakeTimers()
+    mocks.useSignedInUser.mockReturnValue(ref({ id: 'user-1' }))
+    mocks.unreadCount.mockResolvedValue({ unreadCount: 1 })
+
+    const wrapper = mountNotifications()
+    await flushPromises()
+    expect(mocks.unreadCount).toHaveBeenCalledTimes(1)
+
+    await vi.advanceTimersByTimeAsync(5 * 60_000)
+    expect(mocks.unreadCount).toHaveBeenCalledTimes(2)
+
+    Object.defineProperty(document, 'visibilityState', { configurable: true, value: 'visible' })
+    document.dispatchEvent(new Event('visibilitychange'))
+    await flushPromises()
+    expect(mocks.unreadCount).toHaveBeenCalledTimes(3)
+    wrapper.unmount()
+  })
+
+  it('loads pages, marks a notification read, and opens its application route', async () => {
+    mocks.useSignedInUser.mockReturnValue(ref({ id: 'user-1' }))
+    mocks.unreadCount.mockResolvedValue({ unreadCount: 1 })
+    mocks.list.mockResolvedValueOnce({ total: 2, unreadCount: 1, data: [{ ...notification }] }).mockResolvedValueOnce({
+      total: 2,
+      unreadCount: 1,
+      data: [{ ...notification, id: '12', title: 'Earlier notification', readAt: '2026-08-26T07:00:00Z' }]
+    })
+    mocks.markRead.mockResolvedValue({ ...notification, readAt: '2026-08-26T07:01:00Z' })
+
+    const wrapper = mountNotifications()
+    await flushPromises()
+    await wrapper.get('[aria-label="Notifications, 1 unread"]').trigger('click')
+    await flushPromises()
+    expect(mocks.list).toHaveBeenNthCalledWith(1, { pageIndex: 1, pageSize: 50 })
+
+    const loadMoreButton = wrapper.findAll('button').find((button) => button.text().includes('Load more'))
+    expect(loadMoreButton).toBeDefined()
+    await loadMoreButton!.trigger('click')
+    await flushPromises()
+    expect(mocks.list).toHaveBeenNthCalledWith(2, { pageIndex: 2, pageSize: 50 })
+    expect(wrapper.text()).toContain('Earlier notification')
+
+    const notificationButton = wrapper.findAll('button').find((button) => button.text().includes(notification.title))
+    await notificationButton!.trigger('click')
+    await flushPromises()
+    expect(mocks.markRead).toHaveBeenCalledWith(notification.id)
+    expect(wrapper.get('[aria-label="Notifications"]').find('.absolute').exists()).toBe(false)
+
+    const viewDetailsButton = wrapper.findAll('button').find((button) => button.text().includes('View details'))
+    await viewDetailsButton!.trigger('click')
+    await flushPromises()
+    expect(mocks.push).toHaveBeenCalledWith(notification.actionPath)
+  })
+
+  it('does not roll an old failed read request back into a new user session', async () => {
+    const user = ref<{ id: string } | null>({ id: 'user-1' })
+    const pendingRead = deferred<typeof notification>()
+    mocks.useSignedInUser.mockReturnValue(user)
+    mocks.unreadCount.mockResolvedValueOnce({ unreadCount: 2 }).mockResolvedValueOnce({ unreadCount: 4 })
+    mocks.list.mockResolvedValue({ total: 1, unreadCount: 2, data: [{ ...notification }] })
+    mocks.markRead.mockReturnValue(pendingRead.promise)
+
+    const wrapper = mountNotifications()
+    await flushPromises()
+    expect(wrapper.get('[aria-label="Notifications, 2 unread"]').text()).toContain('2')
+
+    await wrapper.get('[aria-label="Notifications, 2 unread"]').trigger('click')
+    await flushPromises()
+    const notificationButton = wrapper.findAll('button').find((button) => button.text().includes(notification.title))
+    expect(notificationButton).toBeDefined()
+    await notificationButton!.trigger('click')
+    expect(mocks.markRead).toHaveBeenCalledWith(notification.id)
+
+    user.value = { id: 'user-2' }
+    await flushPromises()
+    expect(wrapper.get('[aria-label="Notifications, 4 unread"]').text()).toContain('4')
+
+    pendingRead.reject(new Error('old request failed'))
+    await flushPromises()
+    expect(wrapper.get('[aria-label="Notifications, 4 unread"]').text()).toContain('4')
+  })
+})

--- a/spx-gui/src/components/navbar/NavbarNotifications.test.ts
+++ b/spx-gui/src/components/navbar/NavbarNotifications.test.ts
@@ -272,6 +272,38 @@ describe('NavbarNotifications', () => {
     ).toBe(undefined)
   })
 
+  it('silently keeps a notification unread and retryable when marking it read fails', async () => {
+    mocks.useSignedInUser.mockReturnValue(ref({ id: 'user-1' }))
+    mocks.list.mockResolvedValue({ hasUnread: true, nextCursor: null, data: [{ ...notification }] })
+    mocks.markRead.mockRejectedValueOnce(new Error('network error')).mockResolvedValueOnce({
+      ...notification,
+      readAt: '2026-08-26T07:01:00Z'
+    })
+
+    const wrapper = mountNotifications()
+    await flushPromises()
+    await wrapper.get('[aria-label="Notifications, unread notifications available"]').trigger('click')
+    await flushPromises()
+    await wrapper
+      .findAll('button')
+      .find((button) => button.text().includes(notification.title))!
+      .trigger('click')
+    await flushPromises()
+
+    expect(wrapper.get('[aria-label="Notifications, unread notifications available"]').find('.absolute').exists()).toBe(
+      true
+    )
+
+    await wrapper.get('[aria-label="Back to notifications"]').trigger('click')
+    await wrapper
+      .findAll('button')
+      .find((button) => button.text().includes(notification.title))!
+      .trigger('click')
+    await flushPromises()
+
+    expect(mocks.markRead).toHaveBeenCalledTimes(2)
+  })
+
   it('keeps a notification in place after marking it as read', async () => {
     const olderUnread = {
       ...notification,

--- a/spx-gui/src/components/navbar/NavbarNotifications.test.ts
+++ b/spx-gui/src/components/navbar/NavbarNotifications.test.ts
@@ -1,6 +1,7 @@
 import { flushPromises, mount } from '@vue/test-utils'
 import { ref } from 'vue'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { UserNotification } from '@/apis/notification'
 import { createI18n } from '@/utils/i18n'
 import NavbarNotifications from './NavbarNotifications.vue'
 
@@ -36,7 +37,7 @@ vi.mock('@/utils/exception', async (importOriginal) => {
   }
 })
 
-const notification = {
+const notification: UserNotification = {
   id: '11',
   createdAt: '2026-08-26T06:02:00Z',
   updatedAt: '2026-08-26T06:02:00Z',
@@ -56,8 +57,10 @@ function deferred<T>() {
   return { promise, resolve, reject }
 }
 
+const mountedWrappers: ReturnType<typeof mount>[] = []
+
 function mountNotifications() {
-  return mount(NavbarNotifications, {
+  const wrapper = mount(NavbarNotifications, {
     global: {
       plugins: [createI18n({ lang: 'en' })],
       directives: { radar: () => undefined },
@@ -75,6 +78,8 @@ function mountNotifications() {
       }
     }
   })
+  mountedWrappers.push(wrapper)
+  return wrapper
 }
 
 beforeEach(() => {
@@ -82,7 +87,8 @@ beforeEach(() => {
 })
 
 afterEach(() => {
-  vi.useRealTimers()
+  for (const wrapper of mountedWrappers) wrapper.unmount()
+  mountedWrappers.length = 0
 })
 
 describe('NavbarNotifications', () => {
@@ -96,8 +102,7 @@ describe('NavbarNotifications', () => {
     expect(mocks.unreadCount).not.toHaveBeenCalled()
   })
 
-  it('refreshes the unread count periodically and when the page becomes visible', async () => {
-    vi.useFakeTimers()
+  it('refreshes the unread count when opened and when the page becomes visible', async () => {
     mocks.useSignedInUser.mockReturnValue(ref({ id: 'user-1' }))
     mocks.unreadCount.mockResolvedValue({ unreadCount: 1 })
 
@@ -105,23 +110,30 @@ describe('NavbarNotifications', () => {
     await flushPromises()
     expect(mocks.unreadCount).toHaveBeenCalledTimes(1)
 
-    await vi.advanceTimersByTimeAsync(5 * 60_000)
+    await wrapper.get('[aria-label="Notifications, 1 unread"]').trigger('click')
+    await flushPromises()
     expect(mocks.unreadCount).toHaveBeenCalledTimes(2)
 
     Object.defineProperty(document, 'visibilityState', { configurable: true, value: 'visible' })
     document.dispatchEvent(new Event('visibilitychange'))
     await flushPromises()
     expect(mocks.unreadCount).toHaveBeenCalledTimes(3)
-    wrapper.unmount()
   })
 
   it('loads pages, marks a notification read, and opens its application route', async () => {
     mocks.useSignedInUser.mockReturnValue(ref({ id: 'user-1' }))
-    mocks.unreadCount.mockResolvedValue({ unreadCount: 1 })
-    mocks.list.mockResolvedValueOnce({ total: 2, unreadCount: 1, data: [{ ...notification }] }).mockResolvedValueOnce({
-      total: 2,
-      unreadCount: 1,
-      data: [{ ...notification, id: '12', title: 'Earlier notification', readAt: '2026-08-26T07:00:00Z' }]
+    mocks.unreadCount.mockResolvedValueOnce({ unreadCount: 1 }).mockResolvedValue({ unreadCount: 0 })
+    mocks.list.mockResolvedValueOnce({ nextCursor: 'next-page', data: [{ ...notification }] }).mockResolvedValueOnce({
+      nextCursor: null,
+      data: [
+        {
+          ...notification,
+          id: '10',
+          createdAt: '2026-08-25T06:02:00Z',
+          title: 'Earlier notification',
+          readAt: '2026-08-26T07:00:00Z'
+        }
+      ]
     })
     mocks.markRead.mockResolvedValue({ ...notification, readAt: '2026-08-26T07:01:00Z' })
 
@@ -129,19 +141,26 @@ describe('NavbarNotifications', () => {
     await flushPromises()
     await wrapper.get('[aria-label="Notifications, 1 unread"]').trigger('click')
     await flushPromises()
-    expect(mocks.list).toHaveBeenNthCalledWith(1, { pageIndex: 1, pageSize: 50 })
+    expect(mocks.list).toHaveBeenNthCalledWith(1, { pageSize: 50 }, expect.any(AbortSignal))
 
     const loadMoreButton = wrapper.findAll('button').find((button) => button.text().includes('Load more'))
     expect(loadMoreButton).toBeDefined()
     await loadMoreButton!.trigger('click')
     await flushPromises()
-    expect(mocks.list).toHaveBeenNthCalledWith(2, { pageIndex: 2, pageSize: 50 })
+    expect(mocks.list).toHaveBeenNthCalledWith(
+      2,
+      {
+        pageSize: 50,
+        cursor: 'next-page'
+      },
+      expect.any(AbortSignal)
+    )
     expect(wrapper.text()).toContain('Earlier notification')
 
     const notificationButton = wrapper.findAll('button').find((button) => button.text().includes(notification.title))
     await notificationButton!.trigger('click')
     await flushPromises()
-    expect(mocks.markRead).toHaveBeenCalledWith(notification.id)
+    expect(mocks.markRead).toHaveBeenCalledWith(notification.id, expect.any(AbortSignal))
     expect(wrapper.get('[aria-label="Notifications"]').find('.absolute').exists()).toBe(false)
 
     const viewDetailsButton = wrapper.findAll('button').find((button) => button.text().includes('View details'))
@@ -150,12 +169,18 @@ describe('NavbarNotifications', () => {
     expect(mocks.push).toHaveBeenCalledWith(notification.actionPath)
   })
 
-  it('does not overwrite an optimistic unread count with a stale page response', async () => {
+  it('does not overwrite a completed read with a stale cursor page response', async () => {
     mocks.useSignedInUser.mockReturnValue(ref({ id: 'user-1' }))
-    mocks.unreadCount.mockResolvedValue({ unreadCount: 2 })
-    const pendingPage = deferred<{ total: number; unreadCount: number; data: (typeof notification)[] }>()
+    mocks.unreadCount
+      .mockResolvedValueOnce({ unreadCount: 2 })
+      .mockResolvedValueOnce({ unreadCount: 2 })
+      .mockResolvedValue({ unreadCount: 1 })
+    const pendingPage = deferred<{
+      nextCursor: string | null
+      data: (typeof notification)[]
+    }>()
     mocks.list
-      .mockResolvedValueOnce({ total: 2, unreadCount: 2, data: [{ ...notification }] })
+      .mockResolvedValueOnce({ nextCursor: 'next-page', data: [{ ...notification }] })
       .mockReturnValueOnce(pendingPage.promise)
     mocks.markRead.mockResolvedValue({ ...notification, readAt: '2026-08-26T07:01:00Z' })
 
@@ -171,17 +196,108 @@ describe('NavbarNotifications', () => {
     await flushPromises()
     expect(wrapper.get('[aria-label="Notifications, 1 unread"]').text()).toContain('1')
 
-    pendingPage.resolve({ total: 2, unreadCount: 2, data: [] })
+    pendingPage.resolve({ nextCursor: null, data: [] })
     await flushPromises()
     expect(wrapper.get('[aria-label="Notifications, 1 unread"]').text()).toContain('1')
+  })
+
+  it('waits for mark-as-read and defers count refresh while the request is pending', async () => {
+    mocks.useSignedInUser.mockReturnValue(ref({ id: 'user-1' }))
+    mocks.unreadCount
+      .mockResolvedValueOnce({ unreadCount: 2 })
+      .mockResolvedValueOnce({ unreadCount: 2 })
+      .mockResolvedValue({ unreadCount: 1 })
+    mocks.list.mockResolvedValue({ nextCursor: null, data: [{ ...notification }] })
+    const pendingRead = deferred<typeof notification>()
+    mocks.markRead.mockReturnValue(pendingRead.promise)
+
+    const wrapper = mountNotifications()
+    await flushPromises()
+    await wrapper.get('[aria-label="Notifications, 2 unread"]').trigger('click')
+    await flushPromises()
+    const notificationButton = wrapper.findAll('button').find((button) => button.text().includes(notification.title))
+    await notificationButton!.trigger('click')
+
+    expect(wrapper.get('[aria-label="Notifications, 2 unread"]').text()).toContain('2')
+    Object.defineProperty(document, 'visibilityState', { configurable: true, value: 'visible' })
+    document.dispatchEvent(new Event('visibilitychange'))
+    await flushPromises()
+    expect(mocks.unreadCount).toHaveBeenCalledTimes(2)
+
+    pendingRead.resolve({ ...notification, readAt: '2026-08-26T07:01:00Z' })
+    await flushPromises()
+    expect(mocks.unreadCount).toHaveBeenCalledTimes(3)
+    expect(wrapper.get('[aria-label="Notifications, 1 unread"]').text()).toContain('1')
+  })
+
+  it('marks different notifications as read concurrently', async () => {
+    const anotherNotification = { ...notification, id: '12', title: 'Another notification' }
+    mocks.useSignedInUser.mockReturnValue(ref({ id: 'user-1' }))
+    mocks.unreadCount
+      .mockResolvedValueOnce({ unreadCount: 2 })
+      .mockResolvedValueOnce({ unreadCount: 2 })
+      .mockResolvedValue({ unreadCount: 1 })
+    mocks.list.mockResolvedValue({ nextCursor: null, data: [{ ...notification }, anotherNotification] })
+    const firstRead = deferred<typeof notification>()
+    const secondRead = deferred<typeof notification>()
+    mocks.markRead.mockReturnValueOnce(firstRead.promise).mockReturnValueOnce(secondRead.promise)
+
+    const wrapper = mountNotifications()
+    await flushPromises()
+    await wrapper.get('[aria-label="Notifications, 2 unread"]').trigger('click')
+    await flushPromises()
+    await wrapper
+      .findAll('button')
+      .find((button) => button.text().includes(notification.title))!
+      .trigger('click')
+    await wrapper.get('[aria-label="Back to notifications"]').trigger('click')
+    await wrapper
+      .findAll('button')
+      .find((button) => button.text().includes(anotherNotification.title))!
+      .trigger('click')
+
+    expect(mocks.markRead).toHaveBeenCalledTimes(2)
+    expect((mocks.markRead.mock.calls[0][1] as AbortSignal).aborted).toBe(false)
+    expect(wrapper.text()).toContain('Marking as read...')
+
+    secondRead.resolve({ ...anotherNotification, readAt: '2026-08-26T07:01:00Z' })
+    await flushPromises()
+    expect(wrapper.text()).not.toContain('Marking as read...')
+  })
+
+  it('restarts the first page when reopened during an in-flight page request', async () => {
+    mocks.useSignedInUser.mockReturnValue(ref({ id: 'user-1' }))
+    mocks.unreadCount.mockResolvedValue({ unreadCount: 0 })
+    const pendingPage = deferred<{ nextCursor: string | null; data: UserNotification[] }>()
+    mocks.list
+      .mockResolvedValueOnce({ nextCursor: 'next-page', data: [{ ...notification }] })
+      .mockReturnValueOnce(pendingPage.promise)
+      .mockResolvedValueOnce({ nextCursor: null, data: [{ ...notification, title: 'Refreshed notification' }] })
+
+    const wrapper = mountNotifications()
+    await flushPromises()
+    await wrapper.get('[aria-label="Notifications"]').trigger('click')
+    await flushPromises()
+    await wrapper
+      .findAll('button')
+      .find((button) => button.text().includes('Load more'))!
+      .trigger('click')
+    const pageSignal = mocks.list.mock.calls[1][1] as AbortSignal
+
+    await wrapper.get('[aria-label="Close notifications"]').trigger('click')
+    await wrapper.get('[aria-label="Notifications"]').trigger('click')
+    await flushPromises()
+
+    expect(pageSignal.aborted).toBe(true)
+    expect(mocks.list).toHaveBeenCalledTimes(3)
+    expect(wrapper.text()).toContain('Refreshed notification')
   })
 
   it('does not open an unsafe notification action', async () => {
     mocks.useSignedInUser.mockReturnValue(ref({ id: 'user-1' }))
     mocks.unreadCount.mockResolvedValue({ unreadCount: 0 })
     mocks.list.mockResolvedValue({
-      total: 1,
-      unreadCount: 0,
+      nextCursor: null,
       data: [{ ...notification, actionPath: `/\\example.com`, readAt: '2026-08-26T07:00:00Z' }]
     })
 
@@ -198,12 +314,15 @@ describe('NavbarNotifications', () => {
     expect(mocks.push).not.toHaveBeenCalled()
   })
 
-  it('does not roll an old failed read request back into a new user session', async () => {
+  it('does not let an old failed read request affect a new user session', async () => {
     const user = ref<{ id: string } | null>({ id: 'user-1' })
     const pendingRead = deferred<typeof notification>()
     mocks.useSignedInUser.mockReturnValue(user)
-    mocks.unreadCount.mockResolvedValueOnce({ unreadCount: 2 }).mockResolvedValueOnce({ unreadCount: 4 })
-    mocks.list.mockResolvedValue({ total: 1, unreadCount: 2, data: [{ ...notification }] })
+    mocks.unreadCount
+      .mockResolvedValueOnce({ unreadCount: 2 })
+      .mockResolvedValueOnce({ unreadCount: 2 })
+      .mockResolvedValueOnce({ unreadCount: 4 })
+    mocks.list.mockResolvedValue({ nextCursor: null, data: [{ ...notification }] })
     mocks.markRead.mockReturnValue(pendingRead.promise)
 
     const wrapper = mountNotifications()
@@ -215,7 +334,7 @@ describe('NavbarNotifications', () => {
     const notificationButton = wrapper.findAll('button').find((button) => button.text().includes(notification.title))
     expect(notificationButton).toBeDefined()
     await notificationButton!.trigger('click')
-    expect(mocks.markRead).toHaveBeenCalledWith(notification.id)
+    expect(mocks.markRead).toHaveBeenCalledWith(notification.id, expect.any(AbortSignal))
 
     user.value = { id: 'user-2' }
     await flushPromises()

--- a/spx-gui/src/components/navbar/NavbarNotifications.test.ts
+++ b/spx-gui/src/components/navbar/NavbarNotifications.test.ts
@@ -9,7 +9,6 @@ const mocks = vi.hoisted(() => ({
   useSignedInUser: vi.fn(),
   push: vi.fn(),
   list: vi.fn(),
-  status: vi.fn(),
   markRead: vi.fn()
 }))
 
@@ -17,7 +16,6 @@ vi.mock('@/stores/user', () => ({ useSignedInUser: mocks.useSignedInUser }))
 vi.mock('vue-router', () => ({ useRouter: () => ({ push: mocks.push }) }))
 vi.mock('@/apis/notification', () => ({
   listUserNotifications: mocks.list,
-  getUserNotificationStatus: mocks.status,
   markUserNotificationRead: mocks.markRead
 }))
 vi.mock('@/utils/exception', async (importOriginal) => {
@@ -99,56 +97,59 @@ describe('NavbarNotifications', () => {
     await flushPromises()
 
     expect(wrapper.find('button').exists()).toBe(false)
-    expect(mocks.status).not.toHaveBeenCalled()
+    expect(mocks.list).not.toHaveBeenCalled()
   })
 
-  it('refreshes the unread count when opened and when the page becomes visible', async () => {
+  it('refreshes notifications when opened and when the page becomes visible', async () => {
     mocks.useSignedInUser.mockReturnValue(ref({ id: 'user-1' }))
-    mocks.status.mockResolvedValue({ hasUnread: true })
+    mocks.list.mockResolvedValue({ hasUnread: true, nextCursor: null, data: [] })
 
     const wrapper = mountNotifications()
     await flushPromises()
-    expect(mocks.status).toHaveBeenCalledTimes(1)
+    expect(mocks.list).toHaveBeenCalledTimes(1)
 
     await wrapper.get('[aria-label="Notifications, unread notifications available"]').trigger('click')
     await flushPromises()
-    expect(mocks.status).toHaveBeenCalledTimes(2)
+    expect(mocks.list).toHaveBeenCalledTimes(2)
 
     Object.defineProperty(document, 'visibilityState', { configurable: true, value: 'visible' })
     document.dispatchEvent(new Event('visibilitychange'))
     await flushPromises()
-    expect(mocks.status).toHaveBeenCalledTimes(3)
+    expect(mocks.list).toHaveBeenCalledTimes(3)
   })
 
   it('loads pages, marks a notification read, and opens its application route', async () => {
     mocks.useSignedInUser.mockReturnValue(ref({ id: 'user-1' }))
-    mocks.status.mockResolvedValueOnce({ hasUnread: true }).mockResolvedValue({ hasUnread: false })
-    mocks.list.mockResolvedValueOnce({ nextCursor: 'next-page', data: [{ ...notification }] }).mockResolvedValueOnce({
-      nextCursor: null,
-      data: [
-        {
-          ...notification,
-          id: '10',
-          createdAt: '2026-08-25T06:02:00Z',
-          title: 'Earlier notification',
-          readAt: '2026-08-26T07:00:00Z'
-        }
-      ]
-    })
+    mocks.list
+      .mockResolvedValueOnce({ hasUnread: true, nextCursor: 'next-page', data: [{ ...notification }] })
+      .mockResolvedValueOnce({ hasUnread: true, nextCursor: 'next-page', data: [{ ...notification }] })
+      .mockResolvedValueOnce({
+        hasUnread: true,
+        nextCursor: null,
+        data: [
+          {
+            ...notification,
+            id: '10',
+            createdAt: '2026-08-25T06:02:00Z',
+            title: 'Earlier notification',
+            readAt: '2026-08-26T07:00:00Z'
+          }
+        ]
+      })
     mocks.markRead.mockResolvedValue({ ...notification, readAt: '2026-08-26T07:01:00Z' })
 
     const wrapper = mountNotifications()
     await flushPromises()
     await wrapper.get('[aria-label="Notifications, unread notifications available"]').trigger('click')
     await flushPromises()
-    expect(mocks.list).toHaveBeenNthCalledWith(1, { pageSize: 50 }, expect.any(AbortSignal))
+    expect(mocks.list).toHaveBeenNthCalledWith(2, { pageSize: 50 }, expect.any(AbortSignal))
 
     const loadMoreButton = wrapper.findAll('button').find((button) => button.text().includes('Load more'))
     expect(loadMoreButton).toBeDefined()
     await loadMoreButton!.trigger('click')
     await flushPromises()
     expect(mocks.list).toHaveBeenNthCalledWith(
-      2,
+      3,
       {
         pageSize: 50,
         cursor: 'next-page'
@@ -171,13 +172,14 @@ describe('NavbarNotifications', () => {
 
   it('does not overwrite a completed read with a stale cursor page response', async () => {
     mocks.useSignedInUser.mockReturnValue(ref({ id: 'user-1' }))
-    mocks.status.mockResolvedValue({ hasUnread: true })
     const pendingPage = deferred<{
+      hasUnread: boolean
       nextCursor: string | null
       data: (typeof notification)[]
     }>()
     mocks.list
-      .mockResolvedValueOnce({ nextCursor: 'next-page', data: [{ ...notification }] })
+      .mockResolvedValueOnce({ hasUnread: true, nextCursor: 'next-page', data: [{ ...notification }] })
+      .mockResolvedValueOnce({ hasUnread: true, nextCursor: 'next-page', data: [{ ...notification }] })
       .mockReturnValueOnce(pendingPage.promise)
     mocks.markRead.mockResolvedValue({ ...notification, readAt: '2026-08-26T07:01:00Z' })
 
@@ -191,21 +193,16 @@ describe('NavbarNotifications', () => {
     const notificationButton = wrapper.findAll('button').find((button) => button.text().includes(notification.title))
     await notificationButton!.trigger('click')
     await flushPromises()
-    expect(wrapper.get('[aria-label="Notifications, unread notifications available"]').find('.absolute').exists()).toBe(
-      true
-    )
+    expect(wrapper.get('[aria-label="Notifications"]').find('.absolute').exists()).toBe(false)
 
-    pendingPage.resolve({ nextCursor: null, data: [] })
+    pendingPage.resolve({ hasUnread: true, nextCursor: null, data: [] })
     await flushPromises()
-    expect(wrapper.get('[aria-label="Notifications, unread notifications available"]').find('.absolute').exists()).toBe(
-      true
-    )
+    expect(wrapper.get('[aria-label="Notifications"]').find('.absolute').exists()).toBe(false)
   })
 
-  it('waits for mark-as-read and defers count refresh while the request is pending', async () => {
+  it('waits for mark-as-read and defers list refresh while the request is pending', async () => {
     mocks.useSignedInUser.mockReturnValue(ref({ id: 'user-1' }))
-    mocks.status.mockResolvedValue({ hasUnread: true })
-    mocks.list.mockResolvedValue({ nextCursor: null, data: [{ ...notification }] })
+    mocks.list.mockResolvedValue({ hasUnread: true, nextCursor: null, data: [{ ...notification }] })
     const pendingRead = deferred<typeof notification>()
     mocks.markRead.mockReturnValue(pendingRead.promise)
 
@@ -222,21 +219,22 @@ describe('NavbarNotifications', () => {
     Object.defineProperty(document, 'visibilityState', { configurable: true, value: 'visible' })
     document.dispatchEvent(new Event('visibilitychange'))
     await flushPromises()
-    expect(mocks.status).toHaveBeenCalledTimes(2)
+    expect(mocks.list).toHaveBeenCalledTimes(2)
 
     pendingRead.resolve({ ...notification, readAt: '2026-08-26T07:01:00Z' })
     await flushPromises()
-    expect(mocks.status).toHaveBeenCalledTimes(3)
-    expect(wrapper.get('[aria-label="Notifications, unread notifications available"]').find('.absolute').exists()).toBe(
-      true
-    )
+    expect(mocks.list).toHaveBeenCalledTimes(2)
+    expect(wrapper.get('[aria-label="Notifications"]').find('.absolute').exists()).toBe(false)
   })
 
   it('marks different notifications as read concurrently', async () => {
     const anotherNotification = { ...notification, id: '12', title: 'Another notification' }
     mocks.useSignedInUser.mockReturnValue(ref({ id: 'user-1' }))
-    mocks.status.mockResolvedValue({ hasUnread: true })
-    mocks.list.mockResolvedValue({ nextCursor: null, data: [{ ...notification }, anotherNotification] })
+    mocks.list.mockResolvedValue({
+      hasUnread: true,
+      nextCursor: null,
+      data: [{ ...notification }, anotherNotification]
+    })
     const firstRead = deferred<typeof notification>()
     const secondRead = deferred<typeof notification>()
     mocks.markRead.mockReturnValueOnce(firstRead.promise).mockReturnValueOnce(secondRead.promise)
@@ -266,12 +264,16 @@ describe('NavbarNotifications', () => {
 
   it('restarts the first page when reopened during an in-flight page request', async () => {
     mocks.useSignedInUser.mockReturnValue(ref({ id: 'user-1' }))
-    mocks.status.mockResolvedValue({ hasUnread: false })
-    const pendingPage = deferred<{ nextCursor: string | null; data: UserNotification[] }>()
+    const pendingPage = deferred<{ hasUnread: boolean; nextCursor: string | null; data: UserNotification[] }>()
     mocks.list
-      .mockResolvedValueOnce({ nextCursor: 'next-page', data: [{ ...notification }] })
+      .mockResolvedValueOnce({ hasUnread: false, nextCursor: 'next-page', data: [{ ...notification }] })
+      .mockResolvedValueOnce({ hasUnread: false, nextCursor: 'next-page', data: [{ ...notification }] })
       .mockReturnValueOnce(pendingPage.promise)
-      .mockResolvedValueOnce({ nextCursor: null, data: [{ ...notification, title: 'Refreshed notification' }] })
+      .mockResolvedValueOnce({
+        hasUnread: false,
+        nextCursor: null,
+        data: [{ ...notification, title: 'Refreshed notification' }]
+      })
 
     const wrapper = mountNotifications()
     await flushPromises()
@@ -281,21 +283,21 @@ describe('NavbarNotifications', () => {
       .findAll('button')
       .find((button) => button.text().includes('Load more'))!
       .trigger('click')
-    const pageSignal = mocks.list.mock.calls[1][1] as AbortSignal
+    const pageSignal = mocks.list.mock.calls[2][1] as AbortSignal
 
     await wrapper.get('[aria-label="Close notifications"]').trigger('click')
     await wrapper.get('[aria-label="Notifications"]').trigger('click')
     await flushPromises()
 
     expect(pageSignal.aborted).toBe(true)
-    expect(mocks.list).toHaveBeenCalledTimes(3)
+    expect(mocks.list).toHaveBeenCalledTimes(4)
     expect(wrapper.text()).toContain('Refreshed notification')
   })
 
   it('does not open an unsafe notification action', async () => {
     mocks.useSignedInUser.mockReturnValue(ref({ id: 'user-1' }))
-    mocks.status.mockResolvedValue({ hasUnread: false })
     mocks.list.mockResolvedValue({
+      hasUnread: false,
       nextCursor: null,
       data: [{ ...notification, actionPath: `/\\example.com`, readAt: '2026-08-26T07:00:00Z' }]
     })
@@ -317,11 +319,10 @@ describe('NavbarNotifications', () => {
     const user = ref<{ id: string } | null>({ id: 'user-1' })
     const pendingRead = deferred<typeof notification>()
     mocks.useSignedInUser.mockReturnValue(user)
-    mocks.status
-      .mockResolvedValueOnce({ hasUnread: true })
-      .mockResolvedValueOnce({ hasUnread: true })
-      .mockResolvedValueOnce({ hasUnread: false })
-    mocks.list.mockResolvedValue({ nextCursor: null, data: [{ ...notification }] })
+    mocks.list
+      .mockResolvedValueOnce({ hasUnread: true, nextCursor: null, data: [{ ...notification }] })
+      .mockResolvedValueOnce({ hasUnread: true, nextCursor: null, data: [{ ...notification }] })
+      .mockResolvedValueOnce({ hasUnread: false, nextCursor: null, data: [] })
     mocks.markRead.mockReturnValue(pendingRead.promise)
 
     const wrapper = mountNotifications()

--- a/spx-gui/src/components/navbar/NavbarNotifications.test.ts
+++ b/spx-gui/src/components/navbar/NavbarNotifications.test.ts
@@ -333,11 +333,7 @@ describe('NavbarNotifications', () => {
 
     expect(mocks.markRead).toHaveBeenCalledTimes(2)
     expect((mocks.markRead.mock.calls[0][1] as AbortSignal).aborted).toBe(false)
-    expect(wrapper.text()).toContain('Marking as read...')
-
-    secondRead.resolve({ ...anotherNotification, readAt: '2026-08-26T07:01:00Z' })
-    await flushPromises()
-    expect(wrapper.text()).not.toContain('Marking as read...')
+    expect((mocks.markRead.mock.calls[1][1] as AbortSignal).aborted).toBe(false)
   })
 
   it('restarts the first page when reopened during an in-flight page request', async () => {

--- a/spx-gui/src/components/navbar/NavbarNotifications.test.ts
+++ b/spx-gui/src/components/navbar/NavbarNotifications.test.ts
@@ -9,7 +9,7 @@ const mocks = vi.hoisted(() => ({
   useSignedInUser: vi.fn(),
   push: vi.fn(),
   list: vi.fn(),
-  unreadCount: vi.fn(),
+  status: vi.fn(),
   markRead: vi.fn()
 }))
 
@@ -17,7 +17,7 @@ vi.mock('@/stores/user', () => ({ useSignedInUser: mocks.useSignedInUser }))
 vi.mock('vue-router', () => ({ useRouter: () => ({ push: mocks.push }) }))
 vi.mock('@/apis/notification', () => ({
   listUserNotifications: mocks.list,
-  getUserNotificationUnreadCount: mocks.unreadCount,
+  getUserNotificationStatus: mocks.status,
   markUserNotificationRead: mocks.markRead
 }))
 vi.mock('@/utils/exception', async (importOriginal) => {
@@ -99,30 +99,30 @@ describe('NavbarNotifications', () => {
     await flushPromises()
 
     expect(wrapper.find('button').exists()).toBe(false)
-    expect(mocks.unreadCount).not.toHaveBeenCalled()
+    expect(mocks.status).not.toHaveBeenCalled()
   })
 
   it('refreshes the unread count when opened and when the page becomes visible', async () => {
     mocks.useSignedInUser.mockReturnValue(ref({ id: 'user-1' }))
-    mocks.unreadCount.mockResolvedValue({ unreadCount: 1 })
+    mocks.status.mockResolvedValue({ hasUnread: true })
 
     const wrapper = mountNotifications()
     await flushPromises()
-    expect(mocks.unreadCount).toHaveBeenCalledTimes(1)
+    expect(mocks.status).toHaveBeenCalledTimes(1)
 
-    await wrapper.get('[aria-label="Notifications, 1 unread"]').trigger('click')
+    await wrapper.get('[aria-label="Notifications, unread notifications available"]').trigger('click')
     await flushPromises()
-    expect(mocks.unreadCount).toHaveBeenCalledTimes(2)
+    expect(mocks.status).toHaveBeenCalledTimes(2)
 
     Object.defineProperty(document, 'visibilityState', { configurable: true, value: 'visible' })
     document.dispatchEvent(new Event('visibilitychange'))
     await flushPromises()
-    expect(mocks.unreadCount).toHaveBeenCalledTimes(3)
+    expect(mocks.status).toHaveBeenCalledTimes(3)
   })
 
   it('loads pages, marks a notification read, and opens its application route', async () => {
     mocks.useSignedInUser.mockReturnValue(ref({ id: 'user-1' }))
-    mocks.unreadCount.mockResolvedValueOnce({ unreadCount: 1 }).mockResolvedValue({ unreadCount: 0 })
+    mocks.status.mockResolvedValueOnce({ hasUnread: true }).mockResolvedValue({ hasUnread: false })
     mocks.list.mockResolvedValueOnce({ nextCursor: 'next-page', data: [{ ...notification }] }).mockResolvedValueOnce({
       nextCursor: null,
       data: [
@@ -139,7 +139,7 @@ describe('NavbarNotifications', () => {
 
     const wrapper = mountNotifications()
     await flushPromises()
-    await wrapper.get('[aria-label="Notifications, 1 unread"]').trigger('click')
+    await wrapper.get('[aria-label="Notifications, unread notifications available"]').trigger('click')
     await flushPromises()
     expect(mocks.list).toHaveBeenNthCalledWith(1, { pageSize: 50 }, expect.any(AbortSignal))
 
@@ -171,10 +171,7 @@ describe('NavbarNotifications', () => {
 
   it('does not overwrite a completed read with a stale cursor page response', async () => {
     mocks.useSignedInUser.mockReturnValue(ref({ id: 'user-1' }))
-    mocks.unreadCount
-      .mockResolvedValueOnce({ unreadCount: 2 })
-      .mockResolvedValueOnce({ unreadCount: 2 })
-      .mockResolvedValue({ unreadCount: 1 })
+    mocks.status.mockResolvedValue({ hasUnread: true })
     const pendingPage = deferred<{
       nextCursor: string | null
       data: (typeof notification)[]
@@ -186,7 +183,7 @@ describe('NavbarNotifications', () => {
 
     const wrapper = mountNotifications()
     await flushPromises()
-    await wrapper.get('[aria-label="Notifications, 2 unread"]').trigger('click')
+    await wrapper.get('[aria-label="Notifications, unread notifications available"]').trigger('click')
     await flushPromises()
 
     const loadMoreButton = wrapper.findAll('button').find((button) => button.text().includes('Load more'))
@@ -194,49 +191,51 @@ describe('NavbarNotifications', () => {
     const notificationButton = wrapper.findAll('button').find((button) => button.text().includes(notification.title))
     await notificationButton!.trigger('click')
     await flushPromises()
-    expect(wrapper.get('[aria-label="Notifications, 1 unread"]').text()).toContain('1')
+    expect(wrapper.get('[aria-label="Notifications, unread notifications available"]').find('.absolute').exists()).toBe(
+      true
+    )
 
     pendingPage.resolve({ nextCursor: null, data: [] })
     await flushPromises()
-    expect(wrapper.get('[aria-label="Notifications, 1 unread"]').text()).toContain('1')
+    expect(wrapper.get('[aria-label="Notifications, unread notifications available"]').find('.absolute').exists()).toBe(
+      true
+    )
   })
 
   it('waits for mark-as-read and defers count refresh while the request is pending', async () => {
     mocks.useSignedInUser.mockReturnValue(ref({ id: 'user-1' }))
-    mocks.unreadCount
-      .mockResolvedValueOnce({ unreadCount: 2 })
-      .mockResolvedValueOnce({ unreadCount: 2 })
-      .mockResolvedValue({ unreadCount: 1 })
+    mocks.status.mockResolvedValue({ hasUnread: true })
     mocks.list.mockResolvedValue({ nextCursor: null, data: [{ ...notification }] })
     const pendingRead = deferred<typeof notification>()
     mocks.markRead.mockReturnValue(pendingRead.promise)
 
     const wrapper = mountNotifications()
     await flushPromises()
-    await wrapper.get('[aria-label="Notifications, 2 unread"]').trigger('click')
+    await wrapper.get('[aria-label="Notifications, unread notifications available"]').trigger('click')
     await flushPromises()
     const notificationButton = wrapper.findAll('button').find((button) => button.text().includes(notification.title))
     await notificationButton!.trigger('click')
 
-    expect(wrapper.get('[aria-label="Notifications, 2 unread"]').text()).toContain('2')
+    expect(wrapper.get('[aria-label="Notifications, unread notifications available"]').find('.absolute').exists()).toBe(
+      true
+    )
     Object.defineProperty(document, 'visibilityState', { configurable: true, value: 'visible' })
     document.dispatchEvent(new Event('visibilitychange'))
     await flushPromises()
-    expect(mocks.unreadCount).toHaveBeenCalledTimes(2)
+    expect(mocks.status).toHaveBeenCalledTimes(2)
 
     pendingRead.resolve({ ...notification, readAt: '2026-08-26T07:01:00Z' })
     await flushPromises()
-    expect(mocks.unreadCount).toHaveBeenCalledTimes(3)
-    expect(wrapper.get('[aria-label="Notifications, 1 unread"]').text()).toContain('1')
+    expect(mocks.status).toHaveBeenCalledTimes(3)
+    expect(wrapper.get('[aria-label="Notifications, unread notifications available"]').find('.absolute').exists()).toBe(
+      true
+    )
   })
 
   it('marks different notifications as read concurrently', async () => {
     const anotherNotification = { ...notification, id: '12', title: 'Another notification' }
     mocks.useSignedInUser.mockReturnValue(ref({ id: 'user-1' }))
-    mocks.unreadCount
-      .mockResolvedValueOnce({ unreadCount: 2 })
-      .mockResolvedValueOnce({ unreadCount: 2 })
-      .mockResolvedValue({ unreadCount: 1 })
+    mocks.status.mockResolvedValue({ hasUnread: true })
     mocks.list.mockResolvedValue({ nextCursor: null, data: [{ ...notification }, anotherNotification] })
     const firstRead = deferred<typeof notification>()
     const secondRead = deferred<typeof notification>()
@@ -244,7 +243,7 @@ describe('NavbarNotifications', () => {
 
     const wrapper = mountNotifications()
     await flushPromises()
-    await wrapper.get('[aria-label="Notifications, 2 unread"]').trigger('click')
+    await wrapper.get('[aria-label="Notifications, unread notifications available"]').trigger('click')
     await flushPromises()
     await wrapper
       .findAll('button')
@@ -267,7 +266,7 @@ describe('NavbarNotifications', () => {
 
   it('restarts the first page when reopened during an in-flight page request', async () => {
     mocks.useSignedInUser.mockReturnValue(ref({ id: 'user-1' }))
-    mocks.unreadCount.mockResolvedValue({ unreadCount: 0 })
+    mocks.status.mockResolvedValue({ hasUnread: false })
     const pendingPage = deferred<{ nextCursor: string | null; data: UserNotification[] }>()
     mocks.list
       .mockResolvedValueOnce({ nextCursor: 'next-page', data: [{ ...notification }] })
@@ -295,7 +294,7 @@ describe('NavbarNotifications', () => {
 
   it('does not open an unsafe notification action', async () => {
     mocks.useSignedInUser.mockReturnValue(ref({ id: 'user-1' }))
-    mocks.unreadCount.mockResolvedValue({ unreadCount: 0 })
+    mocks.status.mockResolvedValue({ hasUnread: false })
     mocks.list.mockResolvedValue({
       nextCursor: null,
       data: [{ ...notification, actionPath: `/\\example.com`, readAt: '2026-08-26T07:00:00Z' }]
@@ -318,18 +317,20 @@ describe('NavbarNotifications', () => {
     const user = ref<{ id: string } | null>({ id: 'user-1' })
     const pendingRead = deferred<typeof notification>()
     mocks.useSignedInUser.mockReturnValue(user)
-    mocks.unreadCount
-      .mockResolvedValueOnce({ unreadCount: 2 })
-      .mockResolvedValueOnce({ unreadCount: 2 })
-      .mockResolvedValueOnce({ unreadCount: 4 })
+    mocks.status
+      .mockResolvedValueOnce({ hasUnread: true })
+      .mockResolvedValueOnce({ hasUnread: true })
+      .mockResolvedValueOnce({ hasUnread: false })
     mocks.list.mockResolvedValue({ nextCursor: null, data: [{ ...notification }] })
     mocks.markRead.mockReturnValue(pendingRead.promise)
 
     const wrapper = mountNotifications()
     await flushPromises()
-    expect(wrapper.get('[aria-label="Notifications, 2 unread"]').text()).toContain('2')
+    expect(wrapper.get('[aria-label="Notifications, unread notifications available"]').find('.absolute').exists()).toBe(
+      true
+    )
 
-    await wrapper.get('[aria-label="Notifications, 2 unread"]').trigger('click')
+    await wrapper.get('[aria-label="Notifications, unread notifications available"]').trigger('click')
     await flushPromises()
     const notificationButton = wrapper.findAll('button').find((button) => button.text().includes(notification.title))
     expect(notificationButton).toBeDefined()
@@ -338,10 +339,10 @@ describe('NavbarNotifications', () => {
 
     user.value = { id: 'user-2' }
     await flushPromises()
-    expect(wrapper.get('[aria-label="Notifications, 4 unread"]').text()).toContain('4')
+    expect(wrapper.get('[aria-label="Notifications"]').find('.absolute').exists()).toBe(false)
 
     pendingRead.reject(new Error('old request failed'))
     await flushPromises()
-    expect(wrapper.get('[aria-label="Notifications, 4 unread"]').text()).toContain('4')
+    expect(wrapper.get('[aria-label="Notifications"]').find('.absolute').exists()).toBe(false)
   })
 })

--- a/spx-gui/src/components/navbar/NavbarNotifications.test.ts
+++ b/spx-gui/src/components/navbar/NavbarNotifications.test.ts
@@ -65,8 +65,10 @@ function mountNotifications() {
       stubs: {
         UIIcon: true,
         UIButton: {
+          props: ['disabled', 'loading'],
           emits: ['click'],
-          template: '<button type="button" @click="$emit(\'click\')"><slot name="icon"/><slot/></button>'
+          template:
+            '<button type="button" :disabled="disabled || loading" @click="$emit(\'click\')"><slot name="icon"/><slot/></button>'
         },
         UIModal: {
           props: ['visible'],
@@ -176,7 +178,6 @@ describe('NavbarNotifications', () => {
       .mockResolvedValueOnce({ hasUnread: true, nextCursor: 'next-page', data: [{ ...notification }] })
       .mockResolvedValueOnce({ hasUnread: true, nextCursor: 'next-page', data: [{ ...notification }] })
       .mockReturnValueOnce(pendingPage.promise)
-      .mockResolvedValueOnce({ hasUnread: false, nextCursor: null, data: [] })
     mocks.markRead.mockResolvedValue({ ...notification, readAt: '2026-08-26T07:01:00Z' })
 
     const wrapper = mountNotifications()
@@ -239,7 +240,7 @@ describe('NavbarNotifications', () => {
 
   it('waits for mark-as-read before clearing the unread indicator', async () => {
     mocks.useSignedInUser.mockReturnValue(ref({ id: 'user-1' }))
-    mocks.list.mockResolvedValue({ hasUnread: true, nextCursor: null, data: [{ ...notification }] })
+    mocks.list.mockResolvedValue({ hasUnread: true, nextCursor: 'next-page', data: [{ ...notification }] })
     const pendingRead = deferred<typeof notification>()
     mocks.markRead.mockReturnValue(pendingRead.promise)
 
@@ -253,71 +254,22 @@ describe('NavbarNotifications', () => {
     expect(wrapper.get('[aria-label="Notifications, unread notifications available"]').find('.absolute').exists()).toBe(
       true
     )
+    await wrapper.get('[aria-label="Back to notifications"]').trigger('click')
+    expect(
+      wrapper
+        .findAll('button')
+        .find((button) => button.text().includes('Load more'))!
+        .attributes('disabled')
+    ).toBe('')
     pendingRead.resolve({ ...notification, readAt: '2026-08-26T07:01:00Z' })
     await flushPromises()
     expect(wrapper.get('[aria-label="Notifications"]').find('.absolute').exists()).toBe(false)
-  })
-
-  it('runs a queued load-more request after marking a notification as read', async () => {
-    mocks.useSignedInUser.mockReturnValue(ref({ id: 'user-1' }))
-    mocks.list
-      .mockResolvedValueOnce({ hasUnread: true, nextCursor: 'next-page', data: [{ ...notification }] })
-      .mockResolvedValueOnce({ hasUnread: true, nextCursor: 'next-page', data: [{ ...notification }] })
-      .mockResolvedValueOnce({
-        hasUnread: false,
-        nextCursor: null,
-        data: [{ ...notification, id: '10', title: 'Earlier notification', readAt: '2026-08-26T07:00:00Z' }]
-      })
-    const pendingRead = deferred<typeof notification>()
-    mocks.markRead.mockReturnValue(pendingRead.promise)
-
-    const wrapper = mountNotifications()
-    await flushPromises()
-    await wrapper.get('[aria-label="Notifications, unread notifications available"]').trigger('click')
-    await flushPromises()
-    await wrapper
-      .findAll('button')
-      .find((button) => button.text().includes(notification.title))!
-      .trigger('click')
-    await wrapper.get('[aria-label="Back to notifications"]').trigger('click')
-    await wrapper
-      .findAll('button')
-      .find((button) => button.text().includes('Load more'))!
-      .trigger('click')
-    expect(mocks.list).toHaveBeenCalledTimes(2)
-
-    pendingRead.resolve({ ...notification, readAt: '2026-08-26T07:01:00Z' })
-    await flushPromises()
-
-    expect(mocks.list).toHaveBeenNthCalledWith(3, { pageSize: 50, cursor: 'next-page' }, expect.any(AbortSignal))
-    expect(wrapper.text()).toContain('Earlier notification')
-  })
-
-  it('runs a queued refresh after marking a notification as read', async () => {
-    mocks.useSignedInUser.mockReturnValue(ref({ id: 'user-1' }))
-    mocks.list
-      .mockResolvedValueOnce({ hasUnread: true, nextCursor: null, data: [{ ...notification }] })
-      .mockResolvedValueOnce({ hasUnread: true, nextCursor: null, data: [{ ...notification }] })
-      .mockResolvedValueOnce({ hasUnread: false, nextCursor: null, data: [] })
-    const pendingRead = deferred<typeof notification>()
-    mocks.markRead.mockReturnValue(pendingRead.promise)
-
-    const wrapper = mountNotifications()
-    await flushPromises()
-    await wrapper.get('[aria-label="Notifications, unread notifications available"]').trigger('click')
-    await flushPromises()
-    await wrapper
-      .findAll('button')
-      .find((button) => button.text().includes(notification.title))!
-      .trigger('click')
-    await wrapper.get('[aria-label="Notifications, unread notifications available"]').trigger('click')
-    expect(mocks.list).toHaveBeenCalledTimes(2)
-
-    pendingRead.resolve({ ...notification, readAt: '2026-08-26T07:01:00Z' })
-    await flushPromises()
-
-    expect(mocks.list).toHaveBeenNthCalledWith(3, { pageSize: 50 }, expect.any(AbortSignal))
-    expect(wrapper.text()).toContain('No notifications')
+    expect(
+      wrapper
+        .findAll('button')
+        .find((button) => button.text().includes('Load more'))!
+        .attributes('disabled')
+    ).toBe(undefined)
   })
 
   it('keeps a notification in place after marking it as read', async () => {

--- a/spx-gui/src/components/navbar/NavbarNotifications.vue
+++ b/spx-gui/src/components/navbar/NavbarNotifications.vue
@@ -9,23 +9,21 @@ import { useSignedInUser } from '@/stores/user'
 import { UIButton, UIIcon, UIModal } from '@/components/ui'
 
 const pageSize = 50
-// Notifications arrive out of band, so this feature explicitly opts into lightweight freshness checks.
-const refreshInterval = 5 * 60_000
 
 const router = useRouter()
 const i18n = useI18n()
 const signedInUser = useSignedInUser()
 const visible = ref(false)
 const notifications = ref<notificationApis.UserNotification[]>([])
-const total = ref(0)
 const unreadCount = ref(0)
-const nextPage = ref(1)
+const nextCursor = ref<string | null>(null)
 const loading = ref(false)
+const markingReadNotificationIDs = ref(new Set<string>())
 const selectedNotificationID = ref<string | null>(null)
 const selectedNotification = computed(
   () => notifications.value.find((notification) => notification.id === selectedNotificationID.value) ?? null
 )
-const hasMore = computed(() => notifications.value.length < total.value)
+const hasMore = computed(() => nextCursor.value != null)
 const notificationLabel = computed(() =>
   unreadCount.value === 0
     ? i18n.t({ en: 'Notifications', zh: '通知' })
@@ -42,43 +40,49 @@ const notificationRadar = computed(() => ({
         })
 }))
 
-let requestSequence = 0
-let unreadRequestSequence = 0
-
-function invalidateUnreadCountRequests() {
-  unreadRequestSequence += 1
-}
+let listRequest: AbortController | null = null
+let unreadCountRequest: AbortController | null = null
+const readRequests = new Map<string, AbortController>()
 
 async function refreshUnreadCount() {
-  const userID = signedInUser.value?.id
-  if (userID == null) return
-  const sequence = ++unreadRequestSequence
+  if (signedInUser.value == null || readRequests.size > 0) return
+  unreadCountRequest?.abort()
+  const request = new AbortController()
+  unreadCountRequest = request
   try {
-    const result = await notificationApis.getUserNotificationUnreadCount()
-    if (sequence === unreadRequestSequence && signedInUser.value?.id === userID) {
-      unreadCount.value = result.unreadCount
-    }
+    const result = await notificationApis.getUserNotificationUnreadCount(request.signal)
+    request.signal.throwIfAborted()
+    unreadCount.value = result.unreadCount
   } catch (error) {
-    capture(error, 'Failed to refresh unread notification count')
+    if (!request.signal.aborted) capture(error, 'Failed to refresh unread notification count')
+  } finally {
+    if (unreadCountRequest === request) unreadCountRequest = null
   }
 }
 
 async function loadNotifications(reset: boolean) {
-  if (signedInUser.value == null || loading.value) return
-  const sequence = ++requestSequence
-  invalidateUnreadCountRequests()
-  const unreadSequence = unreadRequestSequence
-  const pageIndex = reset ? 1 : nextPage.value
+  if (signedInUser.value == null || (loading.value && !reset)) return
+  if (reset) listRequest?.abort()
+  const cursor = reset ? undefined : nextCursor.value ?? undefined
+  if (!reset && cursor == null) return
+  const request = new AbortController()
+  listRequest = request
   loading.value = true
   try {
-    const result = await notificationApis.listUserNotifications({ pageIndex, pageSize })
-    if (sequence !== requestSequence) return
+    const result = await notificationApis.listUserNotifications(
+      { pageSize, ...(cursor != null ? { cursor } : {}) },
+      request.signal
+    )
+    request.signal.throwIfAborted()
     notifications.value = reset ? result.data : [...notifications.value, ...result.data]
-    total.value = result.total
-    if (unreadSequence === unreadRequestSequence) unreadCount.value = result.unreadCount
-    nextPage.value = pageIndex + 1
+    nextCursor.value = result.nextCursor
+  } catch (error) {
+    if (!request.signal.aborted) throw error
   } finally {
-    if (sequence === requestSequence) loading.value = false
+    if (listRequest === request) {
+      listRequest = null
+      loading.value = false
+    }
   }
 }
 
@@ -90,34 +94,36 @@ const handleLoadNotifications = useMessageHandle(loadNotifications, {
 function openNotificationCenter() {
   selectedNotificationID.value = null
   visible.value = true
+  refreshUnreadCount()
   handleLoadNotifications(true)
 }
 
 const handleOpenNotification = useMessageHandle(
   async (notification: notificationApis.UserNotification) => {
     selectedNotificationID.value = notification.id
-    if (notification.readAt != null) return
+    if (notification.readAt != null || readRequests.has(notification.id)) return
 
-    const userID = signedInUser.value?.id
-    if (userID == null) return
-    // Prevent an older count request from overwriting this optimistic update.
-    invalidateUnreadCountRequests()
-    const optimisticReadAt = new Date().toISOString()
-    notification.readAt = optimisticReadAt
-    unreadCount.value = Math.max(0, unreadCount.value - 1)
-    const isCurrentNotification = () =>
-      signedInUser.value?.id === userID &&
-      notifications.value.includes(notification) &&
-      notification.readAt === optimisticReadAt
+    unreadCountRequest?.abort()
+    const request = new AbortController()
+    readRequests.set(notification.id, request)
+    markingReadNotificationIDs.value.add(notification.id)
     try {
-      const updated = await notificationApis.markUserNotificationRead(notification.id)
-      if (isCurrentNotification()) notification.readAt = updated.readAt
-    } catch (error) {
-      if (isCurrentNotification()) {
-        notification.readAt = null
-        unreadCount.value += 1
+      const updated = await notificationApis.markUserNotificationRead(notification.id, request.signal)
+      request.signal.throwIfAborted()
+      listRequest?.abort()
+      const currentNotification = notifications.value.find((item) => item.id === notification.id) ?? null
+      if (currentNotification != null && currentNotification.readAt == null && updated.readAt != null) {
+        currentNotification.readAt = updated.readAt
+        unreadCount.value = Math.max(0, unreadCount.value - 1)
       }
-      throw error
+    } catch (error) {
+      if (!request.signal.aborted) throw error
+    } finally {
+      if (readRequests.get(notification.id) === request) {
+        readRequests.delete(notification.id)
+        markingReadNotificationIDs.value.delete(notification.id)
+        if (readRequests.size === 0) refreshUnreadCount()
+      }
     }
   },
   { en: 'Failed to mark notification as read', zh: '通知标记已读失败' }
@@ -160,13 +166,17 @@ function refreshWhenVisible() {
 watch(
   () => signedInUser.value?.id ?? null,
   (userID) => {
-    requestSequence += 1
-    invalidateUnreadCountRequests()
+    listRequest?.abort()
+    unreadCountRequest?.abort()
+    for (const request of readRequests.values()) request.abort()
+    listRequest = null
+    unreadCountRequest = null
+    readRequests.clear()
+    markingReadNotificationIDs.value.clear()
     notifications.value = []
-    total.value = 0
     unreadCount.value = 0
     loading.value = false
-    nextPage.value = 1
+    nextCursor.value = null
     selectedNotificationID.value = null
     visible.value = false
     if (userID != null) refreshUnreadCount()
@@ -174,13 +184,13 @@ watch(
   { immediate: true }
 )
 
-let refreshTimer: number | null = null
 onMounted(() => {
-  refreshTimer = window.setInterval(refreshUnreadCount, refreshInterval)
   document.addEventListener('visibilitychange', refreshWhenVisible)
 })
 onUnmounted(() => {
-  if (refreshTimer != null) window.clearInterval(refreshTimer)
+  listRequest?.abort()
+  unreadCountRequest?.abort()
+  for (const request of readRequests.values()) request.abort()
   document.removeEventListener('visibilitychange', refreshWhenVisible)
 })
 </script>
@@ -307,7 +317,12 @@ onUnmounted(() => {
       </template>
 
       <article v-else class="max-h-[480px] overflow-y-auto px-5 py-5">
-        <time class="text-xs text-grey-800">{{ formatTime(selectedNotification.createdAt) }}</time>
+        <div class="flex items-center gap-2 text-xs text-grey-800">
+          <time>{{ formatTime(selectedNotification.createdAt) }}</time>
+          <span v-if="markingReadNotificationIDs.has(selectedNotification.id)">
+            {{ $t({ en: 'Marking as read...', zh: '正在标记已读...' }) }}
+          </span>
+        </div>
         <p class="mt-3 whitespace-pre-wrap text-sm leading-6 text-grey-1000">{{ selectedNotification.body }}</p>
         <UIButton v-if="selectedNotification.actionPath != null" class="mt-6" type="primary" @click="openAction">
           {{ $t({ en: 'View details', zh: '查看详情' }) }}

--- a/spx-gui/src/components/navbar/NavbarNotifications.vue
+++ b/spx-gui/src/components/navbar/NavbarNotifications.vue
@@ -45,6 +45,10 @@ const notificationRadar = computed(() => ({
 let requestSequence = 0
 let unreadRequestSequence = 0
 
+function invalidateUnreadCountRequests() {
+  unreadRequestSequence += 1
+}
+
 async function refreshUnreadCount() {
   const userID = signedInUser.value?.id
   if (userID == null) return
@@ -62,7 +66,8 @@ async function refreshUnreadCount() {
 async function loadNotifications(reset: boolean) {
   if (signedInUser.value == null || loading.value) return
   const sequence = ++requestSequence
-  unreadRequestSequence += 1
+  invalidateUnreadCountRequests()
+  const unreadSequence = unreadRequestSequence
   const pageIndex = reset ? 1 : nextPage.value
   loading.value = true
   try {
@@ -70,7 +75,7 @@ async function loadNotifications(reset: boolean) {
     if (sequence !== requestSequence) return
     notifications.value = reset ? result.data : [...notifications.value, ...result.data]
     total.value = result.total
-    unreadCount.value = result.unreadCount
+    if (unreadSequence === unreadRequestSequence) unreadCount.value = result.unreadCount
     nextPage.value = pageIndex + 1
   } finally {
     if (sequence === requestSequence) loading.value = false
@@ -95,7 +100,8 @@ const handleOpenNotification = useMessageHandle(
 
     const userID = signedInUser.value?.id
     if (userID == null) return
-    unreadRequestSequence += 1
+    // Prevent an older count request from overwriting this optimistic update.
+    invalidateUnreadCountRequests()
     const optimisticReadAt = new Date().toISOString()
     notification.readAt = optimisticReadAt
     unreadCount.value = Math.max(0, unreadCount.value - 1)
@@ -121,21 +127,30 @@ function backToList() {
   selectedNotificationID.value = null
 }
 
+function isValidActionPath(value: string) {
+  return value.startsWith('/') && !value.startsWith('//') && !value.includes('\\')
+}
+
 async function openAction() {
   const actionPath = selectedNotification.value?.actionPath
-  if (actionPath == null) return
+  if (actionPath == null || !isValidActionPath(actionPath)) return
   visible.value = false
   await router.push(actionPath)
 }
 
+const dateTimeFormatter = computed(
+  () =>
+    new Intl.DateTimeFormat(i18n.lang.value === 'zh' ? 'zh-CN' : 'en-US', {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit'
+    })
+)
+
 function formatTime(value: string) {
-  return new Intl.DateTimeFormat(i18n.lang.value === 'zh' ? 'zh-CN' : 'en-US', {
-    year: 'numeric',
-    month: 'short',
-    day: 'numeric',
-    hour: '2-digit',
-    minute: '2-digit'
-  }).format(new Date(value))
+  return dateTimeFormatter.value.format(new Date(value))
 }
 
 function refreshWhenVisible() {
@@ -146,7 +161,7 @@ watch(
   () => signedInUser.value?.id ?? null,
   (userID) => {
     requestSequence += 1
-    unreadRequestSequence += 1
+    invalidateUnreadCountRequests()
     notifications.value = []
     total.value = 0
     unreadCount.value = 0

--- a/spx-gui/src/components/navbar/NavbarNotifications.vue
+++ b/spx-gui/src/components/navbar/NavbarNotifications.vue
@@ -88,37 +88,34 @@ function openNotificationCenter() {
   handleLoadNotifications(true)
 }
 
-const handleOpenNotification = useMessageHandle(
-  async (notification: notificationApis.UserNotification) => {
-    selectedNotificationID.value = notification.id
-    if (notification.readAt != null || readRequests.has(notification.id)) return
+async function handleOpenNotification(notification: notificationApis.UserNotification) {
+  selectedNotificationID.value = notification.id
+  if (notification.readAt != null || readRequests.has(notification.id)) return
 
-    abortListRequest()
-    const request = new AbortController()
-    readRequests.set(notification.id, request)
-    markingReadNotificationIDs.value.add(notification.id)
-    try {
-      const updated = await notificationApis.markUserNotificationRead(notification.id, request.signal)
-      request.signal.throwIfAborted()
-      const currentNotification = notifications.value.find((item) => item.id === notification.id) ?? null
-      if (currentNotification != null && currentNotification.readAt == null && updated.readAt != null) {
-        currentNotification.readAt = updated.readAt
-        const lastNotification = notifications.value[notifications.value.length - 1] ?? null
-        hasUnread.value =
-          notifications.value.some((item) => item.readAt == null) ||
-          (nextCursor.value != null && lastNotification?.readAt == null)
-      }
-    } catch (error) {
-      if (!request.signal.aborted) throw error
-    } finally {
-      if (readRequests.get(notification.id) === request) {
-        readRequests.delete(notification.id)
-        markingReadNotificationIDs.value.delete(notification.id)
-      }
+  abortListRequest()
+  const request = new AbortController()
+  readRequests.set(notification.id, request)
+  markingReadNotificationIDs.value.add(notification.id)
+  try {
+    const updated = await notificationApis.markUserNotificationRead(notification.id, request.signal)
+    request.signal.throwIfAborted()
+    const currentNotification = notifications.value.find((item) => item.id === notification.id) ?? null
+    if (currentNotification != null && currentNotification.readAt == null && updated.readAt != null) {
+      currentNotification.readAt = updated.readAt
+      const lastNotification = notifications.value[notifications.value.length - 1] ?? null
+      hasUnread.value =
+        notifications.value.some((item) => item.readAt == null) ||
+        (nextCursor.value != null && lastNotification?.readAt == null)
     }
-  },
-  { en: 'Failed to mark notification as read', zh: '通知标记已读失败' }
-).fn
+  } catch {
+    // Reading the notification succeeded; keep it unread so a later interaction can retry.
+  } finally {
+    if (readRequests.get(notification.id) === request) {
+      readRequests.delete(notification.id)
+      markingReadNotificationIDs.value.delete(notification.id)
+    }
+  }
+}
 
 function backToList() {
   selectedNotificationID.value = null

--- a/spx-gui/src/components/navbar/NavbarNotifications.vue
+++ b/spx-gui/src/components/navbar/NavbarNotifications.vue
@@ -36,15 +36,34 @@ const notificationRadar = computed(() => ({
 }))
 
 let listRequest: AbortController | null = null
+let listRequestReset: boolean | null = null
+let queuedListRequestReset: boolean | null = null
 const readRequests = new Map<string, AbortController>()
 
+function queueListRequest(reset: boolean) {
+  queuedListRequestReset = queuedListRequestReset == null ? reset : queuedListRequestReset || reset
+}
+
+function abortListRequest() {
+  listRequest?.abort()
+  listRequest = null
+  listRequestReset = null
+  loading.value = false
+}
+
 async function loadNotifications(reset: boolean) {
-  if (signedInUser.value == null || readRequests.size > 0 || (loading.value && !reset)) return
-  if (reset) listRequest?.abort()
+  if (signedInUser.value == null) return
+  if (readRequests.size > 0) {
+    queueListRequest(reset)
+    return
+  }
+  if (loading.value && !reset) return
+  if (reset) abortListRequest()
   const cursor = reset ? undefined : nextCursor.value ?? undefined
   if (!reset && cursor == null) return
   const request = new AbortController()
   listRequest = request
+  listRequestReset = reset
   loading.value = true
   try {
     const result = await notificationApis.listUserNotifications(
@@ -65,6 +84,7 @@ async function loadNotifications(reset: boolean) {
   } finally {
     if (listRequest === request) {
       listRequest = null
+      listRequestReset = null
       loading.value = false
     }
   }
@@ -86,7 +106,10 @@ const handleOpenNotification = useMessageHandle(
     selectedNotificationID.value = notification.id
     if (notification.readAt != null || readRequests.has(notification.id)) return
 
-    listRequest?.abort()
+    if (listRequest != null) {
+      queueListRequest(listRequestReset ?? true)
+      abortListRequest()
+    }
     const request = new AbortController()
     readRequests.set(notification.id, request)
     markingReadNotificationIDs.value.add(notification.id)
@@ -96,6 +119,7 @@ const handleOpenNotification = useMessageHandle(
       const currentNotification = notifications.value.find((item) => item.id === notification.id) ?? null
       if (currentNotification != null && currentNotification.readAt == null && updated.readAt != null) {
         currentNotification.readAt = updated.readAt
+        notifications.value.sort(compareNotifications)
         const lastNotification = notifications.value[notifications.value.length - 1] ?? null
         hasUnread.value =
           notifications.value.some((item) => item.readAt == null) ||
@@ -107,6 +131,11 @@ const handleOpenNotification = useMessageHandle(
       if (readRequests.get(notification.id) === request) {
         readRequests.delete(notification.id)
         markingReadNotificationIDs.value.delete(notification.id)
+        if (readRequests.size === 0 && queuedListRequestReset != null) {
+          const reset = queuedListRequestReset
+          queuedListRequestReset = null
+          handleLoadNotifications(reset)
+        }
       }
     }
   },
@@ -115,6 +144,14 @@ const handleOpenNotification = useMessageHandle(
 
 function backToList() {
   selectedNotificationID.value = null
+}
+
+function compareNotifications(left: notificationApis.UserNotification, right: notificationApis.UserNotification) {
+  const readOrder = Number(left.readAt != null) - Number(right.readAt != null)
+  if (readOrder !== 0) return readOrder
+  const createdAtOrder = Date.parse(right.createdAt) - Date.parse(left.createdAt)
+  if (createdAtOrder !== 0) return createdAtOrder
+  return right.id.length - left.id.length || right.id.localeCompare(left.id)
 }
 
 function isValidActionPath(value: string) {
@@ -146,14 +183,13 @@ function formatTime(value: string) {
 watch(
   () => signedInUser.value?.id ?? null,
   (userID) => {
-    listRequest?.abort()
+    abortListRequest()
     for (const request of readRequests.values()) request.abort()
-    listRequest = null
+    queuedListRequestReset = null
     readRequests.clear()
     markingReadNotificationIDs.value.clear()
     notifications.value = []
     hasUnread.value = false
-    loading.value = false
     nextCursor.value = null
     selectedNotificationID.value = null
     visible.value = false
@@ -163,7 +199,8 @@ watch(
 )
 
 onUnmounted(() => {
-  listRequest?.abort()
+  abortListRequest()
+  queuedListRequestReset = null
   for (const request of readRequests.values()) request.abort()
 })
 </script>

--- a/spx-gui/src/components/navbar/NavbarNotifications.vue
+++ b/spx-gui/src/components/navbar/NavbarNotifications.vue
@@ -298,12 +298,7 @@ onUnmounted(() => {
       </template>
 
       <article v-else class="max-h-[480px] overflow-y-auto px-5 py-5">
-        <div class="flex items-center gap-2 text-xs text-grey-800">
-          <time>{{ formatTime(selectedNotification.createdAt) }}</time>
-          <span v-if="markingReadNotificationIDs.has(selectedNotification.id)">
-            {{ $t({ en: 'Marking as read...', zh: '正在标记已读...' }) }}
-          </span>
-        </div>
+        <time class="text-xs text-grey-800">{{ formatTime(selectedNotification.createdAt) }}</time>
         <p class="mt-3 whitespace-pre-wrap text-sm leading-6 text-grey-1000">{{ selectedNotification.body }}</p>
         <UIButton v-if="selectedNotification.actionPath != null" class="mt-6" type="primary" @click="openAction">
           {{ $t({ en: 'View details', zh: '查看详情' }) }}

--- a/spx-gui/src/components/navbar/NavbarNotifications.vue
+++ b/spx-gui/src/components/navbar/NavbarNotifications.vue
@@ -3,7 +3,7 @@ import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
 import { useRouter } from 'vue-router'
 
 import * as notificationApis from '@/apis/notification'
-import { capture, useMessageHandle } from '@/utils/exception'
+import { useMessageHandle } from '@/utils/exception'
 import { useI18n } from '@/utils/i18n'
 import { useSignedInUser } from '@/stores/user'
 import { UIButton, UIIcon, UIModal } from '@/components/ui'
@@ -36,27 +36,10 @@ const notificationRadar = computed(() => ({
 }))
 
 let listRequest: AbortController | null = null
-let statusRequest: AbortController | null = null
 const readRequests = new Map<string, AbortController>()
 
-async function refreshNotificationStatus() {
-  if (signedInUser.value == null || readRequests.size > 0) return
-  statusRequest?.abort()
-  const request = new AbortController()
-  statusRequest = request
-  try {
-    const result = await notificationApis.getUserNotificationStatus(request.signal)
-    request.signal.throwIfAborted()
-    hasUnread.value = result.hasUnread
-  } catch (error) {
-    if (!request.signal.aborted) capture(error, 'Failed to refresh notification status')
-  } finally {
-    if (statusRequest === request) statusRequest = null
-  }
-}
-
 async function loadNotifications(reset: boolean) {
-  if (signedInUser.value == null || (loading.value && !reset)) return
+  if (signedInUser.value == null || readRequests.size > 0 || (loading.value && !reset)) return
   if (reset) listRequest?.abort()
   const cursor = reset ? undefined : nextCursor.value ?? undefined
   if (!reset && cursor == null) return
@@ -70,6 +53,7 @@ async function loadNotifications(reset: boolean) {
     )
     request.signal.throwIfAborted()
     notifications.value = reset ? result.data : [...notifications.value, ...result.data]
+    hasUnread.value = result.hasUnread
     nextCursor.value = result.nextCursor
   } catch (error) {
     if (!request.signal.aborted) throw error
@@ -89,7 +73,6 @@ const handleLoadNotifications = useMessageHandle(loadNotifications, {
 function openNotificationCenter() {
   selectedNotificationID.value = null
   visible.value = true
-  refreshNotificationStatus()
   handleLoadNotifications(true)
 }
 
@@ -98,7 +81,6 @@ const handleOpenNotification = useMessageHandle(
     selectedNotificationID.value = notification.id
     if (notification.readAt != null || readRequests.has(notification.id)) return
 
-    statusRequest?.abort()
     const request = new AbortController()
     readRequests.set(notification.id, request)
     markingReadNotificationIDs.value.add(notification.id)
@@ -109,6 +91,10 @@ const handleOpenNotification = useMessageHandle(
       const currentNotification = notifications.value.find((item) => item.id === notification.id) ?? null
       if (currentNotification != null && currentNotification.readAt == null && updated.readAt != null) {
         currentNotification.readAt = updated.readAt
+        const lastNotification = notifications.value[notifications.value.length - 1] ?? null
+        hasUnread.value =
+          notifications.value.some((item) => item.readAt == null) ||
+          (nextCursor.value != null && lastNotification?.readAt == null)
       }
     } catch (error) {
       if (!request.signal.aborted) throw error
@@ -116,7 +102,6 @@ const handleOpenNotification = useMessageHandle(
       if (readRequests.get(notification.id) === request) {
         readRequests.delete(notification.id)
         markingReadNotificationIDs.value.delete(notification.id)
-        if (readRequests.size === 0) refreshNotificationStatus()
       }
     }
   },
@@ -154,17 +139,15 @@ function formatTime(value: string) {
 }
 
 function refreshWhenVisible() {
-  if (document.visibilityState === 'visible') refreshNotificationStatus()
+  if (document.visibilityState === 'visible') handleLoadNotifications(true)
 }
 
 watch(
   () => signedInUser.value?.id ?? null,
   (userID) => {
     listRequest?.abort()
-    statusRequest?.abort()
     for (const request of readRequests.values()) request.abort()
     listRequest = null
-    statusRequest = null
     readRequests.clear()
     markingReadNotificationIDs.value.clear()
     notifications.value = []
@@ -173,7 +156,7 @@ watch(
     nextCursor.value = null
     selectedNotificationID.value = null
     visible.value = false
-    if (userID != null) refreshNotificationStatus()
+    if (userID != null) handleLoadNotifications(true)
   },
   { immediate: true }
 )
@@ -183,7 +166,6 @@ onMounted(() => {
 })
 onUnmounted(() => {
   listRequest?.abort()
-  statusRequest?.abort()
   for (const request of readRequests.values()) request.abort()
   document.removeEventListener('visibilitychange', refreshWhenVisible)
 })

--- a/spx-gui/src/components/navbar/NavbarNotifications.vue
+++ b/spx-gui/src/components/navbar/NavbarNotifications.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
+import { computed, onUnmounted, ref, watch } from 'vue'
 import { useRouter } from 'vue-router'
 
 import * as notificationApis from '@/apis/notification'
@@ -143,10 +143,6 @@ function formatTime(value: string) {
   return dateTimeFormatter.value.format(new Date(value))
 }
 
-function refreshWhenVisible() {
-  if (document.visibilityState === 'visible') handleLoadNotifications(true)
-}
-
 watch(
   () => signedInUser.value?.id ?? null,
   (userID) => {
@@ -166,13 +162,9 @@ watch(
   { immediate: true }
 )
 
-onMounted(() => {
-  document.addEventListener('visibilitychange', refreshWhenVisible)
-})
 onUnmounted(() => {
   listRequest?.abort()
   for (const request of readRequests.values()) request.abort()
-  document.removeEventListener('visibilitychange', refreshWhenVisible)
 })
 </script>
 

--- a/spx-gui/src/components/navbar/NavbarNotifications.vue
+++ b/spx-gui/src/components/navbar/NavbarNotifications.vue
@@ -119,7 +119,6 @@ const handleOpenNotification = useMessageHandle(
       const currentNotification = notifications.value.find((item) => item.id === notification.id) ?? null
       if (currentNotification != null && currentNotification.readAt == null && updated.readAt != null) {
         currentNotification.readAt = updated.readAt
-        notifications.value.sort(compareNotifications)
         const lastNotification = notifications.value[notifications.value.length - 1] ?? null
         hasUnread.value =
           notifications.value.some((item) => item.readAt == null) ||
@@ -144,14 +143,6 @@ const handleOpenNotification = useMessageHandle(
 
 function backToList() {
   selectedNotificationID.value = null
-}
-
-function compareNotifications(left: notificationApis.UserNotification, right: notificationApis.UserNotification) {
-  const readOrder = Number(left.readAt != null) - Number(right.readAt != null)
-  if (readOrder !== 0) return readOrder
-  const createdAtOrder = Date.parse(right.createdAt) - Date.parse(left.createdAt)
-  if (createdAtOrder !== 0) return createdAtOrder
-  return right.id.length - left.id.length || right.id.localeCompare(left.id)
 }
 
 function isValidActionPath(value: string) {

--- a/spx-gui/src/components/navbar/NavbarNotifications.vue
+++ b/spx-gui/src/components/navbar/NavbarNotifications.vue
@@ -52,7 +52,12 @@ async function loadNotifications(reset: boolean) {
       request.signal
     )
     request.signal.throwIfAborted()
-    notifications.value = reset ? result.data : [...notifications.value, ...result.data]
+    if (reset) {
+      notifications.value = result.data
+    } else {
+      const loadedIDs = new Set(notifications.value.map((notification) => notification.id))
+      notifications.value.push(...result.data.filter((notification) => !loadedIDs.has(notification.id)))
+    }
     hasUnread.value = result.hasUnread
     nextCursor.value = result.nextCursor
   } catch (error) {
@@ -81,13 +86,13 @@ const handleOpenNotification = useMessageHandle(
     selectedNotificationID.value = notification.id
     if (notification.readAt != null || readRequests.has(notification.id)) return
 
+    listRequest?.abort()
     const request = new AbortController()
     readRequests.set(notification.id, request)
     markingReadNotificationIDs.value.add(notification.id)
     try {
       const updated = await notificationApis.markUserNotificationRead(notification.id, request.signal)
       request.signal.throwIfAborted()
-      listRequest?.abort()
       const currentNotification = notifications.value.find((item) => item.id === notification.id) ?? null
       if (currentNotification != null && currentNotification.readAt == null && updated.readAt != null) {
         currentNotification.readAt = updated.readAt

--- a/spx-gui/src/components/navbar/NavbarNotifications.vue
+++ b/spx-gui/src/components/navbar/NavbarNotifications.vue
@@ -36,34 +36,22 @@ const notificationRadar = computed(() => ({
 }))
 
 let listRequest: AbortController | null = null
-let listRequestReset: boolean | null = null
-let queuedListRequestReset: boolean | null = null
 const readRequests = new Map<string, AbortController>()
-
-function queueListRequest(reset: boolean) {
-  queuedListRequestReset = queuedListRequestReset == null ? reset : queuedListRequestReset || reset
-}
 
 function abortListRequest() {
   listRequest?.abort()
   listRequest = null
-  listRequestReset = null
   loading.value = false
 }
 
 async function loadNotifications(reset: boolean) {
   if (signedInUser.value == null) return
-  if (readRequests.size > 0) {
-    queueListRequest(reset)
-    return
-  }
   if (loading.value && !reset) return
   if (reset) abortListRequest()
   const cursor = reset ? undefined : nextCursor.value ?? undefined
   if (!reset && cursor == null) return
   const request = new AbortController()
   listRequest = request
-  listRequestReset = reset
   loading.value = true
   try {
     const result = await notificationApis.listUserNotifications(
@@ -84,7 +72,6 @@ async function loadNotifications(reset: boolean) {
   } finally {
     if (listRequest === request) {
       listRequest = null
-      listRequestReset = null
       loading.value = false
     }
   }
@@ -106,10 +93,7 @@ const handleOpenNotification = useMessageHandle(
     selectedNotificationID.value = notification.id
     if (notification.readAt != null || readRequests.has(notification.id)) return
 
-    if (listRequest != null) {
-      queueListRequest(listRequestReset ?? true)
-      abortListRequest()
-    }
+    abortListRequest()
     const request = new AbortController()
     readRequests.set(notification.id, request)
     markingReadNotificationIDs.value.add(notification.id)
@@ -130,11 +114,6 @@ const handleOpenNotification = useMessageHandle(
       if (readRequests.get(notification.id) === request) {
         readRequests.delete(notification.id)
         markingReadNotificationIDs.value.delete(notification.id)
-        if (readRequests.size === 0 && queuedListRequestReset != null) {
-          const reset = queuedListRequestReset
-          queuedListRequestReset = null
-          handleLoadNotifications(reset)
-        }
       }
     }
   },
@@ -176,7 +155,6 @@ watch(
   (userID) => {
     abortListRequest()
     for (const request of readRequests.values()) request.abort()
-    queuedListRequestReset = null
     readRequests.clear()
     markingReadNotificationIDs.value.clear()
     notifications.value = []
@@ -191,7 +169,6 @@ watch(
 
 onUnmounted(() => {
   abortListRequest()
-  queuedListRequestReset = null
   for (const request of readRequests.values()) request.abort()
 })
 </script>
@@ -308,7 +285,12 @@ onUnmounted(() => {
             </div>
           </button>
           <div v-if="nextCursor != null" class="border-t border-grey-300 p-3 text-center">
-            <UIButton type="white" size="small" :loading="loading" @click="handleLoadNotifications(false)">
+            <UIButton
+              type="white"
+              size="small"
+              :loading="loading || markingReadNotificationIDs.size > 0"
+              @click="handleLoadNotifications(false)"
+            >
               {{ $t({ en: 'Load more', zh: '加载更多' }) }}
             </UIButton>
           </div>

--- a/spx-gui/src/components/navbar/NavbarNotifications.vue
+++ b/spx-gui/src/components/navbar/NavbarNotifications.vue
@@ -15,48 +15,43 @@ const i18n = useI18n()
 const signedInUser = useSignedInUser()
 const visible = ref(false)
 const notifications = ref<notificationApis.UserNotification[]>([])
-const unreadCount = ref(0)
 const nextCursor = ref<string | null>(null)
 const loading = ref(false)
+const hasUnread = ref(false)
 const markingReadNotificationIDs = ref(new Set<string>())
 const selectedNotificationID = ref<string | null>(null)
 const selectedNotification = computed(
   () => notifications.value.find((notification) => notification.id === selectedNotificationID.value) ?? null
 )
-const hasMore = computed(() => nextCursor.value != null)
 const notificationLabel = computed(() =>
-  unreadCount.value === 0
-    ? i18n.t({ en: 'Notifications', zh: '通知' })
-    : i18n.t({ en: `Notifications, ${unreadCount.value} unread`, zh: `通知，${unreadCount.value} 条未读` })
+  hasUnread.value
+    ? i18n.t({ en: 'Notifications, unread notifications available', zh: '通知，有未读通知' })
+    : i18n.t({ en: 'Notifications', zh: '通知' })
 )
 const notificationRadar = computed(() => ({
   name: notificationLabel.value,
-  desc:
-    unreadCount.value === 0
-      ? i18n.t({ en: 'Open in-product notifications', zh: '打开站内通知' })
-      : i18n.t({
-          en: `Open ${unreadCount.value} unread notifications`,
-          zh: `打开 ${unreadCount.value} 条未读通知`
-        })
+  desc: hasUnread.value
+    ? i18n.t({ en: 'Open unread in-product notifications', zh: '打开未读站内通知' })
+    : i18n.t({ en: 'Open in-product notifications', zh: '打开站内通知' })
 }))
 
 let listRequest: AbortController | null = null
-let unreadCountRequest: AbortController | null = null
+let statusRequest: AbortController | null = null
 const readRequests = new Map<string, AbortController>()
 
-async function refreshUnreadCount() {
+async function refreshNotificationStatus() {
   if (signedInUser.value == null || readRequests.size > 0) return
-  unreadCountRequest?.abort()
+  statusRequest?.abort()
   const request = new AbortController()
-  unreadCountRequest = request
+  statusRequest = request
   try {
-    const result = await notificationApis.getUserNotificationUnreadCount(request.signal)
+    const result = await notificationApis.getUserNotificationStatus(request.signal)
     request.signal.throwIfAborted()
-    unreadCount.value = result.unreadCount
+    hasUnread.value = result.hasUnread
   } catch (error) {
-    if (!request.signal.aborted) capture(error, 'Failed to refresh unread notification count')
+    if (!request.signal.aborted) capture(error, 'Failed to refresh notification status')
   } finally {
-    if (unreadCountRequest === request) unreadCountRequest = null
+    if (statusRequest === request) statusRequest = null
   }
 }
 
@@ -94,7 +89,7 @@ const handleLoadNotifications = useMessageHandle(loadNotifications, {
 function openNotificationCenter() {
   selectedNotificationID.value = null
   visible.value = true
-  refreshUnreadCount()
+  refreshNotificationStatus()
   handleLoadNotifications(true)
 }
 
@@ -103,7 +98,7 @@ const handleOpenNotification = useMessageHandle(
     selectedNotificationID.value = notification.id
     if (notification.readAt != null || readRequests.has(notification.id)) return
 
-    unreadCountRequest?.abort()
+    statusRequest?.abort()
     const request = new AbortController()
     readRequests.set(notification.id, request)
     markingReadNotificationIDs.value.add(notification.id)
@@ -114,7 +109,6 @@ const handleOpenNotification = useMessageHandle(
       const currentNotification = notifications.value.find((item) => item.id === notification.id) ?? null
       if (currentNotification != null && currentNotification.readAt == null && updated.readAt != null) {
         currentNotification.readAt = updated.readAt
-        unreadCount.value = Math.max(0, unreadCount.value - 1)
       }
     } catch (error) {
       if (!request.signal.aborted) throw error
@@ -122,7 +116,7 @@ const handleOpenNotification = useMessageHandle(
       if (readRequests.get(notification.id) === request) {
         readRequests.delete(notification.id)
         markingReadNotificationIDs.value.delete(notification.id)
-        if (readRequests.size === 0) refreshUnreadCount()
+        if (readRequests.size === 0) refreshNotificationStatus()
       }
     }
   },
@@ -160,26 +154,26 @@ function formatTime(value: string) {
 }
 
 function refreshWhenVisible() {
-  if (document.visibilityState === 'visible') refreshUnreadCount()
+  if (document.visibilityState === 'visible') refreshNotificationStatus()
 }
 
 watch(
   () => signedInUser.value?.id ?? null,
   (userID) => {
     listRequest?.abort()
-    unreadCountRequest?.abort()
+    statusRequest?.abort()
     for (const request of readRequests.values()) request.abort()
     listRequest = null
-    unreadCountRequest = null
+    statusRequest = null
     readRequests.clear()
     markingReadNotificationIDs.value.clear()
     notifications.value = []
-    unreadCount.value = 0
+    hasUnread.value = false
     loading.value = false
     nextCursor.value = null
     selectedNotificationID.value = null
     visible.value = false
-    if (userID != null) refreshUnreadCount()
+    if (userID != null) refreshNotificationStatus()
   },
   { immediate: true }
 )
@@ -189,7 +183,7 @@ onMounted(() => {
 })
 onUnmounted(() => {
   listRequest?.abort()
-  unreadCountRequest?.abort()
+  statusRequest?.abort()
   for (const request of readRequests.values()) request.abort()
   document.removeEventListener('visibilitychange', refreshWhenVisible)
 })
@@ -207,11 +201,9 @@ onUnmounted(() => {
       <span class="relative flex size-5 items-center justify-center">
         <UIIcon type="bell" />
         <span
-          v-if="unreadCount > 0"
-          class="absolute -top-1.5 -right-2 flex min-w-4.5 items-center justify-center rounded-full bg-red-500 px-1 text-[10px] leading-4 text-white ring-2 ring-grey-100"
-        >
-          {{ unreadCount > 99 ? '99+' : unreadCount }}
-        </span>
+          v-if="hasUnread"
+          class="absolute -top-0.5 -right-1 size-2 rounded-full bg-red-500 ring-2 ring-grey-100"
+        ></span>
       </span>
     </button>
 
@@ -308,7 +300,7 @@ onUnmounted(() => {
               <UIIcon type="arrowRightSmall" class="mt-1 size-4 shrink-0 text-grey-600" />
             </div>
           </button>
-          <div v-if="hasMore" class="border-t border-grey-300 p-3 text-center">
+          <div v-if="nextCursor != null" class="border-t border-grey-300 p-3 text-center">
             <UIButton type="white" size="small" :loading="loading" @click="handleLoadNotifications(false)">
               {{ $t({ en: 'Load more', zh: '加载更多' }) }}
             </UIButton>

--- a/spx-gui/src/components/navbar/NavbarNotifications.vue
+++ b/spx-gui/src/components/navbar/NavbarNotifications.vue
@@ -1,0 +1,303 @@
+<script setup lang="ts">
+import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
+import { useRouter } from 'vue-router'
+
+import * as notificationApis from '@/apis/notification'
+import { capture, useMessageHandle } from '@/utils/exception'
+import { useI18n } from '@/utils/i18n'
+import { useSignedInUser } from '@/stores/user'
+import { UIButton, UIIcon, UIModal } from '@/components/ui'
+
+const pageSize = 50
+// Notifications arrive out of band, so this feature explicitly opts into lightweight freshness checks.
+const refreshInterval = 5 * 60_000
+
+const router = useRouter()
+const i18n = useI18n()
+const signedInUser = useSignedInUser()
+const visible = ref(false)
+const notifications = ref<notificationApis.UserNotification[]>([])
+const total = ref(0)
+const unreadCount = ref(0)
+const nextPage = ref(1)
+const loading = ref(false)
+const selectedNotificationID = ref<string | null>(null)
+const selectedNotification = computed(
+  () => notifications.value.find((notification) => notification.id === selectedNotificationID.value) ?? null
+)
+const hasMore = computed(() => notifications.value.length < total.value)
+const notificationLabel = computed(() =>
+  unreadCount.value === 0
+    ? i18n.t({ en: 'Notifications', zh: '通知' })
+    : i18n.t({ en: `Notifications, ${unreadCount.value} unread`, zh: `通知，${unreadCount.value} 条未读` })
+)
+const notificationRadar = computed(() => ({
+  name: notificationLabel.value,
+  desc:
+    unreadCount.value === 0
+      ? i18n.t({ en: 'Open in-product notifications', zh: '打开站内通知' })
+      : i18n.t({
+          en: `Open ${unreadCount.value} unread notifications`,
+          zh: `打开 ${unreadCount.value} 条未读通知`
+        })
+}))
+
+let requestSequence = 0
+let unreadRequestSequence = 0
+
+async function refreshUnreadCount() {
+  const userID = signedInUser.value?.id
+  if (userID == null) return
+  const sequence = ++unreadRequestSequence
+  try {
+    const result = await notificationApis.getUserNotificationUnreadCount()
+    if (sequence === unreadRequestSequence && signedInUser.value?.id === userID) {
+      unreadCount.value = result.unreadCount
+    }
+  } catch (error) {
+    capture(error, 'Failed to refresh unread notification count')
+  }
+}
+
+async function loadNotifications(reset: boolean) {
+  if (signedInUser.value == null || loading.value) return
+  const sequence = ++requestSequence
+  unreadRequestSequence += 1
+  const pageIndex = reset ? 1 : nextPage.value
+  loading.value = true
+  try {
+    const result = await notificationApis.listUserNotifications({ pageIndex, pageSize })
+    if (sequence !== requestSequence) return
+    notifications.value = reset ? result.data : [...notifications.value, ...result.data]
+    total.value = result.total
+    unreadCount.value = result.unreadCount
+    nextPage.value = pageIndex + 1
+  } finally {
+    if (sequence === requestSequence) loading.value = false
+  }
+}
+
+const handleLoadNotifications = useMessageHandle(loadNotifications, {
+  en: 'Failed to load notifications',
+  zh: '加载通知失败'
+}).fn
+
+function openNotificationCenter() {
+  selectedNotificationID.value = null
+  visible.value = true
+  handleLoadNotifications(true)
+}
+
+const handleOpenNotification = useMessageHandle(
+  async (notification: notificationApis.UserNotification) => {
+    selectedNotificationID.value = notification.id
+    if (notification.readAt != null) return
+
+    const userID = signedInUser.value?.id
+    if (userID == null) return
+    unreadRequestSequence += 1
+    const optimisticReadAt = new Date().toISOString()
+    notification.readAt = optimisticReadAt
+    unreadCount.value = Math.max(0, unreadCount.value - 1)
+    const isCurrentNotification = () =>
+      signedInUser.value?.id === userID &&
+      notifications.value.includes(notification) &&
+      notification.readAt === optimisticReadAt
+    try {
+      const updated = await notificationApis.markUserNotificationRead(notification.id)
+      if (isCurrentNotification()) notification.readAt = updated.readAt
+    } catch (error) {
+      if (isCurrentNotification()) {
+        notification.readAt = null
+        unreadCount.value += 1
+      }
+      throw error
+    }
+  },
+  { en: 'Failed to mark notification as read', zh: '通知标记已读失败' }
+).fn
+
+function backToList() {
+  selectedNotificationID.value = null
+}
+
+async function openAction() {
+  const actionPath = selectedNotification.value?.actionPath
+  if (actionPath == null) return
+  visible.value = false
+  await router.push(actionPath)
+}
+
+function formatTime(value: string) {
+  return new Intl.DateTimeFormat(i18n.lang.value === 'zh' ? 'zh-CN' : 'en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit'
+  }).format(new Date(value))
+}
+
+function refreshWhenVisible() {
+  if (document.visibilityState === 'visible') refreshUnreadCount()
+}
+
+watch(
+  () => signedInUser.value?.id ?? null,
+  (userID) => {
+    requestSequence += 1
+    unreadRequestSequence += 1
+    notifications.value = []
+    total.value = 0
+    unreadCount.value = 0
+    loading.value = false
+    nextPage.value = 1
+    selectedNotificationID.value = null
+    visible.value = false
+    if (userID != null) refreshUnreadCount()
+  },
+  { immediate: true }
+)
+
+let refreshTimer: number | null = null
+onMounted(() => {
+  refreshTimer = window.setInterval(refreshUnreadCount, refreshInterval)
+  document.addEventListener('visibilitychange', refreshWhenVisible)
+})
+onUnmounted(() => {
+  if (refreshTimer != null) window.clearInterval(refreshTimer)
+  document.removeEventListener('visibilitychange', refreshWhenVisible)
+})
+</script>
+
+<template>
+  <template v-if="signedInUser != null">
+    <button
+      v-radar="notificationRadar"
+      :aria-label="notificationLabel"
+      type="button"
+      class="h-full cursor-pointer border-0 bg-transparent px-3 text-grey-900 hover:bg-grey-400 focus-visible:outline-primary-main"
+      @click="openNotificationCenter"
+    >
+      <span class="relative flex size-5 items-center justify-center">
+        <UIIcon type="bell" />
+        <span
+          v-if="unreadCount > 0"
+          class="absolute -top-1.5 -right-2 flex min-w-4.5 items-center justify-center rounded-full bg-red-500 px-1 text-[10px] leading-4 text-white ring-2 ring-grey-100"
+        >
+          {{ unreadCount > 99 ? '99+' : unreadCount }}
+        </span>
+      </span>
+    </button>
+
+    <UIModal
+      :visible="visible"
+      size="small"
+      class="w-[520px]"
+      :radar="{
+        name: $t({ en: 'Notification center', zh: '通知中心' }),
+        desc: $t({ en: 'Persistent in-product notifications', zh: '持久化站内通知' })
+      }"
+      @update:visible="visible = $event"
+    >
+      <div class="flex items-center justify-between border-b border-grey-400 px-5 py-4">
+        <div class="flex min-w-0 items-center gap-2">
+          <UIButton
+            v-if="selectedNotification != null"
+            v-radar="{
+              name: $t({ en: 'Back to notifications', zh: '返回通知列表' }),
+              desc: $t({ en: 'Return to the notification list', zh: '返回通知列表' })
+            }"
+            :aria-label="$t({ en: 'Back to notifications', zh: '返回通知列表' })"
+            type="white"
+            shape="square"
+            size="small"
+            @click="backToList"
+          >
+            <template #icon>
+              <UIIcon type="arrowRightSmall" class="rotate-180" />
+            </template>
+          </UIButton>
+          <h2 class="truncate font-semibold text-title">
+            {{ selectedNotification?.title ?? $t({ en: 'Notifications', zh: '通知' }) }}
+          </h2>
+        </div>
+        <UIButton
+          v-radar="{
+            name: $t({ en: 'Close notifications', zh: '关闭通知' }),
+            desc: $t({ en: 'Close the notification center', zh: '关闭通知中心' })
+          }"
+          :aria-label="$t({ en: 'Close notifications', zh: '关闭通知' })"
+          type="white"
+          shape="square"
+          size="small"
+          icon="close"
+          @click="visible = false"
+        />
+      </div>
+
+      <template v-if="selectedNotification == null">
+        <div v-if="loading && notifications.length === 0" class="px-5 py-12 text-center text-sm text-grey-800">
+          {{ $t({ en: 'Loading notifications...', zh: '正在加载通知...' }) }}
+        </div>
+        <div v-else-if="notifications.length === 0" class="px-5 py-12 text-center text-sm text-grey-800">
+          {{ $t({ en: 'No notifications', zh: '暂无通知' }) }}
+        </div>
+        <div v-else class="max-h-[480px] overflow-y-auto">
+          <button
+            v-for="notification in notifications"
+            :key="notification.id"
+            v-radar="{
+              name: notification.title,
+              desc:
+                notification.readAt == null
+                  ? $t({ en: 'Open unread notification', zh: '打开未读通知' })
+                  : $t({ en: 'Open notification', zh: '打开通知' })
+            }"
+            type="button"
+            class="block w-full cursor-pointer border-x-0 border-t-0 border-b border-grey-300 px-5 py-4 text-left transition-colors last:border-b-0 focus-visible:relative focus-visible:z-1 focus-visible:outline-2 focus-visible:outline-primary-main"
+            :class="
+              notification.readAt == null
+                ? 'bg-primary-100/60 hover:bg-primary-200 active:bg-primary-300'
+                : 'bg-transparent hover:bg-grey-200 active:bg-grey-300'
+            "
+            @click="handleOpenNotification(notification)"
+          >
+            <div class="flex items-start gap-3">
+              <span
+                class="mt-1.5 size-2 shrink-0 rounded-full"
+                :class="notification.readAt == null ? 'bg-primary-main' : 'bg-transparent'"
+              ></span>
+              <div class="min-w-0 flex-1">
+                <div class="flex items-center justify-between gap-3">
+                  <span
+                    class="truncate text-sm text-title"
+                    :class="notification.readAt == null ? 'font-semibold' : 'font-normal'"
+                  >
+                    {{ notification.title }}
+                  </span>
+                  <time class="shrink-0 text-xs text-grey-800">{{ formatTime(notification.createdAt) }}</time>
+                </div>
+                <p class="mt-1 truncate text-sm text-grey-900">{{ notification.body }}</p>
+              </div>
+              <UIIcon type="arrowRightSmall" class="mt-1 size-4 shrink-0 text-grey-600" />
+            </div>
+          </button>
+          <div v-if="hasMore" class="border-t border-grey-300 p-3 text-center">
+            <UIButton type="white" size="small" :loading="loading" @click="handleLoadNotifications(false)">
+              {{ $t({ en: 'Load more', zh: '加载更多' }) }}
+            </UIButton>
+          </div>
+        </div>
+      </template>
+
+      <article v-else class="max-h-[480px] overflow-y-auto px-5 py-5">
+        <time class="text-xs text-grey-800">{{ formatTime(selectedNotification.createdAt) }}</time>
+        <p class="mt-3 whitespace-pre-wrap text-sm leading-6 text-grey-1000">{{ selectedNotification.body }}</p>
+        <UIButton v-if="selectedNotification.actionPath != null" class="mt-6" type="primary" @click="openAction">
+          {{ $t({ en: 'View details', zh: '查看详情' }) }}
+        </UIButton>
+      </article>
+    </UIModal>
+  </template>
+</template>

--- a/spx-gui/src/components/navbar/NavbarNotifications.vue
+++ b/spx-gui/src/components/navbar/NavbarNotifications.vue
@@ -125,7 +125,12 @@ function backToList() {
 }
 
 function isValidActionPath(value: string) {
-  return value.startsWith('/') && !value.startsWith('//') && !value.includes('\\')
+  if (!value.startsWith('/') || value.startsWith('//') || value.includes('\\')) return false
+  for (const char of value) {
+    const codePoint = char.codePointAt(0) ?? 0
+    if (/\s/u.test(char) || codePoint <= 0x1f || (codePoint >= 0x7f && codePoint <= 0x9f)) return false
+  }
+  return true
 }
 
 async function openAction() {

--- a/spx-gui/src/components/navbar/NavbarWrapper.vue
+++ b/spx-gui/src/components/navbar/NavbarWrapper.vue
@@ -13,6 +13,7 @@
       </div>
       <div class="basis-[30%] flex items-center justify-end" :class="!centered && 'mr-2'">
         <slot name="right"></slot>
+        <NavbarNotifications />
         <NavbarProfile />
       </div>
     </div>
@@ -21,6 +22,7 @@
 
 <script setup lang="ts">
 import NavbarLogo from './NavbarLogo.vue'
+import NavbarNotifications from './NavbarNotifications.vue'
 import NavbarProfile from './NavbarProfile.vue'
 
 withDefaults(

--- a/spx-gui/src/components/ui/icons/UIIcon.vue
+++ b/spx-gui/src/components/ui/icons/UIIcon.vue
@@ -47,6 +47,7 @@ import statePublic from './state-public.svg?raw'
 import statePrivate from './state-private.svg?raw'
 import heart from './heart.svg?raw'
 import calendar from './calendar.svg?raw'
+import bell from './bell.svg?raw'
 import remix from './remix.svg?raw'
 import heartHollow from './heart-hollow.svg?raw'
 import info from './info.svg?raw'
@@ -128,6 +129,7 @@ const typeIconMap = {
   statePrivate,
   heart,
   calendar,
+  bell,
   remix,
   heartHollow,
   info,

--- a/spx-gui/src/components/ui/icons/bell.svg
+++ b/spx-gui/src/components/ui/icons/bell.svg
@@ -1,0 +1,15 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path
+    d="M8 1.5C5.791 1.5 4 3.291 4 5.5V7.257C4 8.079 3.747 8.881 3.275 9.554L2.618 10.493C2.385 10.826 2.623 11.283 3.03 11.283H12.97C13.377 11.283 13.615 10.826 13.382 10.493L12.725 9.554C12.253 8.881 12 8.079 12 7.257V5.5C12 3.291 10.209 1.5 8 1.5Z"
+    stroke="currentColor"
+    stroke-width="1.25"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  />
+  <path
+    d="M6.5 13C6.765 13.612 7.288 14 8 14C8.712 14 9.235 13.612 9.5 13"
+    stroke="currentColor"
+    stroke-width="1.25"
+    stroke-linecap="round"
+  />
+</svg>


### PR DESCRIPTION
## Summary

- add a navbar notification center with a red-dot unread indicator, cursor pagination, notification details, and internal actions
- return unread notifications before read notifications in one flat list without separate sections or pagination
- derive `hasUnread` from the notification list response and refresh on sign-in and notification-center open without polling
- keep notifications in place after marking them read and temporarily disable page loading while that update is pending
- guard user switches, stale requests, and cursor duplicates after notifications move into the read group on subsequent fetches
- add notification API coverage, accessibility metadata, and OpenAPI documentation
- keep Copilot below the standard modal layer so notification dialogs remain modal

Backend: goplus/builder-backend#355

This PR provides reusable notification UI. Feedback replies for #1789 will become the first producer in a separate PR.

## Testing

- notification API and component tests: 13 passed
- `npm run type-check`
- `npm run lint -- --no-fix`
