### PR TITLE
docs(openapi)!: course API contract release for course kinds

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -2837,6 +2837,9 @@ paths:
       description: |
         Create a new course owned by the authenticated user.
 
+        The request either provides `kind` and `content`, or uses the transitional legacy flat shape (`entrypoint` and
+        `prompt` without `kind` and `content`, treated as a guided course) accepted until the API contract release.
+
         Permission requirements:
 
         - Only users with the `courseAdmin` role can create courses.
@@ -2849,13 +2852,15 @@ paths:
               required:
                 - title
                 - thumbnail
-                - entrypoint
-                - prompt
               properties:
+                kind:
+                  $ref: "#/components/schemas/Course/properties/kind"
                 title:
                   $ref: "#/components/schemas/Course/properties/title"
                 thumbnail:
                   $ref: "#/components/schemas/Course/properties/thumbnail"
+                content:
+                  $ref: "#/components/schemas/Course/properties/content"
                 entrypoint:
                   $ref: "#/components/schemas/Course/properties/entrypoint"
                 prompt:
@@ -2882,6 +2887,67 @@ paths:
           $ref: "#/components/responses/Unauthorized"
         "403":
           $ref: "#/components/responses/Forbidden"
+
+  /user/courses/playground/copilot-context:
+    post:
+      operationId: generatePlaygroundCourseCopilotContext
+      tags:
+        - Courses
+      summary: Generate a playground course copilot context
+      description: |
+        Generate an editable Copilot context draft from the author's current, possibly unsaved, playground course
+        content.
+
+        Permission requirements:
+
+        - Only users with the `courseAdmin` role can generate course copilot contexts.
+
+        Quota and rate limits:
+
+        - Each generation consumes 1 quota from the authenticated user's `copilotMessage` allowance; the quota is
+          refunded when generation fails.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - title
+                - content
+              properties:
+                title:
+                  $ref: "#/components/schemas/Course/properties/title"
+                thumbnail:
+                  $ref: "#/components/schemas/Course/properties/thumbnail"
+                content:
+                  description: Current, possibly unsaved, playground course content mapping file paths to universal URLs.
+                  type: object
+                  minProperties: 1
+                  additionalProperties:
+                    type: string
+                    format: uri-reference
+      responses:
+        "200":
+          description: Successfully generated the copilot context.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - copilotContext
+                properties:
+                  copilotContext:
+                    description: Generated copilot context, editable by the author before saving.
+                    type: string
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
 
   /courses/{courseID}:
     get:
@@ -2919,6 +2985,9 @@ paths:
       description: |
         Update the details of a specific course.
 
+        The course kind is immutable: a `kind` field is accepted only when it matches the course's current kind, and the
+        transitional legacy fields (`entrypoint`, `prompt`) apply only to guided courses when `content` is absent.
+
         Permission requirements:
 
         - Only users with the `courseAdmin` role can update courses.
@@ -2937,10 +3006,14 @@ paths:
               type: object
               minProperties: 1
               properties:
+                kind:
+                  $ref: "#/components/schemas/Course/properties/kind"
                 title:
                   $ref: "#/components/schemas/Course/properties/title"
                 thumbnail:
                   $ref: "#/components/schemas/Course/properties/thumbnail"
+                content:
+                  $ref: "#/components/schemas/Course/properties/content"
                 entrypoint:
                   $ref: "#/components/schemas/Course/properties/entrypoint"
                 prompt:
@@ -3060,6 +3133,11 @@ paths:
         - {}
         - bearerAuth: []
       parameters:
+        - name: kind
+          description: Filter course series by kind.
+          in: query
+          schema:
+            $ref: "#/components/schemas/CourseSeries/properties/kind"
         - name: orderBy
           description: Field by which to order the results.
           in: query
@@ -3103,6 +3181,11 @@ paths:
       summary: List course series owned by the authenticated user
       description: Retrieve a list of course series owned by the authenticated user.
       parameters:
+        - name: kind
+          description: Filter course series by kind.
+          in: query
+          schema:
+            $ref: "#/components/schemas/CourseSeries/properties/kind"
         - name: orderBy
           description: Field by which to order the results.
           in: query
@@ -3147,6 +3230,8 @@ paths:
       description: |
         Create a new course series owned by the authenticated user.
 
+        Omitting `kind` means a guided series (transitional legacy shape, accepted until the API contract release).
+
         Permission requirements:
 
         - Only users with the `courseAdmin` role can create course series.
@@ -3162,6 +3247,8 @@ paths:
                 - courseIDs
                 - order
               properties:
+                kind:
+                  $ref: "#/components/schemas/CourseSeries/properties/kind"
                 title:
                   $ref: "#/components/schemas/CourseSeries/properties/title"
                 thumbnail:
@@ -3251,6 +3338,8 @@ paths:
               type: object
               minProperties: 1
               properties:
+                kind:
+                  $ref: "#/components/schemas/CourseSeries/properties/kind"
                 title:
                   $ref: "#/components/schemas/CourseSeries/properties/title"
                 thumbnail:
@@ -3321,6 +3410,11 @@ paths:
           required: true
           schema:
             $ref: "#/components/schemas/User/properties/username"
+        - name: kind
+          description: Filter course series by kind.
+          in: query
+          schema:
+            $ref: "#/components/schemas/CourseSeries/properties/kind"
         - name: orderBy
           description: Field by which to order the results.
           in: query
@@ -7562,8 +7656,10 @@ components:
         - createdAt
         - updatedAt
         - owner
+        - kind
         - title
         - thumbnail
+        - content
         - entrypoint
         - prompt
       properties:
@@ -7576,6 +7672,14 @@ components:
         owner:
           description: Username of the course's owner.
           $ref: "#/components/schemas/User/properties/username"
+        kind:
+          description: Kind of the course, deciding how the course is driven and what its content holds. Immutable after creation.
+          type: string
+          enum:
+            - guided
+            - playground
+          examples:
+            - guided
         title:
           description: Title of the course.
           type: string
@@ -7590,15 +7694,30 @@ components:
           minLength: 1
           examples:
             - kodo://xbuilder-usercontent-test/files/FvYyHLNrtx8qFHSwnLjEe57UA2fF-2824936
+        content:
+          description: |
+            Kind-specific course content. For a `guided` course it holds the guided course data (`entrypoint` and `prompt`);
+            for a `playground` course it is a file collection mapping file paths to universal URLs. The API validates only
+            the top-level shape (and, for `playground`, that every value is a universal URL); internals follow the Tutorial
+            content-format contract and stay opaque to the API and storage.
+          type: object
+          examples:
+            - entrypoint: /editor/john/loop
+              prompt: Learn the basics of XGo programming language
         entrypoint:
-          description: Starting entrypoint of the course.
+          description: |
+            Starting entrypoint of the course. Transitional top-level copy of the guided course content, kept so pre-kind
+            clients keep working; empty for playground courses. Removed by the API contract release.
+          deprecated: true
           type: string
           format: uri-reference
-          minLength: 1
           examples:
             - /editor/john/loop
         prompt:
-          description: Prompt text for the course (used for copilot assistance).
+          description: |
+            Prompt text for the course (used for copilot assistance). Transitional top-level copy of the guided course
+            content; empty for playground courses. Removed by the API contract release.
+          deprecated: true
           type: string
           maxLength: 12000
           examples:
@@ -7612,6 +7731,7 @@ components:
         - createdAt
         - updatedAt
         - owner
+        - kind
         - title
         - thumbnail
         - description
@@ -7627,6 +7747,16 @@ components:
         owner:
           description: Username of the course series' owner.
           $ref: "#/components/schemas/User/properties/username"
+        kind:
+          description: |
+            Kind of the courses in this series; a course series holds courses of exactly one kind. Changing it requires
+            every course in the series to have the new kind.
+          type: string
+          enum:
+            - guided
+            - playground
+          examples:
+            - guided
         title:
           description: Title of the course series.
           type: string

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -2838,7 +2838,7 @@ paths:
         Create a new course owned by the authenticated user.
 
         The request either provides `kind` and `content`, or uses the transitional legacy flat shape (`entrypoint` and
-        `prompt` without `kind` and `content`, treated as a guided course) accepted until the API contract release.
+        `prompt` without `kind` and `content`, treated as a guided course) accepted until the API contract release (goplus/builder-backend#352).
 
         Permission requirements:
 
@@ -3233,7 +3233,7 @@ paths:
       description: |
         Create a new course series owned by the authenticated user.
 
-        Omitting `kind` means a guided series (transitional legacy shape, accepted until the API contract release).
+        Omitting `kind` means a guided series (transitional legacy shape, accepted until the API contract release (goplus/builder-backend#352)).
 
         Permission requirements:
 
@@ -7707,10 +7707,13 @@ components:
           examples:
             - entrypoint: /editor/john/loop
               prompt: Learn the basics of XGo programming language
+            - main_course.gox: kodo://xbuilder-usercontent-test/files/FvYyHLNrtx8qFHSwnLjEe57UA2fF-2824936
+              project/Lita.spx: kodo://xbuilder-usercontent-test/files/FoSC8ngQn_jzAIPBqCp9VZLBVkSq-52661
+              assets/videos/step-to/index.json: data:application/json,%7B%22path%22%3A%22step-to.mp4%22%7D
         entrypoint:
           description: |
             Starting entrypoint of the course. Transitional top-level copy of the guided course content, kept so pre-kind
-            clients keep working; empty for playground courses. Removed by the API contract release.
+            clients keep working; empty for playground courses. Removed by the API contract release (goplus/builder-backend#352).
           deprecated: true
           type: string
           format: uri-reference
@@ -7719,7 +7722,7 @@ components:
         prompt:
           description: |
             Prompt text for the course (used for copilot assistance). Transitional top-level copy of the guided course
-            content; empty for playground courses. Removed by the API contract release.
+            content; empty for playground courses. Removed by the API contract release (goplus/builder-backend#352).
           deprecated: true
           type: string
           maxLength: 12000

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -2837,9 +2837,8 @@ paths:
       description: |
         Create a new course owned by the authenticated user.
 
-        The request either provides `kind` and `content`, or uses the transitional legacy flat shape (`entrypoint` and
-        `prompt` without `content`, with `kind` omitted or `guided`, treated as a guided course) accepted until the API contract
-        release (goplus/builder-backend#352). When both are present, `content` wins.
+        `content` must match `kind`: `GuidedCourseContent` for a `guided` course, `PlaygroundCourseContent` for a
+        `playground` course.
 
         Permission requirements:
 
@@ -2851,8 +2850,10 @@ paths:
             schema:
               type: object
               required:
+                - kind
                 - title
                 - thumbnail
+                - content
               properties:
                 kind:
                   $ref: "#/components/schemas/Course/properties/kind"
@@ -2862,10 +2863,6 @@ paths:
                   $ref: "#/components/schemas/Course/properties/thumbnail"
                 content:
                   $ref: "#/components/schemas/Course/properties/content"
-                entrypoint:
-                  $ref: "#/components/schemas/Course/properties/entrypoint"
-                prompt:
-                  $ref: "#/components/schemas/Course/properties/prompt"
       responses:
         "201":
           description: Successfully created the course.
@@ -2989,8 +2986,8 @@ paths:
       description: |
         Update the details of a specific course.
 
-        The course kind is immutable: a `kind` field is accepted only when it matches the course's current kind, and the
-        transitional legacy fields (`entrypoint`, `prompt`) apply only to guided courses when `content` is absent.
+        The course kind is immutable: a `kind` field is accepted only when it matches the course's current kind. `content`
+        is validated against the course's kind and replaced as a whole, never merged.
 
         Permission requirements:
 
@@ -3018,10 +3015,6 @@ paths:
                   $ref: "#/components/schemas/Course/properties/thumbnail"
                 content:
                   $ref: "#/components/schemas/Course/properties/content"
-                entrypoint:
-                  $ref: "#/components/schemas/Course/properties/entrypoint"
-                prompt:
-                  $ref: "#/components/schemas/Course/properties/prompt"
       responses:
         "200":
           description: Successfully updated the course.
@@ -3234,8 +3227,6 @@ paths:
       description: |
         Create a new course series owned by the authenticated user.
 
-        Omitting `kind` means a guided series (transitional legacy shape, accepted until the API contract release (goplus/builder-backend#352)).
-
         Permission requirements:
 
         - Only users with the `courseAdmin` role can create course series.
@@ -3246,6 +3237,7 @@ paths:
             schema:
               type: object
               required:
+                - kind
                 - title
                 - thumbnail
                 - courseIDs
@@ -7664,8 +7656,6 @@ components:
         - title
         - thumbnail
         - content
-        - entrypoint
-        - prompt
       properties:
         id:
           $ref: "#/components/schemas/Model/properties/id"
@@ -7700,35 +7690,47 @@ components:
             - kodo://xbuilder-usercontent-test/files/FvYyHLNrtx8qFHSwnLjEe57UA2fF-2824936
         content:
           description: |
-            Kind-specific course content. For a `guided` course it holds the guided course data (`entrypoint` and `prompt`);
-            for a `playground` course it is a file collection mapping file paths to universal URLs. The API validates only
-            the top-level shape (and, for `playground`, that every value is a universal URL); internals follow the Tutorial
-            content-format contract and stay opaque to the API and storage.
-          type: object
-          examples:
-            - entrypoint: /editor/john/loop
-              prompt: Learn the basics of XGo programming language
-            - main_course.gox: kodo://xbuilder-usercontent-test/files/FvYyHLNrtx8qFHSwnLjEe57UA2fF-2824936
-              project/Lita.spx: kodo://xbuilder-usercontent-test/files/FoSC8ngQn_jzAIPBqCp9VZLBVkSq-52661
-              assets/videos/step-to/index.json: data:application/json,%7B%22path%22%3A%22step-to.mp4%22%7D
+            Kind-specific course content, selected by `kind`: `GuidedCourseContent` for a `guided` course,
+            `PlaygroundCourseContent` for a `playground` course. The API validates only the top-level shape; internals
+            follow the Tutorial content-format contract and stay opaque to the API and storage.
+          oneOf:
+            - $ref: "#/components/schemas/GuidedCourseContent"
+            - $ref: "#/components/schemas/PlaygroundCourseContent"
+
+    GuidedCourseContent:
+      description: Content of a `guided` course, driven by Copilot.
+      type: object
+      required:
+        - entrypoint
+        - prompt
+      properties:
         entrypoint:
-          description: |
-            Starting entrypoint of the course. Transitional top-level copy of the guided course content, kept so pre-kind
-            clients keep working; empty for playground courses. Removed by the API contract release (goplus/builder-backend#352).
-          deprecated: true
+          description: Starting entrypoint of the course.
           type: string
           format: uri-reference
+          minLength: 1
           examples:
             - /editor/john/loop
         prompt:
-          description: |
-            Prompt text for the course (used for copilot assistance). Transitional top-level copy of the guided course
-            content; empty for playground courses. Removed by the API contract release (goplus/builder-backend#352).
-          deprecated: true
+          description: Prompt text for the course (used for copilot assistance).
           type: string
           maxLength: 12000
           examples:
             - Learn the basics of XGo programming language
+
+    PlaygroundCourseContent:
+      description: |
+        Content of a `playground` course, driven by course code: a file collection mapping file paths to universal URLs.
+        The referenced files form the Tutorial project; its layout is owned by the Tutorial Class Framework contract. An
+        empty collection is valid, so a course can be created before its files are uploaded.
+      type: object
+      additionalProperties:
+        type: string
+        format: uri-reference
+      examples:
+        - main_course.gox: kodo://xbuilder-usercontent-test/files/FvYyHLNrtx8qFHSwnLjEe57UA2fF-2824936
+          project/Lita.spx: kodo://xbuilder-usercontent-test/files/FoSC8ngQn_jzAIPBqCp9VZLBVkSq-52661
+          assets/videos/step-to/index.json: data:application/json,%7B%22path%22%3A%22step-to.mp4%22%7D
 
     CourseSeries:
       description: Collection of related courses.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -2838,7 +2838,8 @@ paths:
         Create a new course owned by the authenticated user.
 
         The request either provides `kind` and `content`, or uses the transitional legacy flat shape (`entrypoint` and
-        `prompt` without `kind` and `content`, treated as a guided course) accepted until the API contract release (goplus/builder-backend#352).
+        `prompt` without `content`, with `kind` omitted or `guided`, treated as a guided course) accepted until the API contract
+        release (goplus/builder-backend#352). When both are present, `content` wins.
 
         Permission requirements:
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -2914,6 +2914,7 @@ paths:
               type: object
               required:
                 - title
+                - thumbnail
                 - content
               properties:
                 title:

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -2904,8 +2904,10 @@ paths:
 
         Quota and rate limits:
 
-        - Each generation consumes 1 quota from the authenticated user's `copilotMessage` allowance; the quota is
-          refunded when generation fails.
+        - Each generation consumes 1 quota from the authenticated user's `copilotMessage` allowance. The quota is
+          refunded when generation fails on the server side; it is not refunded when the client cancels the request.
+        - Per-user short-window rate limits also apply. Hitting them returns 429 with `Retry-After`; reaching the
+          long-window quota limit returns 403 with `Retry-After`.
       requestBody:
         required: true
         content:
@@ -2946,9 +2948,9 @@ paths:
         "401":
           $ref: "#/components/responses/Unauthorized"
         "403":
-          $ref: "#/components/responses/Forbidden"
+          $ref: "#/components/responses/ForbiddenOrQuotaExceeded"
         "429":
-          $ref: "#/components/responses/TooManyRequests"
+          $ref: "#/components/responses/RateLimitExceeded"
 
   /courses/{courseID}:
     get:


### PR DESCRIPTION
Part of #3403 / #3422. Documents the **API contract release** for course kinds: the second half of the expand-contract pair whose first half is #3471.

> [!IMPORTANT]
> Stacked on #3471: this branch is `issue-3422-openapi` plus one commit, so the diff shows #3471's changes too until #3471 merges (GitHub cannot base a goplus/builder PR on a fork branch). Review only the last commit (`docs(openapi)!: course API contract release for course kinds`). **Do not merge before goplus/builder-backend#352 is deployed**: this document describes the API only that release serves. Until then #3471 stays the accurate contract.

## What changes vs. #3471

| Area | Change |
|---|---|
| `Course` | Deprecated top-level `entrypoint` / `prompt` removed. `content` is now `oneOf` `GuidedCourseContent` / `PlaygroundCourseContent`, selected by `kind` (the `oneOf` promised in the #3471 review, now that the shape is final). |
| `POST /user/courses` | `kind` and `content` required; the transitional flat payload is no longer documented. |
| `PATCH /courses/{id}` | Flat `entrypoint` / `prompt` fields removed; `content` is validated against the course's kind and replaced as a whole. |
| `POST /user/course-series` | `kind` required (omitting it no longer means `guided`). |

New component schemas: `GuidedCourseContent` (`entrypoint` non-empty uri-reference, `prompt` ≤ 12000 chars) and `PlaygroundCourseContent` (file collection mapping paths to universal URLs; may be empty so a course can be created before its files are uploaded). The copilot-context request keeps its own inline, non-empty file collection.

Matches `docs/develop/tutorial-v2/module_CourseApis.ts` (`Course = GuidedCourse | PlaygroundCourse`, `CourseSeriesInput` with required `kind`). Verified by the goplus/builder-backend#352 rehearsal (see its description): the documented 400s and response shapes are what the Release 2 binary produces.
